### PR TITLE
Document tmux-first layout and squash-only PR workflow

### DIFF
--- a/.agents/skills/amux-pr-workflow/SKILL.md
+++ b/.agents/skills/amux-pr-workflow/SKILL.md
@@ -10,6 +10,7 @@ Use this skill when the task involves `git push`, `gh pr create`, `gh pr merge`,
 ## Rules
 
 - Rebase onto `origin/main` before the first push: `git fetch origin main && git rebase origin/main`.
+- This repo is squash-only on GitHub. Use `gh pr merge --squash`; merge and rebase merges will fail.
 - Do not present a PR as done until it has had both a review pass and a simplification pass.
 - If benchmarks changed, add a `Baseline numbers` section to the PR description with representative results and hardware.
 - After merge, capture a short postmortem and turn action items into issues or doc updates.
@@ -21,8 +22,9 @@ Use this skill when the task involves `git push`, `gh pr create`, `gh pr merge`,
 3. Create or update the PR.
 4. Run a review pass. Prefer `codex review` when available.
 5. Run a simplification pass focused on unnecessary complexity and cleanup opportunities.
-6. If the change touched benchmarks, add baseline numbers before calling the PR ready.
-7. After merge, record a short postmortem with learnings, pain points, and follow-up actions.
+6. If the change affects layout math or resize behavior, compare against tmux before adding new layout state or diverging from tmux semantics.
+7. If the change touched benchmarks, add baseline numbers before calling the PR ready.
+8. After merge, record a short postmortem with learnings, pain points, and follow-up actions.
 
 ## Output Checklist
 
@@ -30,5 +32,6 @@ Use this skill when the task involves `git push`, `gh pr create`, `gh pr merge`,
 - Rebase-before-first-push handled or explicitly not needed.
 - Review pass completed.
 - Simplification pass completed.
+- Squash merge policy followed.
 - Benchmark baseline section added when relevant.
 - Postmortem captured after merge.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,8 @@ See [README.md -- Philosophy](README.md#philosophy) for the project thesis and t
 
 **Minimize requires a horizontal split.** `Minimize` only works on panes in a horizontal split (`splitH` / top-bottom layout). Panes in a vertical split (`splitV` / left-right layout) cannot be minimized -- the command returns an error. Tests that exercise minimize must use `splitH()`, not `splitV()`.
 
+**Check tmux before changing layout resize behavior.** For pane sizing, resize distribution, and other layout-behavior questions, inspect tmux first and prefer matching its user-visible behavior. In particular, do not recompute sizes from already-rounded live pane geometry if tmux uses exact delta distribution.
+
 **Colors live in `config/config.go`.** The Catppuccin Mocha palette (`CatppuccinMocha`), letter abbreviations (`CatppuccinLetters`), and named hex constants (`DimColorHex`, `TextColorHex`) are defined once in the config package. Reference these constants instead of hardcoding hex values like `"f5e0dc"` or `"6c7086"`.
 
 ## Development
@@ -106,6 +108,10 @@ Commit design specs and implementation plans to the feature branch, not main. Co
 ### Review Before Done
 
 After creating or updating a PR, run a review pass and a simplification pass before considering the work done. Claude Code gets hook reminders for this. Codex users should use the repo PR workflow skill or perform the steps explicitly.
+
+### Merge Policy
+
+GitHub PRs for this repo are squash-only. `gh pr merge --merge` and `gh pr merge --rebase` will fail.
 
 ### Include Baseline Numbers In Performance PRs
 


### PR DESCRIPTION
## Summary
- document that layout resize changes should be checked against tmux first
- document that this repo uses squash-only GitHub merges
- update the amux PR workflow skill to reflect both rules

## Testing
- not run; docs and workflow guidance only

## Notes
- Rebased onto `origin/main` before first push.
- Review pass completed.
- Simplification pass completed.
- No benchmark changes.
