### PR TITLE
Bump Codecov action to v5.5.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() && steps.changes.outputs.code_changed == 'true' }}
-        uses: codecov/codecov-action@v5.5.2
+        uses: codecov/codecov-action@v5.5.3
         with:
           files: unit-results.junit.xml,integration-results.junit.xml
           report_type: test_results
@@ -134,7 +134,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: always() && steps.changes.outputs.code_changed == 'true'
-        uses: codecov/codecov-action@v5.5.2
+        uses: codecov/codecov-action@v5.5.3
         with:
           files: merged-coverage.txt
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Summary
- bump `codecov/codecov-action` from `v5.5.2` to `v5.5.3` in the CI workflow
- pick up Codecov's upstream bump from `actions/github-script@7` to `@8`
- target the remaining Node 20 deprecation warning seen after PR #196

## Testing
- parsed `.github/workflows/ci.yml` with Ruby YAML loader

## Notes
- Rebased onto `origin/main` before first push.
- Review pass completed.
- Simplification pass completed.
- No benchmark changes.
