### PR TITLE
Fix CI: skip tests on docs-only changes without blocking merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,44 +3,60 @@ name: CI
 on:
   push:
     branches: [main]
-    paths-ignore:
-      - "**.md"
-      - "docs/**"
-      - "LICENSE"
   pull_request:
     branches: [main]
-    paths-ignore:
-      - "**.md"
-      - "docs/**"
-      - "LICENSE"
 
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 2
+
+      - name: Check for code changes
+        id: changes
+        run: |
+          if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
+            BASE="${{ github.event.pull_request.base.sha }}"
+          else
+            BASE="${{ github.event.before }}"
+          fi
+          CODE_CHANGED=$(git diff --name-only "$BASE" HEAD | grep -vE '\.(md)$|^docs/|^LICENSE$' | head -1)
+          if [ -z "$CODE_CHANGED" ]; then
+            echo "code_changed=false" >> "$GITHUB_OUTPUT"
+            echo "Docs-only change, skipping tests"
+          else
+            echo "code_changed=true" >> "$GITHUB_OUTPUT"
+          fi
 
       - uses: actions/setup-go@v5.4.0
+        if: steps.changes.outputs.code_changed == 'true'
         with:
           go-version: "1.25"
 
       - name: Install tmux
+        if: steps.changes.outputs.code_changed == 'true'
         run: sudo apt-get update && sudo apt-get install -y tmux
 
       - name: Build
+        if: steps.changes.outputs.code_changed == 'true'
         run: go build ./...
 
       - name: Vet
+        if: steps.changes.outputs.code_changed == 'true'
         run: go vet ./...
 
       - name: Unit tests
+        if: steps.changes.outputs.code_changed == 'true'
         run: go test -json ./internal/... -timeout 60s | tee unit-results.json
 
       - name: Integration tests
+        if: steps.changes.outputs.code_changed == 'true'
         run: go test -json -timeout 120s ./test/ | tee integration-results.json
 
       - name: Test timing summary
-        if: always()
+        if: always() && steps.changes.outputs.code_changed == 'true'
         run: |
           echo '## Test Timing' >> "$GITHUB_STEP_SUMMARY"
           echo '' >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary
- Replaces `paths-ignore` with step-level `if` conditions that detect docs-only changes
- The "test" job always runs (satisfying required status checks) but skips build/test steps when only `.md`, `docs/`, or `LICENSE` files changed
- Fixes the catch-22 where `paths-ignore` prevented the workflow from running, which blocked merging because the required "test" check never reported

## Test plan
- [ ] Push a markdown-only PR and verify CI passes quickly without running tests
- [ ] Push a code PR and verify full test suite runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)