### PR TITLE
Fix junction characters colored on inactive pane borders

### DIFF
--- a/internal/render/border.go
+++ b/internal/render/border.go
@@ -158,7 +158,7 @@ func renderBorders(buf *strings.Builder, bm *borderMap, root *mux.LayoutCell, ac
 			}
 			var color string
 			if neighbors >= 3 {
-				color = borderColorAtJunction(bc.left, bc.right, activePaneID, activeColor)
+				color = borderColorAtJunction(bc.left, bc.right, x, y, activePaneID, activeColor)
 			} else {
 				color = borderColorAt(bc.left, bc.right, x, y, activePaneID, activeColor)
 			}
@@ -208,14 +208,23 @@ func borderColorAt(a, b *mux.LayoutCell, x, y int, activePaneID uint32, activeCo
 	return DimFg
 }
 
-// borderColorAtJunction uses subtree search for junction cells where
-// position-based lookup fails (the junction is at a corner between 3+ panes).
-func borderColorAtJunction(a, b *mux.LayoutCell, activePaneID uint32, activeColor string) string {
+// borderColorAtJunction checks only the directly adjacent leaf panes at a
+// junction position rather than searching entire subtrees. This prevents
+// coloring junctions that are not adjacent to the active pane.
+func borderColorAtJunction(a, b *mux.LayoutCell, x, y int, activePaneID uint32, activeColor string) string {
 	if activePaneID == 0 {
 		return DimFg
 	}
-	if a.FindByPaneID(activePaneID) != nil || b.FindByPaneID(activePaneID) != nil {
-		return activeColor
+	// Check leaves adjacent to the junction in all 4 directions.
+	for _, off := range [][2]int{{-1, 0}, {1, 0}, {0, -1}, {0, 1}} {
+		nx, ny := x+off[0], y+off[1]
+		leaf := findLeafByAxis(a, nx, ny)
+		if leaf == nil {
+			leaf = findLeafByAxis(b, nx, ny)
+		}
+		if leaf != nil && leaf.CellPaneID() == activePaneID {
+			return activeColor
+		}
 	}
 	return DimFg
 }

--- a/test/amux_test.go
+++ b/test/amux_test.go
@@ -1026,6 +1026,108 @@ func TestHotReloadAutoDetect(t *testing.T) {
 	})
 }
 
+func TestJunctionNotColoredOnInactiveBorder(t *testing.T) {
+	t.Parallel()
+	h := newHarness(t)
+
+	// Build layout:
+	//   pane-1 │ pane-2      (left column has 3 stacked panes,
+	//   ───────┤              right column is a single pane)
+	//   pane-3 │ pane-2
+	//   ───────┤
+	//   pane-4 │ pane-2
+	//
+	// Vertical split: pane-1 left, pane-2 right
+	h.sendKeys("C-a", "\\")
+	h.waitFor("[pane-2]", 3*time.Second)
+
+	// Focus left pane (pane-1) and split horizontally twice
+	h.sendKeys("C-a", "h")
+	time.Sleep(300 * time.Millisecond)
+	h.sendKeys("C-a", "-")
+	h.waitFor("[pane-3]", 3*time.Second)
+	h.sendKeys("C-a", "-")
+	h.waitFor("[pane-4]", 3*time.Second)
+
+	// pane-4 is active (bottom-left). The vertical border has junction
+	// characters (┤) where horizontal borders meet it. The junction at
+	// the TOP horizontal border (between pane-1 and pane-3) is NOT
+	// adjacent to pane-4, so it should be DIM.
+
+	// Capture with ANSI escapes
+	out, err := exec.Command("tmux", "capture-pane", "-t", h.session, "-p", "-e").Output()
+	if err != nil {
+		t.Fatalf("capture-pane -e: %v", err)
+	}
+	lines := strings.Split(string(out), "\n")
+
+	// Find horizontal border rows (contain ─ characters).
+	// With 3 stacked panes on the left, there are 2 horizontal borders.
+	var hBorderRows []int
+	for i, line := range lines {
+		if strings.Contains(line, "─") && !isGlobalBar(line) {
+			hBorderRows = append(hBorderRows, i)
+		}
+	}
+	if len(hBorderRows) < 2 {
+		t.Fatalf("expected 2 horizontal border rows, found %d\nScreen:\n%s",
+			len(hBorderRows), string(out))
+	}
+
+	// Extract the color of the junction character on each horizontal border row.
+	// The junction is the box-drawing character at the vertical border column
+	// on that row (e.g., ┤, ├, ┼).
+	topJunctionColor := extractJunctionColor(lines[hBorderRows[0]])
+	bottomJunctionColor := extractJunctionColor(lines[hBorderRows[1]])
+
+	if topJunctionColor == "" || bottomJunctionColor == "" {
+		t.Fatalf("could not extract junction colors: top=%q bottom=%q\n  topLine: %q\n  bottomLine: %q",
+			topJunctionColor, bottomJunctionColor,
+			lines[hBorderRows[0]], lines[hBorderRows[1]])
+	}
+
+	// The bottom junction (between pane-3 and pane-4) IS adjacent to
+	// the active pane-4, so it should be colored. The top junction
+	// (between pane-1 and pane-3) is NOT adjacent to pane-4, so it
+	// should be DIM. They must have DIFFERENT colors.
+	if topJunctionColor == bottomJunctionColor {
+		t.Errorf("top junction (pane-1/pane-3 border, row %d) should be dim but has same color as bottom junction (pane-3/pane-4 border, row %d):\n  top:    %s\n  bottom: %s",
+			hBorderRows[0], hBorderRows[1], topJunctionColor, bottomJunctionColor)
+	}
+}
+
+// extractJunctionColor finds the first junction box-drawing character
+// (┤, ├, ┼, ┬, ┴) in an ANSI-escaped line and returns the most recent
+// ANSI escape sequence before it.
+func extractJunctionColor(line string) string {
+	lastEscape := ""
+	i := 0
+	for i < len(line) {
+		// Track ANSI escapes
+		if line[i] == '\033' && i+1 < len(line) && line[i+1] == '[' {
+			j := i + 2
+			for j < len(line) && line[j] != 'm' {
+				j++
+			}
+			if j < len(line) {
+				lastEscape = line[i : j+1]
+				i = j + 1
+				continue
+			}
+		}
+		// Check for junction box-drawing characters (3-byte UTF-8)
+		if i+2 < len(line) && line[i] == '\xe2' && line[i+1] == '\x94' {
+			b := line[i+2]
+			// ┤=\xa4  ├=\x9c  ┼=\xbc  ┬=\xac  ┴=\xb4
+			if b == '\xa4' || b == '\x9c' || b == '\xbc' || b == '\xac' || b == '\xb4' {
+				return lastEscape
+			}
+		}
+		i++
+	}
+	return ""
+}
+
 func TestVerticalBorderPartialColor(t *testing.T) {
 	t.Parallel()
 	h := newHarness(t)


### PR DESCRIPTION
## Summary
- `borderColorAtJunction()` searched entire layout subtrees with `FindByPaneID()`, coloring junctions even when the active pane wasn't directly adjacent
- Fix: check only the 4 directly adjacent cells using `findLeafByAxis()`, matching the approach already used by `borderColorAt()` for non-junction borders

## Testing
- `TestJunctionNotColoredOnInactiveBorder`: 4-pane layout (3 stacked left, 1 right), verifies top junction is dim while bottom junction is colored when bottom-left pane is active
- All existing tests pass

## Review focus
- `borderColorAtJunction()` in `internal/render/border.go`

🤖 Generated with [Claude Code](https://claude.com/claude-code)