### PR TITLE
Fix ResizeActive panic when active pane is last child

### DIFF
--- a/internal/mux/window.go
+++ b/internal/mux/window.go
@@ -481,9 +481,11 @@ func (w *Window) ResizeActive(direction string, delta int) bool {
 			// tmux convention: resize the border adjacent to this cell.
 			// If we're the last child, use the border to our left (idx-1, idx).
 			// Otherwise, use the border to our right (idx, idx+1).
-			left, right := siblings[idx], siblings[idx+1]
+			var left, right *LayoutCell
 			if idx == len(siblings)-1 {
 				left, right = siblings[idx-1], siblings[idx]
+			} else {
+				left, right = siblings[idx], siblings[idx+1]
 			}
 
 			if change > 0 {

--- a/internal/mux/window_test.go
+++ b/internal/mux/window_test.go
@@ -450,6 +450,62 @@ func TestRotatePanesBackward(t *testing.T) {
 	}
 }
 
+// ---------------------------------------------------------------------------
+// ResizeActive (regression: index out of bounds when active pane is last child)
+// ---------------------------------------------------------------------------
+
+func TestResizeActiveFromLastChild(t *testing.T) {
+	t.Parallel()
+	// Two panes side by side: [pane-1 | pane-2], pane-2 active (last child).
+	// ResizeActive("left", 2) should move the border left without panicking.
+	p1 := fakePaneID(1)
+	p2 := fakePaneID(2)
+
+	root := NewLeaf(p1, 0, 0, 80, 24)
+	root.Split(SplitHorizontal, p2)
+
+	w := &Window{Root: root, ActivePane: p2, Width: 80, Height: 24}
+	w.Root.FixOffsets()
+
+	initialP1W := root.Children[0].W
+
+	ok := w.ResizeActive("left", 2)
+	if !ok {
+		t.Fatal("ResizeActive returned false, expected true")
+	}
+
+	newP1W := root.Children[0].W
+	if newP1W >= initialP1W {
+		t.Errorf("pane-1 width should shrink: was %d, now %d", initialP1W, newP1W)
+	}
+}
+
+func TestResizeActiveFromFirstChild(t *testing.T) {
+	t.Parallel()
+	// Two panes side by side: [pane-1 | pane-2], pane-1 active (first child).
+	// ResizeActive("right", 2) should move the border right.
+	p1 := fakePaneID(1)
+	p2 := fakePaneID(2)
+
+	root := NewLeaf(p1, 0, 0, 80, 24)
+	root.Split(SplitHorizontal, p2)
+
+	w := &Window{Root: root, ActivePane: p1, Width: 80, Height: 24}
+	w.Root.FixOffsets()
+
+	initialP1W := root.Children[0].W
+
+	ok := w.ResizeActive("right", 2)
+	if !ok {
+		t.Fatal("ResizeActive returned false, expected true")
+	}
+
+	newP1W := root.Children[0].W
+	if newP1W <= initialP1W {
+		t.Errorf("pane-1 width should grow: was %d, now %d", initialP1W, newP1W)
+	}
+}
+
 func TestRotateSinglePane(t *testing.T) {
 	t.Parallel()
 	p1 := fakePaneID(1)


### PR DESCRIPTION
## Summary

- Fix index out of bounds in `ResizeActive()` when the active pane is the last child in its parent's children list
- The panic killed the goroutine while holding `sess.mu`, deadlocking all subsequent server operations

## Root cause

In `window.go:484`, the code did:
```go
left, right := siblings[idx], siblings[idx+1]  // panics when idx == len-1
if idx == len(siblings)-1 {
    left, right = siblings[idx-1], siblings[idx]
}
```

The fix reorders so the bounds check happens first.

## Testing

- Added `TestResizeActiveFromLastChild` and `TestResizeActiveFromFirstChild` unit tests
- `TestResizeKeybindFromRightPane` integration test no longer hangs (3/3 passes)
- `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)