### PR TITLE
Event-based wait-busy + cached idle in capture JSON (LAB-192, LAB-193)

### DIFF
--- a/internal/mux/pane.go
+++ b/internal/mux/pane.go
@@ -153,6 +153,22 @@ func (p *Pane) PtmxFd() int {
 	return int(p.ptmx.Fd())
 }
 
+// ShellName returns the shell's command name (e.g., "bash", "zsh") without
+// forking a subprocess. Falls back to processName() if the cmd path is unavailable.
+func (p *Pane) ShellName() string {
+	if p.cmd != nil {
+		name := p.cmd.Path
+		if idx := strings.LastIndex(name, "/"); idx >= 0 {
+			name = name[idx+1:]
+		}
+		return strings.TrimPrefix(name, "-")
+	}
+	if pid := p.ProcessPid(); pid != 0 {
+		return processName(pid)
+	}
+	return ""
+}
+
 // ProcessPid returns the PID of the shell process.
 func (p *Pane) ProcessPid() int {
 	if p.cmd != nil {
@@ -346,16 +362,6 @@ func StripANSI(s string) string {
 	return ansiRe.ReplaceAllString(s, "")
 }
 
-// IsIdle returns true when the shell has no child processes (sitting at a prompt).
-// This is a lightweight check (single pgrep call) suitable for the hot snapshot
-// path. For full agent status with idle_since tracking, use AgentStatus().
-func (p *Pane) IsIdle() bool {
-	pid := p.ProcessPid()
-	if pid == 0 {
-		return true
-	}
-	return len(childPIDs(pid)) == 0
-}
 
 // Close terminates the pane's shell and PTY.
 // For proxy panes (no PTY), Close() just marks the pane as closed.

--- a/internal/server/capture_json.go
+++ b/internal/server/capture_json.go
@@ -15,9 +15,10 @@ type paneCapture struct {
 }
 
 // captureJSON returns the full-screen JSON capture of the active window.
-// Caller does NOT hold s.mu — this method acquires and releases it,
-// then calls AgentStatus() outside the lock to avoid blocking the
-// server on subprocess calls (pgrep/ps).
+// Caller does NOT hold s.mu — this method acquires and releases it.
+// Uses the server's cached idleState for the idle field (no pgrep for idle
+// panes). For busy panes, calls AgentStatus() outside the lock to get
+// current_command and child_pids.
 func (s *Session) captureJSON() string {
 	s.mu.Lock()
 
@@ -57,6 +58,18 @@ func (s *Session) captureJSON() string {
 		Height: w.Height,
 	}
 
+	// Snapshot cached idle state under idleTimerMu.
+	s.idleTimerMu.Lock()
+	idleSnap := make(map[uint32]bool, len(s.idleState))
+	sinceSnap := make(map[uint32]time.Time, len(s.idleSince))
+	for id, idle := range s.idleState {
+		idleSnap[id] = idle
+	}
+	for id, t := range s.idleSince {
+		sinceSnap[id] = t
+	}
+	s.idleTimerMu.Unlock()
+
 	// Gather pane data under the lock (metadata, cursor, content).
 	var panes []paneCapture
 	root.Walk(func(c *mux.LayoutCell) {
@@ -93,13 +106,22 @@ func (s *Session) captureJSON() string {
 
 	s.mu.Unlock()
 
-	// Call AgentStatus() outside the lock — spawns pgrep/ps subprocesses.
+	// Populate agent status using cached idle state where possible.
+	// Idle panes skip pgrep entirely; busy panes call AgentStatus()
+	// for current_command and child_pids.
 	for _, pc := range panes {
-		status := pc.pane.AgentStatus()
-		pc.cp.Idle = status.Idle
-		pc.cp.IdleSince = formatIdleSince(status.IdleSince)
-		pc.cp.CurrentCommand = status.CurrentCommand
-		pc.cp.ChildPIDs = status.ChildPIDs
+		if idleSnap[pc.pane.ID] {
+			pc.cp.Idle = true
+			pc.cp.IdleSince = formatIdleSince(sinceSnap[pc.pane.ID])
+			pc.cp.CurrentCommand = pc.pane.ShellName()
+			pc.cp.ChildPIDs = []int{}
+		} else {
+			status := pc.pane.AgentStatus()
+			pc.cp.Idle = status.Idle
+			pc.cp.IdleSince = formatIdleSince(status.IdleSince)
+			pc.cp.CurrentCommand = status.CurrentCommand
+			pc.cp.ChildPIDs = status.ChildPIDs
+		}
 		capture.Panes = append(capture.Panes, pc.cp)
 	}
 
@@ -108,8 +130,8 @@ func (s *Session) captureJSON() string {
 }
 
 // capturePaneJSON returns a single pane's JSON capture.
-// Caller must hold s.mu. This method releases s.mu before calling
-// AgentStatus() to avoid blocking the server on subprocess calls.
+// Caller must hold s.mu. Uses cached idleState for idle panes (no pgrep).
+// For busy panes, releases s.mu to call AgentStatus(), then re-locks.
 func (s *Session) capturePaneJSON(pane *mux.Pane) string {
 	var activePaneID uint32
 	w := s.ActiveWindow()
@@ -122,13 +144,18 @@ func (s *Session) capturePaneJSON(pane *mux.Pane) string {
 		zoomedPaneID = w.ZoomedPaneID
 	}
 
+	// Snapshot cached idle state.
+	s.idleTimerMu.Lock()
+	idle := s.idleState[pane.ID]
+	since := s.idleSince[pane.ID]
+	s.idleTimerMu.Unlock()
+
 	cp := proto.CapturePane{
 		ID:         pane.ID,
 		Name:       pane.Meta.Name,
 		Active:     pane.ID == activePaneID,
 		Minimized:  pane.Meta.Minimized,
 		Zoomed:     pane.ID == zoomedPaneID,
-		Idle:       pane.IsIdle(),
 		Host:       pane.Meta.Host,
 		Task:       pane.Meta.Task,
 		Color:      pane.Meta.Color,
@@ -137,17 +164,22 @@ func (s *Session) capturePaneJSON(pane *mux.Pane) string {
 		Content:    pane.ContentLines(),
 	}
 
-	// Release s.mu before calling AgentStatus() — the caller re-locks
-	// after this function returns, but we must not hold the session lock
-	// while spawning subprocesses.
-	s.mu.Unlock()
-	status := pane.AgentStatus()
-	s.mu.Lock()
+	if idle {
+		cp.Idle = true
+		cp.IdleSince = formatIdleSince(since)
+		cp.CurrentCommand = pane.ShellName()
+		cp.ChildPIDs = []int{}
+	} else {
+		// Release s.mu before calling AgentStatus() — spawns subprocesses.
+		s.mu.Unlock()
+		status := pane.AgentStatus()
+		s.mu.Lock()
 
-	cp.Idle = status.Idle
-	cp.IdleSince = formatIdleSince(status.IdleSince)
-	cp.CurrentCommand = status.CurrentCommand
-	cp.ChildPIDs = status.ChildPIDs
+		cp.Idle = status.Idle
+		cp.IdleSince = formatIdleSince(status.IdleSince)
+		cp.CurrentCommand = status.CurrentCommand
+		cp.ChildPIDs = status.ChildPIDs
+	}
 
 	out, _ := json.MarshalIndent(cp, "", "  ")
 	return string(out)

--- a/internal/server/client_conn.go
+++ b/internal/server/client_conn.go
@@ -880,42 +880,31 @@ func (cc *ClientConn) handleCommand(srv *Server, sess *Session, msg *Message) {
 			return
 		}
 		paneID := pane.ID
+		paneName := pane.Meta.Name
 		sess.mu.Unlock()
 
-		// Check immediately — the pane may already be busy.
-		if sess.paneIsBusy(paneID) {
+		// Subscribe BEFORE checking state to prevent TOCTOU race.
+		sub := sess.addEventSub(eventFilter{Types: []string{EventBusy}, PaneName: paneName})
+		defer sess.removeEventSub(sub)
+
+		// Check current state — if not idle, it's already busy.
+		sess.idleTimerMu.Lock()
+		idle := sess.idleState[paneID]
+		sess.idleTimerMu.Unlock()
+
+		if !idle {
 			cc.Send(&Message{Type: MsgTypeCmdResult, CmdOutput: "busy\n"})
 			return
 		}
 
-		// Subscribe to pane output notifications and check on each write.
-		// Also use a ticker as fallback: the shell echoes the command
-		// (triggering output) before forking the child, so pgrep may
-		// miss the child on the first check. The ticker rechecks every
-		// 100ms to catch the fork after the echo.
-		ch := sess.subscribePaneOutput(paneID)
-		defer sess.unsubscribePaneOutput(paneID, ch)
-
-		ticker := time.NewTicker(100 * time.Millisecond)
-		defer ticker.Stop()
+		// Wait for busy event or timeout.
 		timer := time.NewTimer(timeout)
 		defer timer.Stop()
-		for {
-			select {
-			case <-ch:
-				if sess.paneIsBusy(paneID) {
-					cc.Send(&Message{Type: MsgTypeCmdResult, CmdOutput: "busy\n"})
-					return
-				}
-			case <-ticker.C:
-				if sess.paneIsBusy(paneID) {
-					cc.Send(&Message{Type: MsgTypeCmdResult, CmdOutput: "busy\n"})
-					return
-				}
-			case <-timer.C:
-				cc.Send(&Message{Type: MsgTypeCmdResult, CmdErr: fmt.Sprintf("timeout waiting for %s to become busy", paneRef)})
-				return
-			}
+		select {
+		case <-sub.ch:
+			cc.Send(&Message{Type: MsgTypeCmdResult, CmdOutput: "busy\n"})
+		case <-timer.C:
+			cc.Send(&Message{Type: MsgTypeCmdResult, CmdErr: fmt.Sprintf("timeout waiting for %s to become busy", paneRef)})
 		}
 
 	case "set-hook":

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -71,6 +71,7 @@ type Session struct {
 	Hooks       *hooks.Registry
 	idleTimers  map[uint32]*time.Timer // per-pane idle timers, protected by idleTimerMu
 	idleState   map[uint32]bool        // true = idle, protected by idleTimerMu
+	idleSince   map[uint32]time.Time   // when each pane became idle, protected by idleTimerMu
 	idleTimerMu sync.Mutex
 
 	// Event stream subscribers — used by `amux events` for push-based notifications.
@@ -646,20 +647,6 @@ func (s *Session) notifyPaneOutputSubs(paneID uint32) {
 	}
 }
 
-// paneIsBusy checks whether the given pane has child processes (i.e., a
-// command is running). Thread-safe: looks up the pane under s.mu, then
-// inspects the process tree outside the lock. Retries once on "not busy"
-// to handle races where pgrep misses a recently-forked child.
-func (s *Session) paneIsBusy(paneID uint32) bool {
-	s.mu.Lock()
-	pane := s.findPaneLocked(paneID)
-	s.mu.Unlock()
-	if pane == nil {
-		return false
-	}
-	return !pane.AgentStatus().Idle
-}
-
 // trackPaneActivity is called on every PTY output. It resets the idle timer
 // and fires on-activity if the pane was previously idle.
 func (s *Session) trackPaneActivity(paneID uint32) {
@@ -669,6 +656,7 @@ func (s *Session) trackPaneActivity(paneID uint32) {
 	// If pane was idle, fire on-activity and emit busy event
 	if s.idleState[paneID] {
 		s.idleState[paneID] = false
+		delete(s.idleSince, paneID)
 		env := s.buildPaneEnv(paneID, hooks.OnActivity)
 		s.Hooks.Fire(hooks.OnActivity, env)
 		s.emitEvent(Event{
@@ -686,6 +674,7 @@ func (s *Session) trackPaneActivity(paneID uint32) {
 		s.idleTimers[paneID] = time.AfterFunc(DefaultIdleTimeout, func() {
 			s.idleTimerMu.Lock()
 			s.idleState[paneID] = true
+			s.idleSince[paneID] = time.Now()
 			env := s.buildPaneEnv(paneID, hooks.OnIdle)
 			s.idleTimerMu.Unlock()
 			s.Hooks.Fire(hooks.OnIdle, env)
@@ -707,6 +696,7 @@ func (s *Session) stopPaneIdleTimer(paneID uint32) {
 		t.Stop()
 		delete(s.idleTimers, paneID)
 		delete(s.idleState, paneID)
+		delete(s.idleSince, paneID)
 	}
 }
 
@@ -830,6 +820,7 @@ func newSession(name string) *Session {
 	sess.Hooks = hooks.NewRegistry()
 	sess.idleTimers = make(map[uint32]*time.Timer)
 	sess.idleState = make(map[uint32]bool)
+	sess.idleSince = make(map[uint32]time.Time)
 	return sess
 }
 

--- a/test/capture_json_test.go
+++ b/test/capture_json_test.go
@@ -255,24 +255,12 @@ func TestCaptureJSON_AgentStatus_Idle(t *testing.T) {
 	h := newServerHarness(t)
 
 	// Shell at prompt — send a harmless command and wait for its output
-	// to confirm the shell is initialized and idle.
+	// to confirm the shell is initialized, then wait for idle timer.
 	h.sendKeys("pane-1", "echo READY", "Enter")
 	h.waitFor("pane-1", "READY")
+	h.waitIdle("pane-1")
 
-	// Retry briefly — under parallel load, pgrep may see transient shell
-	// children (job-control self-fork) that settle within a few hundred ms.
-	deadline := time.Now().Add(3 * time.Second)
-	var pane proto.CapturePane
-	for time.Now().Before(deadline) {
-		out := h.runCmd("capture", "--format", "json", "pane-1")
-		if err := json.Unmarshal([]byte(out), &pane); err != nil {
-			t.Fatalf("failed to parse JSON: %v\nraw output:\n%s", err, out)
-		}
-		if pane.Idle {
-			break
-		}
-		time.Sleep(100 * time.Millisecond)
-	}
+	pane := captureJSONPane(t, h, "pane-1")
 
 	if !pane.Idle {
 		t.Errorf("pane should be idle when no command is running (current_command=%q, child_pids=%v)", pane.CurrentCommand, pane.ChildPIDs)
@@ -347,21 +335,14 @@ func TestCaptureJSON_AgentStatus_ChildPIDsArray(t *testing.T) {
 	h := newServerHarness(t)
 
 	// Even when idle, child_pids should be a JSON array (not null).
-	// Retry briefly — bash's job-control self-fork can create a transient
-	// child process that settles within ~100ms.
 	h.sendKeys("pane-1", "echo ARRAY_TEST", "Enter")
 	h.waitFor("pane-1", "ARRAY_TEST")
+	h.waitIdle("pane-1")
 
-	deadline := time.Now().Add(3 * time.Second)
-	var out string
-	for time.Now().Before(deadline) {
-		out = h.runCmd("capture", "--format", "json", "pane-1")
-		if strings.Contains(out, `"child_pids": []`) {
-			return // pass
-		}
-		time.Sleep(100 * time.Millisecond)
+	out := h.runCmd("capture", "--format", "json", "pane-1")
+	if !strings.Contains(out, `"child_pids": []`) {
+		t.Errorf("idle pane should have child_pids as empty array, got:\n%s", out)
 	}
-	t.Errorf("idle pane should have child_pids as empty array, got:\n%s", out)
 }
 
 func TestCaptureJSON_AgentStatus_MultiPane(t *testing.T) {


### PR DESCRIPTION
## Summary

- **wait-busy** (LAB-192): Replace pgrep + 100ms ticker polling with event subscription pattern (subscribe to `EventBusy` before checking `idleState`), matching the `wait-idle` approach
- **capture JSON** (LAB-193): Use server's cached `idleState`/`idleSince` maps for idle panes — eliminates pgrep forks entirely for idle panes. Add `ShellName()` for subprocess-free shell name lookup
- Remove dead code: `paneIsBusy()`, `IsIdle()`, retry loops in `AgentStatus_Idle` and `ChildPIDsArray` tests

## Motivation

After LAB-185 made `wait-idle` event-based, `wait-busy` was the last pgrep-based wait command, and `capture --format json` still forked pgrep for every pane's idle status. This PR completes the migration to the server's cached idle state as the single source of truth.

## Testing

- [x] `go test ./...` passes
- [x] `go test -count=3` on all affected tests — 30/30 pass

Fixes LAB-192
Fixes LAB-193

🤖 Generated with [Claude Code](https://claude.com/claude-code)