### PR TITLE
Fix out-of-bounds in ResizeActive and minor cleanups

### DIFF
--- a/internal/mux/window.go
+++ b/internal/mux/window.go
@@ -481,9 +481,11 @@ func (w *Window) ResizeActive(direction string, delta int) bool {
 			// tmux convention: resize the border adjacent to this cell.
 			// If we're the last child, use the border to our left (idx-1, idx).
 			// Otherwise, use the border to our right (idx, idx+1).
-			left, right := siblings[idx], siblings[idx+1]
+			var left, right *LayoutCell
 			if idx == len(siblings)-1 {
 				left, right = siblings[idx-1], siblings[idx]
+			} else {
+				left, right = siblings[idx], siblings[idx+1]
 			}
 
 			if change > 0 {

--- a/internal/mux/window_test.go
+++ b/internal/mux/window_test.go
@@ -294,6 +294,49 @@ func collectPaneIDs(w *Window) []uint32 {
 	return ids
 }
 
+func TestResizeActiveLastChild(t *testing.T) {
+	t.Parallel()
+	// Regression: ResizeActive panicked with index out of range when
+	// the active pane was the last child in its parent's children slice.
+	// The bug accessed siblings[idx+1] before checking whether idx was
+	// the last element.
+	p1 := fakePaneID(1)
+	p2 := fakePaneID(2)
+
+	root := NewLeaf(p1, 0, 0, 80, 24)
+	root.Split(SplitHorizontal, p2)
+	root.FixOffsets()
+
+	// Active pane is p2 — the LAST child (idx=1, len=2)
+	w := &Window{Root: root, ActivePane: p2, Width: 80, Height: 24}
+
+	// This should not panic. Resize left on a horizontal split
+	// moves the border between p1 and p2.
+	result := w.ResizeActive("left", 2)
+	if !result {
+		t.Error("ResizeActive(left, 2) on last child should succeed")
+	}
+}
+
+func TestResizeActiveFirstChild(t *testing.T) {
+	t.Parallel()
+	// Complementary test: active pane is the first child.
+	p1 := fakePaneID(1)
+	p2 := fakePaneID(2)
+
+	root := NewLeaf(p1, 0, 0, 80, 24)
+	root.Split(SplitHorizontal, p2)
+	root.FixOffsets()
+
+	// Active pane is p1 — the FIRST child (idx=0)
+	w := &Window{Root: root, ActivePane: p1, Width: 80, Height: 24}
+
+	result := w.ResizeActive("right", 2)
+	if !result {
+		t.Error("ResizeActive(right, 2) on first child should succeed")
+	}
+}
+
 func TestSwapPanes(t *testing.T) {
 	t.Parallel()
 	p1 := fakePaneID(1)

--- a/internal/server/client_conn.go
+++ b/internal/server/client_conn.go
@@ -345,7 +345,7 @@ func (cc *ClientConn) handleCommand(srv *Server, sess *Session, msg *Message) {
 			cc.Send(&Message{Type: MsgTypeCmdResult, CmdErr: "no active window"})
 			return
 		}
-		name, wasMinimized, err := w.ToggleMinimize()
+		name, didMinimize, err := w.ToggleMinimize()
 		sess.mu.Unlock()
 		if err != nil {
 			cc.Send(&Message{Type: MsgTypeCmdResult, CmdErr: err.Error()})
@@ -353,7 +353,7 @@ func (cc *ClientConn) handleCommand(srv *Server, sess *Session, msg *Message) {
 		}
 		sess.broadcastLayout()
 		verb := "Restored"
-		if wasMinimized {
+		if didMinimize {
 			verb = "Minimized"
 		}
 		cc.Send(&Message{Type: MsgTypeCmdResult, CmdOutput: fmt.Sprintf("%s %s\n", verb, name)})
@@ -460,10 +460,13 @@ func (cc *ClientConn) handleCommand(srv *Server, sess *Session, msg *Message) {
 		ref := msg.CmdArgs[0]
 
 		sess.mu.Lock()
-		switched := cc.switchWindow(sess, ref)
+		w := sess.ResolveWindow(ref)
+		if w != nil {
+			sess.ActiveWindowID = w.ID
+		}
 		sess.mu.Unlock()
 
-		if !switched {
+		if w == nil {
 			cc.Send(&Message{Type: MsgTypeCmdResult, CmdErr: fmt.Sprintf("window %q not found", ref)})
 			return
 		}
@@ -675,17 +678,6 @@ func (cc *ClientConn) createNewWindow(srv *Server, sess *Session, name string) {
 	sess.broadcastLayout()
 	cc.Send(&Message{Type: MsgTypeCmdResult,
 		CmdOutput: fmt.Sprintf("Created %s\n", newWin.Name)})
-}
-
-// switchWindow switches to a window by 1-based index or name.
-// Caller must hold sess.mu. Returns true if switched.
-func (cc *ClientConn) switchWindow(sess *Session, ref string) bool {
-	w := sess.ResolveWindow(ref)
-	if w == nil {
-		return false
-	}
-	sess.ActiveWindowID = w.ID
-	return true
 }
 
 // splitNewPane creates a pane, inserts it into the active window's layout,

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"path/filepath"
 	"runtime/coverage"
+	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"syscall"
@@ -107,8 +109,7 @@ func (s *Session) PrevWindow() {
 // Caller must hold s.mu.
 func (s *Session) ResolveWindow(ref string) *mux.Window {
 	// Try as 1-based index
-	var idx int
-	if _, err := fmt.Sscanf(ref, "%d", &idx); err == nil {
+	if idx, err := strconv.Atoi(ref); err == nil {
 		if idx >= 1 && idx <= len(s.Windows) {
 			return s.Windows[idx-1]
 		}
@@ -122,7 +123,7 @@ func (s *Session) ResolveWindow(ref string) *mux.Window {
 	}
 	// Try prefix match
 	for _, w := range s.Windows {
-		if len(ref) > 0 && len(w.Name) >= len(ref) && w.Name[:len(ref)] == ref {
+		if len(ref) > 0 && strings.HasPrefix(w.Name, ref) {
 			return w
 		}
 	}


### PR DESCRIPTION
## Summary

- Fix out-of-bounds array access in `ResizeActive` when the active pane is the last child
- Rename misleading `wasMinimized` variable to `didMinimize`
- Inline single-use `switchWindow` method at its call site
- Use idiomatic `strconv.Atoi` and `strings.HasPrefix` in `ResolveWindow`

## Motivation

Found by the code simplifier agent during review of PR #46. The `ResizeActive` bug accesses `siblings[idx+1]` before checking whether `idx` is the last element, causing an out-of-bounds read. The remaining changes are readability improvements.

## Testing

- All unit tests pass (`go test ./internal/...`)
- Integration tests covering affected areas pass: `TestResizeKeybind*`, `TestToggleMinimize*`, `TestWindow*`, `TestSwap*`

🤖 Generated with [Claude Code](https://claude.com/claude-code)