### PR TITLE
Add configurable key bindings (LAB-92)

### DIFF
--- a/.claude/hooks/post-pr-review.sh
+++ b/.claude/hooks/post-pr-review.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# PostToolUse hook: after `gh pr create`, remind Claude to run review agents.
+# Reads tool input JSON from stdin, checks if command was gh pr create.
+# Exit 2 sends feedback back to Claude.
+
+input=$(cat)
+command=$(echo "$input" | jq -r '.tool_input.command // empty' 2>/dev/null)
+
+if [[ "$command" == gh\ pr\ create* ]]; then
+    echo "PR created. Run the code-reviewer and code-simplifier agents now to review the changes before considering this done." >&2
+    exit 2
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -10,6 +10,17 @@
           }
         ]
       }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/post-pr-review.sh"
+          }
+        ]
+      }
     ]
   }
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -65,11 +65,21 @@ type Host struct {
 // Config is the top-level amux configuration.
 type Config struct {
 	Hosts map[string]Host `toml:"hosts"`
+	Keys  KeyConfig       `toml:"keys"`
 }
 
 // DefaultPath returns the default config file path.
+// Checks AMUX_CONFIG env var first, then ~/.config/amux/config.toml,
+// then falls back to ~/.config/amux/hosts.toml for backward compatibility.
 func DefaultPath() string {
+	if p := os.Getenv("AMUX_CONFIG"); p != "" {
+		return p
+	}
 	home, _ := os.UserHomeDir()
+	configPath := filepath.Join(home, ".config", "amux", "config.toml")
+	if _, err := os.Stat(configPath); err == nil {
+		return configPath
+	}
 	return filepath.Join(home, ".config", "amux", "hosts.toml")
 }
 

--- a/internal/config/keybindings.go
+++ b/internal/config/keybindings.go
@@ -1,0 +1,176 @@
+package config
+
+import (
+	"fmt"
+	"strings"
+)
+
+// KeyConfig represents the [keys] section of the config file.
+type KeyConfig struct {
+	Prefix string            `toml:"prefix"`
+	Unbind []string          `toml:"unbind"`
+	Bind   map[string]string `toml:"bind"`
+}
+
+// Binding represents a single key binding: an action name and its arguments.
+type Binding struct {
+	Action string
+	Args   []string
+}
+
+// Keybindings holds the resolved dispatch table for client-side input handling.
+// The Prefix byte triggers prefix mode; after prefix, the Bindings map
+// dispatches the next byte to an action.
+type Keybindings struct {
+	Prefix   byte
+	Bindings map[byte]Binding
+}
+
+// DefaultKeybindings returns the built-in default keybindings.
+func DefaultKeybindings() *Keybindings {
+	return &Keybindings{
+		Prefix: 0x01, // Ctrl-a
+		Bindings: map[byte]Binding{
+			'\\': {Action: "split"},
+			'-':  {Action: "split", Args: []string{"v"}},
+			'|':  {Action: "split", Args: []string{"root"}},
+			'_':  {Action: "split", Args: []string{"root", "v"}},
+			'}':  {Action: "swap", Args: []string{"forward"}},
+			'{':  {Action: "swap", Args: []string{"backward"}},
+			'o':  {Action: "focus", Args: []string{"next"}},
+			'h':  {Action: "focus", Args: []string{"left"}},
+			'l':  {Action: "focus", Args: []string{"right"}},
+			'k':  {Action: "focus", Args: []string{"up"}},
+			'j':  {Action: "focus", Args: []string{"down"}},
+			'H':  {Action: "resize-active", Args: []string{"left", "2"}},
+			'J':  {Action: "resize-active", Args: []string{"down", "2"}},
+			'K':  {Action: "resize-active", Args: []string{"up", "2"}},
+			'L':  {Action: "resize-active", Args: []string{"right", "2"}},
+			'z':  {Action: "zoom"},
+			'm':  {Action: "toggle-minimize"},
+			'[':  {Action: "copy-mode"},
+			'c':  {Action: "new-window"},
+			'n':  {Action: "next-window"},
+			'p':  {Action: "prev-window"},
+			'1':  {Action: "select-window", Args: []string{"1"}},
+			'2':  {Action: "select-window", Args: []string{"2"}},
+			'3':  {Action: "select-window", Args: []string{"3"}},
+			'4':  {Action: "select-window", Args: []string{"4"}},
+			'5':  {Action: "select-window", Args: []string{"5"}},
+			'6':  {Action: "select-window", Args: []string{"6"}},
+			'7':  {Action: "select-window", Args: []string{"7"}},
+			'8':  {Action: "select-window", Args: []string{"8"}},
+			'9':  {Action: "select-window", Args: []string{"9"}},
+			'd':  {Action: "detach"},
+			'r':  {Action: "reload"},
+		},
+	}
+}
+
+// knownActions is the set of valid action names for key bindings.
+// Actions handled client-side (detach, reload, copy-mode) and actions
+// forwarded as server commands are both included.
+// Keep in sync with server/client_conn.go handleCommand().
+var knownActions = map[string]bool{
+	"split": true, "focus": true, "swap": true, "zoom": true,
+	"rotate": true, "minimize": true, "restore": true, "kill": true,
+	"spawn": true, "send-keys": true, "resize-active": true,
+	"toggle-minimize": true, "new-window": true, "next-window": true,
+	"prev-window": true, "select-window": true, "rename-window": true,
+	"detach": true, "reload": true, "copy-mode": true,
+}
+
+// BuildKeybindings resolves a KeyConfig into a Keybindings dispatch table.
+// It starts with defaults, applies user bind overrides, then removes unbound keys.
+// Note: unbind is applied after bind, so unbinding a key that was just bound
+// will remove it. To replace a default binding, use bind alone.
+func BuildKeybindings(kc *KeyConfig) (*Keybindings, error) {
+	kb := DefaultKeybindings()
+
+	if kc == nil {
+		return kb, nil
+	}
+
+	// Override prefix
+	if kc.Prefix != "" {
+		b, err := ParseKey(kc.Prefix)
+		if err != nil {
+			return nil, fmt.Errorf("invalid prefix %q: %w", kc.Prefix, err)
+		}
+		kb.Prefix = b
+	}
+
+	// Apply user bindings (override or add)
+	for key, action := range kc.Bind {
+		b, err := ParseKey(key)
+		if err != nil {
+			return nil, fmt.Errorf("invalid key %q: %w", key, err)
+		}
+		if b == kb.Prefix {
+			return nil, fmt.Errorf("key %q conflicts with prefix key (use prefix-prefix to send literal)", key)
+		}
+		binding, err := ParseAction(action)
+		if err != nil {
+			return nil, fmt.Errorf("invalid action %q for key %q: %w", action, key, err)
+		}
+		if !knownActions[binding.Action] {
+			return nil, fmt.Errorf("unknown action %q for key %q", binding.Action, key)
+		}
+		kb.Bindings[b] = binding
+	}
+
+	// Remove unbound keys
+	for _, key := range kc.Unbind {
+		b, err := ParseKey(key)
+		if err != nil {
+			return nil, fmt.Errorf("invalid unbind key %q: %w", key, err)
+		}
+		delete(kb.Bindings, b)
+	}
+
+	return kb, nil
+}
+
+// ParseKey converts a key string to its byte value.
+//
+// Supported formats:
+//   - Single printable char: "d", "\\", "-", "|"
+//   - Ctrl combo: "C-a" (0x01), "C-b" (0x02), ..., "C-z" (0x1a)
+func ParseKey(s string) (byte, error) {
+	if len(s) == 0 {
+		return 0, fmt.Errorf("empty key string")
+	}
+
+	// Ctrl combo: "C-x"
+	if len(s) == 3 && s[0] == 'C' && s[1] == '-' {
+		ch := s[2]
+		if ch >= 'a' && ch <= 'z' {
+			return ch - 'a' + 1, nil
+		}
+		if ch >= 'A' && ch <= 'Z' {
+			return ch - 'A' + 1, nil
+		}
+		return 0, fmt.Errorf("unsupported ctrl key: %q", s)
+	}
+
+	// Single character
+	if len(s) == 1 {
+		return s[0], nil
+	}
+
+	return 0, fmt.Errorf("unsupported key format: %q", s)
+}
+
+// ParseAction splits an action string like "split v" into a Binding
+// with Action="split" and Args=["v"].
+func ParseAction(s string) (Binding, error) {
+	parts := strings.Fields(s)
+	if len(parts) == 0 {
+		return Binding{}, fmt.Errorf("empty action string")
+	}
+	b := Binding{Action: parts[0]}
+	if len(parts) > 1 {
+		b.Args = parts[1:]
+	}
+	return b, nil
+}

--- a/internal/config/keybindings_test.go
+++ b/internal/config/keybindings_test.go
@@ -1,0 +1,221 @@
+package config
+
+import (
+	"testing"
+)
+
+func TestParseKey(t *testing.T) {
+	tests := []struct {
+		input string
+		want  byte
+		err   bool
+	}{
+		{"d", 'd', false},
+		{"\\", '\\', false},
+		{"-", '-', false},
+		{"|", '|', false},
+		{"_", '_', false},
+		{"C-a", 0x01, false},
+		{"C-b", 0x02, false},
+		{"C-z", 0x1a, false},
+		{"C-A", 0x01, false}, // uppercase
+		{"", 0, true},        // empty
+		{"C-1", 0, true},     // non-letter ctrl
+		{"ab", 0, true},      // multi-char non-ctrl
+	}
+
+	for _, tt := range tests {
+		got, err := ParseKey(tt.input)
+		if tt.err {
+			if err == nil {
+				t.Errorf("ParseKey(%q): expected error, got %d", tt.input, got)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("ParseKey(%q): unexpected error: %v", tt.input, err)
+			continue
+		}
+		if got != tt.want {
+			t.Errorf("ParseKey(%q) = %d, want %d", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestParseAction(t *testing.T) {
+	tests := []struct {
+		input  string
+		action string
+		args   []string
+		err    bool
+	}{
+		{"split", "split", nil, false},
+		{"split v", "split", []string{"v"}, false},
+		{"split root v", "split", []string{"root", "v"}, false},
+		{"focus next", "focus", []string{"next"}, false},
+		{"detach", "detach", nil, false},
+		{"", "", nil, true},
+	}
+
+	for _, tt := range tests {
+		got, err := ParseAction(tt.input)
+		if tt.err {
+			if err == nil {
+				t.Errorf("ParseAction(%q): expected error", tt.input)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("ParseAction(%q): unexpected error: %v", tt.input, err)
+			continue
+		}
+		if got.Action != tt.action {
+			t.Errorf("ParseAction(%q).Action = %q, want %q", tt.input, got.Action, tt.action)
+		}
+		if len(got.Args) != len(tt.args) {
+			t.Errorf("ParseAction(%q).Args = %v, want %v", tt.input, got.Args, tt.args)
+		} else {
+			for i := range tt.args {
+				if got.Args[i] != tt.args[i] {
+					t.Errorf("ParseAction(%q).Args[%d] = %q, want %q", tt.input, i, got.Args[i], tt.args[i])
+				}
+			}
+		}
+	}
+}
+
+func TestDefaultKeybindings(t *testing.T) {
+	kb := DefaultKeybindings()
+	if kb.Prefix != 0x01 {
+		t.Errorf("default prefix = %d, want 0x01 (Ctrl-a)", kb.Prefix)
+	}
+	if b, ok := kb.Bindings['\\']; !ok || b.Action != "split" {
+		t.Error("default: \\ should be bound to split")
+	}
+	if b, ok := kb.Bindings['d']; !ok || b.Action != "detach" {
+		t.Error("default: d should be bound to detach")
+	}
+	if b, ok := kb.Bindings['o']; !ok || b.Action != "focus" {
+		t.Error("default: o should be bound to focus")
+	}
+}
+
+func TestBuildKeybindingsNil(t *testing.T) {
+	kb, err := BuildKeybindings(nil)
+	if err != nil {
+		t.Fatalf("BuildKeybindings(nil): %v", err)
+	}
+	if kb.Prefix != 0x01 {
+		t.Errorf("nil config: prefix = %d, want 0x01", kb.Prefix)
+	}
+	if len(kb.Bindings) == 0 {
+		t.Error("nil config: should have default bindings")
+	}
+}
+
+func TestBuildKeybindingsCustomPrefix(t *testing.T) {
+	kc := &KeyConfig{Prefix: "C-b"}
+	kb, err := BuildKeybindings(kc)
+	if err != nil {
+		t.Fatalf("BuildKeybindings: %v", err)
+	}
+	if kb.Prefix != 0x02 {
+		t.Errorf("prefix = %d, want 0x02 (Ctrl-b)", kb.Prefix)
+	}
+	if _, ok := kb.Bindings['\\']; !ok {
+		t.Error("default bindings should be preserved with custom prefix")
+	}
+}
+
+func TestBuildKeybindingsAddBinding(t *testing.T) {
+	kc := &KeyConfig{
+		Bind: map[string]string{
+			"s": "split",
+		},
+	}
+	kb, err := BuildKeybindings(kc)
+	if err != nil {
+		t.Fatalf("BuildKeybindings: %v", err)
+	}
+	b, ok := kb.Bindings['s']
+	if !ok {
+		t.Fatal("'s' should be bound")
+	}
+	if b.Action != "split" {
+		t.Errorf("s action = %q, want split", b.Action)
+	}
+	if _, ok := kb.Bindings['\\']; !ok {
+		t.Error("default \\ binding should still exist")
+	}
+}
+
+func TestBuildKeybindingsOverrideBinding(t *testing.T) {
+	kc := &KeyConfig{
+		Bind: map[string]string{
+			"o": "split v",
+		},
+	}
+	kb, err := BuildKeybindings(kc)
+	if err != nil {
+		t.Fatalf("BuildKeybindings: %v", err)
+	}
+	b := kb.Bindings['o']
+	if b.Action != "split" {
+		t.Errorf("o action = %q, want split", b.Action)
+	}
+	if len(b.Args) != 1 || b.Args[0] != "v" {
+		t.Errorf("o args = %v, want [v]", b.Args)
+	}
+}
+
+func TestBuildKeybindingsUnbind(t *testing.T) {
+	kc := &KeyConfig{
+		Unbind: []string{"o", "h"},
+	}
+	kb, err := BuildKeybindings(kc)
+	if err != nil {
+		t.Fatalf("BuildKeybindings: %v", err)
+	}
+	if _, ok := kb.Bindings['o']; ok {
+		t.Error("'o' should be unbound")
+	}
+	if _, ok := kb.Bindings['h']; ok {
+		t.Error("'h' should be unbound")
+	}
+	if _, ok := kb.Bindings['\\']; !ok {
+		t.Error("'\\' should still be bound")
+	}
+}
+
+func TestBuildKeybindingsInvalidPrefix(t *testing.T) {
+	kc := &KeyConfig{Prefix: "C-1"}
+	_, err := BuildKeybindings(kc)
+	if err == nil {
+		t.Error("expected error for invalid prefix C-1")
+	}
+}
+
+func TestBuildKeybindingsUnknownAction(t *testing.T) {
+	kc := &KeyConfig{
+		Bind: map[string]string{
+			"x": "splti", // typo
+		},
+	}
+	_, err := BuildKeybindings(kc)
+	if err == nil {
+		t.Error("expected error for unknown action 'splti'")
+	}
+}
+
+func TestBuildKeybindingsPrefixConflict(t *testing.T) {
+	kc := &KeyConfig{
+		Prefix: "C-b",
+		Bind: map[string]string{
+			"C-b": "split", // conflicts with prefix
+		},
+	}
+	_, err := BuildKeybindings(kc)
+	if err == nil {
+		t.Error("expected error when binding conflicts with prefix key")
+	}
+}

--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/weill-labs/amux/internal/checkpoint"
+	"github.com/weill-labs/amux/internal/config"
 	"github.com/weill-labs/amux/internal/copymode"
 	"github.com/weill-labs/amux/internal/mouse"
 	"github.com/weill-labs/amux/internal/mux"
@@ -245,7 +246,7 @@ Usage:
 
 Panes can be referenced by name (pane-1) or ID (1).
 
-Inside an amux session:
+Inside an amux session (defaults, configurable via config.toml):
   Ctrl-a \                           Split active pane left/right
   Ctrl-a -                           Split active pane top/bottom
   Ctrl-a |                           Root-level split left/right
@@ -266,7 +267,10 @@ Inside an amux session:
   Ctrl-a 1-9                         Select window by number
   Ctrl-a r                           Hot reload (re-exec binary)
   Ctrl-a d                           Detach from session
-  Ctrl-a Ctrl-a                      Send literal Ctrl-a`)
+  Ctrl-a Ctrl-a                      Send literal Ctrl-a
+
+Keybindings are configurable via ~/.config/amux/config.toml (or AMUX_CONFIG env var).
+See https://github.com/weill-labs/amux for config format.`)
 }
 
 // ---------------------------------------------------------------------------
@@ -359,6 +363,17 @@ func runServer(sessionName string) {
 // runMux connects to an existing server or starts one, then enters raw
 // terminal mode for interactive use.
 func runMux(sessionName string) error {
+	// Load config for keybindings
+	cfg, err := config.Load(config.DefaultPath())
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "amux: loading config: %v\n", err)
+		cfg = &config.Config{}
+	}
+	kb, err := config.BuildKeybindings(&cfg.Keys)
+	if err != nil {
+		return fmt.Errorf("invalid keybindings: %w", err)
+	}
+
 	sockPath := server.SocketPath(sessionName)
 
 	// Start server daemon if no socket exists
@@ -525,91 +540,62 @@ func runMux(sessionName string) error {
 
 		// isRepeatableKey returns true for keys that can repeat without prefix.
 		isRepeatableKey := func(b byte) bool {
-			switch b {
-			case 'h', 'j', 'k', 'l', 'H', 'J', 'K', 'L':
-				return true
+			if binding, ok := kb.Bindings[b]; ok {
+				switch binding.Action {
+				case "focus", "resize-active":
+					return true
+				}
 			}
 			return false
 		}
 
-		// execPrefixKey executes a prefix keybinding. Returns true if
-		// the goroutine should exit (detach).
+		// execPrefixKey executes a prefix keybinding via the config-driven
+		// dispatch table. Returns true if the goroutine should exit (detach).
 		execPrefixKey := func(b byte, forward *[]byte) bool {
-			switch b {
-			case 'd':
-				if len(*forward) > 0 {
-					server.WriteMsg(conn, &server.Message{
-						Type: server.MsgTypeInput, Input: *forward,
-					})
-				}
-				server.WriteMsg(conn, &server.Message{Type: server.MsgTypeDetach})
-				conn.Close()
-				return true
-			case '-':
-				sendCommand(conn, "split", []string{"v"})
-			case '\\':
-				sendCommand(conn, "split", nil)
-			case '|':
-				sendCommand(conn, "split", []string{"root"})
-			case '_':
-				sendCommand(conn, "split", []string{"root", "v"})
-			case '}':
-				sendCommand(conn, "swap", []string{"forward"})
-			case '{':
-				sendCommand(conn, "swap", []string{"backward"})
-			case 'o':
-				sendCommand(conn, "focus", []string{"next"})
-			case 'h':
-				sendCommand(conn, "focus", []string{"left"})
-			case 'l':
-				sendCommand(conn, "focus", []string{"right"})
-			case 'k':
-				sendCommand(conn, "focus", []string{"up"})
-			case 'j':
-				sendCommand(conn, "focus", []string{"down"})
-			case 'H':
-				sendCommand(conn, "resize-active", []string{"left", "2"})
-			case 'J':
-				sendCommand(conn, "resize-active", []string{"down", "2"})
-			case 'K':
-				sendCommand(conn, "resize-active", []string{"up", "2"})
-			case 'L':
-				sendCommand(conn, "resize-active", []string{"right", "2"})
-			case 'z':
-				sendCommand(conn, "zoom", nil)
-			case 'm':
-				sendCommand(conn, "toggle-minimize", nil)
-			case '[':
-				cr.EnterCopyMode(cr.ActivePaneID())
-				if data := cr.Render(); data != nil {
-					os.Stdout.Write(data)
-				}
-			case 'c':
-				sendCommand(conn, "new-window", nil)
-			case 'n':
-				sendCommand(conn, "next-window", nil)
-			case 'p':
-				sendCommand(conn, "prev-window", nil)
-			case '1', '2', '3', '4', '5', '6', '7', '8', '9':
-				sendCommand(conn, "select-window", []string{string(b)})
-			case 'r':
-				if len(*forward) > 0 {
-					server.WriteMsg(conn, &server.Message{
-						Type: server.MsgTypeInput, Input: *forward,
-					})
-					*forward = nil
-				}
-				select {
-				case triggerReload <- struct{}{}:
+			// Pressing the prefix key again sends the literal prefix byte
+			if b == kb.Prefix {
+				*forward = append(*forward, kb.Prefix)
+				return false
+			}
+
+			// Look up binding in dispatch table
+			if binding, ok := kb.Bindings[b]; ok {
+				switch binding.Action {
+				case "detach":
+					if len(*forward) > 0 {
+						server.WriteMsg(conn, &server.Message{
+							Type: server.MsgTypeInput, Input: *forward,
+						})
+					}
+					server.WriteMsg(conn, &server.Message{Type: server.MsgTypeDetach})
+					conn.Close()
+					return true
+				case "reload":
+					if len(*forward) > 0 {
+						server.WriteMsg(conn, &server.Message{
+							Type: server.MsgTypeInput, Input: *forward,
+						})
+						*forward = nil
+					}
+					select {
+					case triggerReload <- struct{}{}:
+					default:
+					}
+				case "copy-mode":
+					cr.EnterCopyMode(cr.ActivePaneID())
+					if data := cr.Render(); data != nil {
+						os.Stdout.Write(data)
+					}
 				default:
+					// Generic server command
+					sendCommand(conn, binding.Action, binding.Args)
 				}
-			case 0x1b:
+			} else if b == 0x1b {
 				prefixEsc = true
 				prefixEscBuf = nil
-			case 0x01:
-				*forward = append(*forward, 0x01)
-			default:
-				*forward = append(*forward, 0x01, b)
+			} else {
+				// Unrecognized key after prefix: forward prefix + byte
+				*forward = append(*forward, kb.Prefix, b)
 			}
 			return false
 		}
@@ -671,7 +657,7 @@ func runMux(sessionName string) error {
 				return execPrefixKey(b, forward)
 			}
 
-			if b == 0x01 {
+			if b == kb.Prefix {
 				if len(*forward) > 0 {
 					server.WriteMsg(conn, &server.Message{
 						Type: server.MsgTypeInput, Input: *forward,

--- a/test/keybinding_test.go
+++ b/test/keybinding_test.go
@@ -1,0 +1,216 @@
+package test
+
+import (
+	"crypto/rand"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/weill-labs/amux/internal/server"
+)
+
+// newAmuxHarnessWithConfig creates an AmuxHarness that launches the inner
+// amux with a custom config file via the AMUX_CONFIG env var.
+func newAmuxHarnessWithConfig(t *testing.T, configContent string) *AmuxHarness {
+	t.Helper()
+	outer := newServerHarness(t)
+
+	// Write config to temp file
+	configDir := t.TempDir()
+	configPath := filepath.Join(configDir, "config.toml")
+	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+		t.Fatalf("writing config: %v", err)
+	}
+
+	var b [4]byte
+	rand.Read(b[:])
+	inner := fmt.Sprintf("t-%x", b)
+
+	h := &AmuxHarness{outer: outer, inner: inner, t: t, session: inner}
+
+	// Launch inner amux with AMUX_CONFIG set
+	outer.sendKeys("pane-1", fmt.Sprintf("AMUX_CONFIG=%s %s -s %s", configPath, amuxBin, inner), "Enter")
+	outer.waitFor("pane-1", "[pane-")
+
+	t.Cleanup(func() {
+		// Best-effort detach (only works with default prefix).
+		exec.Command(amuxBin, "-s", inner, "list").Run()
+		out, _ := exec.Command("pgrep", "-f", fmt.Sprintf("amux _server %s$", inner)).Output()
+		for _, pid := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+			if pid != "" {
+				exec.Command("kill", pid).Run()
+			}
+		}
+		time.Sleep(200 * time.Millisecond)
+		socketDir := server.SocketDir()
+		for _, suffix := range []string{"", ".log"} {
+			exec.Command("rm", "-f", fmt.Sprintf("%s/%s%s", socketDir, inner, suffix)).Run()
+		}
+	})
+
+	return h
+}
+
+func TestCustomPrefixKey(t *testing.T) {
+	t.Parallel()
+
+	h := newAmuxHarnessWithConfig(t, `
+[keys]
+prefix = "C-b"
+`)
+
+	// Ctrl-b \ should split (using new prefix)
+	gen := h.generation()
+	h.sendKeys("C-b", "\\")
+	h.waitLayout(gen)
+
+	lines := h.captureAmuxContentLines()
+	found := false
+	for _, line := range lines {
+		if strings.Contains(line, "[pane-1]") && strings.Contains(line, "[pane-2]") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("Ctrl-b \\ should split with custom prefix\n%s", strings.Join(lines, "\n"))
+	}
+}
+
+func TestCustomPrefixOldPrefixPassthrough(t *testing.T) {
+	t.Parallel()
+
+	h := newAmuxHarnessWithConfig(t, `
+[keys]
+prefix = "C-b"
+`)
+
+	// Ctrl-a \ with old prefix should NOT split
+	h.sendKeys("C-a", "\\")
+	time.Sleep(500 * time.Millisecond)
+
+	h.assertScreen("old prefix should not split", func(s string) bool {
+		return strings.Contains(s, "[pane-1]") && !strings.Contains(s, "[pane-2]")
+	})
+}
+
+func TestCustomBindAddNewKey(t *testing.T) {
+	t.Parallel()
+
+	h := newAmuxHarnessWithConfig(t, `
+[keys.bind]
+s = "split"
+`)
+
+	gen := h.generation()
+	h.sendKeys("C-a", "s")
+	h.waitLayout(gen)
+
+	h.assertScreen("Ctrl-a s should split", func(s string) bool {
+		return strings.Contains(s, "[pane-2]")
+	})
+
+	// Default bindings should still work alongside custom ones
+	gen = h.generation()
+	h.sendKeys("C-a", "-")
+	h.waitLayout(gen)
+
+	h.assertScreen("default Ctrl-a - should still work", func(s string) bool {
+		return strings.Contains(s, "[pane-3]")
+	})
+}
+
+func TestCustomBindRemapKey(t *testing.T) {
+	t.Parallel()
+
+	h := newAmuxHarnessWithConfig(t, `
+[keys.bind]
+o = "split v"
+`)
+
+	gen := h.generation()
+	h.sendKeys("C-a", "o")
+	h.waitLayout(gen)
+
+	// Verify horizontal split: pane names on DIFFERENT rows
+	lines := h.captureAmuxContentLines()
+	row1 := paneNameRow(lines, "pane-1")
+	row2 := paneNameRow(lines, "pane-2")
+	if row1 < 0 || row2 < 0 {
+		t.Fatalf("both pane names should be visible")
+	}
+	if row1 == row2 {
+		t.Errorf("horizontal split should put panes on different rows, both on row %d", row1)
+	}
+}
+
+func TestCustomUnbindKey(t *testing.T) {
+	t.Parallel()
+
+	h := newAmuxHarnessWithConfig(t, `
+[keys]
+unbind = ["o"]
+`)
+
+	h.splitV()
+
+	// pane-2 is active after split. Ctrl-a o should do nothing (unbound).
+	h.sendKeys("C-a", "o")
+	time.Sleep(500 * time.Millisecond)
+
+	h.assertScreen("pane-2 should still be active (o unbound)", func(s string) bool {
+		return isPaneActive(s, "pane-2")
+	})
+}
+
+func TestCustomDetachBinding(t *testing.T) {
+	t.Parallel()
+
+	h := newAmuxHarnessWithConfig(t, `
+[keys]
+unbind = ["d"]
+
+[keys.bind]
+q = "detach"
+`)
+
+	// Ctrl-a q should detach the inner client
+	h.sendKeys("C-a", "q")
+	time.Sleep(500 * time.Millisecond)
+
+	// After detach, the outer pane should show the shell prompt,
+	// not the inner amux UI. The inner server still runs but the
+	// client is gone, so the outer pane no longer shows amux chrome.
+	outerContent := h.captureOuter()
+	if strings.Contains(outerContent, "amux") && strings.Contains(outerContent, "panes") {
+		t.Errorf("inner amux should be detached (global bar still visible)\nOuter:\n%s", outerContent)
+	}
+}
+
+func TestDefaultBindingsWithoutConfig(t *testing.T) {
+	t.Parallel()
+
+	h := newAmuxHarnessWithConfig(t, "")
+
+	// Ctrl-a \ should split (default)
+	gen := h.generation()
+	h.sendKeys("C-a", "\\")
+	h.waitLayout(gen)
+
+	h.assertScreen("default split should work", func(s string) bool {
+		return strings.Contains(s, "[pane-2]")
+	})
+
+	// Ctrl-a o should cycle focus (default)
+	gen = h.generation()
+	h.sendKeys("C-a", "o")
+	h.waitLayout(gen)
+
+	h.assertScreen("pane-1 active after cycle", func(s string) bool {
+		return isPaneActive(s, "pane-1")
+	})
+}


### PR DESCRIPTION
## Summary

- Replace hardcoded keybinding switch with config-driven dispatch table
- Users can customize prefix key, remap/add/unbind bindings via `~/.config/amux/config.toml`
- Supports `AMUX_CONFIG` env var for config path override
- Validates action names at config load time (typos fail fast)
- Rejects bindings that conflict with the prefix key
- Add PostToolUse hook that reminds Claude to run review agents after `gh pr create`

Closes LAB-92

## Config format

```toml
[keys]
prefix = "C-b"        # change prefix from Ctrl-a to Ctrl-b
unbind = ["o"]         # remove default bindings

[keys.bind]
s = "split"            # add new binding
x = "focus next"       # remap existing
```

## Motivation

Keybindings were hardcoded in a switch statement in `main.go`. Users who prefer different prefix keys (e.g., Ctrl-b for tmux muscle memory) or want custom shortcuts had no way to configure them.

## Testing

- 7 integration tests in `test/keybinding_test.go`
- 11 unit tests in `internal/config/keybindings_test.go`
- All integration tests pass

## Review focus

- `internal/config/keybindings.go`: dispatch table design, `knownActions` validation, `BuildKeybindings()` layering
- `main.go:execPrefixKey()`: config-driven dispatch replacing hardcoded switch, integration with repeat key and prefix-escape systems

🤖 Generated with [Claude Code](https://claude.com/claude-code)