### PR TITLE
Add wait-idle server command (LAB-173)

### DIFF
--- a/internal/server/client_conn.go
+++ b/internal/server/client_conn.go
@@ -824,6 +824,69 @@ func (cc *ClientConn) handleCommand(srv *Server, sess *Session, msg *Message) {
 			}
 		}
 
+	case "wait-idle":
+		if len(msg.CmdArgs) < 1 {
+			cc.Send(&Message{Type: MsgTypeCmdResult, CmdErr: "usage: wait-idle <pane> [--timeout <duration>]"})
+			return
+		}
+		paneRef := msg.CmdArgs[0]
+		timeout := 5 * time.Second
+		for i := 1; i < len(msg.CmdArgs); i++ {
+			if msg.CmdArgs[i] == "--timeout" && i+1 < len(msg.CmdArgs) {
+				i++
+				d, err := time.ParseDuration(msg.CmdArgs[i])
+				if err != nil {
+					cc.Send(&Message{Type: MsgTypeCmdResult, CmdErr: fmt.Sprintf("invalid timeout: %s", msg.CmdArgs[i])})
+					return
+				}
+				timeout = d
+			}
+		}
+
+		sess.mu.Lock()
+		pane := cc.resolvePaneAcrossWindows(sess, "wait-idle", paneRef)
+		if pane == nil {
+			sess.mu.Unlock()
+			return
+		}
+		paneID := pane.ID
+		sess.mu.Unlock()
+
+		// Check immediately — the pane may already be idle.
+		if sess.paneIsIdle(paneID) {
+			cc.Send(&Message{Type: MsgTypeCmdResult, CmdOutput: "idle\n"})
+			return
+		}
+
+		// Subscribe to pane output notifications and check on each write.
+		// Also use a ticker as fallback: the child process may exit between
+		// output writes, so the ticker rechecks every 100ms to catch the
+		// transition to idle.
+		ch := sess.subscribePaneOutput(paneID)
+		defer sess.unsubscribePaneOutput(paneID, ch)
+
+		ticker := time.NewTicker(100 * time.Millisecond)
+		defer ticker.Stop()
+		timer := time.NewTimer(timeout)
+		defer timer.Stop()
+		for {
+			select {
+			case <-ch:
+				if sess.paneIsIdle(paneID) {
+					cc.Send(&Message{Type: MsgTypeCmdResult, CmdOutput: "idle\n"})
+					return
+				}
+			case <-ticker.C:
+				if sess.paneIsIdle(paneID) {
+					cc.Send(&Message{Type: MsgTypeCmdResult, CmdOutput: "idle\n"})
+					return
+				}
+			case <-timer.C:
+				cc.Send(&Message{Type: MsgTypeCmdResult, CmdErr: fmt.Sprintf("timeout waiting for %s to become idle", paneRef)})
+				return
+			}
+		}
+
 	case "set-hook":
 		if len(msg.CmdArgs) < 2 {
 			cc.Send(&Message{Type: MsgTypeCmdResult, CmdErr: "usage: set-hook <event> <command>"})

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -572,6 +572,26 @@ func (s *Session) paneIsBusy(paneID uint32) bool {
 	return !status.Idle
 }
 
+// paneIsIdle checks whether the given pane has no child processes (shell is
+// at prompt). Thread-safe: looks up the pane under s.mu, then inspects the
+// process tree outside the lock.
+func (s *Session) paneIsIdle(paneID uint32) bool {
+	s.mu.Lock()
+	var pane *mux.Pane
+	for _, p := range s.Panes {
+		if p.ID == paneID {
+			pane = p
+			break
+		}
+	}
+	s.mu.Unlock()
+	if pane == nil {
+		return true
+	}
+	status := pane.AgentStatus()
+	return status.Idle
+}
+
 // trackPaneActivity is called on every PTY output. It resets the idle timer
 // and fires on-activity if the pane was previously idle.
 func (s *Session) trackPaneActivity(paneID uint32) {

--- a/main.go
+++ b/main.go
@@ -172,6 +172,12 @@ func main() {
 			os.Exit(1)
 		}
 		runServerCommand("wait-busy", args[1:])
+	case "wait-idle":
+		if len(args) < 2 {
+			fmt.Fprintf(os.Stderr, "usage: amux wait-idle <pane> [--timeout <duration>]\n")
+			os.Exit(1)
+		}
+		runServerCommand("wait-idle", args[1:])
 	case "clipboard-gen":
 		runServerCommand("clipboard-gen", nil)
 	case "wait-clipboard":
@@ -273,6 +279,10 @@ Usage:
                                        Block until layout generation > N
   amux [-s session] wait-for <pane> <substring> [--timeout 3s]
                                        Block until substring appears in pane
+  amux [-s session] wait-busy <pane> [--timeout 5s]
+                                       Block until pane has child processes
+  amux [-s session] wait-idle <pane> [--timeout 5s]
+                                       Block until pane has no child processes
   amux version                         Show build version
 
 Panes can be referenced by name (pane-1) or ID (1).

--- a/test/capture_test.go
+++ b/test/capture_test.go
@@ -93,15 +93,22 @@ func TestCaptureIdleIndicator(t *testing.T) {
 	// Split so pane-1 becomes inactive (pane-2 gets focus)
 	h.splitV()
 
-	// Wait for the idle timer to fire (DefaultIdleTimeout = 2s).
-	// The inactive pane's shell is at the prompt with no children,
-	// so it will transition to idle and show the ◇ indicator.
+	// Wait for pane-1 to be idle (no child processes), then poll for the
+	// idle timer to fire (DefaultIdleTimeout = 2s) which sets the idle
+	// state tracked by the server and shows the ◇ indicator.
+	h.waitIdle("pane-1")
 	h.waitFor("pane-2", "$")
-	time.Sleep(3 * time.Second)
 
-	out := h.capture()
-	if !strings.Contains(out, "◇") {
-		t.Errorf("capture should show idle diamond indicator for inactive idle pane, got:\n%s", out)
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		out := h.capture()
+		if strings.Contains(out, "◇") {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("capture should show idle diamond indicator for inactive idle pane, got:\n%s", out)
+		}
+		time.Sleep(100 * time.Millisecond)
 	}
 }
 

--- a/test/server_harness_test.go
+++ b/test/server_harness_test.go
@@ -278,6 +278,16 @@ func (h *ServerHarness) waitBusy(pane string) {
 	}
 }
 
+// waitIdle blocks until the named pane has no child processes (shell is at prompt).
+// Uses the server's wait-idle command (blocking, zero polling).
+func (h *ServerHarness) waitIdle(pane string) {
+	h.tb.Helper()
+	out := h.runCmd("wait-idle", pane, "--timeout", "5s")
+	if strings.Contains(out, "timeout") || strings.Contains(out, "not found") {
+		h.tb.Fatalf("wait-idle %s: %s\ncapture:\n%s", pane, strings.TrimSpace(out), h.capture())
+	}
+}
+
 // generation returns the current layout generation counter.
 func (h *ServerHarness) generation() uint64 {
 	h.tb.Helper()


### PR DESCRIPTION
## Summary
- Add `wait-idle` command that blocks until a pane has no child processes (shell is at prompt), mirroring the existing `wait-busy` command
- Add `paneIsIdle()` session method, `wait-idle` handler, CLI dispatch, `waitIdle()` test helper, and usage docs
- Update `TestCaptureIdleIndicator` to use `waitIdle` instead of `time.Sleep(3s)`, polling for the idle timer diamond indicator

## Motivation
Tests that need to wait for a pane to become idle currently use `time.Sleep`, which is slow and flaky. `wait-idle` provides a deterministic, blocking alternative that checks process state via `pgrep`, matching the pattern established by `wait-busy`.

## Testing
- All existing tests pass (`go test ./... -timeout 120s`)
- `TestCaptureIdleIndicator` updated to use the new `waitIdle` helper

## Review focus
- The `wait-idle` handler in `client_conn.go` mirrors `wait-busy` exactly (same timeout parsing, same ticker+subscriber polling pattern)
- `paneIsIdle` in `server.go` is the inverse of `paneIsBusy` (returns `status.Idle` instead of `!status.Idle`)

Fixes LAB-173

🤖 Generated with [Claude Code](https://claude.com/claude-code)