### PR TITLE
Add repeatable key bindings for navigation and resize

### DIFF
--- a/main.go
+++ b/main.go
@@ -415,9 +415,10 @@ func runMux(sessionName string) error {
 
 		// Repeat key state — allows navigation/resize keys to repeat
 		// without re-pressing the prefix, matching tmux's -r behavior.
+		// Uses a deadline instead of a timer to avoid goroutine races.
 		const repeatTimeout = 500 * time.Millisecond
 		var repeatKey byte
-		var repeatTimer *time.Timer
+		var repeatDeadline time.Time
 
 		// isRepeatableKey returns true for keys that can repeat without prefix.
 		isRepeatableKey := func(b byte) bool {
@@ -426,27 +427,6 @@ func runMux(sessionName string) error {
 				return true
 			}
 			return false
-		}
-
-		// clearRepeat cancels repeat mode.
-		clearRepeat := func() {
-			if repeatTimer != nil {
-				repeatTimer.Stop()
-				repeatTimer = nil
-			}
-			repeatKey = 0
-		}
-
-		// startRepeat enters repeat mode for the given key.
-		startRepeat := func(b byte) {
-			repeatKey = b
-			if repeatTimer != nil {
-				repeatTimer.Stop()
-			}
-			repeatTimer = time.AfterFunc(repeatTimeout, func() {
-				repeatKey = 0
-				repeatTimer = nil
-			})
 		}
 
 		// execPrefixKey executes a prefix keybinding. Returns true if
@@ -531,25 +511,26 @@ func runMux(sessionName string) error {
 		// processKeyByte handles a single non-mouse byte through the
 		// Ctrl-a prefix system. Returns true if the goroutine should exit.
 		processKeyByte := func(b byte, forward *[]byte) bool {
-			// Check repeat mode: if a repeatable key arrives within the timeout,
-			// execute it directly without requiring the prefix.
-			if repeatKey != 0 && b == repeatKey {
-				startRepeat(b)
-				return execPrefixKey(b, forward)
+			// Repeat mode: any repeatable key executes without prefix while
+			// the deadline hasn't expired. Matches tmux behavior where all
+			// repeatable bindings stay active, not just the original key.
+			if repeatKey != 0 {
+				if isRepeatableKey(b) && time.Now().Before(repeatDeadline) {
+					repeatKey = b
+					repeatDeadline = time.Now().Add(repeatTimeout)
+					return execPrefixKey(b, forward)
+				}
+				repeatKey = 0
 			}
 
 			if prefix {
 				prefix = false
 				if isRepeatableKey(b) {
-					startRepeat(b)
-				} else {
-					clearRepeat()
+					repeatKey = b
+					repeatDeadline = time.Now().Add(repeatTimeout)
 				}
 				return execPrefixKey(b, forward)
 			}
-
-			// Any non-repeat key clears repeat mode
-			clearRepeat()
 
 			if b == 0x01 {
 				if len(*forward) > 0 {

--- a/test/repeat_test.go
+++ b/test/repeat_test.go
@@ -69,6 +69,32 @@ func TestRepeatFocus(t *testing.T) {
 	}
 }
 
+func TestRepeatCrossKey(t *testing.T) {
+	t.Parallel()
+	h := newHarness(t)
+
+	// Create 3 panes: [pane-1 | pane-2 | pane-3]
+	h.sendKeys("C-a", "\\")
+	h.waitFor("[pane-2]", 3*time.Second)
+	h.sendKeys("C-a", "\\")
+	h.waitFor("[pane-3]", 3*time.Second)
+	time.Sleep(200 * time.Millisecond)
+
+	// Focus is on pane-3. Press Prefix+h (focus left to pane-2),
+	// then l without prefix (focus right back to pane-3).
+	// Tests that repeat mode accepts any repeatable key, not just the original.
+	h.sendKeys("C-a", "h")
+	time.Sleep(100 * time.Millisecond)
+	h.sendKeys("l")
+	time.Sleep(300 * time.Millisecond)
+
+	if !h.waitForFunc(func(s string) bool {
+		return isPaneActive(s, "pane-3")
+	}, 3*time.Second) {
+		t.Errorf("expected pane-3 active after h then l (cross-key repeat).\nScreen:\n%s", h.capture())
+	}
+}
+
 func TestRepeatExpiresAfterTimeout(t *testing.T) {
 	t.Parallel()
 	h := newHarness(t)
@@ -95,6 +121,9 @@ func TestRepeatExpiresAfterTimeout(t *testing.T) {
 	time.Sleep(300 * time.Millisecond)
 
 	newBorder := h.captureAmuxVerticalBorderCol()
+	if newBorder < 0 {
+		t.Fatalf("no vertical border found after timeout.\nScreen:\n%s", h.captureAmux())
+	}
 	// Should have moved only 2 cells (one resize), not 4
 	moved := newBorder - initialBorder
 	if moved > 3 {


### PR DESCRIPTION
## Summary
- Navigation (h/j/k/l) and resize (H/J/K/L) keys now repeat without re-pressing the prefix, matching tmux's `-r` flag behavior
- After pressing Prefix+key, any repeatable key within 500ms executes directly (e.g., `Ctrl-a h l h` works)
- Timer resets on each repeat; any non-repeatable key or timeout exits repeat mode
- Uses deadline-based expiry (no cross-goroutine state)

## Motivation
tmux binds navigation and resize keys with `-r` (repeat) by default. Without this, resizing requires pressing `Ctrl-a L Ctrl-a L Ctrl-a L` instead of `Ctrl-a L L L`.

## Testing
- 4 integration tests: repeated resize, repeated focus, cross-key repeat (h then l), repeat expiry after 700ms
- All existing tests pass

Fixes LAB-146

🤖 Generated with [Claude Code](https://claude.com/claude-code)