### PR TITLE
Fix root splits and test cleanup flakiness

### DIFF
--- a/internal/mux/window.go
+++ b/internal/mux/window.go
@@ -30,28 +30,24 @@ func NewWindow(pane *Pane, width, height int) *Window {
 
 // SplitRoot splits the entire window at the root level.
 func (w *Window) SplitRoot(dir SplitDir, newPane *Pane) (*Pane, error) {
-	// Wrap the current root in a new parent and add the new pane as a sibling
 	oldRoot := w.Root
 
 	newLeaf := NewLeaf(newPane, 0, 0, 0, 0)
-	var child1H, child2H int
 
 	if dir == SplitHorizontal {
 		size2 := (oldRoot.W - 1) / 2
 		size1 := oldRoot.W - 1 - size2
-		child1H = oldRoot.H
-		child2H = oldRoot.H
-		oldRoot.W = size1
 		newLeaf.W = size2
 		newLeaf.H = oldRoot.H
+		// Propagate new width to oldRoot and all its children
+		oldRoot.ResizeAll(size1, oldRoot.H)
 	} else {
 		size2 := (oldRoot.H - 1) / 2
 		size1 := oldRoot.H - 1 - size2
-		child1H = size1
-		child2H = size2
-		oldRoot.H = size1
 		newLeaf.W = oldRoot.W
 		newLeaf.H = size2
+		// Propagate new height to oldRoot and all its children
+		oldRoot.ResizeAll(oldRoot.W, size1)
 	}
 
 	newRoot := &LayoutCell{
@@ -65,9 +61,7 @@ func (w *Window) SplitRoot(dir SplitDir, newPane *Pane) (*Pane, error) {
 
 	w.Root.FixOffsets()
 
-	// Resize all PTYs
-	_ = child1H
-	_ = child2H
+	// Resize all PTYs to match new cell dimensions
 	w.Root.Walk(func(c *LayoutCell) {
 		if c.Pane != nil {
 			c.Pane.Resize(c.W, paneHeight(c.H))

--- a/test/amux_test.go
+++ b/test/amux_test.go
@@ -154,3 +154,77 @@ func TestReattach(t *testing.T) {
 		return strings.Contains(s, "HELLO")
 	})
 }
+
+func TestRootSplitVertical(t *testing.T) {
+	t.Parallel()
+	h := newHarness(t)
+
+	// First do a normal horizontal split to get 2 panes stacked
+	h.sendKeys("C-a", "-")
+	h.waitFor("[pane-2]", 3*time.Second)
+
+	// Now root-split vertical — should create a full-height left/right split
+	h.sendKeys("C-a", "|")
+
+	if !h.waitFor("[pane-3]", 3*time.Second) {
+		screen := h.capture()
+		t.Fatalf("root vertical split failed, screen:\n%s", screen)
+	}
+
+	// Should see 3 panes
+	h.assertScreen("should show 3 panes after root vertical split", func(s string) bool {
+		return strings.Contains(s, "[pane-1]") &&
+			strings.Contains(s, "[pane-2]") &&
+			strings.Contains(s, "[pane-3]")
+	})
+
+	// Should have a vertical border (│) from the root split
+	h.assertScreen("should have vertical border from root split", func(s string) bool {
+		for _, line := range strings.Split(s, "\n") {
+			if strings.Contains(line, "amux") && strings.Contains(line, "panes") {
+				continue
+			}
+			if strings.Contains(line, "│") {
+				return true
+			}
+		}
+		return false
+	})
+}
+
+func TestRootSplitHorizontal(t *testing.T) {
+	t.Parallel()
+	h := newHarness(t)
+
+	// First do a normal vertical split to get 2 panes side by side
+	h.sendKeys("C-a", "\\")
+	h.waitFor("[pane-2]", 3*time.Second)
+
+	// Now root-split horizontal — should create a full-width top/bottom split
+	h.sendKeys("C-a", "_")
+
+	if !h.waitFor("[pane-3]", 3*time.Second) {
+		screen := h.capture()
+		t.Fatalf("root horizontal split failed, screen:\n%s", screen)
+	}
+
+	// Should see 3 panes
+	h.assertScreen("should show 3 panes after root horizontal split", func(s string) bool {
+		return strings.Contains(s, "[pane-1]") &&
+			strings.Contains(s, "[pane-2]") &&
+			strings.Contains(s, "[pane-3]")
+	})
+
+	// Should have a horizontal border (─) from the root split
+	h.assertScreen("should have horizontal border from root split", func(s string) bool {
+		for _, line := range strings.Split(s, "\n") {
+			if strings.Contains(line, "amux") && strings.Contains(line, "panes") {
+				continue
+			}
+			if strings.Contains(line, "─") {
+				return true
+			}
+		}
+		return false
+	})
+}

--- a/test/harness_test.go
+++ b/test/harness_test.go
@@ -80,8 +80,13 @@ func (h *TmuxHarness) cleanup() {
 	exec.Command("tmux", "send-keys", "-t", h.session, "C-a", "d").Run()
 	time.Sleep(200 * time.Millisecond)
 	exec.Command("tmux", "kill-session", "-t", h.session).Run()
-	// Kill only this test's server
-	exec.Command("pkill", "-f", fmt.Sprintf("amux _server %s", h.session)).Run()
+	// Kill only this test's server (exact match with word boundary via pgrep)
+	out, _ := exec.Command("pgrep", "-f", fmt.Sprintf("amux _server %s$", h.session)).Output()
+	for _, pid := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		if pid != "" {
+			exec.Command("kill", pid).Run()
+		}
+	}
 	exec.Command("rm", "-f", fmt.Sprintf("/tmp/amux-%d/%s", os.Getuid(), h.session)).Run()
 	time.Sleep(100 * time.Millisecond)
 }


### PR DESCRIPTION
## Summary

- Fix `SplitRoot`: propagate size changes to children via `ResizeAll` instead of direct assignment
- Fix test flakiness: use `pgrep` with `$` anchor to avoid killing other tests' servers
- Add `TestRootSplitVertical` and `TestRootSplitHorizontal` regression tests

## Test plan

- [x] All tests pass locally (3 consecutive runs, no flakiness)
- [ ] CI passes