### PR TITLE
Add resize-in-copy-mode test and dependency check guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,8 +111,9 @@ After creating a PR, always run the code review and code simplifier agents befor
 
 ### Adding a New Feature
 
-1. **Write an integration test first.** Add a test to `test/amux_test.go` that exercises the feature end-to-end via the tmux harness. Follow existing test patterns.
-2. Implement the feature.
+1. **Check what dependencies already provide.** Before designing a custom solution, check if the underlying library (e.g., `charmbracelet/x/vt`) already supports the capability. Read tests and exported methods in `go/pkg/mod/`. This avoids designing infrastructure that already exists.
+2. **Write an integration test first.** Add a test in `test/` that exercises the feature end-to-end via the tmux harness. Follow existing test patterns.
+3. Implement the feature.
 3. Verify the integration test passes: `go test -v -run TestYourFeature ./test/ -timeout 30s`
 4. Add unit tests for complex logic (layout algorithms, rendering, protocol encoding).
 

--- a/test/copymode_test.go
+++ b/test/copymode_test.go
@@ -3,6 +3,7 @@ package test
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -207,5 +208,45 @@ func TestCopyModeDoesNotForwardInput(t *testing.T) {
 	screen := h.capture()
 	if strings.Contains(screen, "hello") {
 		t.Errorf("copy mode should not forward input to the shell, but 'hello' appeared\nScreen:\n%s", screen)
+	}
+}
+
+func TestCopyModeResizeSurvives(t *testing.T) {
+	t.Parallel()
+	h := newHarness(t)
+
+	// Generate output so scrollback has content
+	scriptPath := filepath.Join(os.TempDir(), fmt.Sprintf("amux-resize-%s.sh", h.session))
+	os.WriteFile(scriptPath, []byte("#!/bin/bash\nfor i in $(seq -w 1 30); do echo \"RESIZE-$i\"; done\n"), 0755)
+	t.Cleanup(func() { os.Remove(scriptPath) })
+
+	h.sendKeys(scriptPath, "Enter")
+	h.waitFor("RESIZE-30", 5*time.Second)
+
+	// Enter copy mode and scroll up
+	h.sendKeys("C-a", "[")
+	if !h.waitFor("[copy]", 3*time.Second) {
+		t.Fatalf("expected [copy] indicator\nScreen:\n%s", h.capture())
+	}
+	for i := 0; i < 20; i++ {
+		h.sendKeys("k")
+	}
+	time.Sleep(300 * time.Millisecond)
+
+	// Resize terminal while in copy mode
+	exec.Command("tmux", "resize-pane", "-t", h.session, "-x", "120", "-y", "40").Run()
+	time.Sleep(1 * time.Second)
+
+	// Copy mode should still be active after resize
+	h.assertScreen("copy mode survives resize", func(s string) bool {
+		return strings.Contains(s, "[copy]")
+	})
+
+	// Should still be able to exit
+	h.sendKeys("q")
+	if !h.waitForFunc(func(s string) bool {
+		return !strings.Contains(s, "[copy]")
+	}, 3*time.Second) {
+		t.Fatalf("expected [copy] to disappear after q\nScreen:\n%s", h.capture())
 	}
 }


### PR DESCRIPTION
## Summary
- Add `TestCopyModeResizeSurvives` regression test for the copy mode resize bug fixed in #35
- Add "check what dependencies already provide" step to CLAUDE.md feature workflow

## Motivation
Two learnings from LAB-89 copy mode implementation:
1. The code reviewer caught that terminal resize didn't propagate to active copy modes — this test prevents regression
2. Significant time was spent designing a custom scrollback buffer before discovering the vt library already had one built in

## Testing
- New test passes: `go test -run TestCopyModeResizeSurvives ./test/`
- Full suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)