### PR TITLE
Clean up orphaned test sessions on start and exit

### DIFF
--- a/test/harness_test.go
+++ b/test/harness_test.go
@@ -47,8 +47,11 @@ func TestMain(m *testing.M) {
 }
 
 // cleanupStaleTestSessions removes orphaned tmux sessions, amux server
-// processes, and sockets left behind by previous test runs that were
-// killed by a timeout panic.
+// processes, sockets, and log files left behind by previous test runs
+// that were killed by a timeout panic.
+//
+// Not safe if multiple `go test` invocations run concurrently — it may
+// kill sessions belonging to the other run.
 func cleanupStaleTestSessions() {
 	// Kill tmux sessions matching the test naming convention (t- + 8 hex chars)
 	out, _ := exec.Command("tmux", "list-sessions", "-F", "#{session_name}").Output()
@@ -58,20 +61,22 @@ func cleanupStaleTestSessions() {
 		}
 	}
 
-	// Kill orphaned amux server processes for test sessions
-	out, _ = exec.Command("pgrep", "-f", "amux _server t-").Output()
-	for _, pid := range strings.Split(strings.TrimSpace(string(out)), "\n") {
-		if pid != "" {
-			exec.Command("kill", pid).Run()
+	// Kill orphaned amux server processes, validating session name
+	out, _ = exec.Command("pgrep", "-fl", "amux _server t-").Output()
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) >= 3 && isTestSession(fields[len(fields)-1]) {
+			exec.Command("kill", fields[0]).Run()
 		}
 	}
 
-	// Clean up stale sockets
+	// Clean up stale sockets and log files
 	socketDir := fmt.Sprintf("/tmp/amux-%d", os.Getuid())
 	entries, _ := os.ReadDir(socketDir)
 	for _, e := range entries {
-		if isTestSession(e.Name()) {
-			os.Remove(filepath.Join(socketDir, e.Name()))
+		name := e.Name()
+		if isTestSession(name) || (strings.HasSuffix(name, ".log") && isTestSession(strings.TrimSuffix(name, ".log"))) {
+			os.Remove(filepath.Join(socketDir, name))
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- Add `cleanupStaleTestSessions()` that sweeps for orphaned tmux sessions, amux server processes, and Unix sockets left by previous test runs
- Runs at both the start and end of `TestMain` so orphans from timeout-killed runs get cleaned up
- Uses the test session naming convention (`t-` + 8 hex chars) to avoid touching real user sessions

Resolves LAB-142.

## Motivation

When Go's `-timeout` fires, it panics the process. `t.Cleanup` callbacks never run, leaving orphaned tmux sessions and amux servers. Over time these accumulate and can interfere with subsequent test runs or waste system resources.

## Testing

- `go vet ./test/` clean
- `go test ./...` all pass

## Review focus

- `isTestSession` pattern matching — verify it won't match real user tmux sessions


🤖 Generated with [Claude Code](https://claude.com/claude-code)