### PR TITLE
Add Codecov Test Analytics integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,9 +47,31 @@ jobs:
         if: steps.changes.outputs.code_changed == 'true'
         run: go vet ./...
 
+      - name: Install go-junit-report
+        if: steps.changes.outputs.code_changed == 'true'
+        run: go install github.com/jstemmer/go-junit-report/v2@v2.1.0
+
       - name: Tests with coverage
         if: steps.changes.outputs.code_changed == 'true'
         run: scripts/coverage.sh --ci
+
+      - name: Convert test results to JUnit XML
+        if: ${{ !cancelled() && steps.changes.outputs.code_changed == 'true' }}
+        run: |
+          if [ -f unit-results.json ]; then
+            go-junit-report -parser gojson -in unit-results.json -out unit-results.junit.xml
+          fi
+          if [ -f integration-results.json ]; then
+            go-junit-report -parser gojson -in integration-results.json -out integration-results.junit.xml
+          fi
+
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() && steps.changes.outputs.code_changed == 'true' }}
+        uses: codecov/test-results-action@v1.2.1
+        with:
+          files: unit-results.junit.xml,integration-results.junit.xml
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
 
       - name: Coverage summary
         if: always() && steps.changes.outputs.code_changed == 'true'


### PR DESCRIPTION
## Summary
- Adds JUnit XML conversion of Go test results via `go-junit-report`
- Uploads test results to Codecov using `codecov/test-results-action@v1`
- Conversion and upload run with `!cancelled()` to capture test failure data

## Motivation
Enables Codecov Test Analytics at https://app.codecov.io/gh/weill-labs/amux/tests — provides test failure tracking, flaky test detection, and per-test duration trends over time.

## Testing
CI will validate this on the PR itself — the new steps will produce and upload JUnit XML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)