### PR TITLE
Resync focused panes on window switches

### DIFF
--- a/internal/client/attach.go
+++ b/internal/client/attach.go
@@ -23,6 +23,14 @@ import (
 	"golang.org/x/term"
 )
 
+func handleDisplayPaneSelection(cr *ClientRenderer, sender *messageSender, b byte) {
+	paneID, ok := cr.ResolveDisplayPaneKey(b)
+	cr.HideDisplayPanes()
+	if ok {
+		sender.Command("focus", []string{fmt.Sprintf("%d", paneID)})
+	}
+}
+
 // RunSession connects to an existing server or starts one, then enters raw
 // terminal mode for interactive use.
 func RunSession(sessionName string) error {
@@ -443,13 +451,9 @@ func RunSession(sessionName string) error {
 				// Process flushed bytes (normal input that passed through parser)
 				for _, fb := range flushed {
 					if cr.DisplayPanesActive() {
-						paneID, ok := cr.ResolveDisplayPaneKey(fb)
-						cr.HideDisplayPanes()
+						handleDisplayPaneSelection(cr, sender, fb)
 						if data := cr.RenderDiff(); data != "" {
 							io.WriteString(os.Stdout, data)
-						}
-						if ok {
-							sender.Command("focus", []string{fmt.Sprintf("%d", paneID)})
 						}
 						continue
 					}

--- a/internal/client/input_dispatch_test.go
+++ b/internal/client/input_dispatch_test.go
@@ -1,0 +1,96 @@
+package client
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/weill-labs/amux/internal/mouse"
+	"github.com/weill-labs/amux/internal/proto"
+)
+
+func readCommandMessage(t *testing.T, conn net.Conn) *proto.Message {
+	t.Helper()
+	if err := conn.SetReadDeadline(time.Now().Add(2 * time.Second)); err != nil {
+		t.Fatalf("set read deadline: %v", err)
+	}
+	msg, err := proto.ReadMsg(conn)
+	if err != nil {
+		t.Fatalf("read command message: %v", err)
+	}
+	return msg
+}
+
+func TestHandleDisplayPaneSelectionSendsFocusCommand(t *testing.T) {
+	t.Parallel()
+
+	cr := buildTestRenderer(t)
+	if !cr.ShowDisplayPanes() {
+		t.Fatal("ShowDisplayPanes should succeed")
+	}
+
+	clientConn, serverConn := net.Pipe()
+	t.Cleanup(func() {
+		clientConn.Close()
+		serverConn.Close()
+	})
+
+	sender := newMessageSender(clientConn)
+	done := make(chan struct{})
+	go func() {
+		handleDisplayPaneSelection(cr, sender, '2')
+		close(done)
+	}()
+
+	msg := readCommandMessage(t, serverConn)
+	if msg.Type != proto.MsgTypeCommand {
+		t.Fatalf("message type = %d, want %d", msg.Type, proto.MsgTypeCommand)
+	}
+	if msg.CmdName != "focus" {
+		t.Fatalf("command = %q, want focus", msg.CmdName)
+	}
+	if len(msg.CmdArgs) != 1 || msg.CmdArgs[0] != "2" {
+		t.Fatalf("command args = %v, want [2]", msg.CmdArgs)
+	}
+	<-done
+	if cr.DisplayPanesActive() {
+		t.Fatal("display-panes overlay should hide after selection")
+	}
+}
+
+func TestHandleMouseEventClickSendsFocusCommand(t *testing.T) {
+	t.Parallel()
+
+	cr := buildTestRenderer(t)
+
+	clientConn, serverConn := net.Pipe()
+	t.Cleanup(func() {
+		clientConn.Close()
+		serverConn.Close()
+	})
+
+	sender := newMessageSender(clientConn)
+	var drag DragState
+	done := make(chan struct{})
+	go func() {
+		HandleMouseEvent(mouse.Event{
+			Action: mouse.Press,
+			Button: mouse.ButtonLeft,
+			X:      60,
+			Y:      5,
+		}, cr, sender, &drag)
+		close(done)
+	}()
+
+	msg := readCommandMessage(t, serverConn)
+	if msg.Type != proto.MsgTypeCommand {
+		t.Fatalf("message type = %d, want %d", msg.Type, proto.MsgTypeCommand)
+	}
+	if msg.CmdName != "focus" {
+		t.Fatalf("command = %q, want focus", msg.CmdName)
+	}
+	if len(msg.CmdArgs) != 1 || msg.CmdArgs[0] != "2" {
+		t.Fatalf("command args = %v, want [2]", msg.CmdArgs)
+	}
+	<-done
+}

--- a/internal/server/commands.go
+++ b/internal/server/commands.go
@@ -80,6 +80,16 @@ func (ctx *CommandContext) activeWindowSnapshot() (activePid, width, height int,
 	return activePid, w.Width, w.Height, nil
 }
 
+func activePaneRender(w *mux.Window) []paneRender {
+	if w == nil || w.ActivePane == nil {
+		return nil
+	}
+	return []paneRender{{
+		paneID: w.ActivePane.ID,
+		data:   []byte(w.ActivePane.RenderScreen()),
+	}}
+}
+
 // commandRegistry maps command names to their handlers, following
 // tmux's pattern of one entry per command.
 var commandRegistry = map[string]CommandHandler{
@@ -250,10 +260,7 @@ func cmdFocus(ctx *CommandContext) {
 			return commandMutationResult{
 				output:          fmt.Sprintf("Focused %s\n", pane.Meta.Name),
 				broadcastLayout: true,
-				paneRenders: []paneRender{{
-					paneID: pane.ID,
-					data:   []byte(pane.RenderScreen()),
-				}},
+				paneRenders:     activePaneRender(w),
 			}
 		default:
 			pane, pw, err := ctx.CC.resolvePaneAcrossWindowsLocked(sess, direction)
@@ -267,10 +274,7 @@ func cmdFocus(ctx *CommandContext) {
 			return commandMutationResult{
 				output:          fmt.Sprintf("Focused %s\n", pane.Meta.Name),
 				broadcastLayout: true,
-				paneRenders: []paneRender{{
-					paneID: pane.ID,
-					data:   []byte(pane.RenderScreen()),
-				}},
+				paneRenders:     activePaneRender(pw),
 			}
 		}
 	}))
@@ -631,7 +635,11 @@ func cmdSelectWindow(ctx *CommandContext) {
 			return commandMutationResult{err: fmt.Errorf("window %q not found", ref)}
 		}
 		sess.ActiveWindowID = w.ID
-		return commandMutationResult{output: "Switched window\n", broadcastLayout: true}
+		return commandMutationResult{
+			output:          "Switched window\n",
+			broadcastLayout: true,
+			paneRenders:     activePaneRender(w),
+		}
 	}))
 }
 
@@ -640,7 +648,11 @@ func cmdNextWindow(ctx *CommandContext) {
 		sess.mu.Lock()
 		defer sess.mu.Unlock()
 		sess.NextWindow()
-		return commandMutationResult{output: "Next window\n", broadcastLayout: true}
+		return commandMutationResult{
+			output:          "Next window\n",
+			broadcastLayout: true,
+			paneRenders:     activePaneRender(sess.ActiveWindow()),
+		}
 	}))
 }
 
@@ -649,7 +661,11 @@ func cmdPrevWindow(ctx *CommandContext) {
 		sess.mu.Lock()
 		defer sess.mu.Unlock()
 		sess.PrevWindow()
-		return commandMutationResult{output: "Previous window\n", broadcastLayout: true}
+		return commandMutationResult{
+			output:          "Previous window\n",
+			broadcastLayout: true,
+			paneRenders:     activePaneRender(sess.ActiveWindow()),
+		}
 	}))
 }
 

--- a/test/window_test.go
+++ b/test/window_test.go
@@ -1,9 +1,12 @@
 package test
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/weill-labs/amux/internal/proto"
 )
 
 // ---------------------------------------------------------------------------
@@ -104,6 +107,71 @@ func TestNextPrevWindowCLI(t *testing.T) {
 	h.assertScreen("next-window should show pane-2", func(s string) bool {
 		return strings.Contains(s, "[pane-2]")
 	})
+}
+
+func TestWindowSwitchResyncsStaleCursorState(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		switchFn func(*ServerHarness)
+	}{
+		{
+			name: "select-window",
+			switchFn: func(h *ServerHarness) {
+				h.runCmd("select-window", "1")
+			},
+		},
+		{
+			name: "next-window",
+			switchFn: func(h *ServerHarness) {
+				h.runCmd("next-window")
+			},
+		},
+		{
+			name: "prev-window",
+			switchFn: func(h *ServerHarness) {
+				h.runCmd("prev-window")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newServerHarnessWithSize(t, 255, 62)
+			h.waitFor("pane-1", "$")
+
+			healthyCapture := h.captureJSON()
+			healthy := h.jsonPane(healthyCapture, "pane-1")
+
+			h.runCmd("new-window")
+			h.waitFor("pane-2", "$")
+
+			// Simulate stale client-side cursor state for the hidden pane in window 1.
+			h.client.renderer.HandlePaneOutput(1, []byte("\033[1;24H"))
+
+			var before proto.CapturePane
+			if err := json.Unmarshal([]byte(h.client.renderer.CapturePaneJSON(1, nil)), &before); err != nil {
+				t.Fatalf("unmarshal pane-1 before switch: %v", err)
+			}
+			if got := before.Cursor.Col; got != 23 {
+				t.Fatalf("precondition failed: pane-1 cursor col = %d, want 23", got)
+			}
+
+			tt.switchFn(h)
+
+			afterCapture := h.captureJSON()
+			after := h.jsonPane(afterCapture, "pane-1")
+			if got, want := after.Content[0], healthy.Content[0]; got != want {
+				t.Fatalf("pane-1 content after switch = %q, want %q", got, want)
+			}
+			if got, want := after.Cursor.Col, healthy.Cursor.Col; got != want {
+				t.Fatalf("pane-1 cursor col after switch = %d, want %d", got, want)
+			}
+		})
+	}
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- replay the active pane screen after select-window, next-window, and prev-window so stale client cursor state is resynced immediately
- keep focus-triggering client paths narrow by extracting display-panes selection dispatch and adding direct client command tests
- add regression coverage for stale cursor state after window switching

## Testing
- go test ./internal/client -run 'Test(HandleDisplayPaneSelectionSendsFocusCommand|HandleMouseEventClickSendsFocusCommand)$' -v
- go test ./internal/client ./test -run 'Test(HandleDisplayPaneSelectionSendsFocusCommand|HandleMouseEventClickSendsFocusCommand|FocusResyncsStaleCursorState|WindowSwitchResyncsStaleCursorState)$' -v
- go test ./...

## Gaps
- none