### PR TITLE
Add integration tests for uncovered commands

### DIFF
--- a/main.go
+++ b/main.go
@@ -232,6 +232,8 @@ func main() {
 		runServerCommand("unsplice", []string{args[1]})
 	case "reload-server":
 		runServerCommand("reload-server", nil)
+	case "_inject-proxy":
+		runServerCommand("_inject-proxy", args[1:])
 	case "dashboard":
 		fmt.Fprintln(os.Stderr, "amux dashboard: not yet migrated to built-in mux")
 		os.Exit(1)

--- a/test/command_coverage_test.go
+++ b/test/command_coverage_test.go
@@ -1,0 +1,132 @@
+package test
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSpawnLocalPane(t *testing.T) {
+	t.Parallel()
+	h := newServerHarness(t)
+
+	out := h.runCmd("spawn", "--name", "worker-1", "--task", "build")
+	if !strings.Contains(out, "Spawned worker-1") {
+		t.Fatalf("unexpected spawn output: %s", out)
+	}
+
+	list := h.runCmd("list")
+	if !strings.Contains(list, "worker-1") {
+		t.Fatalf("list should show spawned pane, got:\n%s", list)
+	}
+	if !strings.Contains(list, "build") {
+		t.Fatalf("list should show task, got:\n%s", list)
+	}
+}
+
+func TestSpawnRequiresName(t *testing.T) {
+	t.Parallel()
+	h := newServerHarness(t)
+
+	out := h.runCmd("spawn")
+	if !strings.Contains(out, "--name is required") {
+		t.Fatalf("expected --name error, got: %s", out)
+	}
+}
+
+func TestKillLastPaneError(t *testing.T) {
+	t.Parallel()
+	h := newServerHarness(t)
+
+	out := h.runCmd("kill", "pane-1")
+	if !strings.Contains(out, "cannot kill last pane") {
+		t.Fatalf("expected last pane error, got: %s", out)
+	}
+}
+
+func TestResizeWindow(t *testing.T) {
+	t.Parallel()
+	h := newServerHarness(t)
+
+	out := h.runCmd("resize-window", "120", "40")
+	if !strings.Contains(out, "Resized to 120x40") {
+		t.Fatalf("unexpected resize output: %s", out)
+	}
+}
+
+func TestResizeWindowInvalidArgs(t *testing.T) {
+	t.Parallel()
+	h := newServerHarness(t)
+
+	out := h.runCmd("resize-window", "abc", "40")
+	if !strings.Contains(out, "invalid") {
+		t.Fatalf("expected invalid dimensions error, got: %s", out)
+	}
+}
+
+func TestZoomUnzoom(t *testing.T) {
+	t.Parallel()
+	h := newServerHarness(t)
+
+	// Need 2 panes to zoom
+	h.runCmd("split")
+
+	out := h.runCmd("zoom")
+	if !strings.Contains(out, "Zoomed") {
+		t.Fatalf("expected Zoomed, got: %s", out)
+	}
+
+	out = h.runCmd("zoom")
+	if !strings.Contains(out, "Unzoomed") {
+		t.Fatalf("expected Unzoomed, got: %s", out)
+	}
+}
+
+func TestZoomByName(t *testing.T) {
+	t.Parallel()
+	h := newServerHarness(t)
+
+	h.runCmd("split")
+	h.runCmd("focus", "pane-1")
+
+	out := h.runCmd("zoom", "pane-2")
+	if !strings.Contains(out, "Zoomed pane-2") {
+		t.Fatalf("expected Zoomed pane-2, got: %s", out)
+	}
+}
+
+func TestZoomNotFound(t *testing.T) {
+	t.Parallel()
+	h := newServerHarness(t)
+
+	out := h.runCmd("zoom", "nonexistent")
+	if !strings.Contains(out, "not found") {
+		t.Fatalf("expected not found error, got: %s", out)
+	}
+}
+
+func TestUnknownCommand(t *testing.T) {
+	t.Parallel()
+	h := newServerHarness(t)
+
+	out := h.runCmd("totally-bogus-command")
+	if !strings.Contains(out, "unknown command") {
+		t.Fatalf("expected unknown command error, got: %s", out)
+	}
+}
+
+func TestReloadServer(t *testing.T) {
+	t.Parallel()
+	h := newServerHarness(t)
+
+	out := h.runCmd("reload-server")
+	if !strings.Contains(out, "reloading") {
+		t.Fatalf("expected reloading message, got: %s", out)
+	}
+
+	// After reload, the session should still be accessible
+	h.waitFor("pane-1", "$")
+	list := h.runCmd("list")
+	if !strings.Contains(list, "pane-1") {
+		t.Fatalf("pane-1 should survive reload, got:\n%s", list)
+	}
+}

--- a/test/proxy_test.go
+++ b/test/proxy_test.go
@@ -1,0 +1,45 @@
+package test
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestInjectProxyAndUnsplice(t *testing.T) {
+	t.Parallel()
+	h := newServerHarness(t)
+
+	// Inject a mock proxy pane for a fake remote host
+	out := h.runCmd("_inject-proxy", "fake-host")
+	if !strings.Contains(out, "Injected proxy pane") {
+		t.Fatalf("unexpected inject output: %s", out)
+	}
+
+	// Verify the proxy pane appears in list
+	list := h.runCmd("list")
+	if !strings.Contains(list, "fake-host") {
+		t.Fatalf("list should show fake-host pane, got:\n%s", list)
+	}
+
+	// Unsplice removes the proxy pane and replaces with a local pane
+	out = h.runCmd("unsplice", "fake-host")
+	if !strings.Contains(out, "Unspliced fake-host") {
+		t.Fatalf("unexpected unsplice output: %s", out)
+	}
+
+	// Verify the proxy pane is gone
+	list = h.runCmd("list")
+	if strings.Contains(list, "fake-host") {
+		t.Fatalf("list should not contain fake-host after unsplice, got:\n%s", list)
+	}
+}
+
+func TestUnspliceNoProxy(t *testing.T) {
+	t.Parallel()
+	h := newServerHarness(t)
+
+	out := h.runCmd("unsplice", "nonexistent")
+	if !strings.Contains(out, "no spliced panes") {
+		t.Fatalf("expected error about no spliced panes, got: %s", out)
+	}
+}

--- a/test/window_commands_test.go
+++ b/test/window_commands_test.go
@@ -1,0 +1,54 @@
+package test
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRenameWindow(t *testing.T) {
+	t.Parallel()
+	h := newServerHarness(t)
+
+	out := h.runCmd("rename-window", "my-window")
+	if !strings.Contains(out, "Renamed window to my-window") {
+		t.Fatalf("unexpected output: %s", out)
+	}
+
+	// Verify via list-windows
+	lw := h.runCmd("list-windows")
+	if !strings.Contains(lw, "my-window") {
+		t.Fatalf("list-windows should show renamed window, got:\n%s", lw)
+	}
+}
+
+func TestSelectWindowByName(t *testing.T) {
+	t.Parallel()
+	h := newServerHarness(t)
+
+	// Create a second window with a name
+	h.runCmd("new-window", "--name", "second")
+
+	// Switch back to first window by index
+	h.runCmd("select-window", "1")
+	lw := h.runCmd("list-windows")
+	if !strings.Contains(lw, "*1:") {
+		t.Fatalf("should be on window 1, got:\n%s", lw)
+	}
+
+	// Switch to second window by name
+	h.runCmd("select-window", "second")
+	lw = h.runCmd("list-windows")
+	if !strings.Contains(lw, "*2:") {
+		t.Fatalf("should be on window 2, got:\n%s", lw)
+	}
+}
+
+func TestSelectWindowNotFound(t *testing.T) {
+	t.Parallel()
+	h := newServerHarness(t)
+
+	out := h.runCmd("select-window", "nonexistent")
+	if !strings.Contains(out, "not found") {
+		t.Fatalf("expected not found error, got: %s", out)
+	}
+}


### PR DESCRIPTION
## Summary

- Add tests for commands with 0% coverage after the registry extraction: rename-window, _inject-proxy, unsplice, spawn, zoom error paths, resize-window error paths, kill last pane, reload-server, unknown command, select-window by name/not found
- Wire `_inject-proxy` through `main.go` so integration tests can reach it

## Motivation

Codecov flagged `commands.go` at 54% patch coverage since it's a new file (code moved from `client_conn.go`). These tests cover the previously-untested commands and error paths.

The remaining 0% commands (`cmdHosts`, `cmdDisconnect`, `cmdReconnect`) require SSH infrastructure and are not testable without the SSH test server.

## Testing

`go test ./...` — all pass

Generated with [Claude Code](https://claude.com/claude-code)