### PR TITLE
Add TDD enforcement hook for Claude Code

### DIFF
--- a/.claude/hooks/tdd-check.sh
+++ b/.claude/hooks/tdd-check.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Stop hook: warn if implementation .go files changed without any test files.
+# Exits 2 (block + feedback) when tests are missing, 0 otherwise.
+
+# Get modified .go files (staged + unstaged)
+changed=$(git diff --name-only HEAD 2>/dev/null; git diff --name-only 2>/dev/null)
+
+if [ -z "$changed" ]; then
+    exit 0
+fi
+
+# Filter to .go files only
+go_files=$(echo "$changed" | grep '\.go$' | sort -u)
+if [ -z "$go_files" ]; then
+    exit 0
+fi
+
+# Separate implementation files from test files
+impl_files=$(echo "$go_files" | grep -v '_test\.go$')
+test_files=$(echo "$go_files" | grep '_test\.go$')
+
+# If no implementation files changed, nothing to check
+if [ -z "$impl_files" ]; then
+    exit 0
+fi
+
+# If at least one test file was also modified, TDD is satisfied
+if [ -n "$test_files" ]; then
+    exit 0
+fi
+
+# Implementation changed but no tests — warn
+echo "TDD check: implementation files changed but no test files were modified:" >&2
+echo "$impl_files" | sed 's/^/  /' >&2
+echo "" >&2
+echo "Write a failing test first, then implement. If this is a pure refactor" >&2
+echo "with no behavior change, explain why no test is needed." >&2
+exit 2

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/tdd-check.sh"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

- Add a Stop hook that warns when implementation `.go` files are modified without corresponding test files
- Sends feedback back to Claude via exit code 2, prompting it to write tests first
- Includes escape hatch: Claude can explain why no test is needed (pure refactoring, config changes)

## Motivation

During LAB-92 (custom keybindings), a `ResizeActive` bug fix was implemented without a regression test. The user had to catch the TDD violation manually. This hook automates that check.

## How it works

On every Stop event (before Claude responds):
1. Checks `git diff` for modified `.go` files
2. If non-test implementation files changed but zero `_test.go` files changed, blocks with feedback
3. If any test file was also modified, passes silently

## Testing

Manually verified:
- Impl-only change → blocks with "Write a failing test first"
- Impl + test change → passes
- Non-Go changes → passes
- Clean working tree → passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)