### PR TITLE
Fix CaptureJSON.Height to report full terminal height (LAB-221)

### DIFF
--- a/internal/client/renderer.go
+++ b/internal/client/renderer.go
@@ -251,7 +251,7 @@ func (r *Renderer) CaptureJSON(agentStatus map[uint32]proto.PaneAgentStatus) str
 	capture := proto.CaptureJSON{
 		Session: r.sessionName,
 		Width:   r.width,
-		Height:  r.compositor.LayoutHeight(),
+		Height:  r.height,
 	}
 	for _, ws := range r.windows {
 		if ws.ID == r.activeWinID {

--- a/test/capture_json_test.go
+++ b/test/capture_json_test.go
@@ -51,6 +51,9 @@ func TestCaptureJSON_FullScreen(t *testing.T) {
 	if capture.Width != 80 {
 		t.Errorf("width: got %d, want 80", capture.Width)
 	}
+	if capture.Height != 24 {
+		t.Errorf("height: got %d, want 24 (full terminal height)", capture.Height)
+	}
 	if len(capture.Panes) != 2 {
 		t.Fatalf("expected 2 panes, got %d", len(capture.Panes))
 	}
@@ -376,4 +379,3 @@ func TestCaptureJSON_AgentStatus_MultiPane(t *testing.T) {
 		}
 	}
 }
-


### PR DESCRIPTION
## Summary

- `CaptureJSON.Height` reported layout height (terminal height minus global bar) while `Width` reported full terminal width
- Now both report the full terminal dimensions for consistency

## Motivation

Agents consuming `capture --format json` expect Width and Height to be symmetric. The global bar is a rendering detail that consumers can account for themselves.

## Testing

Added Height assertion to `TestCaptureJSON_FullScreen`. Full suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)