### PR TITLE
Make integration tests parallel (LAB-83)

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -332,12 +332,15 @@ func (s *Server) handleOneShot(conn net.Conn, msg *Message) {
 	cc := NewClientConn(conn)
 	defer cc.Close()
 
-	sessionName := "default"
+	// Each server process hosts one session — use the first one
 	s.mu.Lock()
-	sess, ok := s.sessions[sessionName]
+	var sess *Session
+	for _, sess = range s.sessions {
+		break
+	}
 	s.mu.Unlock()
 
-	if !ok {
+	if sess == nil {
 		cc.Send(&Message{Type: MsgTypeCmdResult, CmdErr: "no session"})
 		return
 	}

--- a/main.go
+++ b/main.go
@@ -16,29 +16,40 @@ import (
 	"golang.org/x/term"
 )
 
+// sessionName is the global session name, set by -s flag or defaulting to "default".
+var sessionName = "default"
+
 func main() {
-	if len(os.Args) < 2 {
-		// Default: start or attach to amux session
-		if err := runMux("default"); err != nil {
+	// Extract global -s flag before subcommand parsing
+	args := os.Args[1:]
+	for i := 0; i < len(args); i++ {
+		if args[i] == "-s" && i+1 < len(args) {
+			sessionName = args[i+1]
+			args = append(args[:i], args[i+2:]...)
+			break
+		}
+	}
+
+	if len(args) == 0 {
+		if err := runMux(sessionName); err != nil {
 			fmt.Fprintf(os.Stderr, "amux: %v\n", err)
 			os.Exit(1)
 		}
 		return
 	}
 
-	switch os.Args[1] {
-	// --- New built-in multiplexer commands ---
+	switch args[0] {
 	case "_server":
-		sessionName := "default"
-		if len(os.Args) > 2 {
-			sessionName = os.Args[2]
+		name := sessionName
+		if len(args) > 1 {
+			name = args[1]
 		}
-		runServer(sessionName)
+		runServer(name)
 
 	case "attach":
-		name, _ := parseAttachArgs(os.Args[2:])
+		name, _ := parseAttachArgs(args[1:])
 		if name == "" {
-			name = "default"
+			name = sessionName
 		}
 		if err := runMux(name); err != nil {
 			fmt.Fprintf(os.Stderr, "amux: %v\n", err)
@@ -46,30 +57,27 @@ func main() {
 		}
 
 	case "new":
-		name := "default"
-		if len(os.Args) > 2 {
-			name = os.Args[2]
+		name := sessionName
+		if len(args) > 1 {
+			name = args[1]
 		}
 		if err := runMux(name); err != nil {
 			fmt.Fprintf(os.Stderr, "amux: %v\n", err)
 			os.Exit(1)
 		}
 
-	// --- Commands that talk to the server ---
 	case "list":
 		runServerCommand("list", nil)
-
 	case "status":
 		runServerCommand("status", nil)
-
 	case "output", "minimize", "restore", "kill":
-		if len(os.Args) < 3 {
-			fmt.Fprintf(os.Stderr, "usage: amux %s <pane>\n", os.Args[1])
+		if len(args) < 2 {
+			fmt.Fprintf(os.Stderr, "usage: amux %s <pane>\n", args[0])
 			os.Exit(1)
 		}
-		runServerCommand(os.Args[1], []string{os.Args[2]})
+		runServerCommand(args[0], []string{args[1]})
 	case "spawn":
-		runServerCommand("spawn", os.Args[2:])
+		runServerCommand("spawn", args[1:])
 	case "dashboard":
 		fmt.Fprintln(os.Stderr, "amux dashboard: not yet migrated to built-in mux")
 		os.Exit(1)
@@ -77,7 +85,7 @@ func main() {
 	case "help", "--help", "-h":
 		printUsage()
 	default:
-		fmt.Fprintf(os.Stderr, "amux: unknown command %q\n", os.Args[1])
+		fmt.Fprintf(os.Stderr, "amux: unknown command %q\n", args[0])
 		printUsage()
 		os.Exit(1)
 	}
@@ -100,16 +108,16 @@ func printUsage() {
 	fmt.Println(`amux — Agent-Centric Terminal Multiplexer
 
 Usage:
-  amux                              Start or attach to amux session
-  amux attach [session]             Attach to a session
-  amux new [name]                   Start a new named session
-  amux list                         List panes with metadata
-  amux status                       Show pane summary
-  amux output <pane>                Show last 50 lines of pane output
-  amux spawn --name NAME [--task T] Spawn a new agent pane
-  amux minimize <pane>              Minimize a pane
-  amux restore <pane>               Restore a minimized pane
-  amux kill <pane>                  Kill a pane
+  amux [-s session]                   Start or attach to amux session
+  amux [-s session] attach [session]  Attach to a session
+  amux [-s session] new [name]        Start a new named session
+  amux [-s session] list              List panes with metadata
+  amux [-s session] status            Show pane summary
+  amux [-s session] output <pane>     Show last 50 lines of pane output
+  amux [-s session] spawn --name NAME Spawn a new agent pane
+  amux [-s session] minimize <pane>   Minimize a pane
+  amux [-s session] restore <pane>    Restore a minimized pane
+  amux [-s session] kill <pane>       Kill a pane
 
 Panes can be referenced by name (pane-1) or ID (1).
 
@@ -262,7 +270,7 @@ func runMux(sessionName string) error {
 					prefix = false
 					switch buf[i] {
 					case 'd':
-						// Detach — flush any pending bytes, detach, exit
+						// Detach
 						if len(forward) > 0 {
 							server.WriteMsg(conn, &server.Message{
 								Type: server.MsgTypeInput, Input: forward,
@@ -405,7 +413,7 @@ func waitForSocket(sockPath string, timeout time.Duration) error {
 // ---------------------------------------------------------------------------
 
 func runServerCommand(cmdName string, args []string) {
-	sockPath := server.SocketPath("default")
+	sockPath := server.SocketPath(sessionName)
 	conn, err := net.Dial("unix", sockPath)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "amux %s: server not running (run 'amux' first)\n", cmdName)

--- a/test/amux_test.go
+++ b/test/amux_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestBasicStartAndDetach(t *testing.T) {
+	t.Parallel()
 	h := newHarness(t)
 
 	h.assertScreen("should show pane status", func(s string) bool {
@@ -22,6 +23,7 @@ func TestBasicStartAndDetach(t *testing.T) {
 }
 
 func TestSplitVertical(t *testing.T) {
+	t.Parallel()
 	h := newHarness(t)
 
 	h.sendKeys("C-a", "\\")
@@ -37,6 +39,7 @@ func TestSplitVertical(t *testing.T) {
 }
 
 func TestSplitHorizontal(t *testing.T) {
+	t.Parallel()
 	h := newHarness(t)
 
 	h.sendKeys("C-a", "-")
@@ -52,6 +55,7 @@ func TestSplitHorizontal(t *testing.T) {
 }
 
 func TestFocusCycle(t *testing.T) {
+	t.Parallel()
 	h := newHarness(t)
 
 	h.sendKeys("C-a", "\\")
@@ -61,8 +65,7 @@ func TestFocusCycle(t *testing.T) {
 	time.Sleep(500 * time.Millisecond)
 
 	h.assertScreen("pane-1 should have active indicator", func(s string) bool {
-		lines := strings.Split(s, "\n")
-		for _, line := range lines {
+		for _, line := range strings.Split(s, "\n") {
 			if strings.Contains(line, "[pane-1]") && strings.Contains(line, "●") {
 				return true
 			}
@@ -72,6 +75,7 @@ func TestFocusCycle(t *testing.T) {
 }
 
 func TestPaneClose(t *testing.T) {
+	t.Parallel()
 	h := newHarness(t)
 
 	h.sendKeys("C-a", "\\")
@@ -90,8 +94,7 @@ func TestPaneClose(t *testing.T) {
 	})
 
 	h.assertScreen("no pane borders with single pane", func(s string) bool {
-		lines := strings.Split(s, "\n")
-		for _, line := range lines {
+		for _, line := range strings.Split(s, "\n") {
 			if strings.Contains(line, "amux") && strings.Contains(line, "panes") {
 				continue
 			}
@@ -104,6 +107,7 @@ func TestPaneClose(t *testing.T) {
 }
 
 func TestList(t *testing.T) {
+	t.Parallel()
 	h := newHarness(t)
 
 	h.sendKeys("C-a", "\\")
@@ -119,6 +123,7 @@ func TestList(t *testing.T) {
 }
 
 func TestStatus(t *testing.T) {
+	t.Parallel()
 	h := newHarness(t)
 
 	output := h.runCmd("status")
@@ -128,6 +133,7 @@ func TestStatus(t *testing.T) {
 }
 
 func TestReattach(t *testing.T) {
+	t.Parallel()
 	h := newHarness(t)
 
 	h.sendKeys("e", "c", "h", "o", " ", "H", "E", "L", "L", "O", "Enter")
@@ -136,7 +142,8 @@ func TestReattach(t *testing.T) {
 	h.sendKeys("C-a", "d")
 	time.Sleep(500 * time.Millisecond)
 
-	h.sendKeys(amuxBin, "Enter")
+	// Reattach with the same session name
+	h.sendKeys(amuxBin, " -s ", h.session, "Enter")
 
 	if !h.waitFor("[pane-", 5*time.Second) {
 		screen := h.capture()

--- a/test/harness_test.go
+++ b/test/harness_test.go
@@ -1,5 +1,3 @@
-// TODO(LAB-83): Make integration tests parallelizable by giving each test
-// its own amux session name and socket path.
 package test
 
 import (
@@ -45,18 +43,18 @@ func TestMain(m *testing.M) {
 
 type TmuxHarness struct {
 	t       *testing.T
-	session string
+	session string // unique per-test session name (tmux + amux)
 }
 
-// newHarness creates a tmux session with a shell, runs amux inside it,
-// and waits for amux to start. The shell survives amux detach.
+// newHarness creates a tmux session with a shell, runs amux with a unique
+// session name, and waits for it to start. Safe for parallel tests.
 func newHarness(t *testing.T) *TmuxHarness {
 	t.Helper()
-	session := fmt.Sprintf("amux-test-%d", time.Now().UnixNano()%100000)
+	session := fmt.Sprintf("t-%d", time.Now().UnixNano()%1000000)
 
 	h := &TmuxHarness{t: t, session: session}
 
-	// Start tmux session with a shell (not amux directly)
+	// Start tmux session with a shell
 	cmd := exec.Command("tmux", "new-session", "-d", "-s", session,
 		"-x", "80", "-y", "24")
 	if out, err := cmd.CombinedOutput(); err != nil {
@@ -65,8 +63,8 @@ func newHarness(t *testing.T) *TmuxHarness {
 
 	t.Cleanup(h.cleanup)
 
-	// Launch amux
-	h.sendKeys(amuxBin, "Enter")
+	// Launch amux with this test's unique session name (-s flag)
+	h.sendKeys(amuxBin, " -s ", session, "Enter")
 
 	// Wait for amux to start (status bar should appear)
 	if !h.waitFor("[pane-", 8*time.Second) {
@@ -77,19 +75,18 @@ func newHarness(t *testing.T) *TmuxHarness {
 	return h
 }
 
-// cleanup kills the tmux session and the amux server.
+// cleanup kills the tmux session and its amux server.
 func (h *TmuxHarness) cleanup() {
-	// Detach first (so amux server stays running for cleanup)
 	exec.Command("tmux", "send-keys", "-t", h.session, "C-a", "d").Run()
 	time.Sleep(200 * time.Millisecond)
 	exec.Command("tmux", "kill-session", "-t", h.session).Run()
-	exec.Command("pkill", "-f", "amux _server").Run()
-	exec.Command("rm", "-f", fmt.Sprintf("/tmp/amux-%d/default", os.Getuid())).Run()
-	time.Sleep(200 * time.Millisecond)
+	// Kill only this test's server
+	exec.Command("pkill", "-f", fmt.Sprintf("amux _server %s", h.session)).Run()
+	exec.Command("rm", "-f", fmt.Sprintf("/tmp/amux-%d/%s", os.Getuid(), h.session)).Run()
+	time.Sleep(100 * time.Millisecond)
 }
 
-// sendKeys sends keystrokes to the tmux session. Each argument is passed as
-// a separate tmux send-keys argument. Use tmux key names like "C-a" for Ctrl-a.
+// sendKeys sends keystrokes to the tmux session.
 func (h *TmuxHarness) sendKeys(keys ...string) {
 	h.t.Helper()
 	args := append([]string{"send-keys", "-t", h.session}, keys...)
@@ -142,10 +139,10 @@ func (h *TmuxHarness) assertScreen(msg string, fn func(string) bool) {
 	}
 }
 
-// runCmd runs an amux CLI command (e.g., "list") and returns its output.
+// runCmd runs an amux CLI command targeting this test's session.
 func (h *TmuxHarness) runCmd(args ...string) string {
 	h.t.Helper()
-	cmdArgs := append([]string{}, args...)
+	cmdArgs := append([]string{"-s", h.session}, args...)
 	out, err := exec.Command(amuxBin, cmdArgs...).CombinedOutput()
 	if err != nil {
 		return string(out)


### PR DESCRIPTION
## Summary

- Add `-s` flag to amux CLI for targeting named sessions
- Each test gets a unique session name — no socket conflicts
- All 8 tests run in ~2.5s (was ~10s sequential)
- Fix handleOneShot hardcoding "default" session

## Test plan

- [x] All 8 integration tests pass in parallel locally
- [ ] CI passes