### PR TITLE
Add benchmark trend dashboard on GitHub Pages

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -101,7 +101,116 @@ jobs:
           fi
 
           cp /tmp/bench-data/* . 2>/dev/null || true
-          git add benchmarks.json bench-all.txt 2>/dev/null || true
+
+          # Generate dashboard HTML if it doesn't exist
+          if [ ! -f index.html ]; then
+            cat > index.html << 'HTMLEOF'
+          <!DOCTYPE html>
+          <html lang="en">
+          <head>
+            <meta charset="utf-8">
+            <meta name="viewport" content="width=device-width, initial-scale=1">
+            <title>amux benchmarks</title>
+            <script src="https://cdn.jsdelivr.net/npm/chart.js@4"></script>
+            <style>
+              * { margin: 0; padding: 0; box-sizing: border-box; }
+              body { font-family: system-ui, sans-serif; background: #1e1e2e; color: #cdd6f4; padding: 2rem; }
+              h1 { margin-bottom: 0.5rem; }
+              p.subtitle { color: #6c7086; margin-bottom: 2rem; }
+              .chart-container { background: #313244; border-radius: 8px; padding: 1rem; margin-bottom: 1.5rem; }
+              .chart-container h2 { font-size: 1rem; margin-bottom: 0.5rem; color: #89b4fa; }
+              canvas { max-height: 300px; }
+              .error { color: #f38ba8; padding: 2rem; }
+            </style>
+          </head>
+          <body>
+            <h1>amux benchmark trends</h1>
+            <p class="subtitle">Updated on each merge to main</p>
+            <div id="charts"></div>
+            <script>
+              const COLORS = ['#89b4fa','#a6e3a1','#f9e2af','#f38ba8','#cba6f7','#94e2d5','#fab387','#74c7ec'];
+
+              async function main() {
+                const container = document.getElementById('charts');
+                let data;
+                try {
+                  const res = await fetch('benchmarks.json');
+                  data = await res.json();
+                } catch (e) {
+                  container.innerHTML = '<p class="error">No benchmark data yet. Data appears after the first merge to main.</p>';
+                  return;
+                }
+                if (!data || !data.length) {
+                  container.innerHTML = '<p class="error">No benchmark data yet.</p>';
+                  return;
+                }
+
+                // Group benchmarks by suite (top-level name)
+                const suites = {};
+                for (const run of data) {
+                  for (const suite of (run.Suites || [])) {
+                    for (const bench of (suite.Benchmarks || [])) {
+                      const name = bench.Name;
+                      const parts = name.split('/');
+                      const suiteName = parts[0].replace(/^Benchmark/, '');
+                      if (!suites[suiteName]) suites[suiteName] = {};
+                      if (!suites[suiteName][name]) suites[suiteName][name] = [];
+                      suites[suiteName][name].push({
+                        date: run.Date ? new Date(run.Date * 1000).toLocaleDateString() : '?',
+                        nsOp: bench.NsPerOp || 0,
+                        allocsOp: bench.AllocsPerOp || 0,
+                        bytesOp: bench.Mem || 0,
+                      });
+                    }
+                  }
+                }
+
+                let colorIdx = 0;
+                for (const [suiteName, benchmarks] of Object.entries(suites)) {
+                  const div = document.createElement('div');
+                  div.className = 'chart-container';
+                  div.innerHTML = '<h2>' + suiteName + '</h2><canvas></canvas>';
+                  container.appendChild(div);
+
+                  const datasets = [];
+                  let labels = [];
+                  for (const [name, points] of Object.entries(benchmarks)) {
+                    const shortName = name.split('/').slice(1).join('/') || name;
+                    if (points.length > labels.length) labels = points.map(p => p.date);
+                    datasets.push({
+                      label: shortName,
+                      data: points.map(p => p.nsOp / 1e6),
+                      borderColor: COLORS[colorIdx % COLORS.length],
+                      backgroundColor: COLORS[colorIdx % COLORS.length] + '33',
+                      tension: 0.3,
+                      pointRadius: 3,
+                    });
+                    colorIdx++;
+                  }
+
+                  new Chart(div.querySelector('canvas'), {
+                    type: 'line',
+                    data: { labels, datasets },
+                    options: {
+                      responsive: true,
+                      plugins: { legend: { labels: { color: '#cdd6f4' } } },
+                      scales: {
+                        x: { ticks: { color: '#6c7086' }, grid: { color: '#45475a' } },
+                        y: { title: { display: true, text: 'ms/op', color: '#6c7086' },
+                             ticks: { color: '#6c7086' }, grid: { color: '#45475a' } },
+                      },
+                    },
+                  });
+                }
+              }
+              main();
+            </script>
+          </body>
+          </html>
+          HTMLEOF
+          fi
+
+          git add benchmarks.json bench-all.txt index.html 2>/dev/null || true
           git diff --cached --quiet || git commit -m "Update benchmark data [skip ci]"
           git push origin gh-pages 2>/dev/null || true
 


### PR DESCRIPTION
## Summary
- Add `index.html` generation to the benchmark workflow's gh-pages update step
- Uses Chart.js to render `benchmarks.json` as interactive line charts
- Catppuccin Mocha color palette, one chart per benchmark suite
- Dashboard auto-updates on each merge to main

## How it works
1. Benchmark workflow runs on push to main
2. `gobenchdata` merges results into `benchmarks.json`
3. Workflow generates `index.html` if missing (Chart.js dashboard)
4. Both files are committed to `gh-pages` branch
5. GitHub Pages serves the dashboard

Dashboard URL (after first run): https://weill-labs.github.io/amux/

## Testing
Workflow change only. The HTML is static and self-contained — Chart.js loaded from CDN.

## Setup needed after merge
Run `gh api repos/weill-labs/amux/pages -X POST --input - <<< '{"source":{"branch":"gh-pages","path":"/"}}'` to enable GitHub Pages once the gh-pages branch exists.


🤖 Generated with [Claude Code](https://claude.com/claude-code)