### PR TITLE
Skip pre-commit hook during rebase

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,6 +1,12 @@
 #!/bin/bash
 # Pre-commit hook
 
+# Skip during rebase — intermediate states have compilation errors that
+# cause goimports to revert partially-resolved conflict edits.
+if [ -d ".git/rebase-merge" ] || [ -d ".git/rebase-apply" ]; then
+    exit 0
+fi
+
 # Block direct commits to main — use feature branches + PRs
 BRANCH=$(git symbolic-ref --short HEAD 2>/dev/null)
 if [ "$BRANCH" = "main" ] || [ "$BRANCH" = "master" ]; then


### PR DESCRIPTION
## Summary

- Skip the entire pre-commit hook when an active rebase is detected (`.git/rebase-merge` or `.git/rebase-apply` exists)

## Motivation

During rebase conflict resolution, `goimports -w` + `git add` sees intermediate compilation errors in partially-resolved files, reformats them (removing "unused" imports that are needed by unresolved code), and re-stages the result — reverting manual conflict resolution. This caused repeated branch recreations in LAB-192/LAB-193 work.

## Testing

- [x] `go test ./...` passes
- [x] Verified hook skips correctly: `mkdir -p .git/rebase-merge && .githooks/pre-commit; echo $?` → exits 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)