### PR TITLE
Limit integration test parallelism to 4 (LAB-148)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
         if: steps.changes.outputs.code_changed == 'true'
         run: |
           mkdir -p /tmp/amux-covdata
-          GOCOVERDIR=/tmp/amux-covdata go test -json -timeout 120s ./test/ | tee integration-results.json
+          GOCOVERDIR=/tmp/amux-covdata go test -json -parallel 4 -timeout 120s ./test/ | tee integration-results.json
 
       - name: Coverage summary
         if: always() && steps.changes.outputs.code_changed == 'true'


### PR DESCRIPTION
## Summary
- Adds `-parallel 4` to the integration test step in CI

## Motivation
Each integration test spawns a tmux session with an amux process. Running all tests fully parallel causes resource contention and sporadic timeouts on CI runners (and locally). Capping at 4 keeps total runtime reasonable while avoiding contention.

Fixes LAB-148

🤖 Generated with [Claude Code](https://claude.com/claude-code)