### PR TITLE
Bump GitHub Actions for Node.js 24 compatibility

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -11,7 +11,7 @@ jobs:
   benchmark:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.2.2
+      - uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0
 
@@ -28,7 +28,7 @@ jobs:
             echo "code_changed=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - uses: actions/setup-go@v5.4.0
+      - uses: actions/setup-go@v6.3.0
         if: steps.changes.outputs.code_changed == 'true'
         with:
           go-version: "1.25"
@@ -55,7 +55,7 @@ jobs:
 
       - name: Upload benchmark results
         if: always() && steps.changes.outputs.code_changed == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.0
         with:
           name: benchmark-results
           path: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.2.2
+      - uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 2
 
@@ -39,14 +39,14 @@ jobs:
             echo "code_changed=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - uses: actions/setup-go@v5.4.0
+      - uses: actions/setup-go@v6.3.0
         if: steps.changes.outputs.code_changed == 'true'
         with:
           go-version: "1.25"
 
       - name: Cache apt packages
         if: steps.changes.outputs.code_changed == 'true'
-        uses: actions/cache@v4
+        uses: actions/cache@v5.0.3
         with:
           path: ~/apt-cache
           key: apt-tmux-${{ runner.os }}
@@ -65,7 +65,7 @@ jobs:
 
       - name: Cache Go tools
         if: steps.changes.outputs.code_changed == 'true'
-        uses: actions/cache@v4
+        uses: actions/cache@v5.0.3
         with:
           path: ~/go/bin
           key: go-tools-${{ runner.os }}-junit-report-v2.1.0


### PR DESCRIPTION
## Summary

- Bump `actions/checkout` v4.2.2 -> v6.0.2
- Bump `actions/setup-go` v5.4.0 -> v6.3.0
- Bump `actions/cache` v4 -> v5.0.3
- Bump `actions/upload-artifact` v4 -> v7.0.0

GitHub Actions will stop supporting Node.js 20 on **June 2, 2026**. All `actions/*` dependencies are updated to their latest major versions which include Node.js 24 support, resolving the deprecation warnings.

Codecov actions (`codecov-action@v5.5.2`, `test-results-action@v1.2.1`) are already at their latest versions.

## Testing

No workflow logic changed — version pins only. CI on this PR validates that the updated actions work correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)