### PR TITLE
Stabilize copy mode resize exit test

### DIFF
--- a/test/copymode_test.go
+++ b/test/copymode_test.go
@@ -241,11 +241,11 @@ func TestCopyModeResizeSurvives(t *testing.T) {
 	}
 
 	// Should still be able to exit. Use inner type-keys here so the assertion
-	// only depends on copy mode surviving the resize, not on the outer
-	// send-keys path after the terminal resize.
+	// only depends on the inner client handling copy-mode exit, not on the
+	// outer pane render catching up after the terminal resize.
 	h.runCmd("type-keys", "q")
-	if !waitForOuterGone(h, "[copy]", 3*time.Second) {
-		t.Fatalf("expected [copy] to disappear after q\nScreen:\n%s", h.captureOuter())
+	if !h.waitForFunc(func(s string) bool { return !strings.Contains(s, "[copy]") }, 3*time.Second) {
+		t.Fatalf("expected [copy] to disappear after q\nInner:\n%s\nOuter:\n%s", h.capture(), h.captureOuter())
 	}
 }
 


### PR DESCRIPTION
## Summary
- make `TestCopyModeResizeSurvives` assert copy-mode exit against the inner client capture instead of the outer pane render
- keep the test focused on the behavior under test after resize: the inner client receiving `type-keys q` and leaving copy mode

## Root cause
After a terminal resize, the test injected `q` into the inner client with `type-keys` but waited for `[copy]` to disappear from the outer pane render. That added an extra asynchronous render hop, so the assertion could fail even when the inner client had already exited copy mode.

## Testing
- `go test -count=10 -parallel 2 -timeout 300s ./test -run 'TestCopyModeResizeSurvives$' -v`
- `go test -count=3 -parallel 2 -timeout 300s ./test -run 'Test(CopyModeResizeSurvives|MouseClickFocusHorizontalSplit)$' -v`

## Review
- review pass completed
- simplification pass completed

## Notes
- a full local `go test -count=3 -parallel 2 -timeout 300s ./test/` still surfaced other existing unrelated flakes/timeouts (`TestIdleStatus_BusyWhileRunning`, `TestHookFailingCommandLogsToSessionLog`, and event-test timeout fallout). This PR is intentionally scoped to the copy-mode resize flake only.
