### PR TITLE
Add AMUX_EXIT_UNATTACHED for auto-exit test servers

### DIFF
--- a/internal/server/checkpoint.go
+++ b/internal/server/checkpoint.go
@@ -113,8 +113,13 @@ func (s *Server) Reload(execPath string) error {
 		_ = coverage.WriteCountersDir(dir)
 	}
 
-	// Replace process image with new binary
+	// Replace process image with new binary.
+	// Re-export AMUX_EXIT_UNATTACHED if set (unsetenv'd at startup to
+	// prevent child shells from inheriting it, but must survive exec).
 	env := append(os.Environ(), "AMUX_CHECKPOINT="+cpPath)
+	if ExitUnattached {
+		env = append(env, "AMUX_EXIT_UNATTACHED=1")
+	}
 	execErr := syscall.Exec(execPath, os.Args, env)
 
 	// If we get here, the exec call failed — undo changes
@@ -146,6 +151,7 @@ func NewServerFromCheckpoint(cp *checkpoint.ServerCheckpoint) (*Server, error) {
 		sessions: map[string]*Session{cp.SessionName: sess},
 		sockPath: SocketPath(cp.SessionName),
 	}
+	sess.exitServer = s
 
 	// Restore panes
 	paneMap := make(map[uint32]*mux.Pane, len(cp.Panes))

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -95,6 +95,11 @@ type Session struct {
 	sessionEvents    chan sessionEvent
 	sessionEventStop chan struct{}
 	sessionEventDone chan struct{}
+
+	// Exit-unattached: server exits when all clients disconnect after
+	// at least one has connected. Used by test harness to avoid orphans.
+	hadClient  bool    // true after first interactive client attaches
+	exitServer *Server // back-reference to trigger shutdown
 }
 
 // buildCrashCheckpoint builds a crash checkpoint from the current session state.
@@ -232,10 +237,22 @@ func (s *Session) removeClient(cc *ClientConn) {
 			break
 		}
 	}
+	shouldExit := ExitUnattached && s.hadClient && len(s.clients) == 0 && !s.shutdown.Load()
 	s.recalcSizeLocked()
 	s.mu.Unlock()
 	s.broadcastLayout()
+	if shouldExit {
+		// Async: removeClient may run inside the session event loop;
+		// calling Shutdown synchronously would deadlock because
+		// Shutdown waits for the event loop to finish.
+		go s.exitServer.Shutdown()
+	}
 }
+
+// ExitUnattached makes the server exit after all interactive clients disconnect
+// (provided at least one client connected first). Opt-in via AMUX_EXIT_UNATTACHED=1.
+// Used by test harnesses to prevent orphaned server processes.
+var ExitUnattached bool
 
 // BuildVersion is set by main at startup for version reporting in status.
 var BuildVersion string
@@ -315,6 +332,7 @@ func NewServer(sessionName string) (*Server, error) {
 		sessions: map[string]*Session{sessionName: sess},
 		sockPath: sockPath,
 	}
+	sess.exitServer = s
 
 	return s, nil
 }
@@ -351,6 +369,7 @@ func NewServerFromCrashCheckpoint(sessionName string, cp *checkpoint.CrashCheckp
 		sessions: map[string]*Session{sessionName: sess},
 		sockPath: sockPath,
 	}
+	sess.exitServer = s
 
 	// Restore panes — spawn fresh shells (FDs/PIDs are lost on crash)
 	paneMap := make(map[uint32]*mux.Pane, len(cp.PaneStates))
@@ -471,13 +490,17 @@ func (s *Server) Shutdown() {
 		if sess.sessionEventStop != nil {
 			close(sess.sessionEventStop)
 			<-sess.sessionEventDone
+			sess.sessionEventStop = nil
 		}
 
 		// Stop crash checkpoint loop and wait for it to exit.
 		// The shutdown flag prevents any further writes.
+		// Nil out after close so Shutdown() is safe to call twice
+		// (exit-unattached can race with signal-based shutdown).
 		if sess.crashCheckpointStop != nil {
 			close(sess.crashCheckpointStop)
 			<-sess.crashCheckpointDone
+			sess.crashCheckpointStop = nil
 		}
 
 		// Clean shutdown: remove crash checkpoint (no recovery needed)

--- a/internal/server/session_events.go
+++ b/internal/server/session_events.go
@@ -298,6 +298,7 @@ func (s *Session) handleAttachEvent(srv *Server, cc *ClientConn, cols, rows int)
 	}
 
 	s.clients = append(s.clients, cc)
+	s.hadClient = true
 	s.recalcSizeLocked()
 
 	res.snap = s.snapshotLayoutLocked(idleSnap)

--- a/main.go
+++ b/main.go
@@ -453,17 +453,20 @@ func runServer(sessionName string) {
 	}
 
 	// Handle shutdown signals. The goroutine calls Shutdown() which closes
-	// the listener (unblocking Run()), then finishes cleanup (crash checkpoint
-	// removal, pane teardown). shutdownDone lets the main goroutine wait for
-	// cleanup to complete before exiting.
+	// the listener, unblocking Run() below.
 	sigCh := make(chan os.Signal, 1)
-	shutdownDone := make(chan struct{})
 	signal.Notify(sigCh, syscall.SIGTERM, syscall.SIGINT)
 	go func() {
 		<-sigCh
 		s.Shutdown()
-		close(shutdownDone)
 	}()
+
+	// Exit-unattached mode: server exits when all interactive clients disconnect.
+	// Used by test harness so orphaned test servers self-terminate.
+	// Unset so child processes (pane shells, inner amux) don't inherit it.
+	// The value is re-exported in Reload() before syscall.Exec.
+	server.ExitUnattached = os.Getenv("AMUX_EXIT_UNATTACHED") == "1"
+	os.Unsetenv("AMUX_EXIT_UNATTACHED")
 
 	// Server-side binary watcher for auto-reload.
 	// AMUX_NO_WATCH=1 disables watching (used by test harness for the outer
@@ -493,9 +496,10 @@ func runServer(sessionName string) {
 		}
 	}
 
-	// Wait for Shutdown() to finish cleanup (crash checkpoint removal, etc.)
-	// before the process exits.
-	<-shutdownDone
+	// Ensure cleanup runs regardless of what closed the listener (signal,
+	// exit-unattached, etc.). Shutdown is idempotent: if the signal
+	// goroutine already called it, this is a no-op.
+	s.Shutdown()
 }
 
 // ---------------------------------------------------------------------------

--- a/test/crash_recovery_test.go
+++ b/test/crash_recovery_test.go
@@ -22,7 +22,9 @@ import (
 func TestCrashRecovery_LayoutRestored(t *testing.T) {
 	t.Parallel()
 
-	h := newServerHarness(t)
+	// Use persistent server: the test deliberately disconnects the client
+	// before SIGKILL, so exit-unattached would shut down the server early.
+	h := newServerHarnessPersistent(t)
 
 	// Create a multi-pane layout: split vertically (2 panes side-by-side)
 	h.splitV()
@@ -209,7 +211,7 @@ func startServerForSession(t *testing.T, session string) *ServerHarness {
 
 	cmd := exec.Command(amuxBin, "_server", session)
 	cmd.ExtraFiles = []*os.File{writePipe}
-	env := append(os.Environ(), "AMUX_READY_FD=3", "AMUX_NO_WATCH=1")
+	env := append(os.Environ(), "AMUX_READY_FD=3", "AMUX_NO_WATCH=1", "AMUX_EXIT_UNATTACHED=1")
 
 	// Per-test cover dir
 	var coverDir string

--- a/test/server_harness_test.go
+++ b/test/server_harness_test.go
@@ -45,10 +45,25 @@ func newServerHarnessImpl(tb testing.TB, cols, rows int) *ServerHarness {
 	return newServerHarnessWithConfig(tb, cols, rows, "")
 }
 
+// newServerHarnessPersistent starts a server that does NOT exit when all
+// clients disconnect. Used by tests that deliberately detach all clients
+// and then issue commands against the still-running server.
+func newServerHarnessPersistent(tb testing.TB) *ServerHarness {
+	tb.Helper()
+	return newServerHarnessWithOptions(tb, 80, 24, "", false)
+}
+
 // newServerHarnessWithConfig starts a server with a custom config file.
 // The config is written to a temp file and passed via AMUX_CONFIG.
 // Pass an empty configContent to start with the default (no) config.
 func newServerHarnessWithConfig(tb testing.TB, cols, rows int, configContent string) *ServerHarness {
+	tb.Helper()
+	return newServerHarnessWithOptions(tb, cols, rows, configContent, true)
+}
+
+// newServerHarnessWithOptions is the shared constructor. When exitUnattached
+// is true the server self-terminates after all clients disconnect.
+func newServerHarnessWithOptions(tb testing.TB, cols, rows int, configContent string, exitUnattached bool) *ServerHarness {
 	tb.Helper()
 	var b [4]byte
 	rand.Read(b[:])
@@ -63,6 +78,9 @@ func newServerHarnessWithConfig(tb testing.TB, cols, rows int, configContent str
 	cmd := exec.Command(amuxBin, "_server", session)
 	cmd.ExtraFiles = []*os.File{writePipe} // fd 3 in child
 	env := append(os.Environ(), "AMUX_READY_FD=3", "AMUX_NO_WATCH=1")
+	if exitUnattached {
+		env = append(env, "AMUX_EXIT_UNATTACHED=1")
+	}
 
 	// Write config to a temp file and pass via AMUX_CONFIG if provided.
 	if configContent != "" {

--- a/test/type_keys_test.go
+++ b/test/type_keys_test.go
@@ -37,7 +37,7 @@ func TestTypeKeysLiteral(t *testing.T) {
 
 func TestTypeKeysNoClient(t *testing.T) {
 	t.Parallel()
-	h := newServerHarness(t)
+	h := newServerHarnessPersistent(t)
 
 	// Close the headless client so there are no attached clients.
 	h.client.close()


### PR DESCRIPTION
## Summary

- Add opt-in `AMUX_EXIT_UNATTACHED=1` env var: the server exits after all interactive clients disconnect (with a `hadClient` guard to prevent exit during startup)
- Test harness sets the var so orphaned test servers self-terminate when their test process dies, instead of accumulating and causing macOS code-signature invalidation on rebuild
- Interactive sessions are unaffected (env var is not set)

## Design decisions

- **Event-driven, no timer**: client disconnect → `removeClient` → shutdown. Deterministic, no polling
- **`hadClient` guard**: prevents exit before any client connects (startup window)
- **`shutdown` flag check**: prevents exit during hot-reload (where clients temporarily disconnect)
- **Env var unset after read**: child processes (pane shells, inner amux) don't inherit it; re-exported in `Reload()` before `syscall.Exec` so hot-reload preserves the flag
- **Idempotent `Shutdown()`**: nils `crashCheckpointStop` after close so concurrent signal + exit-unattached calls don't panic
- **Simplified `runServer()` shutdown**: removed `shutdownDone` channel; `s.Shutdown()` called after `Run()` returns regardless of what closed the listener

## Test plan

- [x] `go test ./...` passes (all existing tests)
- [x] `TestTypeKeysNoClient` — uses `newServerHarnessPersistent` (deliberately detaches all clients)
- [x] `TestCrashRecovery_LayoutRestored` — uses `newServerHarnessPersistent` (deliberately detaches before SIGKILL)
- [x] Hot-reload tests pass (inner server doesn't inherit `AMUX_EXIT_UNATTACHED`)
- [ ] Manual: start test, kill test process, verify server exits within seconds
- [ ] Manual: interactive `amux` session → detach → verify server stays alive

🤖 Generated with [Claude Code](https://claude.com/claude-code)