### PR TITLE
Fix benchmark workflow checkout failure on gh-pages update

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -89,6 +89,8 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
+          ORIGINAL_REF=$(git rev-parse HEAD)
+
           mkdir -p /tmp/bench-data
           cp benchmarks.json /tmp/bench-data/ 2>/dev/null || true
           cp bench-all.txt /tmp/bench-data/
@@ -105,5 +107,5 @@ jobs:
           git diff --cached --quiet || git commit -m "Update benchmark data [skip ci]"
           git push origin gh-pages 2>/dev/null || true
 
-          git checkout -
+          git checkout "$ORIGINAL_REF"
 


### PR DESCRIPTION
## Summary
- `git checkout -` fails after `git checkout --orphan gh-pages` because there is no valid "previous branch" ref
- Replaced with explicit `git checkout "$ORIGINAL_REF"` using the saved commit SHA
- This was causing 100% failure rate on Benchmarks workflow for every main push

## Motivation
Every Benchmarks CI run on main has been failing with `error: pathspec '-' did not match any file(s) known to git`. The benchmarks themselves run fine — only the trend data update step fails, preventing benchmark history from being saved to gh-pages.

## Testing
The fix is a single-line change in a CI workflow. Verified by reading the git checkout documentation — `git checkout -` is equivalent to `git checkout @{-1}`, which requires a valid previous branch in the reflog. After orphan creation, this ref doesn't exist. Using an explicit SHA avoids the reflog dependency entirely.

## Review focus
- Confirm `git rev-parse HEAD` captures the right ref before the branch switch
- Confirm `git checkout <SHA>` works in detached HEAD state (it does — this is standard git behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)