### PR TITLE
Fix 3x3 grid drift after terminal resize

### DIFF
--- a/internal/mux/layout.go
+++ b/internal/mux/layout.go
@@ -202,89 +202,100 @@ func (c *LayoutCell) FixOffsets() {
 
 // ResizeAll adjusts the layout tree to fit new terminal dimensions.
 func (c *LayoutCell) ResizeAll(newW, newH int) {
-	if c.isLeaf {
-		c.W = newW
-		c.H = newH
+	if c == nil {
 		return
 	}
 
-	c.W = newW
-	c.H = newH
-
-	// Compute target sizes for children proportionally.
-	// Available space = total minus separators between children.
-	n := len(c.Children)
-	separators := n - 1
-	if separators < 0 {
-		separators = 0
+	// Match tmux's resize behavior: distribute exact deltas cell-by-cell
+	// instead of recomputing proportions from already-rounded pane sizes.
+	xchange := newW - c.W
+	xlimit := c.resizeCheck(SplitVertical)
+	if xchange < -xlimit {
+		xchange = -xlimit
+	}
+	if xchange != 0 {
+		c.resizeAdjust(SplitVertical, xchange)
 	}
 
-	if c.Dir == SplitVertical {
-		available := newW - separators
-		targets := proportionalSizes(c.Children, available, true)
-		for i, child := range c.Children {
-			child.ResizeAll(targets[i], newH)
-		}
-	} else {
-		available := newH - separators
-		targets := proportionalSizes(c.Children, available, false)
-		for i, child := range c.Children {
-			child.ResizeAll(newW, targets[i])
-		}
+	ychange := newH - c.H
+	ylimit := c.resizeCheck(SplitHorizontal)
+	if ychange < -ylimit {
+		ychange = -ylimit
+	}
+	if ychange != 0 {
+		c.resizeAdjust(SplitHorizontal, ychange)
 	}
 
 	c.FixOffsets()
 }
 
-// proportionalSizes computes target sizes for children to fill `available` space,
-// proportional to their current sizes. Ensures each child gets at least PaneMinSize.
-func proportionalSizes(children []*LayoutCell, available int, horizontal bool) []int {
-	n := len(children)
-	if n == 0 {
-		return nil
+func (c *LayoutCell) resizeCheck(axis SplitDir) int {
+	if c.IsLeaf() {
+		size := c.W
+		if axis == SplitHorizontal {
+			size = c.H
+		}
+		if size > PaneMinSize {
+			return size - PaneMinSize
+		}
+		return 0
 	}
 
-	// Compute current total
-	total := 0
-	for _, child := range children {
-		if horizontal {
-			total += child.W
-		} else {
-			total += child.H
+	if c.Dir == axis {
+		available := 0
+		for _, child := range c.Children {
+			available += child.resizeCheck(axis)
 		}
+		return available
 	}
 
-	targets := make([]int, n)
-	if total == 0 {
-		// All zero — distribute evenly
-		per := available / n
-		for i := range targets {
-			targets[i] = per
+	minimum := -1
+	for _, child := range c.Children {
+		available := child.resizeCheck(axis)
+		if minimum == -1 || available < minimum {
+			minimum = available
 		}
-		targets[n-1] = available - per*(n-1)
-		return targets
+	}
+	if minimum < 0 {
+		return 0
+	}
+	return minimum
+}
+
+func (c *LayoutCell) resizeAdjust(axis SplitDir, change int) {
+	if axis == SplitVertical {
+		c.W += change
+	} else {
+		c.H += change
 	}
 
-	// Proportional distribution
-	assigned := 0
-	for i, child := range children {
-		cur := child.W
-		if !horizontal {
-			cur = child.H
-		}
-		if i == n-1 {
-			// Last child gets remainder to avoid rounding drift
-			targets[i] = available - assigned
-		} else {
-			targets[i] = cur * available / total
-		}
-		if targets[i] < PaneMinSize {
-			targets[i] = PaneMinSize
-		}
-		assigned += targets[i]
+	if c.IsLeaf() {
+		return
 	}
 
-	return targets
+	if c.Dir != axis {
+		for _, child := range c.Children {
+			child.resizeAdjust(axis, change)
+		}
+		return
+	}
+
+	for change != 0 {
+		for _, child := range c.Children {
+			if change == 0 {
+				break
+			}
+			if change > 0 {
+				child.resizeAdjust(axis, 1)
+				change--
+				continue
+			}
+			if child.resizeCheck(axis) > 0 {
+				child.resizeAdjust(axis, -1)
+				change++
+			}
+		}
+	}
 }
 
 // HasNonMinimizedLeaf returns true if any leaf in the subtree has a

--- a/internal/mux/layout_test.go
+++ b/internal/mux/layout_test.go
@@ -1,6 +1,9 @@
 package mux
 
-import "testing"
+import (
+	"fmt"
+	"testing"
+)
 
 // fakePaneID creates a minimal Pane with just an ID for testing layout.
 func fakePaneID(id uint32) *Pane {
@@ -310,6 +313,58 @@ func TestResizeAll(t *testing.T) {
 			t.Errorf("child[%d].H = %d, want 40", i, child.H)
 		}
 	}
+}
+
+func TestResizeAll_RoundTripKeepsEqualGridStable(t *testing.T) {
+	t.Parallel()
+
+	root := NewLeaf(fakePaneID(1), 0, 0, 80, 23)
+	if _, err := root.Split(SplitVertical, fakePaneID(2)); err != nil {
+		t.Fatalf("split root vertical: %v", err)
+	}
+	if _, err := root.Children[1].Split(SplitVertical, fakePaneID(3)); err != nil {
+		t.Fatalf("split root vertical again: %v", err)
+	}
+
+	nextID := uint32(4)
+	for _, col := range root.Children {
+		if _, err := col.Split(SplitHorizontal, fakePaneID(nextID)); err != nil {
+			t.Fatalf("split column horizontal: %v", err)
+		}
+		nextID++
+		if _, err := col.Children[1].Split(SplitHorizontal, fakePaneID(nextID)); err != nil {
+			t.Fatalf("split column horizontal again: %v", err)
+		}
+		nextID++
+	}
+	root.FixOffsets()
+
+	initial := snapshotLeafGeometry(root)
+
+	root.ResizeAll(120, 39)
+	root.ResizeAll(80, 23)
+
+	if diff := diffLeafGeometry(initial, snapshotLeafGeometry(root)); diff != "" {
+		t.Fatalf("equal 3x3 grid drifted after resize round-trip:\n%s", diff)
+	}
+}
+
+func snapshotLeafGeometry(root *LayoutCell) map[uint32][4]int {
+	out := map[uint32][4]int{}
+	root.Walk(func(c *LayoutCell) {
+		out[c.Pane.ID] = [4]int{c.X, c.Y, c.W, c.H}
+	})
+	return out
+}
+
+func diffLeafGeometry(want, got map[uint32][4]int) string {
+	var out string
+	for id := range want {
+		if want[id] != got[id] {
+			out += fmt.Sprintf("pane-%d: want=%v got=%v\n", id, want[id], got[id])
+		}
+	}
+	return out
 }
 
 func TestWalkAndFindPane(t *testing.T) {

--- a/test/font_resize_grid_test.go
+++ b/test/font_resize_grid_test.go
@@ -1,0 +1,98 @@
+package test
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestFontResize_ThreeByThreeGridReturnsToOriginalLayout(t *testing.T) {
+	t.Parallel()
+	h := newAmuxHarness(t)
+
+	makeThreeByThreeGrid(t, h)
+
+	initial := capturePanePositions(h)
+
+	gen := h.generation()
+	h.outer.runCmd("resize-window", "120", "40")
+	h.waitLayout(gen)
+
+	larger := capturePanePositions(h)
+	assertThreeByThreeGrid(t, larger)
+
+	gen = h.generation()
+	h.outer.runCmd("resize-window", "80", "24")
+	h.waitLayout(gen)
+
+	final := capturePanePositions(h)
+	assertThreeByThreeGrid(t, final)
+
+	if diff := diffPanePositions(initial, final); diff != "" {
+		t.Fatalf("3x3 grid drifted after grow/shrink cycle:\n%s", diff)
+	}
+}
+
+func makeThreeByThreeGrid(t *testing.T, h *AmuxHarness) {
+	t.Helper()
+
+	h.runCmd("split", "v", "root")
+	h.runCmd("split", "v", "root")
+
+	for _, pane := range []string{"pane-1", "pane-2", "pane-3"} {
+		h.runCmd("focus", pane)
+		h.runCmd("split")
+		h.runCmd("split")
+	}
+}
+
+type panePos struct {
+	x int
+	y int
+	w int
+	h int
+}
+
+func capturePanePositions(h *AmuxHarness) map[string]panePos {
+	capture := h.captureJSON()
+	out := make(map[string]panePos, len(capture.Panes))
+	for _, pane := range capture.Panes {
+		if pane.Position == nil {
+			continue
+		}
+		out[pane.Name] = panePos{
+			x: pane.Position.X,
+			y: pane.Position.Y,
+			w: pane.Position.Width,
+			h: pane.Position.Height,
+		}
+	}
+	return out
+}
+
+func assertThreeByThreeGrid(t *testing.T, positions map[string]panePos) {
+	t.Helper()
+	if len(positions) != 9 {
+		t.Fatalf("expected 9 panes, got %d", len(positions))
+	}
+
+	xs := map[int]bool{}
+	ys := map[int]bool{}
+	for _, pos := range positions {
+		xs[pos.x] = true
+		ys[pos.y] = true
+	}
+	if len(xs) != 3 || len(ys) != 3 {
+		t.Fatalf("expected 3 columns and 3 rows, got %d columns and %d rows", len(xs), len(ys))
+	}
+}
+
+func diffPanePositions(want, got map[string]panePos) string {
+	var out string
+	for i := 1; i <= 9; i++ {
+		name := fmt.Sprintf("pane-%d", i)
+		if want[name] != got[name] {
+			out += fmt.Sprintf("%s: initial=%+v final=%+v\n", name, want[name], got[name])
+		}
+	}
+	return out
+}


### PR DESCRIPTION
## Summary
- replace `ResizeAll`'s proportional recompute with a tmux-style delta distributor
- keep 3x3 grids stable across terminal/font-size grow-shrink round trips
- add mux-level and end-to-end regression coverage for the resize drift case

## Testing
- `go test ./...`

## Notes
- Rebased onto `origin/main` before first push.
- Review pass completed.
- Simplification pass completed.
- No benchmark changes.
