### PR TITLE
Add Linear auto-close guideline to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,3 +167,12 @@ All issues and feature requests go in the Linear project (not GitHub Issues):
 https://linear.app/weill-labs/project/amux-b3a52334f77c
 
 Team key: `LAB`. Use the Linear skill to create/query issues.
+
+**Link PRs to Linear issues.** When creating a PR that implements a Linear issue, include `Fixes LAB-XXX` in the PR description. This tells Linear's GitHub integration to auto-transition the issue to Done when the PR merges. Example:
+
+```
+## Summary
+- Implements feature X
+
+Fixes LAB-123
+```


### PR DESCRIPTION
## Summary
- Adds guideline for including `Fixes LAB-XXX` in PR descriptions so Linear auto-transitions issues to Done on merge
- Discovered during cleanup: 6 merged PRs (LAB-87, LAB-89, LAB-90, LAB-91, LAB-93, LAB-104) had to be manually marked Done because none used the keyword

## Test plan
- [ ] Verify next PR with a Linear issue reference auto-closes the issue on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)