### PR TITLE
Fix second cursor in active pane by tracking cursor visibility

### DIFF
--- a/client.go
+++ b/client.go
@@ -222,11 +222,15 @@ type clientPaneData struct {
 }
 
 func (c *clientPaneData) RenderScreen() string {
-	return mux.RenderWithCursor(c.emu)
+	return c.emu.Render()
 }
 
 func (c *clientPaneData) CursorPos() (col, row int) {
 	return c.emu.CursorPosition()
+}
+
+func (c *clientPaneData) CursorHidden() bool {
+	return c.emu.CursorHidden()
 }
 
 func (c *clientPaneData) ID() uint32      { return c.info.ID }

--- a/internal/mux/emulator.go
+++ b/internal/mux/emulator.go
@@ -3,6 +3,7 @@ package mux
 import (
 	"fmt"
 	"sync"
+	"sync/atomic"
 
 	"github.com/charmbracelet/x/vt"
 )
@@ -38,19 +39,28 @@ type TerminalEmulator interface {
 
 // vtEmulator wraps charmbracelet/x/vt.SafeEmulator.
 type vtEmulator struct {
-	emu *vt.SafeEmulator
-	w   int
-	h   int
-	mu  sync.Mutex
+	emu          *vt.SafeEmulator
+	w            int
+	h            int
+	mu           sync.Mutex
+	cursorHidden atomic.Bool
 }
 
 // NewVTEmulator creates a new terminal emulator with the given dimensions.
 func NewVTEmulator(width, height int) TerminalEmulator {
-	return &vtEmulator{
+	v := &vtEmulator{
 		emu: vt.NewSafeEmulator(width, height),
 		w:   width,
 		h:   height,
 	}
+	// Track cursor visibility changes so CursorHidden() reflects the
+	// application's actual cursor state (e.g. \033[?25l / \033[?25h).
+	v.emu.SetCallbacks(vt.Callbacks{
+		CursorVisibility: func(visible bool) {
+			v.cursorHidden.Store(!visible)
+		},
+	})
+	return v
 }
 
 func (v *vtEmulator) Write(data []byte) (int, error) {
@@ -85,9 +95,7 @@ func (v *vtEmulator) CursorPosition() (col, row int) {
 }
 
 func (v *vtEmulator) CursorHidden() bool {
-	// SafeEmulator doesn't expose cursor hidden state directly.
-	// Default to visible. Phase 2 can access screen-level cursor state.
-	return false
+	return v.cursorHidden.Load()
 }
 
 // NewVTEmulatorWithDrain creates a terminal emulator that automatically

--- a/internal/mux/emulator_test.go
+++ b/internal/mux/emulator_test.go
@@ -83,3 +83,34 @@ func TestRenderWithCursor(t *testing.T) {
 		t.Error("RenderWithCursor should contain ANSI cursor positioning")
 	}
 }
+
+func TestCursorHidden(t *testing.T) {
+	t.Parallel()
+
+	t.Run("visible by default", func(t *testing.T) {
+		t.Parallel()
+		emu := NewVTEmulator(80, 24)
+		if emu.CursorHidden() {
+			t.Error("CursorHidden() = true on fresh emulator, want false")
+		}
+	})
+
+	t.Run("hidden after hide sequence", func(t *testing.T) {
+		t.Parallel()
+		emu := NewVTEmulator(80, 24)
+		emu.Write([]byte("\033[?25l")) // hide cursor
+		if !emu.CursorHidden() {
+			t.Error("CursorHidden() = false after \\033[?25l, want true")
+		}
+	})
+
+	t.Run("visible after show sequence", func(t *testing.T) {
+		t.Parallel()
+		emu := NewVTEmulator(80, 24)
+		emu.Write([]byte("\033[?25l")) // hide
+		emu.Write([]byte("\033[?25h")) // show
+		if emu.CursorHidden() {
+			t.Error("CursorHidden() = true after \\033[?25h, want false")
+		}
+	})
+}

--- a/internal/mux/pane.go
+++ b/internal/mux/pane.go
@@ -147,7 +147,16 @@ func (p *Pane) Resize(cols, rows int) error {
 	})
 }
 
-// RenderScreen returns the current screen state as ANSI output.
+// Render returns the current screen cell content as an ANSI string.
+// Used by the compositor via PaneData.RenderScreen(). For the reattach
+// snapshot (which needs cursor positioning embedded), use RenderScreen().
+func (p *Pane) Render() string {
+	return p.emulator.Render()
+}
+
+// RenderScreen returns the screen state with a trailing cursor-position escape.
+// Used when sending a reattach snapshot to a reconnecting client so the
+// client-side emulator seeds the correct cursor position.
 func (p *Pane) RenderScreen() string {
 	return RenderWithCursor(p.emulator)
 }
@@ -155,6 +164,12 @@ func (p *Pane) RenderScreen() string {
 // CursorPos returns the cursor position within this pane (0-indexed).
 func (p *Pane) CursorPos() (col, row int) {
 	return p.emulator.CursorPosition()
+}
+
+// CursorHidden returns true if the application running in this pane has
+// hidden the hardware cursor (e.g. via \033[?25l).
+func (p *Pane) CursorHidden() bool {
+	return p.emulator.CursorHidden()
 }
 
 // Output returns the last N lines of visible pane content from the emulator.

--- a/internal/render/compositor.go
+++ b/internal/render/compositor.go
@@ -92,21 +92,27 @@ func (c *Compositor) RenderFull(root *mux.LayoutCell, activePaneID uint32, looku
 	// Global status bar at bottom
 	renderGlobalBar(&buf, c.sessionName, paneCount, c.width, c.height-1)
 
-	// Restore cursor to active pane's cursor position
+	// Position cursor and respect the active pane's cursor visibility state.
+	// If the application has hidden its cursor (e.g. during streaming output),
+	// keep it hidden rather than showing it at a stale position.
+	showCursor := true
 	if activePaneID != 0 {
-		cell := root.FindByPaneID(activePaneID)
-		if cell != nil {
+		if cell := root.FindByPaneID(activePaneID); cell != nil {
 			if pd := lookup(activePaneID); pd != nil {
-				col, row := pd.CursorPos()
-				absRow := cell.Y + mux.StatusLineRows + row + 1
-				absCol := cell.X + col + 1
-				buf.WriteString(CursorTo(absRow, absCol))
+				if pd.CursorHidden() {
+					showCursor = false
+				} else {
+					col, row := pd.CursorPos()
+					absRow := cell.Y + mux.StatusLineRows + row + 1
+					absCol := cell.X + col + 1
+					buf.WriteString(CursorTo(absRow, absCol))
+				}
 			}
 		}
 	}
-
-	// Show cursor
-	buf.WriteString(ShowCursor)
+	if showCursor {
+		buf.WriteString(ShowCursor)
+	}
 
 	return []byte(buf.String())
 }

--- a/internal/render/panedata.go
+++ b/internal/render/panedata.go
@@ -6,6 +6,7 @@ package render
 type PaneData interface {
 	RenderScreen() string
 	CursorPos() (col, row int)
+	CursorHidden() bool
 	ID() uint32
 	Name() string
 	Host() string

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -165,8 +165,9 @@ func (s *Session) createPaneWithMeta(srv *Server, meta mux.PaneMeta, cols, rows 
 // serverPaneData adapts *mux.Pane to the render.PaneData interface.
 type serverPaneData struct{ p *mux.Pane }
 
-func (s *serverPaneData) RenderScreen() string  { return s.p.RenderScreen() }
+func (s *serverPaneData) RenderScreen() string  { return s.p.Render() }
 func (s *serverPaneData) CursorPos() (int, int) { return s.p.CursorPos() }
+func (s *serverPaneData) CursorHidden() bool    { return s.p.CursorHidden() }
 func (s *serverPaneData) ID() uint32            { return s.p.ID }
 func (s *serverPaneData) Name() string          { return s.p.Meta.Name }
 func (s *serverPaneData) Host() string          { return s.p.Meta.Host }


### PR DESCRIPTION
## Motivation

A phantom second cursor appeared in pane-21 (Claude Code) due to two
independent bugs in the cursor handling pipeline.

**Bug 1 — `CursorHidden()` stub always returned `false`**

The vt emulator internally tracks `\033[?25l`/`\033[?25h` cursor
visibility state, but `vtEmulator.CursorHidden()` was hardcoded to
return `false`. When Claude Code (or any TUI) hides its cursor during
streaming output or mid-render, the compositor would still call
`ShowCursor`, placing the hardware cursor at a stale position alongside
whatever visual indicator the application had drawn — producing two
cursor-looking things.

Fix: wire the `CursorVisibility` callback on `vt.SafeEmulator` to an
`atomic.Bool` on `vtEmulator`, so `CursorHidden()` reflects the
application's actual state in real time.

**Bug 2 — `RenderScreen()` embedded a pane-relative cursor escape**

`RenderWithCursor` appended `\033[row+1;col+1H` (cursor position
*within* the pane, 1-indexed) to the cell content string. `blitPane`
wrote this verbatim into the compositor buffer. For panes near the top
of the screen the wrong absolute position landed inside the pane's own
visible area, and when the OS flushed the buffer in partial chunks the
hidden cursor could flicker at that position before the correct
`CursorTo` fired.

The compositor already repositions the cursor correctly via `CursorPos()`
+ `CursorTo()`, so the embedded escape was entirely redundant for
rendering. Fix: `PaneData.RenderScreen()` now returns plain cell content
via `emu.Render()`. The reattach snapshot path (`server.go:366`) retains
`Pane.RenderScreen()` (which uses `RenderWithCursor`) to seed the
client-side emulator with the correct cursor position on reconnect.

## Changes

- `internal/mux/emulator.go` — add `cursorHidden atomic.Bool`, wire
  `CursorVisibility` callback, implement `CursorHidden()` properly
- `internal/mux/pane.go` — add `Pane.Render()` (cells only) and
  `Pane.CursorHidden()`; keep `Pane.RenderScreen()` for reattach
- `internal/render/panedata.go` — add `CursorHidden() bool` to interface
- `internal/render/compositor.go` — skip `ShowCursor`/`CursorTo` when
  active pane has cursor hidden
- `client.go` / `internal/server/server.go` — implement `CursorHidden()`
  and use plain `Render()` in compositor adapters
- `internal/mux/emulator_test.go` — `TestCursorHidden` with three cases

## Testing

- All unit and integration tests pass (`go test ./...`)
- `TestCursorHidden` verifies: visible by default, hidden after
  `\033[?25l`, restored after `\033[?25h`

## Review focus

- `compositor.go` cursor logic: does the fallback (`showCursor = true`
  when `activePaneID == 0` or lookups fail) seem right?
- `NewVTEmulator` callback setup: any concern about the callback firing
  from inside `SafeEmulator.Write` (which holds `se.mu`) while the
  callback writes to `v.cursorHidden` (an `atomic.Bool`)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)