### PR TITLE
Queue session command mutations

### DIFF
--- a/internal/server/client_conn.go
+++ b/internal/server/client_conn.go
@@ -113,15 +113,10 @@ func (cc *ClientConn) readLoop(srv *Server, sess *Session) {
 func (cc *ClientConn) withPaneWindow(sess *Session, cmdName string, args []string,
 	fn func(pane *mux.Pane, w *mux.Window) (string, error)) {
 	sess.mu.Lock()
-	pane := cc.resolvePane(sess, cmdName, args)
-	if pane == nil {
+	pane, w, err := cc.resolvePaneWindowLocked(sess, cmdName, args)
+	if err != nil {
 		sess.mu.Unlock()
-		return
-	}
-	w := sess.FindWindowByPaneID(pane.ID)
-	if w == nil {
-		sess.mu.Unlock()
-		cc.Send(&Message{Type: MsgTypeCmdResult, CmdErr: "pane not in any window"})
+		cc.Send(&Message{Type: MsgTypeCmdResult, CmdErr: err.Error()})
 		return
 	}
 	result, err := fn(pane, w)
@@ -132,6 +127,20 @@ func (cc *ClientConn) withPaneWindow(sess *Session, cmdName string, args []strin
 	}
 	sess.broadcastLayout()
 	cc.Send(&Message{Type: MsgTypeCmdResult, CmdOutput: result})
+}
+
+func (cc *ClientConn) resolvePaneWindowLocked(sess *Session, cmdName string, args []string) (*mux.Pane, *mux.Window, error) {
+	if len(args) < 1 {
+		return nil, nil, fmt.Errorf("usage: %s <pane>", cmdName)
+	}
+	pane, w, err := cc.resolvePaneAcrossWindowsLocked(sess, args[0])
+	if err != nil {
+		return nil, nil, err
+	}
+	if w == nil {
+		return nil, nil, fmt.Errorf("pane not in any window")
+	}
+	return pane, w, nil
 }
 
 // handleCommand dispatches CLI commands through the command registry.
@@ -145,155 +154,43 @@ func (cc *ClientConn) handleCommand(srv *Server, sess *Session, msg *Message) {
 	handler(&CommandContext{CC: cc, Srv: srv, Sess: sess, Args: msg.CmdArgs})
 }
 
-// createNewWindow creates a new window with one pane and switches to it.
-func (cc *ClientConn) createNewWindow(srv *Server, sess *Session, name string) {
-	// Grab the active pane's PID under the lock, then resolve its cwd
-	// outside the lock (PaneCwd shells out to lsof).
+// splitRemotePane prepares a proxy pane connected to a remote host, then
+// inserts it into the active window through the session event loop.
+func (cc *ClientConn) splitRemotePane(srv *Server, sess *Session, hostName string, dir mux.SplitDir, rootLevel bool) (*mux.Pane, error) {
 	sess.mu.Lock()
 	w := sess.ActiveWindow()
 	if w == nil {
 		sess.mu.Unlock()
-		cc.Send(&Message{Type: MsgTypeCmdResult, CmdErr: "no session"})
-		return
-	}
-	var activePid int
-	if w.ActivePane != nil {
-		activePid = w.ActivePane.ProcessPid()
-	}
-	cols, layoutH := w.Width, w.Height
-	sess.mu.Unlock()
-
-	meta := mux.PaneMeta{Dir: mux.PaneCwd(activePid)}
-
-	sess.mu.Lock()
-	paneH := mux.PaneContentHeight(layoutH)
-	pane, err := sess.createPaneWithMeta(srv, meta, cols, paneH)
-	if err != nil {
-		sess.mu.Unlock()
-		cc.Send(&Message{Type: MsgTypeCmdResult, CmdErr: err.Error()})
-		return
-	}
-
-	winID := sess.windowCounter.Add(1)
-	newWin := mux.NewWindow(pane, cols, layoutH)
-	newWin.ID = winID
-	if name != "" {
-		newWin.Name = name
-	} else {
-		newWin.Name = fmt.Sprintf(WindowNameFormat, winID)
-	}
-	sess.Windows = append(sess.Windows, newWin)
-	sess.ActiveWindowID = winID
-	sess.mu.Unlock()
-
-	pane.Start()
-	sess.broadcastLayout()
-	cc.Send(&Message{Type: MsgTypeCmdResult,
-		CmdOutput: fmt.Sprintf("Created %s\n", newWin.Name)})
-}
-
-// splitRemotePane creates a proxy pane connected to a remote host, inserts it
-// into the active window's layout, and triggers a render. Returns the pane, or nil on error.
-func (cc *ClientConn) splitRemotePane(srv *Server, sess *Session, hostName string, dir mux.SplitDir, rootLevel bool) *mux.Pane {
-	sess.mu.Lock()
-	w := sess.ActiveWindow()
-	if w == nil {
-		sess.mu.Unlock()
-		cc.Send(&Message{Type: MsgTypeCmdResult, CmdErr: "no window"})
-		return nil
+		return nil, fmt.Errorf("no window")
 	}
 	initW, initH := w.Width, w.Height
 	sess.mu.Unlock()
 
-	// createRemotePane must be called without holding s.mu (SSH calls inside)
-	pane, err := sess.createRemotePane(srv, hostName, initW, mux.PaneContentHeight(initH))
+	pane, err := sess.prepareRemotePane(srv, hostName, initW, mux.PaneContentHeight(initH))
 	if err != nil {
-		cc.Send(&Message{Type: MsgTypeCmdResult, CmdErr: err.Error()})
-		return nil
+		return nil, err
 	}
 
-	sess.mu.Lock()
-	w = sess.ActiveWindow()
-	if w == nil {
-		sess.mu.Unlock()
-		cc.Send(&Message{Type: MsgTypeCmdResult, CmdErr: "no window"})
-		return nil
-	}
-	if rootLevel {
-		_, err = w.SplitRoot(dir, pane)
-	} else {
-		_, err = w.Split(dir, pane)
-	}
-	sess.mu.Unlock()
-
-	if err != nil {
-		cc.Send(&Message{Type: MsgTypeCmdResult, CmdErr: err.Error()})
-		return nil
-	}
-
-	// No pane.Start() needed — proxy panes don't have a readLoop/waitLoop
-	sess.broadcastLayout()
-	return pane
-}
-
-// splitNewPane creates a pane, inserts it into the active window's layout,
-// starts it, and triggers a render. Returns the new pane, or nil on error.
-func (cc *ClientConn) splitNewPane(srv *Server, sess *Session, meta mux.PaneMeta, dir mux.SplitDir, rootLevel bool) *mux.Pane {
-	// Grab the active pane's PID under the lock, then resolve its cwd
-	// outside the lock (PaneCwd shells out to lsof).
-	sess.mu.Lock()
-	w := sess.ActiveWindow()
-	if w == nil {
-		sess.mu.Unlock()
-		cc.Send(&Message{Type: MsgTypeCmdResult, CmdErr: "no window"})
-		return nil
-	}
-	var activePid int
-	if w.ActivePane != nil {
-		activePid = w.ActivePane.ProcessPid()
-	}
-	initW, initH := w.Width, w.Height
-	sess.mu.Unlock()
-
-	if meta.Dir == "" {
-		meta.Dir = mux.PaneCwd(activePid)
-	}
-
-	sess.mu.Lock()
-	// Re-fetch window — another command could have changed it while we
-	// resolved the cwd outside the lock.
-	w = sess.ActiveWindow()
-	if w == nil {
-		sess.mu.Unlock()
-		cc.Send(&Message{Type: MsgTypeCmdResult, CmdErr: "no window"})
-		return nil
-	}
-	pane, err := sess.createPaneWithMeta(srv, meta, initW, mux.PaneContentHeight(initH))
-	if err != nil {
-		sess.mu.Unlock()
-		cc.Send(&Message{Type: MsgTypeCmdResult, CmdErr: err.Error()})
-		return nil
-	}
-
-	if rootLevel {
-		_, err = w.SplitRoot(dir, pane)
-	} else {
-		_, err = w.Split(dir, pane)
-	}
-	if err != nil {
-		// Split failed (e.g. not enough space) — remove the pane we just
-		// created so it doesn't become an orphan in the session's pane list.
-		sess.removePane(pane.ID)
+	res := sess.enqueueCommandMutation(func(sess *Session) commandMutationResult {
+		sess.mu.Lock()
+		defer sess.mu.Unlock()
+		if err := sess.insertPreparedPaneIntoActiveWindowLocked(pane, dir, rootLevel); err != nil {
+			return commandMutationResult{err: err}
+		}
+		return commandMutationResult{broadcastLayout: true}
+	})
+	if res.err != nil {
+		if sess.RemoteManager != nil {
+			sess.RemoteManager.RemovePane(pane.ID)
+		}
 		pane.Close()
-		sess.mu.Unlock()
-		cc.Send(&Message{Type: MsgTypeCmdResult, CmdErr: err.Error()})
-		return nil
+		return nil, res.err
 	}
-	sess.mu.Unlock()
+	if res.broadcastLayout {
+		sess.broadcastLayout()
+	}
 
-	pane.Start()
-	sess.broadcastLayout()
-	return pane
+	return pane, nil
 }
 
 // resolvePane validates args and resolves a pane by name or ID.
@@ -304,21 +201,37 @@ func (cc *ClientConn) resolvePane(sess *Session, cmdName string, args []string) 
 		cc.Send(&Message{Type: MsgTypeCmdResult, CmdErr: fmt.Sprintf("usage: %s <pane>", cmdName)})
 		return nil
 	}
-	return cc.resolvePaneAcrossWindows(sess, cmdName, args[0])
+	pane, _, err := cc.resolvePaneAcrossWindowsLocked(sess, args[0])
+	if err != nil {
+		cc.Send(&Message{Type: MsgTypeCmdResult, CmdErr: err.Error()})
+		return nil
+	}
+	return pane
 }
 
 // resolvePaneAcrossWindows resolves a pane reference, searching the active
 // window first, then all other windows.
 // Caller must hold sess.mu.
 func (cc *ClientConn) resolvePaneAcrossWindows(sess *Session, cmdName string, ref string) *mux.Pane {
+	pane, _, err := cc.resolvePaneAcrossWindowsLocked(sess, ref)
+	if err != nil {
+		cc.Send(&Message{Type: MsgTypeCmdResult, CmdErr: err.Error()})
+		return nil
+	}
+	return pane
+}
+
+// resolvePaneAcrossWindowsLocked resolves a pane reference, searching the active
+// window first, then all other windows, then the flat pane registry.
+// Caller must hold sess.mu.
+func (cc *ClientConn) resolvePaneAcrossWindowsLocked(sess *Session, ref string) (*mux.Pane, *mux.Window, error) {
 	w := sess.ActiveWindow()
 	if w == nil {
-		cc.Send(&Message{Type: MsgTypeCmdResult, CmdErr: "no session"})
-		return nil
+		return nil, nil, fmt.Errorf("no session")
 	}
 	// Search active window first
 	if pane := w.ResolvePane(ref); pane != nil {
-		return pane
+		return pane, w, nil
 	}
 	// Search all other windows
 	for _, win := range sess.Windows {
@@ -326,15 +239,14 @@ func (cc *ClientConn) resolvePaneAcrossWindows(sess *Session, cmdName string, re
 			continue
 		}
 		if pane := win.ResolvePane(ref); pane != nil {
-			return pane
+			return pane, win, nil
 		}
 	}
 	// Fall back: search flat pane registry for orphaned/dormant panes
 	if pane := sess.findPaneByRef(ref); pane != nil {
-		return pane
+		return pane, sess.FindWindowByPaneID(pane.ID), nil
 	}
-	cc.Send(&Message{Type: MsgTypeCmdResult, CmdErr: fmt.Sprintf("pane %q not found", ref)})
-	return nil
+	return nil, nil, fmt.Errorf("pane %q not found", ref)
 }
 
 // parseWaitArgs extracts --after and --timeout flags from command arguments.

--- a/internal/server/command_queue_test.go
+++ b/internal/server/command_queue_test.go
@@ -1,0 +1,524 @@
+package server
+
+import (
+	"errors"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/weill-labs/amux/internal/config"
+	"github.com/weill-labs/amux/internal/mux"
+)
+
+func TestEnqueueCommandMutationReturnsOnSessionShutdown(t *testing.T) {
+	t.Parallel()
+
+	sess := &Session{
+		sessionEvents:    make(chan sessionEvent, 1),
+		sessionEventStop: make(chan struct{}),
+		sessionEventDone: make(chan struct{}),
+	}
+
+	resultCh := make(chan commandMutationResult, 1)
+	go func() {
+		resultCh <- sess.enqueueCommandMutation(func(*Session) commandMutationResult {
+			return commandMutationResult{output: "unreachable\n"}
+		})
+	}()
+
+	waitUntil(t, func() bool {
+		return len(sess.sessionEvents) == 1
+	})
+
+	close(sess.sessionEventDone)
+
+	select {
+	case res := <-resultCh:
+		if !errors.Is(res.err, errSessionShuttingDown) {
+			t.Fatalf("command mutation error = %v, want %v", res.err, errSessionShuttingDown)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("enqueueCommandMutation did not return after shutdown")
+	}
+}
+
+func TestQueuedCommandRenameWindow(t *testing.T) {
+	t.Parallel()
+
+	srv, sess, cleanup := newCommandTestSession(t)
+	defer cleanup()
+
+	w := newTestWindowWithPanes(t, sess, 1, "window-1", newTestPane(sess, 1, "pane-1"))
+	sess.mu.Lock()
+	sess.Windows = []*mux.Window{w}
+	sess.ActiveWindowID = w.ID
+	sess.Panes = w.Panes()
+	sess.mu.Unlock()
+
+	before := sess.generation.Load()
+	res := runTestCommand(t, srv, sess, "rename-window", "renamed")
+
+	if res.cmdErr != "" {
+		t.Fatalf("rename-window error: %s", res.cmdErr)
+	}
+	if !strings.Contains(res.output, "Renamed window to renamed") {
+		t.Fatalf("rename-window output = %q", res.output)
+	}
+	if w.Name != "renamed" {
+		t.Fatalf("window name = %q, want %q", w.Name, "renamed")
+	}
+	if sess.generation.Load() <= before {
+		t.Fatal("expected layout generation to increment")
+	}
+}
+
+func TestQueuedCommandResizeWindow(t *testing.T) {
+	t.Parallel()
+
+	srv, sess, cleanup := newCommandTestSession(t)
+	defer cleanup()
+
+	w1 := newTestWindowWithPanes(t, sess, 1, "window-1", newTestPane(sess, 1, "pane-1"))
+	w2 := newTestWindowWithPanes(t, sess, 2, "window-2", newTestPane(sess, 2, "pane-2"))
+	sess.mu.Lock()
+	sess.Windows = []*mux.Window{w1, w2}
+	sess.ActiveWindowID = w1.ID
+	sess.Panes = append(w1.Panes(), w2.Panes()...)
+	sess.mu.Unlock()
+
+	before := sess.generation.Load()
+	res := runTestCommand(t, srv, sess, "resize-window", "120", "40")
+
+	if res.cmdErr != "" {
+		t.Fatalf("resize-window error: %s", res.cmdErr)
+	}
+	if !strings.Contains(res.output, "Resized to 120x40") {
+		t.Fatalf("resize-window output = %q", res.output)
+	}
+	for _, w := range []*mux.Window{w1, w2} {
+		if w.Width != 120 || w.Height != 39 {
+			t.Fatalf("%s size = %dx%d, want 120x39", w.Name, w.Width, w.Height)
+		}
+	}
+	if sess.generation.Load() <= before {
+		t.Fatal("expected layout generation to increment")
+	}
+}
+
+func TestQueuedCommandFocusAcrossWindows(t *testing.T) {
+	t.Parallel()
+
+	srv, sess, cleanup := newCommandTestSession(t)
+	defer cleanup()
+
+	p1 := newTestPane(sess, 1, "pane-1")
+	p2 := newTestPane(sess, 2, "pane-2")
+	w1 := newTestWindowWithPanes(t, sess, 1, "window-1", p1)
+	w2 := newTestWindowWithPanes(t, sess, 2, "window-2", p2)
+	sess.mu.Lock()
+	sess.Windows = []*mux.Window{w1, w2}
+	sess.ActiveWindowID = w1.ID
+	sess.Panes = []*mux.Pane{p1, p2}
+	sess.mu.Unlock()
+
+	before := sess.generation.Load()
+	res := runTestCommand(t, srv, sess, "focus", "pane-2")
+
+	if res.cmdErr != "" {
+		t.Fatalf("focus error: %s", res.cmdErr)
+	}
+	if !strings.Contains(res.output, "Focused pane-2") {
+		t.Fatalf("focus output = %q", res.output)
+	}
+	if sess.ActiveWindowID != w2.ID || w2.ActivePane.ID != p2.ID {
+		t.Fatalf("expected focus to move to window %d pane %d", w2.ID, p2.ID)
+	}
+	if sess.generation.Load() <= before {
+		t.Fatal("expected layout generation to increment")
+	}
+}
+
+func TestQueuedCommandToggleMinimize(t *testing.T) {
+	t.Parallel()
+
+	srv, sess, cleanup := newCommandTestSession(t)
+	defer cleanup()
+
+	p1 := newTestPane(sess, 1, "pane-1")
+	p2 := newTestPane(sess, 2, "pane-2")
+	w := newTestWindowWithPanes(t, sess, 1, "window-1", p1, p2)
+	sess.mu.Lock()
+	sess.Windows = []*mux.Window{w}
+	sess.ActiveWindowID = w.ID
+	sess.Panes = []*mux.Pane{p1, p2}
+	sess.mu.Unlock()
+
+	before := sess.generation.Load()
+	res := runTestCommand(t, srv, sess, "toggle-minimize")
+
+	if res.cmdErr != "" {
+		t.Fatalf("toggle-minimize error: %s", res.cmdErr)
+	}
+	if !strings.Contains(res.output, "Minimized pane-2") {
+		t.Fatalf("toggle-minimize output = %q", res.output)
+	}
+	if !p2.Meta.Minimized {
+		t.Fatal("expected active pane to be minimized")
+	}
+	if sess.generation.Load() <= before {
+		t.Fatal("expected layout generation to increment")
+	}
+}
+
+func TestQueuedCommandNewWindow(t *testing.T) {
+	t.Parallel()
+
+	srv, sess, cleanup := newCommandTestSession(t)
+	defer cleanup()
+
+	p1, err := sess.createPane(srv, 80, 23)
+	if err != nil {
+		t.Fatalf("createPane: %v", err)
+	}
+	p1.Start()
+	w := mux.NewWindow(p1, 80, 23)
+	w.ID = 1
+	w.Name = "window-1"
+	sess.mu.Lock()
+	sess.Windows = []*mux.Window{w}
+	sess.ActiveWindowID = w.ID
+	sess.Panes = []*mux.Pane{p1}
+	sess.mu.Unlock()
+
+	before := sess.generation.Load()
+	res := runTestCommand(t, srv, sess, "new-window", "--name", "second")
+
+	if res.cmdErr != "" {
+		t.Fatalf("new-window error: %s", res.cmdErr)
+	}
+	if !strings.Contains(res.output, "Created second") {
+		t.Fatalf("new-window output = %q", res.output)
+	}
+
+	waitUntil(t, func() bool {
+		sess.mu.Lock()
+		defer sess.mu.Unlock()
+		return len(sess.Windows) == 2 && sess.ActiveWindowID == sess.Windows[1].ID && len(sess.Panes) == 2
+	})
+	if sess.generation.Load() <= before {
+		t.Fatal("expected layout generation to increment")
+	}
+}
+
+func TestQueuedCommandSpawnLocal(t *testing.T) {
+	t.Parallel()
+
+	srv, sess, cleanup := newCommandTestSession(t)
+	defer cleanup()
+
+	p1, err := sess.createPane(srv, 80, 23)
+	if err != nil {
+		t.Fatalf("createPane: %v", err)
+	}
+	p1.Start()
+	w := mux.NewWindow(p1, 80, 23)
+	w.ID = 1
+	w.Name = "window-1"
+	sess.mu.Lock()
+	sess.Windows = []*mux.Window{w}
+	sess.ActiveWindowID = w.ID
+	sess.Panes = []*mux.Pane{p1}
+	sess.mu.Unlock()
+
+	before := sess.generation.Load()
+	res := runTestCommand(t, srv, sess, "spawn", "--name", "worker-1", "--task", "build")
+
+	if res.cmdErr != "" {
+		t.Fatalf("spawn error: %s", res.cmdErr)
+	}
+	if !strings.Contains(res.output, "Spawned worker-1") {
+		t.Fatalf("spawn output = %q", res.output)
+	}
+
+	waitUntil(t, func() bool {
+		sess.mu.Lock()
+		defer sess.mu.Unlock()
+		return len(sess.Panes) == 2
+	})
+	sess.mu.Lock()
+	defer sess.mu.Unlock()
+	found := false
+	for _, p := range sess.Panes {
+		if p.Meta.Name == "worker-1" && p.Meta.Task == "build" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("expected spawned pane metadata to be present")
+	}
+	if sess.generation.Load() <= before {
+		t.Fatal("expected layout generation to increment")
+	}
+}
+
+func TestQueuedCommandKillOrphanPane(t *testing.T) {
+	t.Parallel()
+
+	srv, sess, cleanup := newCommandTestSession(t)
+	defer cleanup()
+
+	p1 := newTestPane(sess, 1, "pane-1")
+	w := newTestWindowWithPanes(t, sess, 1, "window-1", p1)
+	orphan := newTestPane(sess, 2, "orphan-pane")
+	sess.mu.Lock()
+	sess.Windows = []*mux.Window{w}
+	sess.ActiveWindowID = w.ID
+	sess.Panes = []*mux.Pane{p1, orphan}
+	sess.mu.Unlock()
+
+	before := sess.generation.Load()
+	res := runTestCommand(t, srv, sess, "kill", "orphan-pane")
+
+	if res.cmdErr != "" {
+		t.Fatalf("kill error: %s", res.cmdErr)
+	}
+	if !strings.Contains(res.output, "Killed orphan-pane") {
+		t.Fatalf("kill output = %q", res.output)
+	}
+
+	sess.mu.Lock()
+	defer sess.mu.Unlock()
+	if sess.hasPane(orphan.ID) {
+		t.Fatal("expected orphan pane to be removed")
+	}
+	if len(sess.Windows) != 1 || sess.Windows[0].PaneCount() != 1 {
+		t.Fatal("expected window layout to remain intact")
+	}
+	if sess.generation.Load() <= before {
+		t.Fatal("expected layout generation to increment")
+	}
+}
+
+func TestQueuedCommandInjectProxyAndUnsplice(t *testing.T) {
+	t.Parallel()
+
+	srv, sess, cleanup := newCommandTestSession(t)
+	defer cleanup()
+
+	p1, err := sess.createPane(srv, 80, 23)
+	if err != nil {
+		t.Fatalf("createPane: %v", err)
+	}
+	p1.Start()
+	w := mux.NewWindow(p1, 80, 23)
+	w.ID = 1
+	w.Name = "window-1"
+	sess.mu.Lock()
+	sess.Windows = []*mux.Window{w}
+	sess.ActiveWindowID = w.ID
+	sess.Panes = []*mux.Pane{p1}
+	sess.mu.Unlock()
+
+	beforeInject := sess.generation.Load()
+	injectRes := runTestCommand(t, srv, sess, "_inject-proxy", "fake-host")
+	if injectRes.cmdErr != "" {
+		t.Fatalf("inject-proxy error: %s", injectRes.cmdErr)
+	}
+	if !strings.Contains(injectRes.output, "Injected proxy pane") {
+		t.Fatalf("inject-proxy output = %q", injectRes.output)
+	}
+	if sess.generation.Load() <= beforeInject {
+		t.Fatal("expected layout generation to increment after inject")
+	}
+
+	var proxyID uint32
+	sess.mu.Lock()
+	for _, p := range sess.Panes {
+		if p.IsProxy() && p.Meta.Host == "fake-host" {
+			proxyID = p.ID
+		}
+	}
+	sess.mu.Unlock()
+	if proxyID == 0 {
+		t.Fatal("expected injected proxy pane to exist")
+	}
+
+	beforeUnsplice := sess.generation.Load()
+	unspliceRes := runTestCommand(t, srv, sess, "unsplice", "fake-host")
+	if unspliceRes.cmdErr != "" {
+		t.Fatalf("unsplice error: %s", unspliceRes.cmdErr)
+	}
+	if !strings.Contains(unspliceRes.output, "Unspliced fake-host") {
+		t.Fatalf("unsplice output = %q", unspliceRes.output)
+	}
+
+	waitUntil(t, func() bool {
+		sess.mu.Lock()
+		defer sess.mu.Unlock()
+		if sess.hasPane(proxyID) {
+			return false
+		}
+		for _, p := range sess.Panes {
+			if !p.IsProxy() && p.ID != p1.ID {
+				return true
+			}
+		}
+		return false
+	})
+	if sess.generation.Load() <= beforeUnsplice {
+		t.Fatal("expected layout generation to increment after unsplice")
+	}
+}
+
+func TestQueuedPreparedRemotePaneInsert(t *testing.T) {
+	t.Parallel()
+
+	srv, sess, cleanup := newCommandTestSession(t)
+	defer cleanup()
+
+	p1 := newTestPane(sess, 1, "pane-1")
+	w := newTestWindowWithPanes(t, sess, 1, "window-1", p1)
+	sess.mu.Lock()
+	sess.Windows = []*mux.Window{w}
+	sess.ActiveWindowID = w.ID
+	sess.Panes = []*mux.Pane{p1}
+	sess.mu.Unlock()
+
+	proxy := mux.NewProxyPane(2, mux.PaneMeta{
+		Name:  "pane-2",
+		Host:  "gpu-server",
+		Color: config.CatppuccinMocha[1],
+	}, 80, 23, sess.paneOutputCallback(), sess.paneExitCallback(srv), func(data []byte) (int, error) {
+		return len(data), nil
+	})
+
+	res := sess.enqueueCommandMutation(func(sess *Session) commandMutationResult {
+		sess.mu.Lock()
+		defer sess.mu.Unlock()
+
+		if err := sess.insertPreparedPaneIntoActiveWindowLocked(proxy, mux.SplitVertical, false); err != nil {
+			return commandMutationResult{err: err}
+		}
+		return commandMutationResult{
+			output:          "inserted\n",
+			broadcastLayout: true,
+		}
+	})
+	if res.err != nil {
+		t.Fatalf("enqueueCommandMutation insert error: %v", res.err)
+	}
+
+	sess.mu.Lock()
+	defer sess.mu.Unlock()
+	if len(sess.Panes) != 2 {
+		t.Fatalf("expected 2 panes, got %d", len(sess.Panes))
+	}
+	if !sess.hasPane(proxy.ID) {
+		t.Fatal("expected prepared proxy pane to be registered")
+	}
+	if w.Root.FindPane(proxy.ID) == nil {
+		t.Fatal("expected prepared proxy pane to be inserted into active window")
+	}
+}
+
+func newCommandTestSession(t *testing.T) (*Server, *Session, func()) {
+	t.Helper()
+
+	sess := newSession("test-command-queue")
+	srv := &Server{sessions: map[string]*Session{sess.Name: sess}}
+	cleanup := func() {
+		sess.shutdown.Store(true)
+		sess.mu.Lock()
+		panes := append([]*mux.Pane(nil), sess.Panes...)
+		sess.mu.Unlock()
+		for _, p := range panes {
+			p.Close()
+		}
+		if sess.sessionEventStop != nil {
+			close(sess.sessionEventStop)
+			<-sess.sessionEventDone
+		}
+		if sess.crashCheckpointStop != nil {
+			close(sess.crashCheckpointStop)
+			<-sess.crashCheckpointDone
+		}
+	}
+	return srv, sess, cleanup
+}
+
+func newTestPane(sess *Session, id uint32, name string) *mux.Pane {
+	return mux.NewProxyPane(id, mux.PaneMeta{
+		Name:  name,
+		Host:  mux.DefaultHost,
+		Color: config.CatppuccinMocha[(id-1)%uint32(len(config.CatppuccinMocha))],
+	}, 80, 23, sess.paneOutputCallback(), sess.paneExitCallback(&Server{}), func(data []byte) (int, error) {
+		return len(data), nil
+	})
+}
+
+func newTestWindowWithPanes(t *testing.T, sess *Session, id uint32, name string, panes ...*mux.Pane) *mux.Window {
+	t.Helper()
+	if len(panes) == 0 {
+		t.Fatal("need at least one pane")
+	}
+
+	w := mux.NewWindow(panes[0], 80, 23)
+	w.ID = id
+	w.Name = name
+	for _, pane := range panes[1:] {
+		if _, err := w.Split(mux.SplitHorizontal, pane); err != nil {
+			t.Fatalf("Split: %v", err)
+		}
+	}
+	return w
+}
+
+func runTestCommand(t *testing.T, srv *Server, sess *Session, name string, args ...string) struct {
+	output string
+	cmdErr string
+} {
+	t.Helper()
+
+	serverConn, clientConn := net.Pipe()
+	defer serverConn.Close()
+	defer clientConn.Close()
+	cc := NewClientConn(serverConn)
+
+	results := make(chan struct {
+		output string
+		cmdErr string
+	}, 1)
+	go func() {
+		for {
+			msg, err := ReadMsg(clientConn)
+			if err != nil {
+				return
+			}
+			if msg.Type == MsgTypeCmdResult {
+				results <- struct {
+					output string
+					cmdErr string
+				}{output: msg.CmdOutput, cmdErr: msg.CmdErr}
+				return
+			}
+		}
+	}()
+
+	go cc.handleCommand(srv, sess, &Message{
+		Type:    MsgTypeCommand,
+		CmdName: name,
+		CmdArgs: args,
+	})
+
+	select {
+	case res := <-results:
+		return res
+	case <-time.After(5 * time.Second):
+		t.Fatalf("timeout waiting for %s result", name)
+	}
+	return struct {
+		output string
+		cmdErr string
+	}{}
+}

--- a/internal/server/commands.go
+++ b/internal/server/commands.go
@@ -36,6 +36,47 @@ func (ctx *CommandContext) replyErr(errMsg string) {
 	ctx.CC.Send(&Message{Type: MsgTypeCmdResult, CmdErr: errMsg})
 }
 
+func (ctx *CommandContext) replyCommandMutation(res commandMutationResult) {
+	if res.err != nil {
+		ctx.replyErr(res.err.Error())
+		return
+	}
+	for _, pane := range res.startPanes {
+		pane.Start()
+	}
+	for _, pane := range res.closePanes {
+		pane.Close()
+	}
+	if res.broadcastLayout {
+		ctx.Sess.broadcastLayout()
+	}
+	if res.output != "" {
+		ctx.reply(res.output)
+	} else {
+		ctx.CC.Send(&Message{Type: MsgTypeCmdResult})
+	}
+	if res.sendExit {
+		ctx.Sess.broadcast(&Message{Type: MsgTypeExit})
+	}
+	if res.shutdownServer {
+		go ctx.Srv.Shutdown()
+	}
+}
+
+func (ctx *CommandContext) activeWindowSnapshot() (activePid, width, height int, err error) {
+	ctx.Sess.mu.Lock()
+	defer ctx.Sess.mu.Unlock()
+
+	w := ctx.Sess.ActiveWindow()
+	if w == nil {
+		return 0, 0, 0, fmt.Errorf("no window")
+	}
+	if w.ActivePane != nil {
+		activePid = w.ActivePane.ProcessPid()
+	}
+	return activePid, w.Width, w.Height, nil
+}
+
 // commandRegistry maps command names to their handlers, following
 // tmux's pattern of one entry per command.
 var commandRegistry = map[string]CommandHandler{
@@ -142,15 +183,47 @@ func cmdSplit(ctx *CommandContext) {
 	}
 
 	if hostName != "" {
-		pane := ctx.CC.splitRemotePane(ctx.Srv, ctx.Sess, hostName, dir, rootLevel)
-		if pane != nil {
-			ctx.reply(fmt.Sprintf("Split %s: new remote pane %s @%s\n", dirName(dir), pane.Meta.Name, hostName))
+		pane, err := ctx.CC.splitRemotePane(ctx.Srv, ctx.Sess, hostName, dir, rootLevel)
+		if err != nil {
+			ctx.replyErr(err.Error())
+			return
 		}
+		ctx.reply(fmt.Sprintf("Split %s: new remote pane %s @%s\n", dirName(dir), pane.Meta.Name, hostName))
 	} else {
-		pane := ctx.CC.splitNewPane(ctx.Srv, ctx.Sess, mux.PaneMeta{}, dir, rootLevel)
-		if pane != nil {
-			ctx.reply(fmt.Sprintf("Split %s: new pane %s\n", dirName(dir), pane.Meta.Name))
+		activePid, _, _, err := ctx.activeWindowSnapshot()
+		if err != nil {
+			ctx.replyErr(err.Error())
+			return
 		}
+		meta := mux.PaneMeta{Dir: mux.PaneCwd(activePid)}
+		ctx.replyCommandMutation(ctx.Sess.enqueueCommandMutation(func(sess *Session) commandMutationResult {
+			sess.mu.Lock()
+			defer sess.mu.Unlock()
+
+			w := sess.ActiveWindow()
+			if w == nil {
+				return commandMutationResult{err: fmt.Errorf("no window")}
+			}
+			pane, err := sess.createPaneWithMeta(ctx.Srv, meta, w.Width, mux.PaneContentHeight(w.Height))
+			if err != nil {
+				return commandMutationResult{err: err}
+			}
+			if rootLevel {
+				_, err = w.SplitRoot(dir, pane)
+			} else {
+				_, err = w.Split(dir, pane)
+			}
+			if err != nil {
+				sess.removePane(pane.ID)
+				pane.Close()
+				return commandMutationResult{err: err}
+			}
+			return commandMutationResult{
+				output:          fmt.Sprintf("Split %s: new pane %s\n", dirName(dir), pane.Meta.Name),
+				broadcastLayout: true,
+				startPanes:      []*mux.Pane{pane},
+			}
+		}))
 	}
 }
 
@@ -159,35 +232,37 @@ func cmdFocus(ctx *CommandContext) {
 	if len(ctx.Args) > 0 {
 		direction = ctx.Args[0]
 	}
+	ctx.replyCommandMutation(ctx.Sess.enqueueCommandMutation(func(sess *Session) commandMutationResult {
+		sess.mu.Lock()
+		defer sess.mu.Unlock()
 
-	ctx.Sess.mu.Lock()
-	w := ctx.Sess.ActiveWindow()
-	if w == nil {
-		ctx.Sess.mu.Unlock()
-		return
-	}
+		w := sess.ActiveWindow()
+		if w == nil {
+			return commandMutationResult{err: fmt.Errorf("no session")}
+		}
 
-	switch direction {
-	case "next", "left", "right", "up", "down":
-		w.Focus(direction)
-		name := w.ActivePane.Meta.Name
-		ctx.Sess.mu.Unlock()
-		ctx.Sess.broadcastLayout()
-		ctx.reply(fmt.Sprintf("Focused %s\n", name))
-	default:
-		pane := ctx.CC.resolvePaneAcrossWindows(ctx.Sess, "focus", direction)
-		if pane == nil {
-			ctx.Sess.mu.Unlock()
-			return
+		switch direction {
+		case "next", "left", "right", "up", "down":
+			w.Focus(direction)
+			return commandMutationResult{
+				output:          fmt.Sprintf("Focused %s\n", w.ActivePane.Meta.Name),
+				broadcastLayout: true,
+			}
+		default:
+			pane, pw, err := ctx.CC.resolvePaneAcrossWindowsLocked(sess, direction)
+			if err != nil {
+				return commandMutationResult{err: err}
+			}
+			if pw != nil {
+				sess.ActiveWindowID = pw.ID
+				pw.FocusPane(pane)
+			}
+			return commandMutationResult{
+				output:          fmt.Sprintf("Focused %s\n", pane.Meta.Name),
+				broadcastLayout: true,
+			}
 		}
-		if pw := ctx.Sess.FindWindowByPaneID(pane.ID); pw != nil {
-			ctx.Sess.ActiveWindowID = pw.ID
-			pw.FocusPane(pane)
-		}
-		ctx.Sess.mu.Unlock()
-		ctx.Sess.broadcastLayout()
-		ctx.reply(fmt.Sprintf("Focused %s\n", pane.Meta.Name))
-	}
+	}))
 }
 
 func cmdCapture(ctx *CommandContext) {
@@ -216,132 +291,202 @@ func cmdSpawn(ctx *CommandContext) {
 		return
 	}
 	if remoteHost != "" && remoteHost != mux.DefaultHost {
-		pane := ctx.CC.splitRemotePane(ctx.Srv, ctx.Sess, remoteHost, mux.SplitVertical, false)
-		if pane != nil {
-			pane.Meta.Name = meta.Name
-			if meta.Task != "" {
-				pane.Meta.Task = meta.Task
+		pane, err := ctx.CC.splitRemotePane(ctx.Srv, ctx.Sess, remoteHost, mux.SplitVertical, false)
+		if err != nil {
+			ctx.replyErr(err.Error())
+			return
+		}
+		ctx.replyCommandMutation(ctx.Sess.enqueueCommandMutation(func(sess *Session) commandMutationResult {
+			sess.mu.Lock()
+			defer sess.mu.Unlock()
+			registered := sess.findPaneLocked(pane.ID)
+			if registered == nil {
+				return commandMutationResult{err: fmt.Errorf("pane %q not found", pane.Meta.Name)}
 			}
-			ctx.Sess.broadcastLayout()
-			ctx.reply(fmt.Sprintf("Spawned %s in pane %d @%s\n", meta.Name, pane.ID, remoteHost))
-		}
+			registered.Meta.Name = meta.Name
+			if meta.Task != "" {
+				registered.Meta.Task = meta.Task
+			}
+			return commandMutationResult{
+				output:          fmt.Sprintf("Spawned %s in pane %d @%s\n", meta.Name, pane.ID, remoteHost),
+				broadcastLayout: true,
+			}
+		}))
 	} else {
-		pane := ctx.CC.splitNewPane(ctx.Srv, ctx.Sess, meta, mux.SplitVertical, false)
-		if pane != nil {
-			ctx.reply(fmt.Sprintf("Spawned %s in pane %d\n", meta.Name, pane.ID))
+		activePid, _, _, err := ctx.activeWindowSnapshot()
+		if err != nil {
+			ctx.replyErr(err.Error())
+			return
 		}
+		if meta.Dir == "" {
+			meta.Dir = mux.PaneCwd(activePid)
+		}
+		ctx.replyCommandMutation(ctx.Sess.enqueueCommandMutation(func(sess *Session) commandMutationResult {
+			sess.mu.Lock()
+			defer sess.mu.Unlock()
+
+			w := sess.ActiveWindow()
+			if w == nil {
+				return commandMutationResult{err: fmt.Errorf("no window")}
+			}
+			pane, err := sess.createPaneWithMeta(ctx.Srv, meta, w.Width, mux.PaneContentHeight(w.Height))
+			if err != nil {
+				return commandMutationResult{err: err}
+			}
+			if _, err := w.Split(mux.SplitVertical, pane); err != nil {
+				sess.removePane(pane.ID)
+				pane.Close()
+				return commandMutationResult{err: err}
+			}
+			return commandMutationResult{
+				output:          fmt.Sprintf("Spawned %s in pane %d\n", meta.Name, pane.ID),
+				broadcastLayout: true,
+				startPanes:      []*mux.Pane{pane},
+			}
+		}))
 	}
 }
 
 func cmdZoom(ctx *CommandContext) {
-	ctx.Sess.mu.Lock()
-	w := ctx.Sess.ActiveWindow()
-	if w == nil {
-		ctx.Sess.mu.Unlock()
-		ctx.replyErr("no session")
-		return
-	}
-	var pane *mux.Pane
-	if len(ctx.Args) > 0 {
-		pane = w.ResolvePane(ctx.Args[0])
-		if pane == nil {
-			ctx.Sess.mu.Unlock()
-			ctx.replyErr(fmt.Sprintf("pane %q not found", ctx.Args[0]))
-			return
+	ctx.replyCommandMutation(ctx.Sess.enqueueCommandMutation(func(sess *Session) commandMutationResult {
+		sess.mu.Lock()
+		defer sess.mu.Unlock()
+
+		w := sess.ActiveWindow()
+		if w == nil {
+			return commandMutationResult{err: fmt.Errorf("no session")}
 		}
-	} else {
-		pane = w.ActivePane
-	}
-	if pane == nil {
-		ctx.Sess.mu.Unlock()
-		ctx.replyErr("no active pane")
-		return
-	}
-	willUnzoom := w.ZoomedPaneID == pane.ID
-	err := w.Zoom(pane.ID)
-	ctx.Sess.mu.Unlock()
-	if err != nil {
-		ctx.replyErr(err.Error())
-		return
-	}
-	ctx.Sess.broadcastLayout()
-	verb := "Zoomed"
-	if willUnzoom {
-		verb = "Unzoomed"
-	}
-	ctx.reply(fmt.Sprintf("%s %s\n", verb, pane.Meta.Name))
+		var pane *mux.Pane
+		if len(ctx.Args) > 0 {
+			pane = w.ResolvePane(ctx.Args[0])
+			if pane == nil {
+				return commandMutationResult{err: fmt.Errorf("pane %q not found", ctx.Args[0])}
+			}
+		} else {
+			pane = w.ActivePane
+		}
+		if pane == nil {
+			return commandMutationResult{err: fmt.Errorf("no active pane")}
+		}
+		willUnzoom := w.ZoomedPaneID == pane.ID
+		if err := w.Zoom(pane.ID); err != nil {
+			return commandMutationResult{err: err}
+		}
+		verb := "Zoomed"
+		if willUnzoom {
+			verb = "Unzoomed"
+		}
+		return commandMutationResult{
+			output:          fmt.Sprintf("%s %s\n", verb, pane.Meta.Name),
+			broadcastLayout: true,
+		}
+	}))
 }
 
 func cmdMinimize(ctx *CommandContext) {
-	ctx.CC.withPaneWindow(ctx.Sess, "minimize", ctx.Args, func(p *mux.Pane, w *mux.Window) (string, error) {
-		return fmt.Sprintf("Minimized %s\n", p.Meta.Name), w.Minimize(p.ID)
-	})
+	ctx.replyCommandMutation(ctx.Sess.enqueueCommandMutation(func(sess *Session) commandMutationResult {
+		sess.mu.Lock()
+		defer sess.mu.Unlock()
+
+		p, w, err := ctx.CC.resolvePaneWindowLocked(sess, "minimize", ctx.Args)
+		if err != nil {
+			return commandMutationResult{err: err}
+		}
+		if err := w.Minimize(p.ID); err != nil {
+			return commandMutationResult{err: err}
+		}
+		return commandMutationResult{
+			output:          fmt.Sprintf("Minimized %s\n", p.Meta.Name),
+			broadcastLayout: true,
+		}
+	}))
 }
 
 func cmdRestore(ctx *CommandContext) {
-	ctx.CC.withPaneWindow(ctx.Sess, "restore", ctx.Args, func(p *mux.Pane, w *mux.Window) (string, error) {
-		return fmt.Sprintf("Restored %s\n", p.Meta.Name), w.Restore(p.ID)
-	})
+	ctx.replyCommandMutation(ctx.Sess.enqueueCommandMutation(func(sess *Session) commandMutationResult {
+		sess.mu.Lock()
+		defer sess.mu.Unlock()
+
+		p, w, err := ctx.CC.resolvePaneWindowLocked(sess, "restore", ctx.Args)
+		if err != nil {
+			return commandMutationResult{err: err}
+		}
+		if err := w.Restore(p.ID); err != nil {
+			return commandMutationResult{err: err}
+		}
+		return commandMutationResult{
+			output:          fmt.Sprintf("Restored %s\n", p.Meta.Name),
+			broadcastLayout: true,
+		}
+	}))
 }
 
 func cmdToggleMinimize(ctx *CommandContext) {
-	ctx.Sess.mu.Lock()
-	w := ctx.Sess.ActiveWindow()
-	if w == nil {
-		ctx.Sess.mu.Unlock()
-		ctx.replyErr("no active window")
-		return
-	}
-	name, didMinimize, err := w.ToggleMinimize()
-	ctx.Sess.mu.Unlock()
-	if err != nil {
-		ctx.replyErr(err.Error())
-		return
-	}
-	ctx.Sess.broadcastLayout()
-	verb := "Restored"
-	if didMinimize {
-		verb = "Minimized"
-	}
-	ctx.reply(fmt.Sprintf("%s %s\n", verb, name))
+	ctx.replyCommandMutation(ctx.Sess.enqueueCommandMutation(func(sess *Session) commandMutationResult {
+		sess.mu.Lock()
+		defer sess.mu.Unlock()
+
+		w := sess.ActiveWindow()
+		if w == nil {
+			return commandMutationResult{err: fmt.Errorf("no active window")}
+		}
+		name, didMinimize, err := w.ToggleMinimize()
+		if err != nil {
+			return commandMutationResult{err: err}
+		}
+		verb := "Restored"
+		if didMinimize {
+			verb = "Minimized"
+		}
+		return commandMutationResult{
+			output:          fmt.Sprintf("%s %s\n", verb, name),
+			broadcastLayout: true,
+		}
+	}))
 }
 
 func cmdKill(ctx *CommandContext) {
-	ctx.Sess.mu.Lock()
-	var pane *mux.Pane
-	if len(ctx.Args) == 0 {
-		w := ctx.Sess.ActiveWindow()
-		if w != nil {
-			pane = w.ActivePane
+	ctx.replyCommandMutation(ctx.Sess.enqueueCommandMutation(func(sess *Session) commandMutationResult {
+		sess.mu.Lock()
+		defer sess.mu.Unlock()
+
+		var pane *mux.Pane
+		if len(ctx.Args) == 0 {
+			w := sess.ActiveWindow()
+			if w != nil {
+				pane = w.ActivePane
+			}
+		} else {
+			pane = ctx.CC.resolvePane(sess, "kill", ctx.Args)
 		}
-	} else {
-		pane = ctx.CC.resolvePane(ctx.Sess, "kill", ctx.Args)
-	}
-	if pane == nil {
-		ctx.Sess.mu.Unlock()
-		return
-	}
-	paneID := pane.ID
-	paneName := pane.Meta.Name
-	lastPane := len(ctx.Sess.Panes) <= 1
-	ctx.Sess.removePane(paneID)
-	closedWindow := ctx.Sess.closePaneInWindow(paneID)
-	ctx.Sess.mu.Unlock()
-	pane.Close()
+		if pane == nil {
+			return commandMutationResult{}
+		}
 
-	if lastPane {
-		ctx.reply(fmt.Sprintf("Killed %s (session exiting)\n", paneName))
-		ctx.Sess.broadcast(&Message{Type: MsgTypeExit})
-		ctx.Srv.Shutdown()
-		return
-	}
+		paneID := pane.ID
+		paneName := pane.Meta.Name
+		lastPane := len(sess.Panes) <= 1
+		sess.removePane(paneID)
+		closedWindow := sess.closePaneInWindow(paneID)
 
-	ctx.Sess.broadcastLayout()
-	if closedWindow != "" {
-		ctx.reply(fmt.Sprintf("Killed %s (closed %s)\n", paneName, closedWindow))
-	} else {
-		ctx.reply(fmt.Sprintf("Killed %s\n", paneName))
-	}
+		res := commandMutationResult{
+			closePanes: []*mux.Pane{pane},
+		}
+		if lastPane {
+			res.output = fmt.Sprintf("Killed %s (session exiting)\n", paneName)
+			res.sendExit = true
+			res.shutdownServer = true
+			return res
+		}
+
+		res.broadcastLayout = true
+		if closedWindow != "" {
+			res.output = fmt.Sprintf("Killed %s (closed %s)\n", paneName, closedWindow)
+		} else {
+			res.output = fmt.Sprintf("Killed %s\n", paneName)
+		}
+		return res
+	}))
 }
 
 func cmdSendKeys(ctx *CommandContext) {
@@ -405,7 +550,42 @@ func cmdNewWindow(ctx *CommandContext) {
 			name = ctx.Args[i+1]
 		}
 	}
-	ctx.CC.createNewWindow(ctx.Srv, ctx.Sess, name)
+	activePid, _, _, err := ctx.activeWindowSnapshot()
+	if err != nil {
+		ctx.replyErr(err.Error())
+		return
+	}
+	meta := mux.PaneMeta{Dir: mux.PaneCwd(activePid)}
+	ctx.replyCommandMutation(ctx.Sess.enqueueCommandMutation(func(sess *Session) commandMutationResult {
+		sess.mu.Lock()
+		defer sess.mu.Unlock()
+
+		w := sess.ActiveWindow()
+		if w == nil {
+			return commandMutationResult{err: fmt.Errorf("no session")}
+		}
+		pane, err := sess.createPaneWithMeta(ctx.Srv, meta, w.Width, mux.PaneContentHeight(w.Height))
+		if err != nil {
+			return commandMutationResult{err: err}
+		}
+
+		winID := sess.windowCounter.Add(1)
+		newWin := mux.NewWindow(pane, w.Width, w.Height)
+		newWin.ID = winID
+		if name != "" {
+			newWin.Name = name
+		} else {
+			newWin.Name = fmt.Sprintf(WindowNameFormat, winID)
+		}
+		sess.Windows = append(sess.Windows, newWin)
+		sess.ActiveWindowID = winID
+
+		return commandMutationResult{
+			output:          fmt.Sprintf("Created %s\n", newWin.Name),
+			broadcastLayout: true,
+			startPanes:      []*mux.Pane{pane},
+		}
+	}))
 }
 
 func cmdListWindows(ctx *CommandContext) {
@@ -431,35 +611,35 @@ func cmdSelectWindow(ctx *CommandContext) {
 	}
 	ref := ctx.Args[0]
 
-	ctx.Sess.mu.Lock()
-	w := ctx.Sess.ResolveWindow(ref)
-	if w != nil {
-		ctx.Sess.ActiveWindowID = w.ID
-	}
-	ctx.Sess.mu.Unlock()
+	ctx.replyCommandMutation(ctx.Sess.enqueueCommandMutation(func(sess *Session) commandMutationResult {
+		sess.mu.Lock()
+		defer sess.mu.Unlock()
 
-	if w == nil {
-		ctx.replyErr(fmt.Sprintf("window %q not found", ref))
-		return
-	}
-	ctx.Sess.broadcastLayout()
-	ctx.reply("Switched window\n")
+		w := sess.ResolveWindow(ref)
+		if w == nil {
+			return commandMutationResult{err: fmt.Errorf("window %q not found", ref)}
+		}
+		sess.ActiveWindowID = w.ID
+		return commandMutationResult{output: "Switched window\n", broadcastLayout: true}
+	}))
 }
 
 func cmdNextWindow(ctx *CommandContext) {
-	ctx.Sess.mu.Lock()
-	ctx.Sess.NextWindow()
-	ctx.Sess.mu.Unlock()
-	ctx.Sess.broadcastLayout()
-	ctx.reply("Next window\n")
+	ctx.replyCommandMutation(ctx.Sess.enqueueCommandMutation(func(sess *Session) commandMutationResult {
+		sess.mu.Lock()
+		defer sess.mu.Unlock()
+		sess.NextWindow()
+		return commandMutationResult{output: "Next window\n", broadcastLayout: true}
+	}))
 }
 
 func cmdPrevWindow(ctx *CommandContext) {
-	ctx.Sess.mu.Lock()
-	ctx.Sess.PrevWindow()
-	ctx.Sess.mu.Unlock()
-	ctx.Sess.broadcastLayout()
-	ctx.reply("Previous window\n")
+	ctx.replyCommandMutation(ctx.Sess.enqueueCommandMutation(func(sess *Session) commandMutationResult {
+		sess.mu.Lock()
+		defer sess.mu.Unlock()
+		sess.PrevWindow()
+		return commandMutationResult{output: "Previous window\n", broadcastLayout: true}
+	}))
 }
 
 func cmdRenameWindow(ctx *CommandContext) {
@@ -467,17 +647,20 @@ func cmdRenameWindow(ctx *CommandContext) {
 		ctx.replyErr("usage: rename-window <name>")
 		return
 	}
-	ctx.Sess.mu.Lock()
-	w := ctx.Sess.ActiveWindow()
-	if w == nil {
-		ctx.Sess.mu.Unlock()
-		ctx.replyErr("no window")
-		return
-	}
-	w.Name = ctx.Args[0]
-	ctx.Sess.mu.Unlock()
-	ctx.Sess.broadcastLayout()
-	ctx.reply(fmt.Sprintf("Renamed window to %s\n", ctx.Args[0]))
+	name := ctx.Args[0]
+	ctx.replyCommandMutation(ctx.Sess.enqueueCommandMutation(func(sess *Session) commandMutationResult {
+		sess.mu.Lock()
+		defer sess.mu.Unlock()
+		w := sess.ActiveWindow()
+		if w == nil {
+			return commandMutationResult{err: fmt.Errorf("no window")}
+		}
+		w.Name = name
+		return commandMutationResult{
+			output:          fmt.Sprintf("Renamed window to %s\n", name),
+			broadcastLayout: true,
+		}
+	}))
 }
 
 func cmdResizeBorder(ctx *CommandContext) {
@@ -492,13 +675,14 @@ func cmdResizeBorder(ctx *CommandContext) {
 		ctx.replyErr("resize-border: invalid arguments")
 		return
 	}
-	ctx.Sess.mu.Lock()
-	w := ctx.Sess.ActiveWindow()
-	if w != nil {
-		w.ResizeBorder(x, y, delta)
-	}
-	ctx.Sess.mu.Unlock()
-	ctx.Sess.broadcastLayout()
+	ctx.replyCommandMutation(ctx.Sess.enqueueCommandMutation(func(sess *Session) commandMutationResult {
+		sess.mu.Lock()
+		defer sess.mu.Unlock()
+		if w := sess.ActiveWindow(); w != nil {
+			w.ResizeBorder(x, y, delta)
+		}
+		return commandMutationResult{broadcastLayout: true}
+	}))
 }
 
 func cmdResizeActive(ctx *CommandContext) {
@@ -512,14 +696,14 @@ func cmdResizeActive(ctx *CommandContext) {
 		ctx.replyErr("resize-active: invalid delta")
 		return
 	}
-	ctx.Sess.mu.Lock()
-	w := ctx.Sess.ActiveWindow()
-	if w != nil {
-		w.ResizeActive(direction, delta)
-	}
-	ctx.Sess.mu.Unlock()
-	ctx.Sess.broadcastLayout()
-	ctx.CC.Send(&Message{Type: MsgTypeCmdResult})
+	ctx.replyCommandMutation(ctx.Sess.enqueueCommandMutation(func(sess *Session) commandMutationResult {
+		sess.mu.Lock()
+		defer sess.mu.Unlock()
+		if w := sess.ActiveWindow(); w != nil {
+			w.ResizeActive(direction, delta)
+		}
+		return commandMutationResult{broadcastLayout: true}
+	}))
 }
 
 func cmdResizePane(ctx *CommandContext) {
@@ -543,10 +727,20 @@ func cmdResizePane(ctx *CommandContext) {
 			return
 		}
 	}
-	ctx.CC.withPaneWindow(ctx.Sess, "resize-pane", ctx.Args[:1], func(p *mux.Pane, w *mux.Window) (string, error) {
+	ctx.replyCommandMutation(ctx.Sess.enqueueCommandMutation(func(sess *Session) commandMutationResult {
+		sess.mu.Lock()
+		defer sess.mu.Unlock()
+
+		p, w, err := ctx.CC.resolvePaneWindowLocked(sess, "resize-pane", ctx.Args[:1])
+		if err != nil {
+			return commandMutationResult{err: err}
+		}
 		w.ResizePane(p.ID, direction, delta)
-		return fmt.Sprintf("Resized %s %s by %d\n", p.Meta.Name, direction, delta), nil
-	})
+		return commandMutationResult{
+			output:          fmt.Sprintf("Resized %s %s by %d\n", p.Meta.Name, direction, delta),
+			broadcastLayout: true,
+		}
+	}))
 }
 
 func cmdResizeWindow(ctx *CommandContext) {
@@ -560,79 +754,74 @@ func cmdResizeWindow(ctx *CommandContext) {
 		ctx.replyErr("resize-window: invalid dimensions")
 		return
 	}
-	ctx.Sess.mu.Lock()
-	layoutH := rows - render.GlobalBarHeight
-	for _, w := range ctx.Sess.Windows {
-		w.Resize(cols, layoutH)
-	}
-	ctx.Sess.mu.Unlock()
-	ctx.Sess.broadcastLayout()
-	ctx.reply(fmt.Sprintf("Resized to %dx%d\n", cols, rows))
+	ctx.replyCommandMutation(ctx.Sess.enqueueCommandMutation(func(sess *Session) commandMutationResult {
+		sess.mu.Lock()
+		defer sess.mu.Unlock()
+		layoutH := rows - render.GlobalBarHeight
+		for _, w := range sess.Windows {
+			w.Resize(cols, layoutH)
+		}
+		return commandMutationResult{
+			output:          fmt.Sprintf("Resized to %dx%d\n", cols, rows),
+			broadcastLayout: true,
+		}
+	}))
 }
 
 func cmdSwap(ctx *CommandContext) {
-	ctx.Sess.mu.Lock()
-	w := ctx.Sess.ActiveWindow()
-	if w == nil {
-		ctx.Sess.mu.Unlock()
-		return
-	}
-
-	var err error
-	switch {
-	case len(ctx.Args) == 1 && ctx.Args[0] == "forward":
-		err = w.SwapPaneForward()
-	case len(ctx.Args) == 1 && ctx.Args[0] == "backward":
-		err = w.SwapPaneBackward()
-	case len(ctx.Args) == 2:
-		pane1 := w.ResolvePane(ctx.Args[0])
-		if pane1 == nil {
-			ctx.Sess.mu.Unlock()
-			ctx.replyErr(fmt.Sprintf("pane %q not found", ctx.Args[0]))
-			return
+	ctx.replyCommandMutation(ctx.Sess.enqueueCommandMutation(func(sess *Session) commandMutationResult {
+		sess.mu.Lock()
+		defer sess.mu.Unlock()
+		w := sess.ActiveWindow()
+		if w == nil {
+			return commandMutationResult{err: fmt.Errorf("no session")}
 		}
-		pane2 := w.ResolvePane(ctx.Args[1])
-		if pane2 == nil {
-			ctx.Sess.mu.Unlock()
-			ctx.replyErr(fmt.Sprintf("pane %q not found", ctx.Args[1]))
-			return
-		}
-		err = w.SwapPanes(pane1.ID, pane2.ID)
-	default:
-		ctx.Sess.mu.Unlock()
-		ctx.replyErr("usage: swap <pane1> <pane2> | swap forward | swap backward")
-		return
-	}
-	ctx.Sess.mu.Unlock()
 
-	if err != nil {
-		ctx.replyErr(err.Error())
-		return
-	}
-	ctx.Sess.broadcastLayout()
-	ctx.reply("Swapped\n")
+		var err error
+		switch {
+		case len(ctx.Args) == 1 && ctx.Args[0] == "forward":
+			err = w.SwapPaneForward()
+		case len(ctx.Args) == 1 && ctx.Args[0] == "backward":
+			err = w.SwapPaneBackward()
+		case len(ctx.Args) == 2:
+			pane1 := w.ResolvePane(ctx.Args[0])
+			if pane1 == nil {
+				return commandMutationResult{err: fmt.Errorf("pane %q not found", ctx.Args[0])}
+			}
+			pane2 := w.ResolvePane(ctx.Args[1])
+			if pane2 == nil {
+				return commandMutationResult{err: fmt.Errorf("pane %q not found", ctx.Args[1])}
+			}
+			err = w.SwapPanes(pane1.ID, pane2.ID)
+		default:
+			return commandMutationResult{err: fmt.Errorf("usage: swap <pane1> <pane2> | swap forward | swap backward")}
+		}
+		if err != nil {
+			return commandMutationResult{err: err}
+		}
+		return commandMutationResult{output: "Swapped\n", broadcastLayout: true}
+	}))
 }
 
 func cmdRotate(ctx *CommandContext) {
-	ctx.Sess.mu.Lock()
-	w := ctx.Sess.ActiveWindow()
-	if w == nil {
-		ctx.Sess.mu.Unlock()
-		return
-	}
-
-	forward := true
-	for _, arg := range ctx.Args {
-		if arg == "--reverse" {
-			forward = false
+	ctx.replyCommandMutation(ctx.Sess.enqueueCommandMutation(func(sess *Session) commandMutationResult {
+		sess.mu.Lock()
+		defer sess.mu.Unlock()
+		w := sess.ActiveWindow()
+		if w == nil {
+			return commandMutationResult{err: fmt.Errorf("no session")}
 		}
-	}
 
-	w.RotatePanes(forward)
-	ctx.Sess.mu.Unlock()
+		forward := true
+		for _, arg := range ctx.Args {
+			if arg == "--reverse" {
+				forward = false
+			}
+		}
 
-	ctx.Sess.broadcastLayout()
-	ctx.reply("Rotated\n")
+		w.RotatePanes(forward)
+		return commandMutationResult{output: "Rotated\n", broadcastLayout: true}
+	}))
 }
 
 func cmdCopyMode(ctx *CommandContext) {
@@ -1064,60 +1253,58 @@ func cmdUnsplice(ctx *CommandContext) {
 	}
 	hostName := ctx.Args[0]
 
-	ctx.Sess.mu.Lock()
-	w := ctx.Sess.ActiveWindow()
-	if w == nil {
-		ctx.Sess.mu.Unlock()
-		ctx.replyErr("no active window")
-		return
-	}
+	ctx.replyCommandMutation(ctx.Sess.enqueueCommandMutation(func(sess *Session) commandMutationResult {
+		sess.mu.Lock()
+		defer sess.mu.Unlock()
 
-	var proxyIDs []uint32
-	for _, p := range ctx.Sess.Panes {
-		if p.Meta.Host == hostName && p.IsProxy() {
-			proxyIDs = append(proxyIDs, p.ID)
+		w := sess.ActiveWindow()
+		if w == nil {
+			return commandMutationResult{err: fmt.Errorf("no active window")}
 		}
-	}
-	if len(proxyIDs) == 0 {
-		ctx.Sess.mu.Unlock()
-		ctx.replyErr(fmt.Sprintf("no spliced panes for host %q", hostName))
-		return
-	}
 
-	var cellW, cellH int
-	for _, p := range ctx.Sess.Panes {
-		if p.Meta.Host == hostName && p.IsProxy() {
-			if c := w.Root.FindPane(p.ID); c != nil && c.Parent != nil {
-				cellW, cellH = c.Parent.W, c.Parent.H
-				break
+		var proxyIDs []uint32
+		for _, p := range sess.Panes {
+			if p.Meta.Host == hostName && p.IsProxy() {
+				proxyIDs = append(proxyIDs, p.ID)
 			}
 		}
-	}
-	if cellW == 0 {
-		cellW, cellH = w.Width, w.Height
-	}
-	pane, err := ctx.Sess.createPane(ctx.Srv, cellW, mux.PaneContentHeight(cellH))
-	if err != nil {
-		ctx.Sess.mu.Unlock()
-		ctx.replyErr(err.Error())
-		return
-	}
+		if len(proxyIDs) == 0 {
+			return commandMutationResult{err: fmt.Errorf("no spliced panes for host %q", hostName)}
+		}
 
-	err = w.UnsplicePane(hostName, pane)
-	if err != nil {
-		ctx.Sess.mu.Unlock()
-		ctx.replyErr(err.Error())
-		return
-	}
+		var cellW, cellH int
+		for _, p := range sess.Panes {
+			if p.Meta.Host == hostName && p.IsProxy() {
+				if c := w.Root.FindPane(p.ID); c != nil && c.Parent != nil {
+					cellW, cellH = c.Parent.W, c.Parent.H
+					break
+				}
+			}
+		}
+		if cellW == 0 {
+			cellW, cellH = w.Width, w.Height
+		}
 
-	for _, id := range proxyIDs {
-		ctx.Sess.removePane(id)
-	}
-	ctx.Sess.mu.Unlock()
+		pane, err := sess.createPane(ctx.Srv, cellW, mux.PaneContentHeight(cellH))
+		if err != nil {
+			return commandMutationResult{err: err}
+		}
+		if err := w.UnsplicePane(hostName, pane); err != nil {
+			sess.removePane(pane.ID)
+			pane.Close()
+			return commandMutationResult{err: err}
+		}
 
-	pane.Start()
-	ctx.Sess.broadcastLayout()
-	ctx.reply(fmt.Sprintf("Unspliced %s: %d proxy panes removed\n", hostName, len(proxyIDs)))
+		for _, id := range proxyIDs {
+			sess.removePane(id)
+		}
+
+		return commandMutationResult{
+			output:          fmt.Sprintf("Unspliced %s: %d proxy panes removed\n", hostName, len(proxyIDs)),
+			broadcastLayout: true,
+			startPanes:      []*mux.Pane{pane},
+		}
+	}))
 }
 
 func cmdTypeKeys(ctx *CommandContext) {
@@ -1187,31 +1374,33 @@ func cmdInjectProxy(ctx *CommandContext) {
 		return
 	}
 	hostName := ctx.Args[0]
-	ctx.Sess.mu.Lock()
-	w := ctx.Sess.ActiveWindow()
-	if w == nil {
-		ctx.Sess.mu.Unlock()
-		ctx.replyErr("no window")
-		return
-	}
-	id := ctx.Sess.counter.Add(1)
-	meta := mux.PaneMeta{
-		Name:  fmt.Sprintf(mux.PaneNameFormat, id),
-		Host:  hostName,
-		Color: config.CatppuccinMocha[0], // Rosewater
-	}
-	proxyPane := mux.NewProxyPane(id, meta, w.Width/2, mux.PaneContentHeight(w.Height),
-		ctx.Sess.paneOutputCallback(),
-		ctx.Sess.paneExitCallback(ctx.Srv),
-		func(data []byte) (int, error) { return len(data), nil },
-	)
-	ctx.Sess.Panes = append(ctx.Sess.Panes, proxyPane)
-	_, err := w.Split(mux.SplitVertical, proxyPane)
-	ctx.Sess.mu.Unlock()
-	if err != nil {
-		ctx.replyErr(err.Error())
-		return
-	}
-	ctx.Sess.broadcastLayout()
-	ctx.reply(fmt.Sprintf("Injected proxy pane %s @%s\n", meta.Name, hostName))
+	ctx.replyCommandMutation(ctx.Sess.enqueueCommandMutation(func(sess *Session) commandMutationResult {
+		sess.mu.Lock()
+		defer sess.mu.Unlock()
+
+		w := sess.ActiveWindow()
+		if w == nil {
+			return commandMutationResult{err: fmt.Errorf("no window")}
+		}
+		id := sess.counter.Add(1)
+		meta := mux.PaneMeta{
+			Name:  fmt.Sprintf(mux.PaneNameFormat, id),
+			Host:  hostName,
+			Color: config.CatppuccinMocha[0], // Rosewater
+		}
+		proxyPane := mux.NewProxyPane(id, meta, w.Width/2, mux.PaneContentHeight(w.Height),
+			sess.paneOutputCallback(),
+			sess.paneExitCallback(ctx.Srv),
+			func(data []byte) (int, error) { return len(data), nil },
+		)
+		sess.Panes = append(sess.Panes, proxyPane)
+		if _, err := w.Split(mux.SplitVertical, proxyPane); err != nil {
+			sess.removePane(proxyPane.ID)
+			return commandMutationResult{err: err}
+		}
+		return commandMutationResult{
+			output:          fmt.Sprintf("Injected proxy pane %s @%s\n", meta.Name, hostName),
+			broadcastLayout: true,
+		}
+	}))
 }

--- a/internal/server/session_events.go
+++ b/internal/server/session_events.go
@@ -17,6 +17,16 @@ type sessionEvent interface {
 	handle(*Session)
 }
 
+type commandMutationResult struct {
+	output          string
+	err             error
+	broadcastLayout bool
+	startPanes      []*mux.Pane
+	closePanes      []*mux.Pane
+	sendExit        bool
+	shutdownServer  bool
+}
+
 type paneRender struct {
 	paneID uint32
 	data   []byte
@@ -39,6 +49,15 @@ type attachClientEvent struct {
 
 func (e attachClientEvent) handle(s *Session) {
 	e.reply <- s.handleAttachEvent(e.srv, e.cc, e.cols, e.rows)
+}
+
+type commandMutationEvent struct {
+	fn    func(*Session) commandMutationResult
+	reply chan commandMutationResult
+}
+
+func (e commandMutationEvent) handle(s *Session) {
+	e.reply <- e.fn(s)
 }
 
 type detachClientEvent struct {
@@ -231,6 +250,22 @@ func (s *Session) enqueueAttachClient(srv *Server, cc *ClientConn, cols, rows in
 		return res
 	case <-s.sessionEventDone:
 		return attachResult{err: errSessionShuttingDown}
+	}
+}
+
+func (s *Session) enqueueCommandMutation(fn func(*Session) commandMutationResult) commandMutationResult {
+	reply := make(chan commandMutationResult, 1)
+	if !s.enqueueEvent(commandMutationEvent{
+		fn:    fn,
+		reply: reply,
+	}) {
+		return commandMutationResult{err: errSessionShuttingDown}
+	}
+	select {
+	case res := <-reply:
+		return res
+	case <-s.sessionEventDone:
+		return commandMutationResult{err: errSessionShuttingDown}
 	}
 }
 

--- a/internal/server/session_pane.go
+++ b/internal/server/session_pane.go
@@ -116,9 +116,10 @@ func (s *Session) createPaneWithMeta(srv *Server, meta mux.PaneMeta, cols, rows 
 	return pane, nil
 }
 
-// createRemotePane creates a proxy pane that routes I/O to a remote host.
+// prepareRemotePane creates and connects a proxy pane that routes I/O to a
+// remote host, but does not register it in session state or any window.
 // Caller must NOT hold s.mu (the remote manager needs to make SSH calls).
-func (s *Session) createRemotePane(srv *Server, hostName string, cols, rows int) (*mux.Pane, error) {
+func (s *Session) prepareRemotePane(srv *Server, hostName string, cols, rows int) (*mux.Pane, error) {
 	if s.RemoteManager == nil {
 		return nil, fmt.Errorf("no remote hosts configured")
 	}
@@ -140,19 +141,37 @@ func (s *Session) createRemotePane(srv *Server, hostName string, cols, rows int)
 		},
 	)
 
-	s.mu.Lock()
-	s.Panes = append(s.Panes, pane)
-	s.mu.Unlock()
-
 	// Create the corresponding pane on the remote server
 	_, err := s.RemoteManager.CreatePane(hostName, id, s.Name)
 	if err != nil {
-		// Roll back: remove the pane we just added
-		s.mu.Lock()
-		s.removePane(id)
-		s.mu.Unlock()
+		s.RemoteManager.RemovePane(id)
 		return nil, err
 	}
 
 	return pane, nil
+}
+
+// insertPreparedPaneIntoActiveWindowLocked registers a pre-created pane in the
+// session and inserts it into the active window layout. Caller must hold s.mu.
+func (s *Session) insertPreparedPaneIntoActiveWindowLocked(pane *mux.Pane, dir mux.SplitDir, rootLevel bool) error {
+	w := s.ActiveWindow()
+	if w == nil {
+		return fmt.Errorf("no window")
+	}
+
+	s.Panes = append(s.Panes, pane)
+	var err error
+	if rootLevel {
+		_, err = w.SplitRoot(dir, pane)
+	} else {
+		_, err = w.Split(dir, pane)
+	}
+	if err != nil {
+		s.removePane(pane.ID)
+		if s.RemoteManager != nil && pane.IsProxy() {
+			s.RemoteManager.RemovePane(pane.ID)
+		}
+		return err
+	}
+	return nil
 }


### PR DESCRIPTION
## Summary
- move mutating session command paths behind the session event loop
- queue local and remote pane-creation commands instead of mutating `Session` directly from command handlers
- add focused server coverage for queued command mutation, orphan-pane kill, proxy unsplice, and prepared remote pane insertion

## Scope
This continues the actor-model refactor that already moved async callback-driven writes behind `session_events.go`.

Queued in this PR:
- layout/window mutation commands (`focus`, `zoom`, `minimize`, `restore`, `toggle-minimize`, window selection/navigation, resize, swap, rotate)
- local pane-creation commands (`new-window`, local `split`, local `spawn`)
- pane lifecycle commands (`kill`, `unsplice`, `_inject-proxy`)
- remote pane creation insertion path (`split --host`, remote `spawn`)

Intentionally left direct:
- `send-keys`
- `copy-mode`
- `type-keys`

Those paths are targeted writes or pane-local behavior, not shared session-structure mutations, so they do not benefit much from actorization.

## Notes
- `commandMutationResult` now carries deferred side effects (`startPanes`, `closePanes`, exit/shutdown flags) so session-owned mutations stay serialized while PTY/process side effects still happen outside the event loop.
- remote pane creation now does SSH work off-loop and inserts the prepared proxy pane on-loop.
- fixed a couple of cleanup edges while moving these paths:
  - failed `unsplice` replacement creation now removes and closes the temporary pane
  - failed `_inject-proxy` split no longer leaks a proxy pane in `Session.Panes`
  - failed remote insert removes the local/remote proxy mapping instead of leaving it orphaned

## Testing
- `go test ./internal/server ./internal/mux`
- `go test -race ./internal/server/... ./internal/mux/...`
- `go test ./test -run 'Test(KillLastPaneExitsSession|InjectProxyAndUnsplice|UnspliceNoProxy|SplitRemotePaneInheritsHost|RemotePaneViaSSH|HostsCommand|RemotePaneKill)'`

## Review Pass
- completed manually after rebase onto `origin/main`

## Simplification Pass
- completed manually; no additional simplification looked worth the extra helper churn in the queued remote path
