### PR TITLE
Preserve zoomed pane width across idle layouts

### DIFF
--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -52,6 +52,15 @@ func buildTestRenderer(t *testing.T) *ClientRenderer {
 	return cr
 }
 
+func twoPane80x23Zoomed(paneID uint32) *proto.LayoutSnapshot {
+	snap := twoPane80x23()
+	snap.ZoomedPaneID = paneID
+	if len(snap.Windows) > 0 {
+		snap.Windows[0].ZoomedPaneID = paneID
+	}
+	return snap
+}
+
 func buildManyPaneRenderer(t *testing.T, n int) *ClientRenderer {
 	t.Helper()
 	cr := NewClientRenderer(200, 24)
@@ -249,6 +258,42 @@ func TestClientRendererCapturePaneJSON(t *testing.T) {
 	empty := cr.CapturePaneJSON(999, nil)
 	if empty != "{}" {
 		t.Errorf("nonexistent pane should return {}, got %q", empty)
+	}
+}
+
+func TestClientRendererZoomedPaneSurvivesMetadataOnlyLayout(t *testing.T) {
+	t.Parallel()
+
+	cr := NewClientRenderer(80, 24)
+	cr.HandleLayout(twoPane80x23Zoomed(2))
+
+	const wideLine = "012345678901234567890123456789012345678901234567890123456789"
+	cr.HandlePaneOutput(2, []byte("\033[2J\033[H"+wideLine))
+
+	emu, ok := cr.Emulator(2)
+	if !ok {
+		t.Fatal("pane-2 emulator missing")
+	}
+	if w, h := emu.Size(); w != 80 || h != 22 {
+		t.Fatalf("zoomed pane-2 size after initial layout = %dx%d, want 80x22", w, h)
+	}
+
+	idleSnap := twoPane80x23Zoomed(2)
+	idleSnap.Panes[1].Idle = true
+	idleSnap.Windows[0].Panes[1].Idle = true
+	cr.HandleLayout(idleSnap)
+
+	emu, ok = cr.Emulator(2)
+	if !ok {
+		t.Fatal("pane-2 emulator missing after idle layout")
+	}
+	if w, h := emu.Size(); w != 80 || h != 22 {
+		t.Fatalf("zoomed pane-2 size after idle layout = %dx%d, want 80x22", w, h)
+	}
+
+	lines := strings.Split(cr.CapturePaneText(2, false), "\n")
+	if len(lines) == 0 || lines[0] != wideLine {
+		t.Fatalf("pane-2 first line after idle layout = %q, want %q", lines[0], wideLine)
 	}
 }
 

--- a/internal/client/renderer.go
+++ b/internal/client/renderer.go
@@ -137,6 +137,9 @@ func (r *Renderer) HandleLayout(snap *proto.LayoutSnapshot) bool {
 			if info, ok := r.paneInfo[cell.PaneID]; ok && info.Minimized {
 				return
 			}
+			if cell.PaneID == r.zoomedPaneID {
+				return
+			}
 			contentH := mux.PaneContentHeight(cell.H)
 			emu.Resize(cell.W, contentH)
 			if r.OnPaneResize != nil {


### PR DESCRIPTION
## Summary
- preserve the zoomed pane emulator width during client layout refreshes
- add a regression test for metadata-only layout updates while a pane is zoomed
- align the client resize behavior more closely with tmux, where the zoomed layout is authoritative

## Root cause
The client renderer was still resizing the zoomed pane emulator through the hidden unzoomed layout tree on every later layout broadcast. A metadata-only layout update, such as the 2-second idle-state broadcast, would shrink the zoomed pane back to its old split-cell width before rendering it full-screen again.

In tmux, zoom swaps in a zoomed layout and treats that as authoritative until unzoom. This change keeps amux from reapplying hidden split-cell geometry to the zoomed pane during client-side layout refreshes.

## Testing
- `make build`
- `go test ./internal/client -run 'TestClientRendererZoomedPaneSurvivesMetadataOnlyLayout$' -v`
- `go test ./test -run 'Test(ZoomToggle|ZoomResyncsStaleCursorState|MouseClickInsideZoomedPaneDoesNotUnzoom)$' -v`
- `go test ./internal/client ./test -run 'Test(ClientRendererZoomedPaneSurvivesMetadataOnlyLayout|ZoomToggle|ZoomResyncsStaleCursorState|MouseClickInsideZoomedPaneDoesNotUnzoom)$' -v`

## Review
- review pass completed
- simplification pass completed

## Gaps
- did not rerun `go test ./...` in this branch
