### PR TITLE
Enable race detector in CI unit tests

### DIFF
--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -31,7 +31,7 @@ integ_rc=0
 
 # --- Unit tests ---
 echo "=== Unit tests ==="
-unit_args=(-coverprofile=unit-coverage.txt -covermode=atomic ./internal/... -timeout 60s)
+unit_args=(-race -coverprofile=unit-coverage.txt -covermode=atomic ./internal/... -timeout 60s)
 if [[ "$CI_MODE" == true ]]; then
   go test -json "${unit_args[@]}" | tee unit-results.json || unit_rc=$?
 else


### PR DESCRIPTION
## Summary
- Add `-race` flag to unit test invocation in `scripts/coverage.sh`

## Motivation
The hexColorCache data race (LAB-169) was only caught by code review. Adding `-race` to CI catches these automatically. Applied only to unit tests — integration tests fork subprocesses where the race detector adds too much overhead.

## Testing
One-line change to a shell script. CI will validate itself.


🤖 Generated with [Claude Code](https://claude.com/claude-code)