### PR TITLE
Document `make setup` in Build and Test section

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,7 @@ test/
 ### Build and Test
 
 ```bash
+make setup                         # after cloning: activate git hooks (formatting, lint, commit guards)
 go build -o ~/.local/bin/amux .    # build + install (client hot-reloads automatically)
 go test ./...                       # run all tests
 ```


### PR DESCRIPTION
## Summary
- Add `make setup` as the first command in the Build and Test code block in CLAUDE.md
- The `.githooks/` directory has pre-commit hooks (goimports, time.Sleep blocker, YAML lint) that only activate after `make setup` runs `git config core.hooksPath .githooks`
- This makes the setup step discoverable for developers cloning the repo

## Motivation
Developers cloning the repo without running `make setup` won't have pre-commit hooks active, so formatting and lint issues slip through to PR review. Adding it to the Build and Test section ensures it's the first thing developers see.

## Test plan
- [ ] Documentation-only change, no functional impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)