### PR TITLE
Surface gh-pages push errors in benchmark workflow

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -214,7 +214,7 @@ jobs:
 
           git add benchmarks.json bench-all.txt index.html 2>/dev/null || true
           git diff --cached --quiet || git commit -m "Update benchmark data [skip ci]"
-          git push origin gh-pages 2>/dev/null || true
+          git push origin gh-pages || echo "::warning::Failed to push to gh-pages"
 
           git checkout "$ORIGINAL_REF"
 


### PR DESCRIPTION
## Summary
Replace `2>/dev/null || true` on the gh-pages push with a visible warning annotation so we can diagnose why the benchmark dashboard isn't populating.

## Motivation
The benchmark workflow's "Update trend data" step succeeds but the gh-pages branch never gets created. The push error is silenced by `2>/dev/null || true`. This change surfaces the error as a workflow warning.


🤖 Generated with [Claude Code](https://claude.com/claude-code)