### PR TITLE
Return string from RenderFull to eliminate double-copy

### DIFF
--- a/client.go
+++ b/client.go
@@ -148,12 +148,12 @@ func (cr *ClientRenderer) HandlePaneOutput(paneID uint32, data []byte) {
 }
 
 // Render produces ANSI output compositing all panes. Returns nil if no layout.
-func (cr *ClientRenderer) Render() []byte {
+func (cr *ClientRenderer) Render() string {
 	cr.mu.Lock()
 	defer cr.mu.Unlock()
 
 	if cr.layout == nil {
-		return nil
+		return ""
 	}
 
 	cr.dirty = false
@@ -198,12 +198,12 @@ func (cr *ClientRenderer) Resize(width, height int) {
 // renderCoalesced runs a select loop that reads messages from msgCh,
 // updates the client renderer, and coalesces renders at ~60fps.
 // Layout changes render immediately; pane output is debounced.
-func (cr *ClientRenderer) renderCoalesced(msgCh <-chan *renderMsg, write func([]byte)) {
+func (cr *ClientRenderer) renderCoalesced(msgCh <-chan *renderMsg, write func(string)) {
 	var renderTimer *time.Timer
 	var renderC <-chan time.Time
 
 	doRender := func() {
-		if data := cr.Render(); data != nil {
+		if data := cr.Render(); data != "" {
 			write(data)
 		}
 		renderTimer = nil
@@ -241,9 +241,9 @@ func (cr *ClientRenderer) renderCoalesced(msgCh <-chan *renderMsg, write func([]
 				}
 				doRender()
 			case renderMsgBell:
-				write([]byte{0x07})
+				write("\x07")
 			case renderMsgClipboard:
-				write(msg.data)
+				write(string(msg.data))
 			case renderMsgExit:
 				// Final render before exit
 				if cr.IsDirty() {

--- a/internal/render/compositor.go
+++ b/internal/render/compositor.go
@@ -60,14 +60,14 @@ func (c *Compositor) LayoutHeight() int {
 }
 
 // ClearScreen returns ANSI sequences to clear the screen and home the cursor.
-func ClearScreen() []byte {
-	return []byte(ClearAll + CursorHome)
+func ClearScreen() string {
+	return ClearAll + CursorHome
 }
 
 // RenderFull composes all panes, status lines, and borders into ANSI output.
 // lookup maps pane IDs to their rendering data. Client provides emulator-backed
 // adapters; server could provide Pane wrappers.
-func (c *Compositor) RenderFull(root *mux.LayoutCell, activePaneID uint32, lookup func(uint32) PaneData) []byte {
+func (c *Compositor) RenderFull(root *mux.LayoutCell, activePaneID uint32, lookup func(uint32) PaneData) string {
 	var buf strings.Builder
 	buf.Grow(c.width * c.height * 4) // pre-allocate for typical ANSI output
 
@@ -128,7 +128,7 @@ func (c *Compositor) RenderFull(root *mux.LayoutCell, activePaneID uint32, looku
 	// hide the terminal cursor to avoid showing two cursors.
 	c.renderCursor(&buf, root, activePaneID, lookup)
 
-	return []byte(buf.String())
+	return buf.String()
 }
 
 // renderCursor positions the terminal cursor at the active pane's cursor

--- a/internal/render/compositor_test.go
+++ b/internal/render/compositor_test.go
@@ -60,7 +60,7 @@ func TestMinimizedPaneHidesCursor(t *testing.T) {
 	}
 
 	// Active pane is the minimized pane-1
-	output := string(comp.RenderFull(root, 1, lookup))
+	output := comp.RenderFull(root, 1, lookup)
 
 	// Should NOT contain ShowCursor since the active pane is minimized
 	if strings.Contains(output, ShowCursor) {
@@ -113,7 +113,7 @@ func TestRenderCursorEdgeCases(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			comp := NewCompositor(width, height+GlobalBarHeight, "test")
-			output := string(comp.RenderFull(root, tt.activeID, tt.lookup))
+			output := comp.RenderFull(root, tt.activeID, tt.lookup)
 			hasCursor := strings.Contains(output, ShowCursor)
 			if hasCursor != tt.wantVisible {
 				t.Errorf("cursor visible = %v, want %v", hasCursor, tt.wantVisible)
@@ -228,7 +228,7 @@ func TestBlitPaneClipsToWidth(t *testing.T) {
 	}
 
 	output := comp.RenderFull(root, 1, lookup)
-	grid := MaterializeGrid(string(output), width, height+GlobalBarHeight)
+	grid := MaterializeGrid(output, width, height+GlobalBarHeight)
 	lines := strings.Split(grid, "\n")
 
 	// Row 0 is the status line; row 1 is the content row.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -413,9 +413,9 @@ func (s *Session) renderCapture(stripANSI bool) string {
 		root = mux.NewLeafByID(w.ZoomedPaneID, 0, 0, w.Width, w.Height)
 	}
 
-	raw := string(comp.RenderFull(root, activePaneID, func(id uint32) render.PaneData {
+	raw := comp.RenderFull(root, activePaneID, func(id uint32) render.PaneData {
 		return paneMap[id]
-	}))
+	})
 
 	if stripANSI {
 		return render.MaterializeGrid(raw, w.Width, totalH)

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"net"
 	"os"
 	"os/exec"
@@ -522,8 +523,8 @@ func runMux(sessionName string) error {
 	// Coalescing render loop
 	go func() {
 		defer close(done)
-		cr.renderCoalesced(msgCh, func(data []byte) {
-			os.Stdout.Write(data)
+		cr.renderCoalesced(msgCh, func(data string) {
+			io.WriteString(os.Stdout, data)
 		})
 	}()
 
@@ -609,8 +610,8 @@ func runMux(sessionName string) error {
 					}
 				case "copy-mode":
 					cr.EnterCopyMode(cr.ActivePaneID())
-					if data := cr.Render(); data != nil {
-						os.Stdout.Write(data)
+					if data := cr.Render(); data != "" {
+						io.WriteString(os.Stdout, data)
 					}
 				default:
 					// Generic server command
@@ -724,8 +725,8 @@ func runMux(sessionName string) error {
 					}
 					cr.ExitCopyMode(paneID)
 				}
-				if data := cr.Render(); data != nil {
-					os.Stdout.Write(data)
+				if data := cr.Render(); data != "" {
+					io.WriteString(os.Stdout, data)
 				}
 				continue
 			}


### PR DESCRIPTION
## Summary
- Change `RenderFull` return type from `[]byte` to `string`, returning `buf.String()` directly instead of `[]byte(buf.String())` which copies the buffer twice
- Update `ClearScreen` return type from `[]byte` to `string` for consistency
- Update `ClientRenderer.Render()` and `renderCoalesced` callback to use `string` throughout
- Update all callers: `server.go` (remove `string()` wrapper), `main.go` (use `io.WriteString`), tests (remove `string()` casts)

## Motivation
`[]byte(buf.String())` performs two allocations: `String()` copies the builder's internal buffer, then the `[]byte()` conversion copies it again. Returning `string` directly eliminates one copy on every render frame.

## Testing
- `go build ./...` compiles cleanly
- `go test ./...` passes (all packages including integration tests)

Fixes LAB-170

🤖 Generated with [Claude Code](https://claude.com/claude-code)