### PR TITLE
Guard shared amux installs across checkouts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -146,6 +146,8 @@ Trigger patterns for compositor bugs: long or truncated lines near pane boundari
 
 Both client and server watch the binary and re-exec on changes (`reload.go`). Running `make build` replaces the installed binary atomically, which then triggers automatic reload of both -- panes and shells are preserved across server reloads via checkpoint and restore.
 
+`make build` also writes install metadata and refuses to overwrite the shared `~/.local/bin/amux` when that metadata shows it was last installed from a different checkout. Use `AMUX_INSTALL_FORCE=1 make build` only when you intentionally want to replace the shared binary.
+
 Socket location: `/tmp/amux-$UID/<session-name>`
 
 ## Configuration

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,9 @@ make build                         # build + install atomically
 go test ./...                       # run all tests
 ```
 
-Hot-reload: both client and server watch the binary and re-exec on changes. Use `make build` so the installed binary is replaced atomically before reload — panes and shells are preserved.
+Hot-reload: both client and server watch the binary and re-exec on changes. Use `make build` so the installed binary is replaced atomically before reload, preserving panes and shells.
+
+`make build` records which checkout last installed `~/.local/bin/amux` and refuses to overwrite it when that install metadata points at a different checkout, unless you opt in with `AMUX_INSTALL_FORCE=1 make build`.
 
 To test manually after building:
 

--- a/README.md
+++ b/README.md
@@ -180,6 +180,8 @@ For local development builds, prefer `make build` instead of writing `go build` 
 
 Single binary, no runtime dependencies.
 
+For local development builds, prefer `make build` instead of writing `go build` directly to `~/.local/bin/amux`. The atomic replace avoids transient invalid binaries during hot-reload on macOS, and the install guard blocks cross-checkout overwrites when the existing install metadata points at another repo unless you opt in with `AMUX_INSTALL_FORCE=1`.
+
 ## Quick Start
 
 **Human:**

--- a/build_install_test.go
+++ b/build_install_test.go
@@ -1,0 +1,96 @@
+package main_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestBuildInstallRefusesCrossCheckoutOverwrite(t *testing.T) {
+	t.Parallel()
+
+	dest := filepath.Join(t.TempDir(), "amux")
+	metaPath := dest + ".install-meta"
+	if err := os.WriteFile(metaPath, []byte("source_repo=/tmp/other-checkout\n"), 0644); err != nil {
+		t.Fatalf("write meta: %v", err)
+	}
+
+	cmd := exec.Command("bash", "scripts/build-install.sh", dest)
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected cross-checkout install to fail\n%s", out)
+	}
+	if !strings.Contains(string(out), "refusing to overwrite") {
+		t.Fatalf("expected refusal message, got:\n%s", out)
+	}
+	if _, statErr := os.Stat(dest); !os.IsNotExist(statErr) {
+		t.Fatalf("expected %s to remain absent, stat err=%v", dest, statErr)
+	}
+}
+
+func TestBuildInstallForceOverridesCrossCheckoutMetadata(t *testing.T) {
+	t.Parallel()
+
+	repoRoot := repoRoot(t)
+	dest := filepath.Join(t.TempDir(), "amux")
+	metaPath := dest + ".install-meta"
+	if err := os.WriteFile(metaPath, []byte("source_repo=/tmp/other-checkout\n"), 0644); err != nil {
+		t.Fatalf("write meta: %v", err)
+	}
+
+	cmd := exec.Command("bash", "scripts/build-install.sh", dest)
+	cmd.Env = append(os.Environ(), "AMUX_INSTALL_FORCE=1")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("forced install failed: %v\n%s", err, out)
+	}
+
+	if _, statErr := os.Stat(dest); statErr != nil {
+		t.Fatalf("installed binary missing: %v", statErr)
+	}
+
+	meta, err := os.ReadFile(metaPath)
+	if err != nil {
+		t.Fatalf("read meta: %v", err)
+	}
+	if !strings.Contains(string(meta), "source_repo="+repoRoot) {
+		t.Fatalf("expected updated source_repo in metadata, got:\n%s", meta)
+	}
+}
+
+func TestBuildInstallRewritesInvalidMetadata(t *testing.T) {
+	t.Parallel()
+
+	repoRoot := repoRoot(t)
+	dest := filepath.Join(t.TempDir(), "amux")
+	metaPath := dest + ".install-meta"
+	if err := os.WriteFile(metaPath, []byte("not-valid-metadata\n"), 0644); err != nil {
+		t.Fatalf("write meta: %v", err)
+	}
+
+	cmd := exec.Command("bash", "scripts/build-install.sh", dest)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("install with invalid metadata failed: %v\n%s", err, out)
+	}
+
+	meta, err := os.ReadFile(metaPath)
+	if err != nil {
+		t.Fatalf("read meta: %v", err)
+	}
+	if !strings.Contains(string(meta), "source_repo="+repoRoot) {
+		t.Fatalf("expected metadata rewrite, got:\n%s", meta)
+	}
+}
+
+func repoRoot(t *testing.T) string {
+	t.Helper()
+
+	out, err := exec.Command("git", "rev-parse", "--show-toplevel").CombinedOutput()
+	if err != nil {
+		t.Fatalf("repo root: %v\n%s", err, out)
+	}
+	return strings.TrimSpace(string(out))
+}

--- a/scripts/build-install.sh
+++ b/scripts/build-install.sh
@@ -4,14 +4,53 @@ set -euo pipefail
 
 dest="${1:-$HOME/.local/bin/amux}"
 dest_dir="$(dirname "$dest")"
+meta_path="${dest}.install-meta"
+repo_root="$(git rev-parse --show-toplevel)"
+repo_name="${repo_root##*/}"
+branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo detached)"
+revision="$(git rev-parse HEAD 2>/dev/null || echo unknown)"
 
 mkdir -p "$dest_dir"
+
+refuse_cross_checkout_overwrite() {
+	echo "amux build: refusing to overwrite $dest" >&2
+	echo "  installed from: $current_source" >&2
+	echo "  current repo:    $repo_root" >&2
+	echo "Use AMUX_INSTALL_FORCE=1 make build to replace the shared binary intentionally." >&2
+	exit 1
+}
+
+if [[ "${AMUX_INSTALL_FORCE:-0}" != "1" && -f "$meta_path" ]]; then
+	current_source="$(awk -F= '$1=="source_repo"{print substr($0, index($0, "=") + 1)}' "$meta_path")"
+	if [[ -n "$current_source" && "$current_source" != "$repo_root" ]]; then
+		refuse_cross_checkout_overwrite
+	fi
+fi
+
 tmp="$(mktemp "$dest_dir/.amux.tmp.XXXXXX")"
+meta_tmp="$(mktemp "$dest_dir/.amux-meta.tmp.XXXXXX")"
 
 cleanup() {
-	rm -f "$tmp"
+	rm -f "$tmp" "$meta_tmp"
 }
 trap cleanup EXIT
 
 go build -o "$tmp" .
+
+if [[ $(uname -s) == Darwin ]]; then
+	if ! codesign -f -s - "$tmp" >/dev/null 2>&1; then
+		echo "amux build: codesign failed for $tmp" >&2
+		exit 1
+	fi
+fi
+
+cat >"$meta_tmp" <<EOF
+source_repo=$repo_root
+repo_name=$repo_name
+branch=$branch
+revision=$revision
+built_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+EOF
+
 mv "$tmp" "$dest"
+mv "$meta_tmp" "$meta_path"


### PR DESCRIPTION
## Summary
- record install metadata in `make build` installs and refuse to overwrite `~/.local/bin/amux` when it was last installed from a different checkout unless `AMUX_INSTALL_FORCE=1`
- fail the Darwin install path if ad-hoc signing fails instead of continuing with a broken binary
- document the guarded workflow and add regression coverage for refusal, force override, and invalid metadata rewrite

## Testing
- go test ./... -run TestBuildInstall -count=1
- go test ./... -timeout 120s

## Review
- simplification pass completed
- code review pass completed