### PR TITLE
Stabilize event and layout tests

### DIFF
--- a/internal/mux/window.go
+++ b/internal/mux/window.go
@@ -995,27 +995,62 @@ func (w *Window) SplicePane(oldPaneID uint32, newPanes []*Pane) ([]*LayoutCell, 
 // proxy panes for a specific host) with a single pane. Used to revert
 // a takeover and restore the original SSH pane.
 func (w *Window) UnsplicePane(hostName string, replacement *Pane) error {
-	// Find a cell containing proxy panes for this host
+	allProxyLeavesForHost := func(cell *LayoutCell) bool {
+		if cell == nil {
+			return false
+		}
+		hasLeaf := false
+		ok := true
+		cell.Walk(func(c *LayoutCell) {
+			if !ok || c == nil || !c.IsLeaf() || c.Pane == nil {
+				return
+			}
+			hasLeaf = true
+			if !c.Pane.IsProxy() || c.Pane.Meta.Host != hostName {
+				ok = false
+			}
+		})
+		return hasLeaf && ok
+	}
+
+	// Find either:
+	// - a full spliced parent containing only proxy panes for this host, or
+	// - a single injected proxy leaf for this host
 	var targetCell *LayoutCell
 	w.Root.Walk(func(c *LayoutCell) {
-		if c.Pane != nil && c.Pane.Meta.Host == hostName && c.Pane.IsProxy() {
-			if c.Parent != nil && !c.Parent.IsLeaf() {
-				targetCell = c.Parent
-			}
+		if targetCell != nil || c == nil || c.Pane == nil || !c.Pane.IsProxy() || c.Pane.Meta.Host != hostName {
+			return
 		}
+		if c.Parent != nil && !c.Parent.IsLeaf() && allProxyLeavesForHost(c.Parent) {
+			targetCell = c.Parent
+			return
+		}
+		targetCell = c
 	})
 	if targetCell == nil {
 		return fmt.Errorf("no spliced panes found for host %q", hostName)
 	}
 
-	// Convert back to a leaf with the replacement pane
-	targetCell.isLeaf = true
-	targetCell.Dir = -1
-	targetCell.Pane = replacement
-	targetCell.Children = nil
+	// Convert back to a leaf with the replacement pane.
+	if targetCell.IsLeaf() {
+		targetCell.Pane = replacement
+	} else {
+		targetCell.isLeaf = true
+		targetCell.Dir = -1
+		targetCell.Pane = replacement
+		targetCell.Children = nil
+	}
 
 	replacement.Resize(targetCell.W, PaneContentHeight(targetCell.H))
-	w.setActive(replacement)
+	if w.ActivePane == nil || w.ActivePane.Meta.Host == hostName || w.Root.FindPane(w.ActivePane.ID) == nil {
+		w.setActive(replacement)
+	} else if targetCell.Parent == nil {
+		// If the root cell was collapsed back to a leaf, keep the current active
+		// pane only when it still exists in the new layout.
+		if w.Root.FindPane(w.ActivePane.ID) == nil {
+			w.setActive(replacement)
+		}
+	}
 	w.Root.FixOffsets()
 	w.resizePTYs()
 

--- a/internal/server/command_queue_test.go
+++ b/internal/server/command_queue_test.go
@@ -71,6 +71,7 @@ func TestQueuedCommandRenameWindow(t *testing.T) {
 	if sess.generation.Load() <= before {
 		t.Fatal("expected layout generation to increment")
 	}
+	assertSessionLayoutConsistent(t, sess)
 }
 
 func TestQueuedCommandResizeWindow(t *testing.T) {
@@ -104,6 +105,7 @@ func TestQueuedCommandResizeWindow(t *testing.T) {
 	if sess.generation.Load() <= before {
 		t.Fatal("expected layout generation to increment")
 	}
+	assertSessionLayoutConsistent(t, sess)
 }
 
 func TestQueuedCommandFocusAcrossWindows(t *testing.T) {
@@ -137,6 +139,7 @@ func TestQueuedCommandFocusAcrossWindows(t *testing.T) {
 	if sess.generation.Load() <= before {
 		t.Fatal("expected layout generation to increment")
 	}
+	assertSessionLayoutConsistent(t, sess)
 }
 
 func TestQueuedCommandToggleMinimize(t *testing.T) {
@@ -169,6 +172,7 @@ func TestQueuedCommandToggleMinimize(t *testing.T) {
 	if sess.generation.Load() <= before {
 		t.Fatal("expected layout generation to increment")
 	}
+	assertSessionLayoutConsistent(t, sess)
 }
 
 func TestQueuedCommandNewWindow(t *testing.T) {
@@ -209,6 +213,7 @@ func TestQueuedCommandNewWindow(t *testing.T) {
 	if sess.generation.Load() <= before {
 		t.Fatal("expected layout generation to increment")
 	}
+	assertSessionLayoutConsistent(t, sess)
 }
 
 func TestQueuedCommandSpawnLocal(t *testing.T) {
@@ -247,7 +252,6 @@ func TestQueuedCommandSpawnLocal(t *testing.T) {
 		return len(sess.Panes) == 2
 	})
 	sess.mu.Lock()
-	defer sess.mu.Unlock()
 	found := false
 	for _, p := range sess.Panes {
 		if p.Meta.Name == "worker-1" && p.Meta.Task == "build" {
@@ -260,6 +264,8 @@ func TestQueuedCommandSpawnLocal(t *testing.T) {
 	if sess.generation.Load() <= before {
 		t.Fatal("expected layout generation to increment")
 	}
+	sess.mu.Unlock()
+	assertSessionLayoutConsistent(t, sess)
 }
 
 func TestQueuedCommandKillOrphanPane(t *testing.T) {
@@ -288,16 +294,20 @@ func TestQueuedCommandKillOrphanPane(t *testing.T) {
 	}
 
 	sess.mu.Lock()
-	defer sess.mu.Unlock()
 	if sess.hasPane(orphan.ID) {
+		sess.mu.Unlock()
 		t.Fatal("expected orphan pane to be removed")
 	}
 	if len(sess.Windows) != 1 || sess.Windows[0].PaneCount() != 1 {
+		sess.mu.Unlock()
 		t.Fatal("expected window layout to remain intact")
 	}
 	if sess.generation.Load() <= before {
+		sess.mu.Unlock()
 		t.Fatal("expected layout generation to increment")
 	}
+	sess.mu.Unlock()
+	assertSessionLayoutConsistent(t, sess)
 }
 
 func TestQueuedCommandInjectProxyAndUnsplice(t *testing.T) {
@@ -369,6 +379,7 @@ func TestQueuedCommandInjectProxyAndUnsplice(t *testing.T) {
 	if sess.generation.Load() <= beforeUnsplice {
 		t.Fatal("expected layout generation to increment after unsplice")
 	}
+	assertSessionLayoutConsistent(t, sess)
 }
 
 func TestQueuedPreparedRemotePaneInsert(t *testing.T) {
@@ -410,22 +421,27 @@ func TestQueuedPreparedRemotePaneInsert(t *testing.T) {
 	}
 
 	sess.mu.Lock()
-	defer sess.mu.Unlock()
 	if len(sess.Panes) != 2 {
+		sess.mu.Unlock()
 		t.Fatalf("expected 2 panes, got %d", len(sess.Panes))
 	}
 	if !sess.hasPane(proxy.ID) {
+		sess.mu.Unlock()
 		t.Fatal("expected prepared proxy pane to be registered")
 	}
 	if w.Root.FindPane(proxy.ID) == nil {
+		sess.mu.Unlock()
 		t.Fatal("expected prepared proxy pane to be inserted into active window")
 	}
+	sess.mu.Unlock()
+	assertSessionLayoutConsistent(t, sess)
 }
 
 func newCommandTestSession(t *testing.T) (*Server, *Session, func()) {
 	t.Helper()
 
 	sess := newSession("test-command-queue")
+	stopCrashCheckpointLoop(t, sess)
 	srv := &Server{sessions: map[string]*Session{sess.Name: sess}}
 	cleanup := func() {
 		sess.shutdown.Store(true)
@@ -435,14 +451,7 @@ func newCommandTestSession(t *testing.T) (*Server, *Session, func()) {
 		for _, p := range panes {
 			p.Close()
 		}
-		if sess.sessionEventStop != nil {
-			close(sess.sessionEventStop)
-			<-sess.sessionEventDone
-		}
-		if sess.crashCheckpointStop != nil {
-			close(sess.crashCheckpointStop)
-			<-sess.crashCheckpointDone
-		}
+		stopSessionBackgroundLoops(t, sess)
 	}
 	return srv, sess, cleanup
 }

--- a/internal/server/dormant_test.go
+++ b/internal/server/dormant_test.go
@@ -29,14 +29,19 @@ func TestAssertPaneLayoutConsistency(t *testing.T) {
 			t.Parallel()
 
 			sess := newSession("test-consistency")
+			stopCrashCheckpointLoop(t, sess)
 
-			pane1 := &mux.Pane{ID: 1, Meta: mux.PaneMeta{Name: "pane-1"}}
+			pane1 := mux.NewProxyPane(1, mux.PaneMeta{
+				Name: "pane-1", Host: mux.DefaultHost, Color: "f5e0dc",
+			}, 80, 23, nil, nil, func(data []byte) (int, error) { return len(data), nil })
 			w := mux.NewWindow(pane1, 80, 24)
 			w.ID = 1
 			sess.Windows = append(sess.Windows, w)
 			sess.Panes = append(sess.Panes, pane1)
 
-			extra := &mux.Pane{ID: 2, Meta: mux.PaneMeta{Name: "extra-pane", Dormant: tt.dormant}}
+			extra := mux.NewProxyPane(2, mux.PaneMeta{
+				Name: "extra-pane", Host: mux.DefaultHost, Color: "f2cdcd", Dormant: tt.dormant,
+			}, 80, 23, nil, nil, func(data []byte) (int, error) { return len(data), nil })
 			sess.Panes = append(sess.Panes, extra)
 
 			if n := sess.assertPaneLayoutConsistency(); n != tt.wantViolations {

--- a/internal/server/event_test.go
+++ b/internal/server/event_test.go
@@ -147,6 +147,7 @@ func TestEventJSONOmitsZeroFields(t *testing.T) {
 func TestEmitEventDelivery(t *testing.T) {
 	t.Parallel()
 	sess := newSession("test-emit")
+	stopCrashCheckpointLoop(t, sess)
 
 	sub := sess.events.Subscribe(eventFilter{})
 	defer sess.events.Unsubscribe(sub)
@@ -173,6 +174,7 @@ func TestEmitEventDelivery(t *testing.T) {
 func TestEmitEventFiltered(t *testing.T) {
 	t.Parallel()
 	sess := newSession("test-filter")
+	stopCrashCheckpointLoop(t, sess)
 
 	sub := sess.events.Subscribe(eventFilter{Types: []string{EventIdle}})
 	defer sess.events.Unsubscribe(sub)
@@ -203,6 +205,7 @@ func TestEmitEventFiltered(t *testing.T) {
 func TestEmitEventDropsWhenFull(t *testing.T) {
 	t.Parallel()
 	sess := newSession("test-drop")
+	stopCrashCheckpointLoop(t, sess)
 
 	sub := sess.events.Subscribe(eventFilter{})
 
@@ -231,6 +234,7 @@ func TestEmitEventDropsWhenFull(t *testing.T) {
 func TestEmitEventAfterRemove(t *testing.T) {
 	t.Parallel()
 	sess := newSession("test-remove-race")
+	stopCrashCheckpointLoop(t, sess)
 
 	sub := sess.events.Subscribe(eventFilter{})
 	sess.events.Unsubscribe(sub)
@@ -284,6 +288,7 @@ func TestCurrentStateEventsIncludesClientUIState(t *testing.T) {
 	t.Parallel()
 
 	sess := newSession("test-ui-state")
+	stopCrashCheckpointLoop(t, sess)
 	sess.clients = append(sess.clients,
 		&ClientConn{ID: "client-1"},
 		&ClientConn{ID: "client-2", displayPanesShown: true},

--- a/internal/server/find_pane_test.go
+++ b/internal/server/find_pane_test.go
@@ -13,6 +13,7 @@ func TestSessionFindPaneByRef(t *testing.T) {
 	t.Parallel()
 
 	sess := newSession("test-find")
+	stopCrashCheckpointLoop(t, sess)
 
 	// Create mock panes in the flat registry (not in any window layout)
 	panes := []struct {
@@ -24,10 +25,15 @@ func TestSessionFindPaneByRef(t *testing.T) {
 		{10, "agent-task"},
 	}
 	for _, p := range panes {
-		sess.Panes = append(sess.Panes, &mux.Pane{
-			ID:   p.id,
-			Meta: mux.PaneMeta{Name: p.name},
-		})
+		sess.Panes = append(sess.Panes, mux.NewProxyPane(
+			p.id,
+			mux.PaneMeta{Name: p.name, Host: mux.DefaultHost, Color: "f5e0dc"},
+			80,
+			23,
+			nil,
+			nil,
+			func(data []byte) (int, error) { return len(data), nil },
+		))
 	}
 
 	tests := []struct {
@@ -117,6 +123,7 @@ func TestKillOrphanedPaneViaFallback(t *testing.T) {
 		t.Fatal("orphan pane should be in Session.Panes")
 	}
 	sess.mu.Unlock()
+	assertSessionLayoutConsistent(t, sess, orphanID)
 
 	// Send "kill orphan-pane" through the command path via net.Pipe.
 	serverConn, clientConn := net.Pipe()
@@ -166,4 +173,5 @@ func TestKillOrphanedPaneViaFallback(t *testing.T) {
 	if stillExists {
 		t.Error("orphan pane should be removed from Session.Panes after kill")
 	}
+	assertSessionLayoutConsistent(t, sess)
 }

--- a/internal/server/session_events_test.go
+++ b/internal/server/session_events_test.go
@@ -16,6 +16,7 @@ func TestHandleAttachAndResizeThroughSessionQueue(t *testing.T) {
 	t.Parallel()
 
 	sess := newSession("test-attach-resize")
+	stopCrashCheckpointLoop(t, sess)
 	pane := mux.NewProxyPane(1, mux.PaneMeta{
 		Name:  "pane-1",
 		Host:  mux.DefaultHost,
@@ -97,6 +98,7 @@ func TestPaneOutputCallbackEnqueuesOutputNotifications(t *testing.T) {
 	t.Parallel()
 
 	sess := newSession("test-pane-output")
+	stopCrashCheckpointLoop(t, sess)
 	pane := mux.NewProxyPane(1, mux.PaneMeta{
 		Name:  "pane-1",
 		Host:  "local",
@@ -136,6 +138,7 @@ func TestPaneExitCallbackEnqueuesRemoval(t *testing.T) {
 	t.Parallel()
 
 	sess := newSession("test-pane-exit")
+	stopCrashCheckpointLoop(t, sess)
 	p1 := mux.NewProxyPane(1, mux.PaneMeta{Name: "pane-1", Host: "local", Color: "f5e0dc"}, 80, 23, nil, nil, func(data []byte) (int, error) {
 		return len(data), nil
 	})

--- a/internal/server/session_invariants_test.go
+++ b/internal/server/session_invariants_test.go
@@ -1,0 +1,65 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/weill-labs/amux/internal/mux"
+)
+
+func assertSessionLayoutConsistent(t *testing.T, sess *Session, allowedOrphans ...uint32) {
+	t.Helper()
+
+	allowed := make(map[uint32]bool, len(allowedOrphans))
+	for _, id := range allowedOrphans {
+		allowed[id] = true
+	}
+
+	sess.mu.Lock()
+	defer sess.mu.Unlock()
+
+	if len(sess.Windows) > 0 {
+		if sess.ActiveWindow() == nil {
+			t.Fatal("active window id does not resolve to a window")
+		}
+	}
+
+	registry := make(map[uint32]*mux.Pane, len(sess.Panes))
+	for _, p := range sess.Panes {
+		if registry[p.ID] != nil {
+			t.Fatalf("duplicate pane id %d in session registry", p.ID)
+		}
+		registry[p.ID] = p
+	}
+
+	layoutIDs := map[uint32]bool{}
+	for _, w := range sess.Windows {
+		if w == nil || w.Root == nil {
+			t.Fatal("window or root layout is nil")
+		}
+		if w.ActivePane == nil {
+			t.Fatalf("window %q has no active pane", w.Name)
+		}
+		w.Root.Walk(func(c *mux.LayoutCell) {
+			if c == nil || c.Pane == nil {
+				return
+			}
+			if layoutIDs[c.Pane.ID] {
+				t.Fatalf("pane %d appears multiple times in window layouts", c.Pane.ID)
+			}
+			layoutIDs[c.Pane.ID] = true
+			if registry[c.Pane.ID] == nil {
+				t.Fatalf("pane %d appears in layout but not in session registry", c.Pane.ID)
+			}
+		})
+		if !layoutIDs[w.ActivePane.ID] {
+			t.Fatalf("window %q active pane %d is not present in its layout", w.Name, w.ActivePane.ID)
+		}
+	}
+
+	for _, p := range sess.Panes {
+		if layoutIDs[p.ID] || p.Meta.Dormant || allowed[p.ID] {
+			continue
+		}
+		t.Fatalf("pane %d (%s) is registered but not present in any layout", p.ID, p.Meta.Name)
+	}
+}

--- a/internal/server/test_session_helpers_test.go
+++ b/internal/server/test_session_helpers_test.go
@@ -1,0 +1,26 @@
+package server
+
+import "testing"
+
+func stopCrashCheckpointLoop(t *testing.T, sess *Session) {
+	t.Helper()
+
+	if sess.crashCheckpointStop != nil {
+		close(sess.crashCheckpointStop)
+		<-sess.crashCheckpointDone
+		sess.crashCheckpointStop = nil
+		sess.crashCheckpointDone = nil
+	}
+}
+
+func stopSessionBackgroundLoops(t *testing.T, sess *Session) {
+	t.Helper()
+
+	if sess.sessionEventStop != nil {
+		close(sess.sessionEventStop)
+		<-sess.sessionEventDone
+		sess.sessionEventStop = nil
+		sess.sessionEventDone = nil
+	}
+	stopCrashCheckpointLoop(t, sess)
+}

--- a/test/event_helpers_test.go
+++ b/test/event_helpers_test.go
@@ -1,0 +1,98 @@
+package test
+
+import (
+	"bufio"
+	"encoding/json"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/weill-labs/amux/internal/server"
+)
+
+// eventJSON is a minimal struct for parsing event stream output.
+type eventJSON struct {
+	Type       string `json:"type"`
+	Timestamp  string `json:"ts"`
+	Generation uint64 `json:"generation,omitempty"`
+	PaneID     uint32 `json:"pane_id,omitempty"`
+	PaneName   string `json:"pane_name,omitempty"`
+	Host       string `json:"host,omitempty"`
+	ActivePane string `json:"active_pane,omitempty"`
+	ClientID   string `json:"client_id,omitempty"`
+	TimedOut   bool   `json:"-"` // set by readEvent on timeout
+}
+
+// eventStream connects to the server's events command and returns a scanner
+// that reads one JSON event per line, plus a close function.
+func eventStream(t *testing.T, session string, args ...string) (*bufio.Scanner, func()) {
+	t.Helper()
+	sockPath := server.SocketPath(session)
+	conn, err := net.Dial("unix", sockPath)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+
+	if err := server.WriteMsg(conn, &server.Message{
+		Type:    server.MsgTypeCommand,
+		CmdName: "events",
+		CmdArgs: args,
+	}); err != nil {
+		conn.Close()
+		t.Fatalf("write: %v", err)
+	}
+
+	pr, pw := net.Pipe()
+	go func() {
+		defer pw.Close()
+		for {
+			msg, err := server.ReadMsg(conn)
+			if err != nil {
+				return
+			}
+			if msg.CmdOutput != "" {
+				pw.Write([]byte(msg.CmdOutput))
+			}
+		}
+	}()
+
+	scanner := bufio.NewScanner(pr)
+	closer := func() {
+		conn.Close()
+		pr.Close()
+	}
+	return scanner, closer
+}
+
+// readEvent reads the next event from the scanner within timeout.
+// Returns a zero eventJSON with TimedOut=true if the deadline expires.
+func readEvent(t *testing.T, scanner *bufio.Scanner, timeout time.Duration) eventJSON {
+	t.Helper()
+	done := make(chan eventJSON, 1)
+	go func() {
+		if scanner.Scan() {
+			var ev eventJSON
+			if err := json.Unmarshal(scanner.Bytes(), &ev); err != nil {
+				return
+			}
+			done <- ev
+		}
+	}()
+
+	select {
+	case ev := <-done:
+		return ev
+	case <-time.After(timeout):
+		return eventJSON{TimedOut: true}
+	}
+}
+
+// mustReadEvent reads the next event, fataling on timeout.
+func mustReadEvent(t *testing.T, scanner *bufio.Scanner, timeout time.Duration) eventJSON {
+	t.Helper()
+	ev := readEvent(t, scanner, timeout)
+	if ev.TimedOut {
+		t.Fatal("timeout reading event")
+	}
+	return ev
+}

--- a/test/events_test.go
+++ b/test/events_test.go
@@ -3,7 +3,6 @@ package test
 import (
 	"bufio"
 	"encoding/json"
-	"net"
 	"os"
 	"os/exec"
 	"strings"
@@ -13,95 +12,6 @@ import (
 	"github.com/weill-labs/amux/internal/proto"
 	"github.com/weill-labs/amux/internal/server"
 )
-
-// eventJSON is a minimal struct for parsing event stream output.
-type eventJSON struct {
-	Type       string `json:"type"`
-	Timestamp  string `json:"ts"`
-	Generation uint64 `json:"generation,omitempty"`
-	PaneID     uint32 `json:"pane_id,omitempty"`
-	PaneName   string `json:"pane_name,omitempty"`
-	Host       string `json:"host,omitempty"`
-	ActivePane string `json:"active_pane,omitempty"`
-	ClientID   string `json:"client_id,omitempty"`
-	TimedOut   bool   `json:"-"` // set by readEvent on timeout
-}
-
-// eventStream connects to the server's events command and returns a scanner
-// that reads one JSON event per line, plus a close function.
-func eventStream(t *testing.T, session string, args ...string) (*bufio.Scanner, func()) {
-	t.Helper()
-	sockPath := server.SocketPath(session)
-	conn, err := net.Dial("unix", sockPath)
-	if err != nil {
-		t.Fatalf("dial: %v", err)
-	}
-
-	cmdArgs := args
-	if err := server.WriteMsg(conn, &server.Message{
-		Type:    server.MsgTypeCommand,
-		CmdName: "events",
-		CmdArgs: cmdArgs,
-	}); err != nil {
-		conn.Close()
-		t.Fatalf("write: %v", err)
-	}
-
-	// Read events by reading protocol messages and extracting CmdOutput
-	pr, pw := net.Pipe()
-	go func() {
-		defer pw.Close()
-		for {
-			msg, err := server.ReadMsg(conn)
-			if err != nil {
-				return
-			}
-			if msg.CmdOutput != "" {
-				pw.Write([]byte(msg.CmdOutput))
-			}
-		}
-	}()
-
-	scanner := bufio.NewScanner(pr)
-	closer := func() {
-		conn.Close()
-		pr.Close()
-	}
-	return scanner, closer
-}
-
-// readEvent reads the next event from the scanner within timeout.
-// Returns a zero eventJSON with TimedOut=true if the deadline expires.
-func readEvent(t *testing.T, scanner *bufio.Scanner, timeout time.Duration) eventJSON {
-	t.Helper()
-	done := make(chan eventJSON, 1)
-	go func() {
-		if scanner.Scan() {
-			var ev eventJSON
-			if err := json.Unmarshal(scanner.Bytes(), &ev); err != nil {
-				return
-			}
-			done <- ev
-		}
-	}()
-
-	select {
-	case ev := <-done:
-		return ev
-	case <-time.After(timeout):
-		return eventJSON{TimedOut: true}
-	}
-}
-
-// mustReadEvent reads the next event, fataling on timeout.
-func mustReadEvent(t *testing.T, scanner *bufio.Scanner, timeout time.Duration) eventJSON {
-	t.Helper()
-	ev := readEvent(t, scanner, timeout)
-	if ev.TimedOut {
-		t.Fatal("timeout reading event")
-	}
-	return ev
-}
 
 func parseClientIDs(listing string) []string {
 	var ids []string

--- a/test/hooks_test.go
+++ b/test/hooks_test.go
@@ -120,15 +120,22 @@ func TestHookOnIdleFires(t *testing.T) {
 	tmp := t.TempDir()
 	marker := filepath.Join(tmp, "idle-fired")
 
-	// Establish a known idle baseline first, then force an idle transition
-	// after registering the hook.
 	h.waitIdle("pane-1")
+	scanner, closer := eventStream(t, h.session, "--filter", "idle,busy", "--pane", "pane-1")
+	defer closer()
+	if ev := mustReadEvent(t, scanner, 5*time.Second); ev.Type != "idle" {
+		t.Fatalf("initial event: got %q, want idle", ev.Type)
+	}
+
 	h.runCmd("set-hook", "on-idle", "touch "+marker)
 
 	h.sendKeys("pane-1", "echo TRIGGER_ACTIVITY", "Enter")
-	h.waitFor("pane-1", "TRIGGER_ACTIVITY")
-	h.waitBusy("pane-1")
-	h.waitIdle("pane-1")
+	if ev := mustReadEvent(t, scanner, 5*time.Second); ev.Type != "busy" {
+		t.Fatalf("activity event: got %q, want busy", ev.Type)
+	}
+	if ev := mustReadEvent(t, scanner, 10*time.Second); ev.Type != "idle" {
+		t.Fatalf("post-activity event: got %q, want idle", ev.Type)
+	}
 
 	if !waitForFile(t, marker, 2*time.Second) {
 		t.Fatal("on-idle hook did not fire within timeout")
@@ -142,12 +149,18 @@ func TestHookOnActivityFires(t *testing.T) {
 	tmp := t.TempDir()
 	marker := filepath.Join(tmp, "activity-fired")
 
-	// Wait for initial idle state (shell prompt appears, then quiet period expires)
 	h.waitIdle("pane-1")
+	scanner, closer := eventStream(t, h.session, "--filter", "idle,busy", "--pane", "pane-1")
+	defer closer()
+	if ev := mustReadEvent(t, scanner, 5*time.Second); ev.Type != "idle" {
+		t.Fatalf("initial event: got %q, want idle", ev.Type)
+	}
 
 	h.runCmd("set-hook", "on-activity", "touch "+marker)
-
 	h.sendKeys("pane-1", "echo TRIGGER", "Enter")
+	if ev := mustReadEvent(t, scanner, 5*time.Second); ev.Type != "busy" {
+		t.Fatalf("activity event: got %q, want busy", ev.Type)
+	}
 
 	if !waitForFile(t, marker, 5*time.Second) {
 		t.Fatal("on-activity hook did not fire within timeout")

--- a/test/proxy_test.go
+++ b/test/proxy_test.go
@@ -32,6 +32,11 @@ func TestInjectProxyAndUnsplice(t *testing.T) {
 	if strings.Contains(list, "fake-host") {
 		t.Fatalf("list should not contain fake-host after unsplice, got:\n%s", list)
 	}
+
+	c := h.captureJSON()
+	if len(c.Panes) != 2 {
+		t.Fatalf("expected original pane plus replacement pane after unsplice, got %d panes", len(c.Panes))
+	}
 }
 
 func TestUnspliceNoProxy(t *testing.T) {


### PR DESCRIPTION
## Summary
- add shared event-stream test helpers and reuse them in the integration event tests
- make hook tests transition-aware and add session/layout invariant assertions in server tests
- fix `Window.UnsplicePane` so plain proxy unsplice does not orphan the original sibling pane

## Testing
- `go test -timeout 45s ./internal/server ./internal/mux`
- `go test -timeout 45s -race ./internal/server/... ./internal/mux/...`
- `go test ./test -run 'Test(Events|HookOnIdleFires|HookOnActivityFires|InjectProxyAndUnsplice|UnspliceNoProxy|FontResize_ThreeByThreeGridReturnsToOriginalLayout|CopyModeResizeSurvives)'`

## Notes
- Manual review pass completed.
- Simplification pass completed.
- The planning files from the local planning workflow are intentionally not included because they are gitignored in this repo.
