### PR TITLE
Add adopt and merge commands

### DIFF
--- a/internal/merge/merge.go
+++ b/internal/merge/merge.go
@@ -1,0 +1,36 @@
+package merge
+
+import (
+	"fmt"
+
+	"github.com/weill-labs/amux/internal/tmux"
+)
+
+// Merge moves all panes from srcWindow into dstWindow within the current session.
+// The source window is automatically destroyed by tmux when its last pane is moved.
+// Windows are referenced by index (e.g., "0", "1", "2").
+func Merge(t tmux.Tmux, srcWindow, dstWindow string) (int, error) {
+	session := t.CurrentSession()
+	if session == "" {
+		return 0, fmt.Errorf("not inside a tmux session")
+	}
+
+	srcPanes, err := t.SessionWindowPanes(session + ":" + srcWindow)
+	if err != nil || len(srcPanes) == 0 {
+		return 0, fmt.Errorf("no panes found in window %s", srcWindow)
+	}
+
+	dstPanes, err := t.SessionWindowPanes(session + ":" + dstWindow)
+	if err != nil || len(dstPanes) == 0 {
+		return 0, fmt.Errorf("no panes found in window %s", dstWindow)
+	}
+
+	dstTarget := dstPanes[0]
+	for _, paneID := range srcPanes {
+		if err := t.JoinPane(paneID, dstTarget); err != nil {
+			return 0, fmt.Errorf("joining pane %s into window %s: %w", paneID, dstWindow, err)
+		}
+	}
+
+	return len(srcPanes), nil
+}

--- a/internal/merge/merge_test.go
+++ b/internal/merge/merge_test.go
@@ -1,0 +1,134 @@
+package merge
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/weill-labs/amux/internal/tmux"
+)
+
+type mockTmux struct {
+	session string
+	windows map[string][]string // "session:window" -> pane IDs
+	joined  []joinCall
+}
+
+type joinCall struct{ src, dst string }
+
+func newMock() *mockTmux {
+	return &mockTmux{
+		session: "amux",
+		windows: make(map[string][]string),
+	}
+}
+
+func (m *mockTmux) ListPanes() (map[string]tmux.PaneFields, error)           { return nil, nil }
+func (m *mockTmux) PaneOutput(paneID string, lines int) (string, error)      { return "", nil }
+func (m *mockTmux) ResizePane(paneID string, height int) error               { return nil }
+func (m *mockTmux) SwapPane(src, dst string) error                           { return nil }
+func (m *mockTmux) PaneHeight(paneID string) (int, error)                    { return 20, nil }
+func (m *mockTmux) GetOption(paneID, key string) (string, error)             { return "", nil }
+func (m *mockTmux) SetOption(paneID, key, value string) error                { return nil }
+func (m *mockTmux) SetPaneTitle(paneID, title string) error                  { return nil }
+func (m *mockTmux) SelectPane(paneID string) error                           { return nil }
+func (m *mockTmux) KillPane(paneID string) error                             { return nil }
+func (m *mockTmux) SplitWindow(cmd string) (string, error)                   { return "%99", nil }
+func (m *mockTmux) SendKeys(paneID string, keys ...string) error             { return nil }
+func (m *mockTmux) CurrentSession() string                                   { return m.session }
+func (m *mockTmux) RemoteSessionAlive(user, host, session string) bool       { return false }
+func (m *mockTmux) WindowPanes(paneID string) ([]string, error)              { return []string{paneID}, nil }
+
+func (m *mockTmux) JoinPane(src, dst string) error {
+	m.joined = append(m.joined, joinCall{src, dst})
+	return nil
+}
+
+func (m *mockTmux) SessionWindowPanes(sessionWindow string) ([]string, error) {
+	if panes, ok := m.windows[sessionWindow]; ok {
+		return panes, nil
+	}
+	return nil, fmt.Errorf("window not found: %s", sessionWindow)
+}
+
+func TestMerge(t *testing.T) {
+	mt := newMock()
+	mt.windows["amux:0"] = []string{"%1"}
+	mt.windows["amux:1"] = []string{"%2", "%3"}
+
+	count, err := Merge(mt, "1", "0")
+	if err != nil {
+		t.Fatalf("Merge: %v", err)
+	}
+
+	if count != 2 {
+		t.Errorf("expected 2 panes merged, got %d", count)
+	}
+
+	if len(mt.joined) != 2 {
+		t.Fatalf("expected 2 JoinPane calls, got %d", len(mt.joined))
+	}
+
+	for _, j := range mt.joined {
+		if j.dst != "%1" {
+			t.Errorf("expected join target %%1, got %s", j.dst)
+		}
+	}
+}
+
+func TestMergeSrcNotFound(t *testing.T) {
+	mt := newMock()
+	mt.windows["amux:0"] = []string{"%1"}
+
+	_, err := Merge(mt, "5", "0")
+	if err == nil {
+		t.Fatal("expected error for missing source window")
+	}
+}
+
+func TestMergeDstNotFound(t *testing.T) {
+	mt := newMock()
+	mt.windows["amux:0"] = []string{"%1"}
+
+	_, err := Merge(mt, "0", "5")
+	if err == nil {
+		t.Fatal("expected error for missing destination window")
+	}
+}
+
+func TestMergeNotInTmux(t *testing.T) {
+	mt := newMock()
+	mt.session = ""
+
+	_, err := Merge(mt, "1", "0")
+	if err == nil {
+		t.Fatal("expected error when not in tmux")
+	}
+	if err.Error() != "not inside a tmux session" {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestMergeJoinError(t *testing.T) {
+	mt := &errorMock{
+		mockTmux: mockTmux{
+			session: "amux",
+			windows: map[string][]string{
+				"amux:0": {"%1"},
+				"amux:1": {"%2"},
+			},
+		},
+	}
+
+	_, err := Merge(mt, "1", "0")
+	if err == nil {
+		t.Fatal("expected error from JoinPane failure")
+	}
+}
+
+type errorMock struct {
+	mockTmux
+}
+
+func (m *errorMock) JoinPane(src, dst string) error {
+	return fmt.Errorf("tmux error")
+}

--- a/internal/minimize/minimize_test.go
+++ b/internal/minimize/minimize_test.go
@@ -68,6 +68,8 @@ func (m *mockTmux) WindowPanes(paneID string) ([]string, error) {
 	}
 	return []string{paneID}, nil
 }
+func (m *mockTmux) JoinPane(src, dst string) error                          { return nil }
+func (m *mockTmux) SessionWindowPanes(sessionWindow string) ([]string, error) { return nil, nil }
 
 func TestMinimize(t *testing.T) {
 	mt := newMock()

--- a/internal/pane/pane_test.go
+++ b/internal/pane/pane_test.go
@@ -61,7 +61,9 @@ func (m *mockTmux) SendKeys(paneID string, keys ...string) error {
 }
 func (m *mockTmux) CurrentSession() string                                { return "main" }
 func (m *mockTmux) RemoteSessionAlive(user, host, session string) bool    { return false }
-func (m *mockTmux) WindowPanes(paneID string) ([]string, error)          { return []string{paneID}, nil }
+func (m *mockTmux) WindowPanes(paneID string) ([]string, error) { return []string{paneID}, nil }
+func (m *mockTmux) JoinPane(src, dst string) error                          { return nil }
+func (m *mockTmux) SessionWindowPanes(sessionWindow string) ([]string, error) { return nil, nil }
 
 func TestDiscover(t *testing.T) {
 	mt := newMockTmux()

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -46,6 +46,68 @@ func Start(sessionName string, detachOthers bool) error {
 	return attach(sessionName, detachOthers)
 }
 
+// Adopt converts an existing tmux session into an amux-managed session.
+// When run from inside a different tmux session, it links the source session's
+// windows into the current session (non-destructive — source session is preserved).
+// When run outside tmux, it configures the session in place.
+func Adopt(sessionName string) error {
+	if !sessionExists(sessionName) {
+		return fmt.Errorf("session %q does not exist", sessionName)
+	}
+
+	// If inside a different tmux session, link windows into it
+	if os.Getenv("TMUX") != "" {
+		current := currentSession()
+		if current != "" && current != sessionName {
+			return adoptInto(current, sessionName)
+		}
+	}
+
+	// Otherwise, configure the session in place
+	configure(sessionName)
+
+	panes := allPanes(sessionName)
+	for _, paneID := range panes {
+		initPane(sessionName, paneID)
+	}
+
+	fmt.Printf("Adopted %s: %d panes\n", sessionName, len(panes))
+	return nil
+}
+
+// adoptInto links windows from sourceSession into targetSession and tags their panes.
+// The source session is preserved (link-window creates shared references).
+func adoptInto(targetSession, sourceSession string) error {
+	// Collect pane IDs before linking (pane IDs are globally stable)
+	panes := allPanes(sourceSession)
+	windows := allWindows(sourceSession)
+
+	if len(windows) == 0 {
+		return fmt.Errorf("no windows found in session %q", sourceSession)
+	}
+
+	// Find next available window index in target session
+	startIdx := maxWindowIndex(targetSession) + 1
+
+	for i, winID := range windows {
+		err := tmuxCmd("link-window", "-s",
+			fmt.Sprintf("%s:%s", sourceSession, winID), "-t",
+			fmt.Sprintf("%s:%d", targetSession, startIdx+i))
+		if err != nil {
+			return fmt.Errorf("linking window %s: %w", winID, err)
+		}
+	}
+
+	// Tag all linked panes with amux metadata
+	for _, paneID := range panes {
+		initPane(targetSession, paneID)
+	}
+
+	fmt.Printf("Adopted %s into %s: %d panes across %d windows\n",
+		sourceSession, targetSession, len(panes), len(windows))
+	return nil
+}
+
 func sessionExists(name string) bool {
 	return exec.Command("tmux", "has-session", "-t", name).Run() == nil
 }
@@ -70,18 +132,67 @@ func attach(sessionName string, detachOthers bool) error {
 	return syscall.Exec(tmuxPath, args, os.Environ())
 }
 
+// allPanes returns the pane IDs of all panes across all windows in a session.
+func allPanes(sessionName string) []string {
+	out, err := exec.Command("tmux", "list-panes", "-t", sessionName,
+		"-s", "-F", "#{pane_id}").Output()
+	if err != nil {
+		return nil
+	}
+	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
+	if len(lines) == 1 && lines[0] == "" {
+		return nil
+	}
+	return lines
+}
+
 // firstPane returns the pane ID of the first pane in a session.
 func firstPane(sessionName string) string {
-	out, err := exec.Command("tmux", "list-panes", "-t", sessionName,
-		"-F", "#{pane_id}").Output()
+	panes := allPanes(sessionName)
+	if len(panes) > 0 {
+		return panes[0]
+	}
+	return ""
+}
+
+// currentSession returns the name of the tmux session this process is running in.
+func currentSession() string {
+	out, err := exec.Command("tmux", "display-message", "-p", "#{session_name}").Output()
 	if err != nil {
 		return ""
 	}
-	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
-	if len(lines) > 0 {
-		return lines[0]
+	return strings.TrimSpace(string(out))
+}
+
+// allWindows returns the window IDs (e.g., @0, @1) for all windows in a session.
+// Window IDs are stable across link/move operations, unlike indices.
+func allWindows(sessionName string) []string {
+	out, err := exec.Command("tmux", "list-windows", "-t", sessionName,
+		"-F", "#{window_id}").Output()
+	if err != nil {
+		return nil
 	}
-	return ""
+	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
+	if len(lines) == 1 && lines[0] == "" {
+		return nil
+	}
+	return lines
+}
+
+// maxWindowIndex returns the highest window index in a session.
+func maxWindowIndex(sessionName string) int {
+	out, err := exec.Command("tmux", "list-windows", "-t", sessionName,
+		"-F", "#{window_index}").Output()
+	if err != nil {
+		return 0
+	}
+	max := 0
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		if idx, err := strconv.Atoi(line); err == nil && idx > max {
+			max = idx
+		}
+	}
+	return max
 }
 
 // configure sets up amux-specific keybindings, hooks, and status bar on a session.

--- a/internal/swap/swap_test.go
+++ b/internal/swap/swap_test.go
@@ -35,6 +35,8 @@ func (m *mockTmux) RemoteSessionAlive(user, host, session string) bool {
 func (m *mockTmux) WindowPanes(paneID string) ([]string, error) {
 	return []string{paneID}, nil
 }
+func (m *mockTmux) JoinPane(src, dst string) error                          { return nil }
+func (m *mockTmux) SessionWindowPanes(sessionWindow string) ([]string, error) { return nil, nil }
 
 func (m *mockTmux) SwapPane(src, dst string) error {
 	m.swapped = true

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -55,6 +55,12 @@ type Tmux interface {
 
 	// WindowPanes returns pane IDs in the same window as the given pane.
 	WindowPanes(paneID string) ([]string, error)
+
+	// JoinPane moves src pane to be adjacent to dst pane (in dst's window).
+	JoinPane(src, dst string) error
+
+	// SessionWindowPanes returns pane IDs in a specific session:window.
+	SessionWindowPanes(sessionWindow string) ([]string, error)
 }
 
 // PaneFields holds raw tmux fields for a single pane.
@@ -246,6 +252,24 @@ func (t *LiveTmux) WindowPanes(paneID string) ([]string, error) {
 		return nil, err
 	}
 
+	var panes []string
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		if line != "" {
+			panes = append(panes, line)
+		}
+	}
+	return panes, nil
+}
+
+func (t *LiveTmux) JoinPane(src, dst string) error {
+	return exec.Command("tmux", "join-pane", "-s", src, "-t", dst).Run()
+}
+
+func (t *LiveTmux) SessionWindowPanes(sessionWindow string) ([]string, error) {
+	out, err := exec.Command("tmux", "list-panes", "-t", sessionWindow, "-F", "#{pane_id}").Output()
+	if err != nil {
+		return nil, err
+	}
 	var panes []string
 	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
 		if line != "" {

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/weill-labs/amux/internal/config"
 	"github.com/weill-labs/amux/internal/grid"
+	"github.com/weill-labs/amux/internal/merge"
 	"github.com/weill-labs/amux/internal/minimize"
 	"github.com/weill-labs/amux/internal/pane"
 	"github.com/weill-labs/amux/internal/session"
@@ -58,6 +59,12 @@ func main() {
 			fmt.Fprintf(os.Stderr, "amux: %v\n", err)
 			os.Exit(1)
 		}
+	case "adopt":
+		requireArg("adopt", 1)
+		if err := session.Adopt(os.Args[2]); err != nil {
+			fmt.Fprintf(os.Stderr, "amux adopt: %v\n", err)
+			os.Exit(1)
+		}
 	case "dashboard":
 		runDashboard()
 	case "list":
@@ -70,6 +77,9 @@ func main() {
 	case "restore":
 		requireArg("restore", 2)
 		runRestore(resolveOrDie(os.Args[2]))
+	case "merge":
+		requireArg("merge", 2)
+		runMerge(os.Args[2], os.Args[3])
 	case "swap":
 		requireArg("swap", 3)
 		runSwap(resolveOrDie(os.Args[2]), resolveOrDie(os.Args[3]))
@@ -132,12 +142,14 @@ Usage:
   amux -d [session]                 Attach and detach other clients
   amux attach [-d] [session]        Attach (tmux muscle-memory compat)
   amux new [name]                   Start a new named session
+  amux adopt <session>              Adopt an existing tmux session
   amux dashboard                    Open TUI dashboard (in popup or standalone)
   amux list                         List agent panes with metadata
   amux status                       Show agent status (for scripts/prompts)
   amux output <pane>                Show pane output (last 50 lines)
   amux minimize <pane>              Minimize a pane to 1 row
   amux restore <pane>               Restore a minimized pane
+  amux merge <src_win> <dst_win>    Merge panes from one window into another
   amux swap <pane_a> <pane_b>       Swap two panes (with metadata)
   amux spawn [flags]                Spawn a new agent
 
@@ -263,6 +275,16 @@ func runRestore(paneID string) {
 		os.Exit(1)
 	}
 	fmt.Printf("Restored %s\n", paneID)
+}
+
+func runMerge(srcWindow, dstWindow string) {
+	t := newTmux()
+	count, err := merge.Merge(t, srcWindow, dstWindow)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "amux merge: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Printf("Merged %d panes from window %s into window %s\n", count, srcWindow, dstWindow)
 }
 
 func runSwap(paneA, paneB string) {


### PR DESCRIPTION
## Summary

- **`amux adopt <session>`** — links an existing tmux session's windows into the current amux session using `tmux link-window` (non-destructive; source session is preserved). When run outside tmux, configures the session in place with amux keybindings/hooks and tags all panes.
- **`amux merge <src_win> <dst_win>`** — moves all panes from one window into another using `join-pane`. Source window auto-destroys when empty.
- Fixes `allPanes()` to use `-s` flag for listing panes across all windows (not just the first).
- Adds `JoinPane` and `SessionWindowPanes` to the `Tmux` interface. `SessionWindowPanes` queries panes scoped to a specific `session:window`, avoiding a dedup bug in `ListPanes()` where linked panes (same pane ID in multiple sessions) overwrite each other in the map.

## Motivation

The `local` tmux session had 9 panes created before amux existed. `adopt` converts it to an amux-managed session so it can use the dashboard, minimize/restore, named panes, etc. `merge` allows combining adopted windows with existing ones.

## Testing

- `go test ./...` passes (new merge tests + existing tests updated for interface changes)
- Live tested: `amux adopt local` (9 panes across 1 window), `amux merge 1 2` (combined windows)

## Review focus

- `link-window` semantics: linked windows share pane state between sessions, so `@amux_*` metadata set from either session is visible in both. Killing from either side destroys the shared window.
- `SessionWindowPanes` was added specifically because `ListPanes()` (which uses `-a`) produces duplicate entries for linked panes, with map last-write-wins causing session name mismatches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)