### PR TITLE
Add double-click pane to toggle zoom

### DIFF
--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -231,6 +231,9 @@ func configure(sessionName string) {
 	tmuxCmd("bind-key", "-T", "root", `C-\`,
 		"split-window", "-h", "-c", "#{pane_current_path}")
 
+	// Double-click pane → toggle zoom
+	tmuxCmd("bind-key", "-T", "root", "DoubleClick1Pane", "resize-pane", "-Z")
+
 	// Standard splits/windows inherit current directory
 	tmuxCmd("bind-key", `"`, "split-window", "-c", "#{pane_current_path}")
 	tmuxCmd("bind-key", "%", "split-window", "-h", "-c", "#{pane_current_path}")


### PR DESCRIPTION
## Summary

- Binds `DoubleClick1Pane` to `resize-pane -Z` in the root keytable for mouse-driven zoom toggle.
- Uses pane targeting (not border targeting) to avoid a tmux quirk where border clicks resolve to the adjacent pane.

## Test plan

- [x] Double-click on a pane zooms it full-window
- [x] Double-click again unzooms back to original layout
- [x] Correct pane is targeted when multiple panes are visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)