### PR TITLE
Stabilize copy mode resize test

### DIFF
--- a/test/copymode_test.go
+++ b/test/copymode_test.go
@@ -245,7 +245,9 @@ func TestCopyModeResizeSurvives(t *testing.T) {
 	}
 
 	// Resize terminal while in copy mode via the outer server
+	gen := h.generation()
 	h.outer.runCmd("resize-window", "120", "40")
+	h.waitLayout(gen)
 
 	// Copy mode should still be active after resize
 	if !h.waitFor("[copy]", 3*time.Second) {


### PR DESCRIPTION
## Summary
- synchronize `TestCopyModeResizeSurvives` to the post-resize inner layout generation
- avoid treating the pre-existing `[copy]` indicator as proof that the resize finished

## Testing
- go test -count=30 -run TestCopyModeResizeSurvives ./test

## Testing gap
- `go test -count=3 -parallel 2 -timeout 300s ./test/` still shows unrelated existing flakes on `main` (`TestFontResize_ThreeByThreeGridReturnsToOriginalLayout`, `TestHookOnIdleFires`), so this PR is validated with the targeted stress run instead of the full integration sweep
