### PR TITLE
Force TUI redraw after server reload via SIGWINCH

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"syscall"
+	"time"
 
 	"github.com/weill-labs/amux/internal/checkpoint"
 	"github.com/weill-labs/amux/internal/config"
@@ -458,6 +459,39 @@ func NewServerFromCheckpoint(cp *checkpoint.ServerCheckpoint) (*Server, error) {
 	for _, p := range sess.Panes {
 		p.Start()
 	}
+
+	// Force TUI apps (Claude Code, vim, etc.) to do a full screen redraw.
+	// Without this, incremental updates buffered during the reload window
+	// corrupt the display because they assume the pre-reload screen state.
+	// We resize each PTY (shrink then restore) to trigger SIGWINCH. The
+	// delay lets readLoops drain buffered PTY output first; the gap between
+	// resizes prevents SIGWINCH coalescing.
+	go func() {
+		time.Sleep(500 * time.Millisecond)
+		sess.mu.Lock()
+		defer sess.mu.Unlock()
+		if sess.Window == nil {
+			return
+		}
+		// First pass: shrink by 1 row
+		for _, p := range sess.Panes {
+			cell := sess.Window.Root.FindPane(p.ID)
+			if cell != nil {
+				p.Resize(cell.W, mux.PaneContentHeight(cell.H)-1)
+			}
+		}
+		// Let TUI apps process the first SIGWINCH
+		sess.mu.Unlock()
+		time.Sleep(200 * time.Millisecond)
+		sess.mu.Lock()
+		// Second pass: restore original size
+		for _, p := range sess.Panes {
+			cell := sess.Window.Root.FindPane(p.ID)
+			if cell != nil {
+				p.Resize(cell.W, mux.PaneContentHeight(cell.H))
+			}
+		}
+	}()
 
 	return s, nil
 }

--- a/test/amux_test.go
+++ b/test/amux_test.go
@@ -2,7 +2,9 @@ package test
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -1470,6 +1472,41 @@ func TestServerReloadBorderColors(t *testing.T) {
 	// Border colors should match before and after reload
 	if colorsBefore[0] != colorsAfter[0] {
 		t.Errorf("border color changed after reload:\n  before: %s\n  after:  %s", colorsBefore[0], colorsAfter[0])
+	}
+}
+
+func TestServerReloadTUIRedraw(t *testing.T) {
+	t.Parallel()
+	h := newHarness(t)
+
+	// Write a small TUI script that enters alternate screen buffer,
+	// draws a marker, and redraws on SIGWINCH — simulates Claude Code, vim, etc.
+	scriptPath := filepath.Join(os.TempDir(), fmt.Sprintf("amux-tui-%s.sh", h.session))
+	os.WriteFile(scriptPath, []byte(`#!/bin/bash
+printf '\033[?1049h'
+draw() { printf '\033[2J\033[H'; echo TUIMARK_OK; }
+trap draw WINCH
+draw
+while true; do sleep 60; done
+`), 0755)
+	t.Cleanup(func() { os.Remove(scriptPath) })
+
+	// Run the TUI script in the pane
+	h.sendKeys(scriptPath, "Enter")
+	if !h.waitFor("TUIMARK_OK", 5*time.Second) {
+		screen := h.capture()
+		t.Fatalf("TUI script did not start\nScreen:\n%s", screen)
+	}
+
+	// Reload server
+	h.runCmd("reload-server")
+
+	// Wait for recovery + SIGWINCH-triggered redraw
+	// The server nudges PTY sizes after reload, triggering SIGWINCH
+	// which causes the TUI script to redraw cleanly
+	if !h.waitFor("TUIMARK_OK", 15*time.Second) {
+		screen := h.capture()
+		t.Fatalf("TUI marker should be visible after reload (SIGWINCH redraw)\nScreen:\n%s", screen)
 	}
 }
 


### PR DESCRIPTION
## Summary

- After server hot-reload, TUI apps (Claude Code, vim, etc.) show garbled rendering because incremental ANSI updates buffered during the reload window assume the pre-reload screen state
- Fix: nudge each PTY size (shrink 1 row, wait 200ms, restore) after restoring panes to trigger SIGWINCH, forcing TUI apps to clear and fully redraw

## Testing

- `TestServerReloadTUIRedraw`: runs a bash script that enters alternate screen buffer, draws a marker, and redraws on SIGWINCH — verifies marker survives reload
- All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)