### PR TITLE
Update CI Codecov actions and opt into Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -107,9 +110,10 @@ jobs:
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() && steps.changes.outputs.code_changed == 'true' }}
-        uses: codecov/test-results-action@v1.2.1
+        uses: codecov/codecov-action@v5.5.2
         with:
           files: unit-results.junit.xml,integration-results.junit.xml
+          report_type: test_results
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
 


### PR DESCRIPTION
## Summary
- replace deprecated `codecov/test-results-action` with `codecov-action` using `report_type: test_results`
- opt CI into `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` to avoid the Node 20 deprecation path
- keep the existing coverage upload step unchanged apart from sharing the same action family

## Testing
- parsed `.github/workflows/ci.yml` with Ruby YAML loader

## Notes
- Rebased onto `origin/main` before first push.
- Review pass completed.
- Simplification pass completed.
- No benchmark changes.
