### PR TITLE
Upload Codecov coverage before flake detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,10 +94,6 @@ jobs:
         if: steps.changes.outputs.code_changed == 'true'
         run: scripts/coverage.sh --ci
 
-      - name: Flake detection (integration tests x3)
-        if: steps.changes.outputs.code_changed == 'true'
-        run: go test -count=3 -parallel 2 -timeout 300s ./test/
-
       - name: Convert test results to JUnit XML
         if: ${{ !cancelled() && steps.changes.outputs.code_changed == 'true' }}
         run: |
@@ -155,6 +151,10 @@ jobs:
             integration-coverage.txt
             merged-coverage.txt
             coverage-summary.txt
+
+      - name: Flake detection (integration tests x3)
+        if: steps.changes.outputs.code_changed == 'true'
+        run: go test -count=3 -parallel 2 -timeout 300s ./test/
 
       - name: Test timing summary
         if: always() && steps.changes.outputs.code_changed == 'true'


### PR DESCRIPTION
## Summary
- move Codecov uploads and coverage artifact upload to immediately follow `Tests with coverage`
- keep flake detection in the same job, but after coverage has already been published

## Why
- coverage is generated promptly today, but Codecov stays stale until flake detection finishes
- this makes coverage updates visible earlier and preserves artifacts even if later flake checks fail

## Testing
- not run; workflow ordering only

## Notes
- review pass completed on the minimal workflow diff
- simplification pass completed by reordering existing steps rather than adding new jobs or conditions
