### PR TITLE
Harden remote and resize test coverage

### DIFF
--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -107,6 +107,13 @@ func TestClientRendererCaptureJSON(t *testing.T) {
 	t.Parallel()
 	cr := buildTestRenderer(t)
 
+	cr.renderer.mu.Lock()
+	info := cr.renderer.paneInfo[2]
+	info.Host = "test-remote"
+	info.ConnStatus = "connected"
+	cr.renderer.paneInfo[2] = info
+	cr.renderer.mu.Unlock()
+
 	out := cr.CaptureJSON(nil)
 	var capture proto.CaptureJSON
 	if err := json.Unmarshal([]byte(out), &capture); err != nil {
@@ -121,6 +128,18 @@ func TestClientRendererCaptureJSON(t *testing.T) {
 	}
 	if len(capture.Panes) != 2 {
 		t.Fatalf("panes: got %d, want 2", len(capture.Panes))
+	}
+	foundRemote := false
+	for _, p := range capture.Panes {
+		if p.Name == "pane-2" {
+			foundRemote = true
+			if p.ConnStatus != "connected" {
+				t.Fatalf("pane-2 conn_status = %q, want connected", p.ConnStatus)
+			}
+		}
+	}
+	if !foundRemote {
+		t.Fatal("pane-2 missing from capture")
 	}
 
 	// With agent status

--- a/internal/client/renderer.go
+++ b/internal/client/renderer.go
@@ -472,14 +472,15 @@ func (r *Renderer) buildCapturePaneLocked(paneID uint32, agentStatus map[uint32]
 	}
 	col, row := emu.CursorPosition()
 	cp := proto.CapturePane{
-		ID:        info.ID,
-		Name:      info.Name,
-		Active:    info.ID == r.activePaneID,
-		Minimized: info.Minimized,
-		Zoomed:    info.ID == r.zoomedPaneID,
-		Host:      info.Host,
-		Task:      info.Task,
-		Color:     info.Color,
+		ID:         info.ID,
+		Name:       info.Name,
+		Active:     info.ID == r.activePaneID,
+		Minimized:  info.Minimized,
+		Zoomed:     info.ID == r.zoomedPaneID,
+		Host:       info.Host,
+		Task:       info.Task,
+		Color:      info.Color,
+		ConnStatus: info.ConnStatus,
 		Cursor: proto.CaptureCursor{
 			Col:    col,
 			Row:    row,

--- a/test/capture_invariants_test.go
+++ b/test/capture_invariants_test.go
@@ -1,0 +1,49 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/weill-labs/amux/internal/proto"
+)
+
+func assertCaptureConsistent(t *testing.T, capture proto.CaptureJSON) {
+	t.Helper()
+
+	if capture.Window.ID == 0 {
+		t.Fatal("capture window id must be non-zero")
+	}
+	if len(capture.Panes) == 0 {
+		t.Fatal("capture must contain at least one pane")
+	}
+
+	seenIDs := make(map[uint32]bool, len(capture.Panes))
+	seenNames := make(map[string]bool, len(capture.Panes))
+	activeCount := 0
+
+	for _, pane := range capture.Panes {
+		if seenIDs[pane.ID] {
+			t.Fatalf("duplicate pane id %d in capture", pane.ID)
+		}
+		seenIDs[pane.ID] = true
+
+		if seenNames[pane.Name] {
+			t.Fatalf("duplicate pane name %q in capture", pane.Name)
+		}
+		seenNames[pane.Name] = true
+
+		if pane.Active {
+			activeCount++
+		}
+
+		if pane.Position == nil {
+			t.Fatalf("pane %s is missing position in full-screen capture", pane.Name)
+		}
+		if pane.Position.Width <= 0 || pane.Position.Height <= 0 {
+			t.Fatalf("pane %s has invalid position size %dx%d", pane.Name, pane.Position.Width, pane.Position.Height)
+		}
+	}
+
+	if activeCount != 1 {
+		t.Fatalf("capture must have exactly one active pane, got %d", activeCount)
+	}
+}

--- a/test/multiclient_resize_test.go
+++ b/test/multiclient_resize_test.go
@@ -45,6 +45,7 @@ func TestMultiClientLargestWins(t *testing.T) {
 
 	// Layout should stay at 80×23 (the larger client's dimensions).
 	h.assertLayoutSize(80, 24, 80, 23)
+	assertCaptureConsistent(t, h.captureJSON())
 
 	// Disconnect the small client — removeClient broadcasts layout.
 	gen = h.generation()
@@ -52,6 +53,7 @@ func TestMultiClientLargestWins(t *testing.T) {
 	h.waitLayout(gen)
 
 	h.assertLayoutSize(80, 24, 80, 23)
+	assertCaptureConsistent(t, h.captureJSON())
 }
 
 func TestMultiClientExpandOnLarger(t *testing.T) {
@@ -67,6 +69,7 @@ func TestMultiClientExpandOnLarger(t *testing.T) {
 
 	// Layout should expand to 120×39 (the larger client's dimensions).
 	h.assertLayoutSize(120, 40, 120, 39)
+	assertCaptureConsistent(t, h.captureJSON())
 
 	// Disconnect the large client — layout should shrink back to 80×23.
 	gen = h.generation()
@@ -74,6 +77,7 @@ func TestMultiClientExpandOnLarger(t *testing.T) {
 	h.waitLayout(gen)
 
 	h.assertLayoutSize(80, 24, 80, 23)
+	assertCaptureConsistent(t, h.captureJSON())
 }
 
 func TestMultiClientSmallClientSeesAllPanes(t *testing.T) {
@@ -96,6 +100,7 @@ func TestMultiClientSmallClientSeesAllPanes(t *testing.T) {
 	if !strings.Contains(text, "pane-2") {
 		t.Errorf("small client should see pane-2\ncapture:\n%s", text)
 	}
+	assertCaptureConsistent(t, h.captureJSON())
 }
 
 func TestMultiClientResizeRecalculates(t *testing.T) {
@@ -115,6 +120,22 @@ func TestMultiClientResizeRecalculates(t *testing.T) {
 	h.waitLayout(gen)
 
 	h.assertLayoutSize(120, 40, 120, 39)
+	assertCaptureConsistent(t, h.captureJSON())
 
 	large.close()
+}
+
+func TestMultiClientLargestClientShrinkRecalculates(t *testing.T) {
+	t.Parallel()
+	h := newServerHarness(t) // 80x24
+
+	large := h.attachClient(120, 40)
+	defer large.close()
+
+	gen := h.generation()
+	large.resize(70, 20)
+	h.waitLayout(gen)
+
+	h.assertLayoutSize(80, 24, 80, 23)
+	assertCaptureConsistent(t, h.captureJSON())
 }

--- a/test/remote_management_test.go
+++ b/test/remote_management_test.go
@@ -61,6 +61,12 @@ func TestHostsCommand(t *testing.T) {
 
 	// Split a remote pane to trigger connection
 	splitRemotePane(t, h)
+	c := h.captureJSON()
+	assertCaptureConsistent(t, c)
+	p2 := h.jsonPane(c, "pane-2")
+	if p2.ConnStatus != "connected" {
+		t.Fatalf("pane-2 conn_status = %q, want connected", p2.ConnStatus)
+	}
 
 	// After connecting, hosts should show connected (not "disconnected")
 	out = h.runCmd("hosts")
@@ -81,12 +87,20 @@ func TestDisconnectAndReconnect(t *testing.T) {
 	h.waitForTimeout("pane-2", "REMOTE_OK", "5s")
 
 	// Disconnect
+	gen := h.generation()
 	out := h.runCmd("disconnect", "test-remote")
 	if strings.Contains(out, "error") || strings.Contains(out, "Error") {
 		t.Fatalf("disconnect failed: %s", out)
 	}
 	if !strings.Contains(out, "Disconnected") {
 		t.Errorf("disconnect should confirm, got: %s", out)
+	}
+	h.waitLayout(gen)
+	c := h.captureJSON()
+	assertCaptureConsistent(t, c)
+	p2 := h.jsonPane(c, "pane-2")
+	if p2.ConnStatus != "disconnected" {
+		t.Fatalf("pane-2 conn_status after disconnect = %q, want disconnected", p2.ConnStatus)
 	}
 
 	// Verify hosts shows disconnected
@@ -96,6 +110,7 @@ func TestDisconnectAndReconnect(t *testing.T) {
 	}
 
 	// Reconnect
+	gen = h.generation()
 	out = h.runCmd("reconnect", "test-remote")
 	if strings.Contains(out, "error") || strings.Contains(out, "Error") {
 		t.Fatalf("reconnect failed: %s", out)
@@ -103,6 +118,16 @@ func TestDisconnectAndReconnect(t *testing.T) {
 	if !strings.Contains(out, "Reconnected") {
 		t.Errorf("reconnect should confirm, got: %s", out)
 	}
+	h.waitLayout(gen)
+	c = h.captureJSON()
+	assertCaptureConsistent(t, c)
+	p2 = h.jsonPane(c, "pane-2")
+	if p2.ConnStatus != "connected" {
+		t.Fatalf("pane-2 conn_status after reconnect = %q, want connected", p2.ConnStatus)
+	}
+
+	h.sendKeys("pane-2", "echo RECONNECTED_OK", "Enter")
+	h.waitForTimeout("pane-2", "RECONNECTED_OK", "5s")
 
 	// Verify hosts shows connected again
 	out = h.runCmd("hosts")
@@ -122,6 +147,11 @@ func TestRemotePaneKill(t *testing.T) {
 	if len(c.Panes) != 2 {
 		t.Fatalf("expected 2 panes, got %d", len(c.Panes))
 	}
+	assertCaptureConsistent(t, c)
+	p2 := h.jsonPane(c, "pane-2")
+	if p2.ConnStatus != "connected" {
+		t.Fatalf("pane-2 conn_status before kill = %q, want connected", p2.ConnStatus)
+	}
 
 	// Kill the remote pane
 	gen := h.generation()
@@ -135,4 +165,5 @@ func TestRemotePaneKill(t *testing.T) {
 	if len(c.Panes) != 1 {
 		t.Fatalf("expected 1 pane after kill, got %d", len(c.Panes))
 	}
+	assertCaptureConsistent(t, c)
 }


### PR DESCRIPTION
## Summary
- add a reusable full-capture invariant helper for integration tests
- extend multi-client resize and remote lifecycle tests to assert explicit layout and connection-state transitions
- fix client JSON capture so remote pane `conn_status` is preserved

## Testing
- `go test ./internal/client`
- `go test ./test -run 'Test(MultiClient|HostsCommand|DisconnectAndReconnect|RemotePaneKill|RemotePaneViaSSH|SplitRemotePaneInheritsHost|ReattachResize)'`

## Notes
- Manual review pass completed.
- Simplification pass completed.
