### PR TITLE
Skip CI on documentation-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,16 @@ name: CI
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - "**.md"
+      - "docs/**"
+      - "LICENSE"
   pull_request:
     branches: [main]
+    paths-ignore:
+      - "**.md"
+      - "docs/**"
+      - "LICENSE"
 
 jobs:
   test:


### PR DESCRIPTION
## Summary
- Adds `paths-ignore` for `**.md`, `docs/**`, and `LICENSE` to both push and PR triggers
- Documentation-only changes no longer trigger the full build + test suite

## Test plan
- [ ] Push a markdown-only change and verify CI does not run
- [ ] Push a code change and verify CI still runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)