### PR TITLE
Add attach -d flag and attach subcommand

### DIFF
--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -14,14 +14,15 @@ const defaultSession = "amux"
 // Start creates or attaches to an amux tmux session.
 // If the session already exists, it attaches. Otherwise it creates a new one,
 // configures amux keybindings and hooks, tags the initial pane, then attaches.
+// When detachOthers is true, other clients are detached on attach (like tmux attach -d).
 // This function does not return on success — it execs into tmux.
-func Start(sessionName string) error {
+func Start(sessionName string, detachOthers bool) error {
 	if sessionName == "" {
 		sessionName = defaultSession
 	}
 
 	if sessionExists(sessionName) {
-		return attach(sessionName)
+		return attach(sessionName, detachOthers)
 	}
 
 	// Create new detached session
@@ -42,7 +43,7 @@ func Start(sessionName string) error {
 		initPane(sessionName, initialPane)
 	}
 
-	return attach(sessionName)
+	return attach(sessionName, detachOthers)
 }
 
 func sessionExists(name string) bool {
@@ -50,7 +51,8 @@ func sessionExists(name string) bool {
 }
 
 // attach execs into tmux attach, replacing the current process.
-func attach(sessionName string) error {
+// When detachOthers is true, passes -d to detach other clients (like tmux attach -d).
+func attach(sessionName string, detachOthers bool) error {
 	tmuxPath, err := exec.LookPath("tmux")
 	if err != nil {
 		return fmt.Errorf("tmux not found: %w", err)
@@ -61,7 +63,11 @@ func attach(sessionName string) error {
 		return syscall.Exec(tmuxPath, []string{"tmux", "switch-client", "-t", sessionName}, os.Environ())
 	}
 
-	return syscall.Exec(tmuxPath, []string{"tmux", "attach-session", "-t", sessionName}, os.Environ())
+	args := []string{"tmux", "attach-session", "-t", sessionName}
+	if detachOthers {
+		args = []string{"tmux", "attach-session", "-d", "-t", sessionName}
+	}
+	return syscall.Exec(tmuxPath, args, os.Environ())
 }
 
 // firstPane returns the pane ID of the first pane in a session.

--- a/main.go
+++ b/main.go
@@ -20,7 +20,20 @@ import (
 func main() {
 	if len(os.Args) < 2 {
 		// Default: create or attach to amux tmux session
-		if err := session.Start(""); err != nil {
+		if err := session.Start("", false); err != nil {
+			fmt.Fprintf(os.Stderr, "amux: %v\n", err)
+			os.Exit(1)
+		}
+		return
+	}
+
+	// Handle top-level -d flag: amux -d [session]
+	if os.Args[1] == "-d" {
+		name := ""
+		if len(os.Args) > 2 {
+			name = os.Args[2]
+		}
+		if err := session.Start(name, true); err != nil {
 			fmt.Fprintf(os.Stderr, "amux: %v\n", err)
 			os.Exit(1)
 		}
@@ -28,13 +41,20 @@ func main() {
 	}
 
 	switch os.Args[1] {
+	case "attach":
+		// tmux muscle-memory compat: amux attach [-d] [session]
+		name, detach := parseAttachArgs(os.Args[2:])
+		if err := session.Start(name, detach); err != nil {
+			fmt.Fprintf(os.Stderr, "amux: %v\n", err)
+			os.Exit(1)
+		}
 	case "new":
 		// Create a named session: amux new <name>
 		name := ""
 		if len(os.Args) > 2 {
 			name = os.Args[2]
 		}
-		if err := session.Start(name); err != nil {
+		if err := session.Start(name, false); err != nil {
 			fmt.Fprintf(os.Stderr, "amux: %v\n", err)
 			os.Exit(1)
 		}
@@ -73,6 +93,19 @@ func main() {
 	}
 }
 
+// parseAttachArgs parses args for "amux attach [-d] [session]".
+func parseAttachArgs(args []string) (sessionName string, detachOthers bool) {
+	for _, arg := range args {
+		switch arg {
+		case "-d":
+			detachOthers = true
+		default:
+			sessionName = arg
+		}
+	}
+	return
+}
+
 func requireArg(cmd string, minArgs int) {
 	if len(os.Args) < minArgs+1 {
 		fmt.Fprintf(os.Stderr, "amux %s: requires %d argument(s)\n", cmd, minArgs)
@@ -96,6 +129,8 @@ func printUsage() {
 
 Usage:
   amux                              Start or attach to amux session
+  amux -d [session]                 Attach and detach other clients
+  amux attach [-d] [session]        Attach (tmux muscle-memory compat)
   amux new [name]                   Start a new named session
   amux dashboard                    Open TUI dashboard (in popup or standalone)
   amux list                         List agent panes with metadata


### PR DESCRIPTION
## Summary

- Add `-d` flag to detach other clients on attach (matches `tmux attach -d`)
- Add `amux attach [-d] [session]` subcommand for tmux muscle-memory compatibility
- `amux -d [session]` as shorthand

## Motivation

When multiple terminals are attached to the same amux session, you often want to detach the others (e.g., stale SSH connections). tmux users reach for `tmux attach -d` — amux should support the same pattern.

## Testing

- `go test ./...` passes
- `amux -d` attaches with `-d` flag
- `amux attach -d mysession` parses correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)