### PR TITLE
Fix newServerHarnessWithSize: pass cols/rows to headless client (LAB-220)

### DIFF
--- a/test/server_harness_test.go
+++ b/test/server_harness_test.go
@@ -126,7 +126,7 @@ func newServerHarnessWithConfig(tb testing.TB, cols, rows int, configContent str
 	// Attach a headless client — seeds the first pane and stays connected
 	// so capture requests route through client-side emulators.
 	sockPath := server.SocketPath(session)
-	client, err := newHeadlessClient(sockPath, session, 80, 24)
+	client, err := newHeadlessClient(sockPath, session, cols, rows)
 	if err != nil {
 		cmd.Process.Kill()
 		tb.Fatalf("attaching headless client: %v", err)


### PR DESCRIPTION
## Summary

- One-line fix: headless client was hardcoded to 80x24, ignoring the `cols`/`rows` parameters

## Motivation

`newServerHarnessWithSize(t, 200, 60)` silently ran at 80x24. Any test relying on a custom terminal size was broken.

## Testing

Full test suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)