### PR TITLE
Fix minimized pane content lost after server hot-reload

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -834,6 +834,19 @@ func NewServerFromCheckpoint(cp *checkpoint.ServerCheckpoint) (*Server, error) {
 		p.Start()
 	}
 
+	// Save screen data for minimized panes so we can re-replay after the
+	// SIGWINCH loop. Between Start() and the SIGWINCH delay, the readLoop
+	// may consume buffered PTY output (e.g. a shell prompt produced during
+	// the exec gap) that overwrites the replayed emulator content. Visible
+	// panes recover via the SIGWINCH-triggered redraw; minimized panes need
+	// an explicit re-replay.
+	minimizedScreens := make(map[uint32]string)
+	for _, pc := range cp.Panes {
+		if pc.Meta.Minimized {
+			minimizedScreens[pc.ID] = pc.Screen
+		}
+	}
+
 	// Force TUI apps to do a full screen redraw via SIGWINCH.
 	// Skip minimized panes — their PTYs stay at pre-minimize dimensions.
 	go func() {
@@ -861,6 +874,16 @@ func NewServerFromCheckpoint(cp *checkpoint.ServerCheckpoint) (*Server, error) {
 		sess.mu.Lock()
 
 		resizeVisible(0) // Restore original size
+
+		// Re-replay saved screen data for minimized panes. The readLoop
+		// may have fed buffered PTY output into their emulators, garbling
+		// the content that was replayed during restore. Clear the screen
+		// first so the replay starts from a known state.
+		for _, p := range sess.Panes {
+			if screen, ok := minimizedScreens[p.ID]; ok {
+				p.ReplayScreen("\033[H\033[2J" + screen)
+			}
+		}
 	}()
 
 	return s, nil

--- a/test/hotreload_test.go
+++ b/test/hotreload_test.go
@@ -161,10 +161,8 @@ func TestServerReloadMinimizedPanePreservesContent(t *testing.T) {
 
 	h.splitH()
 
-	// Put content in pane-1
-	gen := h.generation()
-	h.sendKeys("C-a", "h")
-	h.waitLayout(gen)
+	// Focus pane-1 (above pane-2 in vertical stack) and put content in it
+	h.runCmd("focus", "pane-1")
 	h.sendKeys("echo RELOAD_MARKER", "Enter")
 	h.waitFor("RELOAD_MARKER", 3*time.Second)
 
@@ -187,12 +185,15 @@ func TestServerReloadMinimizedPanePreservesContent(t *testing.T) {
 		t.Fatalf("minimized pane emulator should not be garbled by SIGWINCH loop after reload, got:\n%s", paneBeforeRestore)
 	}
 
-	// Restore pane-1 and verify content survived
+	// Restore pane-1 and verify the content is still in the emulator.
+	// After restore the shell receives SIGWINCH and may redraw its prompt,
+	// but RELOAD_MARKER should still be on the visible screen or at least
+	// in the server-side emulator output.
 	h.runCmd("restore", "pane-1")
 
-	if !h.waitFor("RELOAD_MARKER", 5*time.Second) {
-		paneOut := h.runCmd("capture", "pane-1")
-		t.Fatalf("minimized pane content should survive server reload, got:\n%s", paneOut)
+	paneAfterRestore := h.runCmd("capture", "pane-1")
+	if !strings.Contains(paneAfterRestore, "RELOAD_MARKER") {
+		t.Fatalf("minimized pane content should survive server reload and restore, got:\n%s", paneAfterRestore)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Re-replay saved screen data for minimized panes after the post-reload SIGWINCH loop, preventing buffered PTY output from garbling their emulator content
- Fix test to use `runCmd("focus", "pane-1")` instead of `C-a h` (which doesn't work in vertical splits) and use server-side capture for the post-restore assertion

## Motivation
After server hot-reload, the readLoop starts consuming buffered PTY output (e.g. shell prompts produced during the exec gap) that overwrites the emulator content replayed from the checkpoint. Visible panes recover via the SIGWINCH-triggered redraw, but minimized panes are skipped by the SIGWINCH loop and have no recovery mechanism. The test also had a focus bug from the ServerHarness migration: `C-a h` (focus left) has no effect in a vertical split, so RELOAD_MARKER was written to pane-2 instead of pane-1.

## Testing
- `TestServerReloadMinimizedPanePreservesContent` passes consistently (3/3 runs with cleared cache)
- All `TestServerReload*` tests pass
- All `TestMinimize*` tests pass
- Unit tests pass (`go test ./internal/...`)

Fixes LAB-152

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>