### PR TITLE
Revert parallel limit, increase integration test timeout to 5m

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
         if: steps.changes.outputs.code_changed == 'true'
         run: |
           mkdir -p /tmp/amux-covdata
-          GOCOVERDIR=/tmp/amux-covdata go test -json -parallel 4 -timeout 120s ./test/ | tee integration-results.json
+          GOCOVERDIR=/tmp/amux-covdata go test -json -timeout 300s ./test/ | tee integration-results.json
 
       - name: Coverage summary
         if: always() && steps.changes.outputs.code_changed == 'true'


### PR DESCRIPTION
## Summary
- Reverts `-parallel 4` from #58
- Increases integration test timeout from 2m to 5m

## Motivation
Full parallelism is faster. The sporadic timeouts were from a tight deadline, not resource contention. A higher timeout is the right fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)