### PR TITLE
Binary protocol for PaneOutput messages (LAB-167)

### DIFF
--- a/internal/server/protocol.go
+++ b/internal/server/protocol.go
@@ -73,28 +73,118 @@ type Message struct {
 
 const maxMessageSize = 16 * 1024 * 1024 // 16 MB
 
-// WriteMsg encodes and writes a length-prefixed message to w.
+// Wire format discriminators. The first byte on the wire identifies the
+// encoding used for the rest of the message:
+//   - wireFormatGob:    [0x00][length:4 BE][gob payload]
+//   - wireFormatBinary: [0x01][paneID:4 BE][length:4 BE][pane data]
+const (
+	wireFormatGob    byte = 0x00
+	wireFormatBinary byte = 0x01
+)
+
+// WriteMsg encodes and writes a message to w.
+//
+// MsgTypePaneOutput uses a compact binary encoding (no gob overhead).
+// All other message types use the original length-prefixed gob encoding.
 func WriteMsg(w io.Writer, msg *Message) error {
+	if msg.Type == MsgTypePaneOutput {
+		return writePaneOutputBinary(w, msg)
+	}
+	return writeMsgGob(w, msg)
+}
+
+// writePaneOutputBinary writes a PaneOutput message using compact binary
+// framing: [0x01][paneID:4 BE][length:4 BE][data].
+func writePaneOutputBinary(w io.Writer, msg *Message) error {
+	dataLen := len(msg.PaneData)
+	// Header: 1 (discriminator) + 4 (paneID) + 4 (length) = 9 bytes
+	var hdr [9]byte
+	hdr[0] = wireFormatBinary
+	binary.BigEndian.PutUint32(hdr[1:5], msg.PaneID)
+	binary.BigEndian.PutUint32(hdr[5:9], uint32(dataLen))
+	if _, err := w.Write(hdr[:]); err != nil {
+		return fmt.Errorf("writing binary header: %w", err)
+	}
+	if dataLen > 0 {
+		if _, err := w.Write(msg.PaneData); err != nil {
+			return fmt.Errorf("writing pane data: %w", err)
+		}
+	}
+	return nil
+}
+
+// writeMsgGob writes a gob-encoded message with format:
+// [0x00][length:4 BE][gob payload].
+func writeMsgGob(w io.Writer, msg *Message) error {
 	var buf bytes.Buffer
 	if err := gob.NewEncoder(&buf).Encode(msg); err != nil {
 		return fmt.Errorf("encoding message: %w", err)
 	}
 
-	length := uint32(buf.Len())
-	if err := binary.Write(w, binary.BigEndian, length); err != nil {
-		return fmt.Errorf("writing length: %w", err)
+	// Header: 1 (discriminator) + 4 (length) = 5 bytes
+	var hdr [5]byte
+	hdr[0] = wireFormatGob
+	binary.BigEndian.PutUint32(hdr[1:5], uint32(buf.Len()))
+	if _, err := w.Write(hdr[:]); err != nil {
+		return fmt.Errorf("writing gob header: %w", err)
 	}
 
 	_, err := w.Write(buf.Bytes())
 	return err
 }
 
-// ReadMsg reads a length-prefixed message from r.
+// ReadMsg reads a message from r. It inspects the first byte to determine
+// whether the message uses binary PaneOutput encoding or gob encoding.
 func ReadMsg(r io.Reader) (*Message, error) {
-	var length uint32
-	if err := binary.Read(r, binary.BigEndian, &length); err != nil {
+	var disc [1]byte
+	if _, err := io.ReadFull(r, disc[:]); err != nil {
 		return nil, err
 	}
+
+	if disc[0] == wireFormatBinary {
+		return readPaneOutputBinary(r)
+	}
+	return readMsgGob(r)
+}
+
+// readPaneOutputBinary reads the remainder of a binary PaneOutput message
+// after the discriminator byte has been consumed.
+// Format: [paneID:4 BE][length:4 BE][data].
+func readPaneOutputBinary(r io.Reader) (*Message, error) {
+	var hdr [8]byte
+	if _, err := io.ReadFull(r, hdr[:]); err != nil {
+		return nil, err
+	}
+
+	paneID := binary.BigEndian.Uint32(hdr[0:4])
+	dataLen := binary.BigEndian.Uint32(hdr[4:8])
+
+	if dataLen > maxMessageSize {
+		return nil, fmt.Errorf("message too large: %d bytes", dataLen)
+	}
+
+	data := make([]byte, dataLen)
+	if dataLen > 0 {
+		if _, err := io.ReadFull(r, data); err != nil {
+			return nil, err
+		}
+	}
+
+	return &Message{
+		Type:     MsgTypePaneOutput,
+		PaneID:   paneID,
+		PaneData: data,
+	}, nil
+}
+
+// readMsgGob reads the remainder of a gob-encoded message after the
+// discriminator byte has been consumed. Format: [length:4 BE][gob payload].
+func readMsgGob(r io.Reader) (*Message, error) {
+	var lenBuf [4]byte
+	if _, err := io.ReadFull(r, lenBuf[:]); err != nil {
+		return nil, err
+	}
+	length := binary.BigEndian.Uint32(lenBuf[:])
 
 	if length > maxMessageSize {
 		return nil, fmt.Errorf("message too large: %d bytes", length)

--- a/internal/server/protocol_test.go
+++ b/internal/server/protocol_test.go
@@ -47,6 +47,18 @@ func TestWriteReadMsg(t *testing.T) {
 			name: "empty input",
 			msg:  Message{Type: MsgTypeInput, Input: []byte{}},
 		},
+		{
+			name: "pane output",
+			msg:  Message{Type: MsgTypePaneOutput, PaneID: 7, PaneData: []byte("terminal output")},
+		},
+		{
+			name: "pane output empty data",
+			msg:  Message{Type: MsgTypePaneOutput, PaneID: 1, PaneData: []byte{}},
+		},
+		{
+			name: "pane output large pane id",
+			msg:  Message{Type: MsgTypePaneOutput, PaneID: 0xFFFFFFFF, PaneData: []byte("x")},
+		},
 	}
 
 	for _, tt := range tests {
@@ -84,6 +96,12 @@ func TestWriteReadMsg(t *testing.T) {
 			if got.CmdOutput != tt.msg.CmdOutput {
 				t.Errorf("CmdOutput = %q, want %q", got.CmdOutput, tt.msg.CmdOutput)
 			}
+			if got.PaneID != tt.msg.PaneID {
+				t.Errorf("PaneID = %d, want %d", got.PaneID, tt.msg.PaneID)
+			}
+			if !bytes.Equal(got.PaneData, tt.msg.PaneData) {
+				t.Errorf("PaneData = %q, want %q", got.PaneData, tt.msg.PaneData)
+			}
 		})
 	}
 }
@@ -92,9 +110,13 @@ func TestWriteReadMultiple(t *testing.T) {
 	t.Parallel()
 	var buf bytes.Buffer
 
+	// Interleave gob and binary (PaneOutput) messages on the same stream
+	// to verify the discriminator byte correctly routes decoding.
 	msgs := []Message{
 		{Type: MsgTypeAttach, Session: "s1", Cols: 80, Rows: 24},
+		{Type: MsgTypePaneOutput, PaneID: 1, PaneData: []byte("hello from pane 1")},
 		{Type: MsgTypeInput, Input: []byte("ls\n")},
+		{Type: MsgTypePaneOutput, PaneID: 2, PaneData: []byte("hello from pane 2")},
 		{Type: MsgTypeResize, Cols: 120, Rows: 40},
 		{Type: MsgTypeDetach},
 	}
@@ -112,6 +134,12 @@ func TestWriteReadMultiple(t *testing.T) {
 		}
 		if got.Type != want.Type {
 			t.Errorf("msg[%d].Type = %d, want %d", i, got.Type, want.Type)
+		}
+		if got.PaneID != want.PaneID {
+			t.Errorf("msg[%d].PaneID = %d, want %d", i, got.PaneID, want.PaneID)
+		}
+		if !bytes.Equal(got.PaneData, want.PaneData) {
+			t.Errorf("msg[%d].PaneData = %q, want %q", i, got.PaneData, want.PaneData)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- Replace gob encoding with compact binary framing for `MsgTypePaneOutput` messages, the hottest path in the wire protocol (every byte of terminal output flows through it)
- All other message types retain gob encoding unchanged
- Uses a 1-byte wire format discriminator (`0x00` = gob, `0x01` = binary) to multiplex both formats on the same stream

## Motivation

PaneOutput is sent for every byte of terminal output from every pane. Gob encoding imposes reflection overhead and high allocation counts that are unnecessary for this simple `(paneID, data)` message. Binary framing eliminates this overhead entirely.

## Wire format

```
Gob:    [0x00][length:4 BE][gob payload]
Binary: [0x01][paneID:4 BE][length:4 BE][pane data]
```

The discriminator byte approach is backwards-incompatible at the wire level, but server and client are always the same binary (hot-reload rebuilds both), so this is safe.

## Baseline numbers

Apple M4, macOS, `go test -bench -count=3`:

### WriteMsg PaneOutput

| Payload | Before (ns/op) | After (ns/op) | Speedup | Before allocs | After allocs |
|---------|----------------|---------------|---------|---------------|--------------|
| 256B    | 7,043          | 14.8          | **476x** | 35            | 1            |
| 4KB     | 6,800          | 60            | **113x** | 35            | 1            |
| 32KB    | 11,850         | 589           | **20x**  | 35            | 1            |

### ReadMsg PaneOutput

| Payload | Before (ns/op) | After (ns/op) | Speedup | Before allocs | After allocs |
|---------|----------------|---------------|---------|---------------|--------------|
| 256B    | 16,900         | 93.5          | **181x** | 417           | 5            |
| 4KB     | 17,700         | 410           | **43x**  | 417           | 5            |
| 32KB    | 24,300         | 2,329         | **10x**  | 417           | 5            |

Layout message benchmarks are unchanged (gob path unaffected).

## Testing

- All existing unit tests pass (protocol round-trip for all message types)
- Added test cases for binary PaneOutput: normal data, empty data, max pane ID
- Added interleaved binary/gob messages in `TestWriteReadMultiple` to verify discriminator routing
- All integration tests pass (`go test ./...`)

## Review focus

- Wire format discriminator design in `WriteMsg`/`ReadMsg`
- Edge cases: empty `PaneData`, max `PaneID` (`0xFFFFFFFF`)

Fixes LAB-167