### PR TITLE
Resync focused pane cursor state

### DIFF
--- a/internal/server/commands.go
+++ b/internal/server/commands.go
@@ -50,6 +50,9 @@ func (ctx *CommandContext) replyCommandMutation(res commandMutationResult) {
 	if res.broadcastLayout {
 		ctx.Sess.broadcastLayout()
 	}
+	for _, pr := range res.paneRenders {
+		ctx.Sess.broadcastPaneOutput(pr.paneID, pr.data)
+	}
 	if res.output != "" {
 		ctx.reply(res.output)
 	} else {
@@ -240,13 +243,17 @@ func cmdFocus(ctx *CommandContext) {
 		if w == nil {
 			return commandMutationResult{err: fmt.Errorf("no session")}
 		}
-
 		switch direction {
 		case "next", "left", "right", "up", "down":
 			w.Focus(direction)
+			pane := w.ActivePane
 			return commandMutationResult{
-				output:          fmt.Sprintf("Focused %s\n", w.ActivePane.Meta.Name),
+				output:          fmt.Sprintf("Focused %s\n", pane.Meta.Name),
 				broadcastLayout: true,
+				paneRenders: []paneRender{{
+					paneID: pane.ID,
+					data:   []byte(pane.RenderScreen()),
+				}},
 			}
 		default:
 			pane, pw, err := ctx.CC.resolvePaneAcrossWindowsLocked(sess, direction)
@@ -260,6 +267,10 @@ func cmdFocus(ctx *CommandContext) {
 			return commandMutationResult{
 				output:          fmt.Sprintf("Focused %s\n", pane.Meta.Name),
 				broadcastLayout: true,
+				paneRenders: []paneRender{{
+					paneID: pane.ID,
+					data:   []byte(pane.RenderScreen()),
+				}},
 			}
 		}
 	}))

--- a/internal/server/session_events.go
+++ b/internal/server/session_events.go
@@ -21,6 +21,7 @@ type commandMutationResult struct {
 	output          string
 	err             error
 	broadcastLayout bool
+	paneRenders     []paneRender
 	startPanes      []*mux.Pane
 	closePanes      []*mux.Pane
 	sendExit        bool

--- a/test/focus_test.go
+++ b/test/focus_test.go
@@ -1,8 +1,11 @@
 package test
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
+
+	"github.com/weill-labs/amux/internal/proto"
 )
 
 // ---------------------------------------------------------------------------
@@ -38,6 +41,40 @@ func TestFocusByID(t *testing.T) {
 	}
 
 	h.assertActive("pane-1")
+}
+
+func TestFocusResyncsStaleCursorState(t *testing.T) {
+	t.Parallel()
+	h := newServerHarnessWithSize(t, 255, 62)
+
+	h.splitV()
+	h.splitH()
+	h.waitFor("pane-2", "$")
+
+	healthyCapture := h.captureJSON()
+	healthy := h.jsonPane(healthyCapture, "pane-2")
+
+	// Simulate stale client-side cursor state for the inactive top-right pane.
+	h.client.renderer.HandlePaneOutput(2, []byte("\033[1;24H"))
+
+	var before proto.CapturePane
+	if err := json.Unmarshal([]byte(h.client.renderer.CapturePaneJSON(2, nil)), &before); err != nil {
+		t.Fatalf("unmarshal pane-2 before focus: %v", err)
+	}
+	if got := before.Cursor.Col; got != 23 {
+		t.Fatalf("precondition failed: pane-2 cursor col = %d, want 23", got)
+	}
+
+	h.doFocus("pane-2")
+
+	afterCapture := h.captureJSON()
+	after := h.jsonPane(afterCapture, "pane-2")
+	if got, want := after.Content[0], healthy.Content[0]; got != want {
+		t.Fatalf("pane-2 content after focus = %q, want %q", got, want)
+	}
+	if got, want := after.Cursor.Col, healthy.Cursor.Col; got != want {
+		t.Fatalf("pane-2 cursor col after focus = %d, want %d", got, want)
+	}
 }
 
 func TestFocusNotFound(t *testing.T) {


### PR DESCRIPTION
## Summary
- replay the focused pane's current rendered screen after a focus change so attached clients resync stale cursor state immediately
- route that replay through the command-mutation path so focus keeps the current server command architecture
- add a regression test that corrupts the client-side cursor state for an inactive pane and verifies `focus` repairs it

## Testing
- `go test ./test -run 'TestFocus(ByName|ByID|ResyncsStaleCursorState|NotFound)$' -v`

## Review
- review pass: adapted the fix to `main`'s current `replyCommandMutation` flow during rebase instead of restoring the older direct-broadcast implementation
- simplification pass: kept the resync narrow to the focused pane only, rather than adding a broader pane replay on every layout update
