### PR TITLE
Bump upload-artifact to v7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,7 +142,7 @@ jobs:
 
       - name: Upload coverage artifacts
         if: always() && steps.changes.outputs.code_changed == 'true'
-        uses: actions/upload-artifact@v4.6.2
+        uses: actions/upload-artifact@v7.0.0
         with:
           name: coverage-artifacts
           if-no-files-found: ignore


### PR DESCRIPTION
## Summary
- bump `actions/upload-artifact` from `v4.6.2` to `v7.0.0` in CI
- target the remaining Node 20 deprecation warning seen after PR #215
- keep artifact upload behavior unchanged apart from the action version

## Testing
- parsed `.github/workflows/ci.yml` with Ruby YAML loader

## Notes
- Rebased onto `origin/main` before first push.
- Review pass completed.
- Simplification pass completed.
- No benchmark changes.
