### PR TITLE
Make Codex and Claude Code first-class citizens

### DIFF
--- a/.agents/skills/amux-pr-workflow/SKILL.md
+++ b/.agents/skills/amux-pr-workflow/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: amux-pr-workflow
+description: Use when creating, updating, reviewing, or merging a PR in this repo. Covers first-push rebases, review and simplification passes, benchmark baseline requirements, and post-merge postmortems.
+---
+
+# amux PR Workflow
+
+Use this skill when the task involves `git push`, `gh pr create`, `gh pr merge`, PR review, benchmark PR prep, or "wrap this up" work near the end of a change.
+
+## Rules
+
+- Rebase onto `origin/main` before the first push: `git fetch origin main && git rebase origin/main`.
+- Do not present a PR as done until it has had both a review pass and a simplification pass.
+- If benchmarks changed, add a `Baseline numbers` section to the PR description with representative results and hardware.
+- After merge, capture a short postmortem and turn action items into issues or doc updates.
+
+## Workflow
+
+1. Confirm the relevant tests ran and note any gaps.
+2. If this is the first push for the branch, rebase onto `origin/main`.
+3. Create or update the PR.
+4. Run a review pass. Prefer `codex review` when available.
+5. Run a simplification pass focused on unnecessary complexity and cleanup opportunities.
+6. If the change touched benchmarks, add baseline numbers before calling the PR ready.
+7. After merge, record a short postmortem with learnings, pain points, and follow-up actions.
+
+## Output Checklist
+
+- Tests run, or an explicit testing gap is called out.
+- Rebase-before-first-push handled or explicitly not needed.
+- Review pass completed.
+- Simplification pass completed.
+- Benchmark baseline section added when relevant.
+- Postmortem captured after merge.

--- a/.claude/hooks/post-merge-postmortem.sh
+++ b/.claude/hooks/post-merge-postmortem.sh
@@ -6,7 +6,7 @@ input=$(cat)
 command=$(echo "$input" | jq -r '.tool_input.command // empty' 2>/dev/null)
 
 if [[ "$command" == gh\ pr\ merge* ]]; then
-    echo "PR merged. Run /postmortem now to capture session learnings: What did you learn? Any pain points? Any action items for issues, CLAUDE.md updates, documentation, or hooks?" >&2
+    echo "PR merged. Run /postmortem now to capture session learnings: What did you learn? Any pain points? Any action items for issues, AGENTS.md or CLAUDE.md updates, documentation, or hooks?" >&2
     exit 2
 fi
 

--- a/.claude/hooks/post-pr-review.sh
+++ b/.claude/hooks/post-pr-review.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# PostToolUse hook: after PR creation/push, run review agents and check for conflicts.
+# PostToolUse hook: after PR creation/push, remind about review workflow and check for conflicts.
 # Reads tool input JSON from stdin. Exit 2 sends feedback back to Claude.
 # Uses `mergeable` field (CONFLICTING/MERGEABLE/UNKNOWN) — not `mergeStateStatus`
 # which also reflects CI check status and would false-positive on pending checks.
@@ -19,21 +19,21 @@ check_conflicts() {
     fi
 }
 
-# After gh pr create: remind to run review agents + check conflicts
+# After gh pr create: remind to run review workflow + check conflicts
 if [[ "$command" == gh\ pr\ create* ]]; then
     pr_num=$(gh pr view --json number --jq .number 2>/dev/null)
     if [[ -n "$pr_num" ]]; then
-        echo "PR created. Run the code-reviewer and code-simplifier agents now to review the changes before considering this done." >&2
+        echo "PR created. Run a review pass and a simplification pass now before considering this done." >&2
         check_conflicts "$pr_num"
         exit 2
     fi
 fi
 
-# After git push: remind to run review agents + check for merge conflicts
+# After git push: remind to run review workflow + check for merge conflicts
 if [[ "$command" == git\ push* ]]; then
     pr_num=$(gh pr view --json number --jq .number 2>/dev/null)
     if [[ -n "$pr_num" ]]; then
-        echo "Pushed to PR #$pr_num. Run the code-reviewer and code-simplifier agents in background now." >&2
+        echo "Pushed to PR #$pr_num. Run a review pass and a simplification pass now." >&2
         check_conflicts "$pr_num"
         exit 2
     fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,1 +1,143 @@
-CLAUDE.md
+# AGENTS.md
+
+## Agent Surfaces
+
+This file is the canonical shared guidance for coding agents in this repo.
+
+- `AGENTS.md` is the source of truth for shared repo policy.
+- `CLAUDE.md` is a thin Claude Code shim plus notes about Claude-only hooks.
+- `.claude/settings.json` and `.claude/hooks/` provide Claude-only automation.
+- `.agents/skills/` holds Codex skills for reusable repo workflows.
+- `make setup` installs Git hooks for everyone. It is not Claude-specific.
+
+If a tool-specific file disagrees with this file, follow `AGENTS.md` and update the stale tool-specific file.
+
+## Design Philosophy
+
+See [README.md -- Philosophy](README.md#philosophy) for the project thesis and three tenets.
+
+**Client-server architecture.** The server is a background daemon that owns PTYs and layout state. Clients connect over a Unix socket, receive layout snapshots and raw pane output, and render locally. This enables hot-reload: rebuilding the binary auto-restarts the client with new rendering code while preserving running shells.
+
+**Pane metadata is in-memory.** All pane state lives in `mux.PaneMeta` structs on the server. No external database or state files.
+
+**Names over IDs.** Users reference panes by name (`pane-3`) or numeric ID (`3`). `Window.ResolvePane()` handles resolution. Prefix matches are also supported.
+
+## Architecture
+
+### Key Abstractions
+
+**Client-server protocol** -- Clients send `MsgTypeInput`, `MsgTypeResize`, `MsgTypeCommand`. Server sends `MsgTypePaneOutput` (raw PTY bytes per pane), `MsgTypeLayout` (layout tree snapshot), `MsgTypeRender` (legacy pre-rendered ANSI).
+
+**`mux.Window`** -- Owns the layout tree (`LayoutCell`) and active pane. All layout operations (split, close, resize, focus) go through Window methods.
+
+**`mux.LayoutCell`** -- Binary tree of splits. Leaves hold panes. Internal nodes hold a split direction and children. `Walk()` for traversal, `FindPane()` for lookup, `FixOffsets()` after structural changes.
+
+**`Window.ResolvePane(ref)`** -- Accepts pane name (`pane-1`), numeric ID (`1`), or prefix match. All CLI commands route through this.
+
+**`render.RenderFull()`** -- Composites pane content, borders with junction characters, per-pane status lines, and the global session bar into a single ANSI output string.
+
+### Patterns To Follow
+
+**One package per concern.** Layout logic in `mux/`, rendering in `render/`, server protocol in `server/`. Packages depend on interfaces and shared types (`proto/`), not on each other's internals.
+
+**Unit tests for layout/rendering logic.** See `layout_test.go`, `window_test.go`, `emulator_test.go`. Use `fakePaneID()` helper to create minimal panes for testing.
+
+**Integration tests for end-to-end behavior.** The harness in `test/server_harness_test.go` drives amux directly over the Unix socket -- no tmux dependency. Tests run in ~6s total.
+
+**Guard against impossible states.** Minimize checks that at least one pane stays non-minimized. Restore caps height at available space. Focus fallback finds nearest pane when strict overlap matching fails.
+
+**Save/restore cursor state in copy mode motions.** Compound motions (word, paragraph, etc.) call `moveDown()` and `moveUp()` in scanning loops. These helpers mutate `cy` and `oy` on each call, so the caller must save both values before the loop and restore them when returning `ActionNone`. Otherwise the cursor drifts silently on failed motions.
+
+**Minimize requires a horizontal split.** `Minimize` only works on panes in a horizontal split (`splitH` / top-bottom layout). Panes in a vertical split (`splitV` / left-right layout) cannot be minimized -- the command returns an error. Tests that exercise minimize must use `splitH()`, not `splitV()`.
+
+**Colors live in `config/config.go`.** The Catppuccin Mocha palette (`CatppuccinMocha`), letter abbreviations (`CatppuccinLetters`), and named hex constants (`DimColorHex`, `TextColorHex`) are defined once in the config package. Reference these constants instead of hardcoding hex values like `"f5e0dc"` or `"6c7086"`.
+
+## Development
+
+### Build And Test
+
+```bash
+make setup                         # activate repo git hooks
+go build -o ~/.local/bin/amux .    # build + install (client hot-reloads automatically)
+go test ./...                      # run all tests
+```
+
+### Testing Live
+
+See [README.md -- CLI Reference](README.md#cli-reference) for the full command reference. Key commands for testing:
+
+```bash
+amux                              # start or reattach
+amux capture --format json        # structured JSON for agents
+amux capture --format json pane-1 # single pane JSON
+```
+
+### TDD Workflow
+
+All development follows test-driven development: write a failing test first, then implement. The integration test harness makes this fast (~6s for the full suite).
+
+### Test Philosophy
+
+Tests should read like specs. Minimize logic in assertions so a human can read the test and immediately understand what behavior is expected. Prefer golden file comparisons (`assertGolden`) over inline predicate functions -- the golden file is the spec, viewable as a standalone document. Use table-driven tests for unit tests with multiple cases -- define a `tests` slice of structs, iterate with `t.Run(tt.name, ...)`, and call `t.Parallel()` in each subtest.
+
+**Golden files** live in `test/testdata/`. Two types:
+
+- `.golden` -- structural layout frame (status lines, borders, global bar). Open one and you see the expected screen layout.
+- `.color` -- border color map using Catppuccin color initials (`R`=Rosewater, `F`=Flamingo, `M`=Mauve, `.`=dim, `|`=global bar). Shows which borders should be colored at a glance.
+
+Regenerate goldens after intentional rendering changes: `cd test && go test -run TestGolden -update`
+
+### Pre-Push Rebase
+
+Rebase onto `origin/main` before the first push (`git fetch origin main && git rebase origin/main`). Multiple features often land in parallel; rebasing before push avoids repeated merge conflict resolution after the PR is open.
+
+### Specs And Plans On Feature Branches
+
+Commit design specs and implementation plans to the feature branch, not main. Committing to main before creating the feature branch causes divergent branches on subsequent pulls.
+
+### Review Before Done
+
+After creating or updating a PR, run a review pass and a simplification pass before considering the work done. Claude Code gets hook reminders for this. Codex users should use the repo PR workflow skill or perform the steps explicitly.
+
+### Include Baseline Numbers In Performance PRs
+
+When creating PRs that add or modify benchmarks, include a `Baseline numbers` section in the PR description with representative results in a markdown table. Include the hardware (for example, `Apple M4, macOS`) for context. Development run results are ephemeral -- the PR description is the permanent record.
+
+### Adding A New Feature
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the workflow. Additional note for agents:
+
+1. **Check what dependencies already provide.** Before designing a custom solution, check if the underlying library (for example, `charmbracelet/x/vt`) already supports the capability. Read tests and exported methods in `go/pkg/mod/`.
+
+### Fixing A Bug
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the workflow.
+
+### Adding A New CLI Command
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the workflow.
+
+### Debugging Rendering
+
+Use `amux capture --format json` to inspect composited output programmatically. To isolate whether a rendering bug is in the compositor (multi-pane compositing) or per-pane terminal emulation:
+
+1. Capture the full session: `amux capture --format json` -- identify which panes show artifacts
+2. Zoom the affected pane: `amux zoom pane-N` -- wait a few seconds, capture again
+3. If the zoomed view is clean but the unzoomed view is corrupted, the bug is in the compositor or diff renderer (cell-grid boundary calculation, status bar overlay, or border compositing)
+4. If the zoomed view is also corrupted, the bug is in the terminal emulator or PTY output
+
+Trigger patterns for compositor bugs: long or truncated lines near pane boundaries, status bar overlays adjacent to wrapped content, and high-frequency output (for example, `htop` or progress bars).
+
+### Hot-Reload
+
+Both client and server watch the binary and re-exec on changes (`reload.go`). Running `go build -o ~/.local/bin/amux .` triggers automatic reload of both -- panes and shells are preserved across server reloads via checkpoint and restore.
+
+Socket location: `/tmp/amux-$UID/<session-name>`
+
+## Configuration
+
+See [README.md -- Configuration](README.md#configuration) for the `hosts.toml` format. Config parsing lives in `config/config.go`. Pane colors are optional -- if omitted, they're auto-assigned from the Catppuccin Mocha palette.
+
+## Issue Tracking
+
+File bugs and feature requests in the [Linear LAB project](https://linear.app/weill-labs/team/LAB). GitHub Issues is not actively monitored.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,130 +1,19 @@
 # CLAUDE.md
 
-## Design Philosophy
+This repo uses [AGENTS.md](AGENTS.md) as the canonical shared guidance. Read and follow `AGENTS.md` first.
 
-See [README.md — Philosophy](README.md#philosophy) for the project thesis and three tenets.
+If `CLAUDE.md` and `AGENTS.md` ever disagree, follow `AGENTS.md` and update this file.
 
-**Client-server architecture.** The server is a background daemon that owns PTYs and layout state. Clients connect over a Unix socket, receive layout snapshots and raw pane output, and render locally. This enables hot-reload: rebuilding the binary auto-restarts the client with new rendering code while preserving running shells.
+## Claude-Specific Behavior
 
-**Pane metadata is in-memory.** All pane state lives in `mux.PaneMeta` structs on the server. No external database or state files.
+Claude Code has extra repo automation configured in `.claude/settings.json`.
 
-**Names over IDs.** Users reference panes by name (`pane-3`) or numeric ID (`3`). `Window.ResolvePane()` handles resolution. Prefix matches are also supported.
+- `SessionStart` runs `.claude/hooks/session-start.sh` to ensure `make setup` has activated `.githooks`.
+- `Stop` runs `.claude/hooks/tdd-check.sh` and warns when implementation `.go` files changed without test changes.
+- `PostToolUse` on Bash runs `.claude/hooks/post-pr-review.sh` and `.claude/hooks/post-merge-postmortem.sh`.
 
-## Architecture
+Treat hook feedback as repo policy, not optional guidance.
 
-### Key Abstractions
+## Claude PR Workflow
 
-**Client-server protocol** — Clients send `MsgTypeInput`, `MsgTypeResize`, `MsgTypeCommand`. Server sends `MsgTypePaneOutput` (raw PTY bytes per pane), `MsgTypeLayout` (layout tree snapshot), `MsgTypeRender` (legacy pre-rendered ANSI).
-
-**`mux.Window`** — Owns the layout tree (`LayoutCell`) and active pane. All layout operations (split, close, resize, focus) go through Window methods.
-
-**`mux.LayoutCell`** — Binary tree of splits. Leaves hold panes. Internal nodes hold a split direction and children. `Walk()` for traversal, `FindPane()` for lookup, `FixOffsets()` after structural changes.
-
-**`Window.ResolvePane(ref)`** — Accepts pane name (`pane-1`), numeric ID (`1`), or prefix match. All CLI commands route through this.
-
-**`render.RenderFull()`** — Composites pane content, borders with junction characters, per-pane status lines, and the global session bar into a single ANSI output string.
-
-### Patterns to Follow
-
-**One package per concern.** Layout logic in `mux/`, rendering in `render/`, server protocol in `server/`. Packages depend on interfaces and shared types (`proto/`), not on each other's internals.
-
-**Unit tests for layout/rendering logic.** See `layout_test.go`, `window_test.go`, `emulator_test.go`. Use `fakePaneID()` helper to create minimal panes for testing.
-
-**Integration tests for end-to-end behavior.** The harness in `test/server_harness_test.go` drives amux directly over the Unix socket — no tmux dependency. Tests run in ~6s total.
-
-**Guard against impossible states.** Minimize checks that at least one pane stays non-minimized. Restore caps height at available space. Focus fallback finds nearest pane when strict overlap matching fails.
-
-**Save/restore cursor state in copy mode motions.** Compound motions (word, paragraph, etc.) call `moveDown()`/`moveUp()` in scanning loops. These helpers mutate `cy`/`oy` on each call, so the caller must save both values before the loop and restore them when returning `ActionNone`. Otherwise the cursor drifts silently on failed motions.
-
-**Minimize requires a horizontal split.** `Minimize` only works on panes in a horizontal split (`splitH` / top-bottom layout). Panes in a vertical split (`splitV` / left-right layout) cannot be minimized — the command returns an error. Tests that exercise minimize must use `splitH()`, not `splitV()`.
-
-**Colors live in `config/config.go`.** The Catppuccin Mocha palette (`CatppuccinMocha`), letter abbreviations (`CatppuccinLetters`), and named hex constants (`DimColorHex`, `TextColorHex`) are defined once in the config package. Reference these constants instead of hardcoding hex values like `"f5e0dc"` or `"6c7086"`.
-
-## Development
-
-### Build and Test
-
-```bash
-make setup                         # after cloning: activate git hooks (formatting, lint, commit guards)
-go build -o ~/.local/bin/amux .    # build + install (client hot-reloads automatically)
-go test ./...                       # run all tests
-```
-
-### Testing Live
-
-See [README.md — CLI Reference](README.md#cli-reference) for the full command reference. Key commands for testing:
-
-```bash
-amux                              # start or reattach
-amux capture --format json        # structured JSON for agents
-amux capture --format json pane-1 # single pane JSON
-```
-
-### TDD Workflow
-
-All development follows test-driven development: write a failing test first, then implement. The integration test harness makes this fast (~6s for the full suite).
-
-### Test Philosophy
-
-Tests should read like specs. Minimize logic in assertions so a human can read the test and immediately understand what behavior is expected. Prefer golden file comparisons (`assertGolden`) over inline predicate functions — the golden file *is* the spec, viewable as a standalone document. Use table-driven tests for unit tests with multiple cases — define a `tests` slice of structs, iterate with `t.Run(tt.name, ...)`, and call `t.Parallel()` in each subtest.
-
-**Golden files** live in `test/testdata/`. Two types:
-- `.golden` — structural layout frame (status lines, borders, global bar). Open one and you see the expected screen layout.
-- `.color` — border color map using Catppuccin color initials (`R`=Rosewater, `F`=Flamingo, `M`=Mauve, `.`=dim, `|`=global bar). Shows which borders should be colored at a glance.
-
-Regenerate goldens after intentional rendering changes: `cd test && go test -run TestGolden -update`
-
-### Pre-Push Rebase
-
-Rebase onto `origin/main` before the first push (`git fetch origin main && git rebase origin/main`). Multiple features often land in parallel; rebasing before push avoids repeated merge conflict resolution after the PR is open.
-
-### Specs and Plans on Feature Branches
-
-Commit design specs and implementation plans to the feature branch, not main. Committing to main before creating the feature branch causes divergent branches on subsequent pulls.
-
-### Post-PR Review
-
-After creating a PR, immediately dispatch the code review and code simplifier agents (in background) before presenting the PR URL. Address their feedback before considering the work done. These catch issues that are easy to miss during implementation: style inconsistencies, unnecessary complexity, and subtle bugs.
-
-### Include Baseline Numbers in Performance PRs
-
-When creating PRs that add or modify benchmarks, include a "Baseline numbers" section in the PR description with representative results in a markdown table. Include the hardware (e.g., "Apple M4, macOS") for context. Development run results are ephemeral — the PR description is the permanent record.
-
-### Adding a New Feature
-
-See [CONTRIBUTING.md](CONTRIBUTING.md) for the workflow. Additional note for AI agents:
-
-1. **Check what dependencies already provide.** Before designing a custom solution, check if the underlying library (e.g., `charmbracelet/x/vt`) already supports the capability. Read tests and exported methods in `go/pkg/mod/`.
-
-### Fixing a Bug
-
-See [CONTRIBUTING.md](CONTRIBUTING.md) for the workflow.
-
-### Adding a New CLI Command
-
-See [CONTRIBUTING.md](CONTRIBUTING.md) for the workflow.
-
-### Debugging Rendering
-
-Use `amux capture --format json` to inspect composited output programmatically. To isolate whether a rendering bug is in the compositor (multi-pane compositing) or per-pane terminal emulation:
-
-1. Capture the full session: `amux capture --format json` — identify which panes show artifacts
-2. Zoom the affected pane: `amux zoom pane-N` — wait a few seconds, capture again
-3. If zoomed view is clean but unzoomed is corrupted, the bug is in the compositor/diff renderer (cell-grid boundary calculation, status bar overlay, or border compositing)
-4. If zoomed view is also corrupted, the bug is in the terminal emulator or PTY output
-
-Trigger patterns for compositor bugs: long/truncated lines near pane boundaries, status bar overlays adjacent to wrapped content, and high-frequency output (e.g., htop, progress bars).
-
-### Hot-Reload
-
-Both client and server watch the binary and re-exec on changes (`reload.go`). Running `go build -o ~/.local/bin/amux .` triggers automatic reload of both — panes and shells are preserved across server reloads via checkpoint/restore.
-
-Socket location: `/tmp/amux-$UID/<session-name>`
-
-## Configuration
-
-See [README.md — Configuration](README.md#configuration) for the `hosts.toml` format. Config parsing lives in `config/config.go`. Pane colors are optional — if omitted, they're auto-assigned from the Catppuccin Mocha palette.
-
-## Issue Tracking
-
-File bugs and feature requests in the [Linear LAB project](https://linear.app/weill-labs/team/LAB). GitHub Issues is not actively monitored.
+When Claude hook messaging says to run review and simplification passes, use the Claude review agents that fit the task. The goal is the shared repo rule from `AGENTS.md`: do not present a PR as done until it has had both a review pass and a simplification pass.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,7 @@
 ## Build
 
 ```bash
+make setup                         # activate repo git hooks
 go build -o ~/.local/bin/amux .    # build + install
 go test ./...                       # run all tests
 ```
@@ -20,6 +21,15 @@ To test manually after building:
 amux                              # start or reattach to a session
 amux capture --format json        # structured JSON output for agents
 ```
+
+## AI Agents
+
+- Shared repo instructions live in `AGENTS.md`.
+- `CLAUDE.md` is a thin Claude Code shim plus notes about Claude-only hooks.
+- Claude Code also loads `.claude/settings.json` and `.claude/hooks/`.
+- Codex reads `AGENTS.md` and can discover repo skills from `.agents/skills/`.
+- Run `make setup` after cloning so repo Git hooks are active regardless of which tool you use.
+- Optional for Codex users: trust the repo, then install the OpenAI Docs MCP server with `codex mcp add openaiDeveloperDocs --url https://developers.openai.com/mcp`.
 
 ## Test
 

--- a/README.md
+++ b/README.md
@@ -191,6 +191,15 @@ amux wait-idle pane-1         # block until command finishes
 amux events --filter idle     # subscribe to idle/busy transitions
 ```
 
+## AI Agent Support
+
+Shared repo guidance lives in [AGENTS.md](AGENTS.md). This is the canonical instruction file for coding agents in this repo.
+
+- Claude Code also loads repo automation from `.claude/settings.json` and `.claude/hooks/`.
+- Codex reads `AGENTS.md` and can discover repo skills from `.agents/skills/`.
+- `make setup` installs the repo Git hooks for everyone. It is not Claude-specific.
+- Optional for Codex users: trust the repo, then install the OpenAI Docs MCP server with `codex mcp add openaiDeveloperDocs --url https://developers.openai.com/mcp`.
+
 ## CLI Reference
 
 All commands accept `-s <session>` to target a specific session. Panes are referenced by name (`pane-1`) or numeric ID (`1`). Prefix matches are also supported.


### PR DESCRIPTION
Summary
- make AGENTS.md the canonical shared agent instruction file instead of a symlink to CLAUDE.md
- reduce CLAUDE.md to a Claude-specific shim and update Claude hook wording to match the shared workflow
- document Codex support in the repo and add a repo-local Codex skill for PR workflow

Testing
- verified Codex loads the repo instructions via codex exec from the repo root
- verified Codex can discover the repo-local amux-pr-workflow skill
- no Go tests run; docs/config only
