### PR TITLE
Use atomic local build install for hot reload

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,7 +62,7 @@ See [README.md -- Philosophy](README.md#philosophy) for the project thesis and t
 
 ```bash
 make setup                         # activate repo git hooks
-go build -o ~/.local/bin/amux .    # build + install (client hot-reloads automatically)
+make build                         # build + install atomically (client hot-reloads automatically)
 go test ./...                      # run all tests
 ```
 
@@ -144,7 +144,7 @@ Trigger patterns for compositor bugs: long or truncated lines near pane boundari
 
 ### Hot-Reload
 
-Both client and server watch the binary and re-exec on changes (`reload.go`). Running `go build -o ~/.local/bin/amux .` triggers automatic reload of both -- panes and shells are preserved across server reloads via checkpoint and restore.
+Both client and server watch the binary and re-exec on changes (`reload.go`). Running `make build` replaces the installed binary atomically, which then triggers automatic reload of both -- panes and shells are preserved across server reloads via checkpoint and restore.
 
 Socket location: `/tmp/amux-$UID/<session-name>`
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,11 +9,11 @@
 
 ```bash
 make setup                         # activate repo git hooks
-go build -o ~/.local/bin/amux .    # build + install
+make build                         # build + install atomically
 go test ./...                       # run all tests
 ```
 
-Hot-reload: both client and server watch the binary and re-exec on changes. Running `go build` triggers automatic reload — panes and shells are preserved.
+Hot-reload: both client and server watch the binary and re-exec on changes. Use `make build` so the installed binary is replaced atomically before reload — panes and shells are preserved.
 
 To test manually after building:
 

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ setup: ## Configure git hooks and install tools
 	@echo "Hooks activated from .githooks/"
 
 build: ## Build and install amux
-	go build -o ~/.local/bin/amux .
+	scripts/build-install.sh
 
 test: ## Run all tests
 	go test ./... -timeout 120s

--- a/README.md
+++ b/README.md
@@ -176,6 +176,8 @@ No, and it doesn't aim to. amux implements what matters for human+agent pairing:
 go install github.com/weill-labs/amux@latest
 ```
 
+For local development builds, prefer `make build` instead of writing `go build` directly to `~/.local/bin/amux`. The atomic replace avoids transient invalid binaries during hot-reload on macOS.
+
 Single binary, no runtime dependencies.
 
 ## Quick Start

--- a/scripts/build-install.sh
+++ b/scripts/build-install.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+dest="${1:-$HOME/.local/bin/amux}"
+dest_dir="$(dirname "$dest")"
+
+mkdir -p "$dest_dir"
+tmp="$(mktemp "$dest_dir/.amux.tmp.XXXXXX")"
+
+cleanup() {
+	rm -f "$tmp"
+}
+trap cleanup EXIT
+
+go build -o "$tmp" .
+mv "$tmp" "$dest"


### PR DESCRIPTION
## Summary
- replace the local dev install step with an atomic build-and-move helper instead of writing directly to `~/.local/bin/amux`
- update the documented local workflow to use `make build` for hot-reload installs
- note the macOS motivation so local rebuilds avoid transient invalid binaries during reload

## Testing
- `bash -n scripts/build-install.sh`
- `scripts/build-install.sh "$tmpdir/bin/amux" && "$tmpdir/bin/amux" -h >/dev/null` with a fresh temp destination
- `make build`
- `go test ./...` *(fails in `github.com/weill-labs/amux/test` on this macOS 15.6 machine because the integration harness launches temp `amux` binaries that are being killed by taskgated with code-signature-invalid errors; unit and package tests passed before the integration package failures)*

## Review
- review pass: found and fixed a fresh-install bug where `mktemp` ran before `mkdir -p`
- simplification pass: kept the change to a small shell helper plus doc updates instead of adding installer logic to Go reload paths
