### PR TITLE
Add amux focus <pane> CLI command

### DIFF
--- a/internal/server/client_conn.go
+++ b/internal/server/client_conn.go
@@ -130,8 +130,23 @@ func (cc *ClientConn) handleCommand(srv *Server, sess *Session, msg *Message) {
 			sess.mu.Unlock()
 			return
 		}
-		sess.Window.Focus(direction)
-		sess.mu.Unlock()
+
+		switch direction {
+		case "next", "left", "right", "up", "down":
+			sess.Window.Focus(direction)
+			sess.mu.Unlock()
+		default:
+			// Treat as pane name or ID
+			pane := sess.Window.ResolvePane(direction)
+			if pane == nil {
+				sess.mu.Unlock()
+				cc.Send(&Message{Type: MsgTypeCmdResult, CmdErr: fmt.Sprintf("pane %q not found", direction)})
+				return
+			}
+			sess.Window.ActivePane = pane
+			sess.mu.Unlock()
+			cc.Send(&Message{Type: MsgTypeCmdResult, CmdOutput: fmt.Sprintf("Focused %s\n", pane.Meta.Name)})
+		}
 
 		sess.renderAndBroadcast()
 

--- a/main.go
+++ b/main.go
@@ -71,7 +71,7 @@ func main() {
 		runServerCommand("list", nil)
 	case "status":
 		runServerCommand("status", nil)
-	case "output", "minimize", "restore", "kill":
+	case "output", "minimize", "restore", "kill", "focus":
 		if len(args) < 2 {
 			fmt.Fprintf(os.Stderr, "usage: amux %s <pane>\n", args[0])
 			os.Exit(1)
@@ -119,6 +119,7 @@ Usage:
   amux [-s session] minimize <pane>   Minimize a pane
   amux [-s session] restore <pane>    Restore a minimized pane
   amux [-s session] kill <pane>       Kill a pane
+  amux [-s session] focus <pane>      Focus a pane by name or ID
 
 Panes can be referenced by name (pane-1) or ID (1).
 

--- a/test/amux_test.go
+++ b/test/amux_test.go
@@ -832,6 +832,91 @@ func TestOnlyActivePaneBordersColored(t *testing.T) {
 	}
 }
 
+func TestFocusByName(t *testing.T) {
+	t.Parallel()
+	h := newHarness(t)
+
+	// Create two panes side by side
+	h.sendKeys("C-a", "\\")
+	h.waitFor("[pane-2]", 3*time.Second)
+
+	// pane-2 should be active after split
+	h.assertScreen("pane-2 active after split", func(s string) bool {
+		for _, line := range strings.Split(s, "\n") {
+			if strings.Contains(line, "[pane-2]") && strings.Contains(line, "●") {
+				return true
+			}
+		}
+		return false
+	})
+
+	// Focus pane-1 by name via CLI
+	output := h.runCmd("focus", "pane-1")
+	if !strings.Contains(output, "Focused") {
+		t.Errorf("focus should confirm, got:\n%s", output)
+	}
+
+	time.Sleep(500 * time.Millisecond)
+
+	// pane-1 should now be active
+	h.assertScreen("pane-1 active after focus by name", func(s string) bool {
+		for _, line := range strings.Split(s, "\n") {
+			if strings.Contains(line, "[pane-1]") && strings.Contains(line, "●") {
+				return true
+			}
+		}
+		return false
+	})
+
+	// pane-2 should be inactive
+	h.assertScreen("pane-2 inactive after focus by name", func(s string) bool {
+		for _, line := range strings.Split(s, "\n") {
+			if strings.Contains(line, "[pane-2]") && strings.Contains(line, "○") {
+				return true
+			}
+		}
+		return false
+	})
+}
+
+func TestFocusByID(t *testing.T) {
+	t.Parallel()
+	h := newHarness(t)
+
+	// Create two panes
+	h.sendKeys("C-a", "\\")
+	h.waitFor("[pane-2]", 3*time.Second)
+
+	// Focus pane-1 by numeric ID
+	output := h.runCmd("focus", "1")
+	if !strings.Contains(output, "Focused") {
+		t.Errorf("focus by ID should confirm, got:\n%s", output)
+	}
+
+	time.Sleep(500 * time.Millisecond)
+
+	// pane-1 should be active
+	h.assertScreen("pane-1 active after focus by ID", func(s string) bool {
+		for _, line := range strings.Split(s, "\n") {
+			if strings.Contains(line, "[pane-1]") && strings.Contains(line, "●") {
+				return true
+			}
+		}
+		return false
+	})
+}
+
+func TestFocusNotFound(t *testing.T) {
+	t.Parallel()
+	h := newHarness(t)
+
+	// Try to focus a non-existent pane
+	output := h.runCmd("focus", "nonexistent")
+	if !strings.Contains(output, "not found") {
+		t.Errorf("focus of nonexistent pane should report error, got:\n%s", output)
+	}
+}
+
 // pickContentLine returns a middle content line from ANSI-escaped screen output,
 // skipping status lines and empty lines.
 func pickContentLine(screen string) string {


### PR DESCRIPTION
## Summary
- Add `amux focus <pane>` subcommand to focus a pane by name or numeric ID
- Routes through the existing `MsgTypeCommand` protocol to the server, which resolves via `Window.ResolvePane()`
- Adds help text entry for the new command

## Testing
- 3 integration tests: focus by name, by numeric ID, not-found error
- `go test ./...` passes

## Review focus
- Server-side handling in `client_conn.go` — the focus-by-name branch in the existing `"focus"` command handler

🤖 Generated with [Claude Code](https://claude.com/claude-code)