### PR TITLE
Fix attachRendererAt to drain non-layout messages on attach

### DIFF
--- a/test/reattach_resize_test.go
+++ b/test/reattach_resize_test.go
@@ -65,13 +65,20 @@ func (h *ServerHarness) attachRendererAt(cols, rows int, afterLayout func(*clien
 		h.tb.Fatalf("attachRendererAt: write: %v", err)
 	}
 
-	conn.SetReadDeadline(time.Now().Add(5 * time.Second))
-	layoutMsg, err := server.ReadMsg(conn)
-	if err != nil {
-		h.tb.Fatalf("attachRendererAt: read layout: %v", err)
-	}
-	if layoutMsg.Type != server.MsgTypeLayout {
-		h.tb.Fatalf("attachRendererAt: expected layout, got type %d", layoutMsg.Type)
+	conn.SetReadDeadline(time.Now().Add(10 * time.Second))
+
+	// Drain until the initial layout arrives (pane output may arrive first
+	// under -race).
+	var layoutMsg *server.Message
+	for {
+		msg, err := server.ReadMsg(conn)
+		if err != nil {
+			h.tb.Fatalf("attachRendererAt: read: %v", err)
+		}
+		if msg.Type == server.MsgTypeLayout {
+			layoutMsg = msg
+			break
+		}
 	}
 
 	r := client.New(cols, rows)
@@ -80,15 +87,17 @@ func (h *ServerHarness) attachRendererAt(cols, rows int, afterLayout func(*clien
 		afterLayout(r)
 	}
 
-	for i := 0; i < len(layoutMsg.Layout.Panes); i++ {
-		paneMsg, err := server.ReadMsg(conn)
+	// Read pane replay messages, skipping any interleaved non-pane messages.
+	replayed := 0
+	for replayed < len(layoutMsg.Layout.Panes) {
+		msg, err := server.ReadMsg(conn)
 		if err != nil {
 			h.tb.Fatalf("attachRendererAt: read pane output: %v", err)
 		}
-		if paneMsg.Type != server.MsgTypePaneOutput {
-			h.tb.Fatalf("attachRendererAt: expected pane output, got type %d", paneMsg.Type)
+		if msg.Type == server.MsgTypePaneOutput {
+			r.HandlePaneOutput(msg.PaneID, msg.PaneData)
+			replayed++
 		}
-		r.HandlePaneOutput(paneMsg.PaneID, paneMsg.PaneData)
 	}
 
 	return r


### PR DESCRIPTION
## Summary
- `attachRendererAt` assumed `MsgTypeLayout` was always the first message on attach. Under `-race`, `MsgTypePaneOutput` can arrive first, causing test failures.
- Apply the same drain-until-layout pattern already used in `attachAt` (fixed in #131), and tolerate interleaved messages during pane replay.

## Test plan
- [x] `AMUX_TEST_RACE=1 go test -race -run TestReattachResize ./test/` passes
- [x] Full integration suite passes (pre-existing `TestFontResize_ThreeByThreeGridReturnsToOriginalLayout` flake excluded)

🤖 Generated with [Claude Code](https://claude.com/claude-code)