### PR TITLE
Skip benchmark trend updates after benchmark failures

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -84,10 +84,12 @@ jobs:
         if: steps.changes.outputs.code_changed == 'true'
         run: |
           go install go.bobheadxi.dev/gobenchdata@latest
-          # Strip test harness noise. gobenchdata expects raw benchmark output
-          # on stdin and does not tolerate PASS/ok/? summary lines.
-          grep -v -E '^(PASS|FAIL|ok[[:space:]]|\\?[[:space:]])' bench-all.txt > bench-filtered.txt || true
-          if [ -s bench-filtered.txt ]; then
+          # Strip harness noise and failed benchmark lines. gobenchdata expects
+          # only successful raw benchmark output on stdin.
+          grep -v -E '^(PASS|FAIL|ok[[:space:]]|\\?[[:space:]]|--- FAIL: )' bench-all.txt > bench-filtered.txt || true
+          if grep -q '^--- FAIL: Benchmark' bench-all.txt; then
+            echo "::warning::Skipping benchmark trend update because one or more benchmarks failed"
+          elif [ -s bench-filtered.txt ]; then
             cat bench-filtered.txt | gobenchdata --json bench-current.json
           fi
 


### PR DESCRIPTION
## Summary
- filter per-benchmark failure lines out of benchmark trend input
- skip gobenchdata JSON generation when any benchmark failed
- keep the benchmark workflow green when trend data cannot be safely updated from a failed run

## Testing
- local filter validation with the exact  line shape from CI
- 

## Context
PR #224 fixed the raw-text-vs-JSON misuse in , but the next  run still failed because  can contain per-benchmark failure lines like , which gobenchdata should be used with a pipe - see 'gobenchdata help' cannot parse. This follow-up makes the trend step robust to that failure mode.