### PR TITLE
Fix test binary resolution: AMUX_BIN overrides stale ~/.local/bin/amux (LAB-253)

### DIFF
--- a/internal/remote/host_conn.go
+++ b/internal/remote/host_conn.go
@@ -347,11 +347,11 @@ func (hc *HostConn) ensureRemoteServer(client *ssh.Client, sessionName string) e
 }
 
 // buildEnsureServerCmd returns the shell command that starts amux _server if
-// the socket doesn't already exist. Tries ~/.local/bin/amux first (where deploy
-// installs), then falls back to amux in PATH.
+// the socket doesn't already exist. Checks AMUX_BIN env var first (set by
+// test harness), then ~/.local/bin/amux (where deploy installs), then PATH.
 func buildEnsureServerCmd(sockPath, sessionName string) string {
 	return fmt.Sprintf(
-		`if [ ! -S %s ]; then AMUX=$(command -v ~/.local/bin/amux 2>/dev/null || command -v amux 2>/dev/null || echo amux); nohup "$AMUX" _server %s </dev/null >/dev/null 2>&1 & for i in 1 2 3 4 5 6 7 8 9 10; do [ -S %s ] && break; sleep 0.2; done; fi`,
+		`if [ ! -S %s ]; then AMUX=${AMUX_BIN:-$(command -v ~/.local/bin/amux 2>/dev/null || command -v amux 2>/dev/null || echo amux)}; nohup "$AMUX" _server %s </dev/null >/dev/null 2>&1 & for i in 1 2 3 4 5 6 7 8 9 10; do [ -S %s ] && break; sleep 0.2; done; fi`,
 		sockPath, sessionName, sockPath,
 	)
 }

--- a/internal/remote/host_conn_test.go
+++ b/internal/remote/host_conn_test.go
@@ -25,9 +25,14 @@ func TestBuildEnsureServerCmd(t *testing.T) {
 		t.Error("command should check socket existence")
 	}
 
-	// Must try ~/.local/bin/amux first (deploy location)
+	// Must respect AMUX_BIN env var override (used by test harness)
+	if !strings.Contains(cmd, "${AMUX_BIN:-") {
+		t.Error("command should check AMUX_BIN env var first")
+	}
+
+	// Must try ~/.local/bin/amux as fallback (deploy location)
 	if !strings.Contains(cmd, "~/.local/bin/amux") {
-		t.Error("command should try ~/.local/bin/amux first")
+		t.Error("command should try ~/.local/bin/amux as fallback")
 	}
 
 	// Must pass session name to _server

--- a/test/test_sshd_test.go
+++ b/test/test_sshd_test.go
@@ -43,6 +43,9 @@ func startTestSSHServer(t *testing.T, authorizedKey ssh.PublicKey) string {
 			}
 		}
 	}
+	// Override the binary used by buildEnsureServerCmd so the remote server
+	// always uses the test binary, not a stale ~/.local/bin/amux.
+	execEnv = append(execEnv, "AMUX_BIN="+amuxBin)
 
 	// Generate ed25519 host key
 	_, hostPriv, err := ed25519.GenerateKey(rand.Reader)


### PR DESCRIPTION
## Summary

- `buildEnsureServerCmd` hardcoded `~/.local/bin/amux` as first-choice binary, bypassing the test binary that `TestMain` builds to a temp dir
- This caused false test failures after branch switches (stale binary) and deploy interference under parallel load
- Root cause identified via five-whys analysis across 3 sessions

## Changes

- `buildEnsureServerCmd`: Check `AMUX_BIN` env var before hardcoded path: `${AMUX_BIN:-$(command -v ~/.local/bin/amux ...)}`
- `startTestSSHServer`: Set `AMUX_BIN` to the test binary path in the SSH exec environment
- Updated `TestBuildEnsureServerCmd` to verify `AMUX_BIN` override

## Testing

- `go test ./...` passes (all packages)
- `TestBuildEnsureServerCmd` verifies the env var is checked first
- SSH integration tests use the correct binary via `AMUX_BIN`

## Review focus

- Shell variable expansion correctness in `buildEnsureServerCmd` (`${AMUX_BIN:-...}` syntax)

🤖 Generated with [Claude Code](https://claude.com/claude-code)