### PR TITLE
Stabilize font resize and idle hook tests

### DIFF
--- a/test/font_resize_grid_test.go
+++ b/test/font_resize_grid_test.go
@@ -59,13 +59,13 @@ func TestFontResize_UnevenGridReturnsToOriginalLayout(t *testing.T) {
 func makeThreeByThreeGrid(t *testing.T, h *AmuxHarness) {
 	t.Helper()
 
-	h.runCmd("split", "v", "root")
-	h.runCmd("split", "v", "root")
+	runLayoutCommand(t, h, "split", "v", "root")
+	runLayoutCommand(t, h, "split", "v", "root")
 
 	for _, pane := range []string{"pane-1", "pane-2", "pane-3"} {
-		h.runCmd("focus", pane)
-		h.runCmd("split")
-		h.runCmd("split")
+		runLayoutCommand(t, h, "focus", pane)
+		runLayoutCommand(t, h, "split")
+		runLayoutCommand(t, h, "split")
 	}
 }
 
@@ -81,6 +81,16 @@ func makeGridUneven(t *testing.T, h *AmuxHarness) {
 	if out := h.runCmd("resize-pane", "pane-9", "left", "3"); !strings.Contains(out, "Resized") {
 		t.Fatalf("resize-pane pane-9 left failed: %s", out)
 	}
+}
+
+func runLayoutCommand(t *testing.T, h *AmuxHarness, args ...string) {
+	t.Helper()
+	gen := h.generation()
+	out := h.runCmd(args...)
+	if out != "" && (strings.Contains(out, "error") || strings.Contains(out, "cannot")) {
+		t.Fatalf("%v failed: %s", args, out)
+	}
+	h.waitLayout(gen)
 }
 
 type panePos struct {

--- a/test/hooks_test.go
+++ b/test/hooks_test.go
@@ -120,12 +120,17 @@ func TestHookOnIdleFires(t *testing.T) {
 	tmp := t.TempDir()
 	marker := filepath.Join(tmp, "idle-fired")
 
+	// Establish a known idle baseline first, then force an idle transition
+	// after registering the hook.
+	h.waitIdle("pane-1")
 	h.runCmd("set-hook", "on-idle", "touch "+marker)
 
 	h.sendKeys("pane-1", "echo TRIGGER_ACTIVITY", "Enter")
 	h.waitFor("pane-1", "TRIGGER_ACTIVITY")
+	h.waitBusy("pane-1")
+	h.waitIdle("pane-1")
 
-	if !waitForFile(t, marker, 5*time.Second) {
+	if !waitForFile(t, marker, 2*time.Second) {
 		t.Fatal("on-idle hook did not fire within timeout")
 	}
 }


### PR DESCRIPTION
## Summary
- wait for each layout mutation while building the 3x3 font-resize test grid before snapshotting positions
- make the idle hook test establish an idle baseline, then wait through the busy-to-idle transition before asserting the hook side effect

## Testing
- go test ./test -run "^(TestFontResize_ThreeByThreeGridReturnsToOriginalLayout|TestHookOnIdleFires)$" -count=1
- go test ./test -run "^TestFontResize_ThreeByThreeGridReturnsToOriginalLayout$" -count=10
- go test ./test -run "^TestHookOnIdleFires$" -count=10

## Review
- review pass completed locally against the final diff
- simplification pass completed; no smaller deterministic version remained after removing the extra position-polling helper