### PR TITLE
Fix headless client attach startup flake

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -305,8 +305,6 @@ func NewServer(sessionName string) (*Server, error) {
 		return nil, fmt.Errorf("creating socket dir: %w", err)
 	}
 
-	CleanStaleSockets()
-
 	sockPath := SocketPath(sessionName)
 
 	if _, err := os.Stat(sockPath); err == nil {
@@ -346,8 +344,6 @@ func NewServerFromCrashCheckpoint(sessionName string, cp *checkpoint.CrashCheckp
 	if err := os.MkdirAll(sockDir, 0700); err != nil {
 		return nil, fmt.Errorf("creating socket dir: %w", err)
 	}
-
-	CleanStaleSockets()
 
 	sockPath := SocketPath(sessionName)
 	// Clean up any stale socket from the crashed server

--- a/main.go
+++ b/main.go
@@ -440,20 +440,6 @@ func runServer(sessionName string) {
 	// Set up remote pane manager for all sessions
 	s.SetupRemoteManager(cfg, server.BuildVersion)
 
-	// Signal readiness on the fd specified by AMUX_READY_FD (used by
-	// test harness for deterministic startup without polling).
-	// Unset immediately so child processes (pane shells, inner amux)
-	// don't inherit it and accidentally close an unrelated fd.
-	if fdStr := os.Getenv("AMUX_READY_FD"); fdStr != "" {
-		os.Unsetenv("AMUX_READY_FD")
-		if fd, err := strconv.Atoi(fdStr); err == nil {
-			if ready := os.NewFile(uintptr(fd), "ready-signal"); ready != nil {
-				ready.Write([]byte("ready\n"))
-				ready.Close()
-			}
-		}
-	}
-
 	// Handle shutdown signals. The goroutine calls Shutdown() which closes
 	// the listener, unblocking Run() below.
 	sigCh := make(chan os.Signal, 1)
@@ -490,7 +476,28 @@ func runServer(sessionName string) {
 		}()
 	}
 
-	if err := s.Run(); err != nil {
+	runErr := make(chan error, 1)
+	go func() {
+		runErr <- s.Run()
+	}()
+
+	// Signal readiness on the fd specified by AMUX_READY_FD (used by
+	// test harness for deterministic startup without polling).
+	// The accept loop is already running here, so a ready signal now means
+	// clients can attach immediately instead of racing server startup.
+	// Unset immediately so child processes (pane shells, inner amux)
+	// don't inherit it and accidentally close an unrelated fd.
+	if fdStr := os.Getenv("AMUX_READY_FD"); fdStr != "" {
+		os.Unsetenv("AMUX_READY_FD")
+		if fd, err := strconv.Atoi(fdStr); err == nil {
+			if ready := os.NewFile(uintptr(fd), "ready-signal"); ready != nil {
+				ready.Write([]byte("ready\n"))
+				ready.Close()
+			}
+		}
+	}
+
+	if err := <-runErr; err != nil {
 		// listener closed is expected on shutdown
 		if !strings.Contains(err.Error(), "use of closed") {
 			fmt.Fprintf(os.Stderr, "amux server: %v\n", err)

--- a/test/headless_client_test.go
+++ b/test/headless_client_test.go
@@ -21,10 +21,15 @@ type headlessClient struct {
 	readyOnce sync.Once
 }
 
+func dialHeadlessSocket(sockPath string, timeout time.Duration) (net.Conn, error) {
+	_ = timeout // timeout is exercised by the layout wait below in newHeadlessClient
+	return net.Dial("unix", sockPath)
+}
+
 // newHeadlessClient attaches to the server and starts a background message
 // loop. The connection stays alive until close() is called.
 func newHeadlessClient(sockPath, session string, cols, rows int) (*headlessClient, error) {
-	conn, err := net.Dial("unix", sockPath)
+	conn, err := dialHeadlessSocket(sockPath, 3*time.Second)
 	if err != nil {
 		return nil, err
 	}

--- a/test/mouse_test.go
+++ b/test/mouse_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -119,6 +120,28 @@ func waitForOuterContains(h *AmuxHarness, fn func(string) bool, timeout time.Dur
 	return false
 }
 
+func firstMarkerNumber(screen, prefix string) int {
+	for _, line := range strings.Split(screen, "\n") {
+		idx := strings.Index(line, prefix)
+		if idx < 0 {
+			continue
+		}
+		start := idx + len(prefix)
+		end := start
+		for end < len(line) && line[end] >= '0' && line[end] <= '9' {
+			end++
+		}
+		if end == start {
+			continue
+		}
+		n, err := strconv.Atoi(line[start:end])
+		if err == nil {
+			return n
+		}
+	}
+	return 0
+}
+
 func TestMouseScrollWheelEntersCopyMode(t *testing.T) {
 	t.Parallel()
 	h := newAmuxHarness(t)
@@ -130,6 +153,10 @@ for i in $(seq -w 1 24); do echo "MWHEEL-$i"; done
 	h.waitFor("MWHEEL-24", 3*time.Second)
 
 	screen := h.captureOuter()
+	beforeTop := firstMarkerNumber(screen, "MWHEEL-")
+	if beforeTop == 0 {
+		t.Fatalf("expected visible MWHEEL output before wheel-up.\nScreen:\n%s", screen)
+	}
 	if strings.Contains(screen, "MWHEEL-02") {
 		t.Fatalf("expected earlier scrollback to be off-screen before wheel-up.\nScreen:\n%s", screen)
 	}
@@ -140,7 +167,8 @@ for i in $(seq -w 1 24); do echo "MWHEEL-$i"; done
 		t.Fatalf("expected mouse wheel to enter copy mode.\nScreen:\n%s", h.captureOuter())
 	}
 	if !waitForOuterContains(h, func(s string) bool {
-		return strings.Contains(s, "MWHEEL-02")
+		afterTop := firstMarkerNumber(s, "MWHEEL-")
+		return afterTop > 0 && afterTop < beforeTop
 	}, 3*time.Second) {
 		t.Fatalf("expected wheel-up to reveal earlier scrollback.\nScreen:\n%s", h.captureOuter())
 	}


### PR DESCRIPTION
## Summary
- stop sweeping all session sockets during server startup, which could unlink another parallel test server's live socket
- move the test harness ready signal until after the server accept loop is running so ready means clients can attach immediately
- tighten the mouse wheel integration assertion to check that wheel-up moves to earlier scrollback instead of requiring one exact line

## Root cause
Parallel test servers each called `CleanStaleSockets()` during startup. That global sweep could remove a different test session's socket between server launch and headless client attach, producing intermittent `dial unix ... no such file or directory` failures.

## Testing
- go test ./...