### PR TITLE
Restore faster integration coverage runs

### DIFF
--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -41,9 +41,14 @@ fi
 # --- Integration tests ---
 echo ""
 echo "=== Integration tests (GOCOVERDIR) ==="
-integ_args=(-race -timeout 900s ./test/)
+# Keep the coverage run close to the historical CI shape: parallelism capped
+# at 2 for harness stability, no -race on the integration test binary, and no
+# AMUX_TEST_RACE in the spawned amux subprocesses. Turning on both coverage and
+# race instrumentation here balloons CI wall time because each test harness
+# rebuilds and runs a race-enabled amux binary under GOCOVERDIR.
+integ_args=(-parallel 2 -timeout 300s ./test/)
 if [[ "$CI_MODE" == true ]]; then
-  AMUX_TEST_RACE=1 GOCOVERDIR="$COVDIR" go test -json "${integ_args[@]}" | tee integration-results.json || integ_rc=$?
+  GOCOVERDIR="$COVDIR" go test -json "${integ_args[@]}" | tee integration-results.json || integ_rc=$?
 else
   GOCOVERDIR="$COVDIR" go test "${integ_args[@]}" || integ_rc=$?
 fi


### PR DESCRIPTION
## Summary
- restore the integration coverage step to the pre-regression CI shape
- remove race instrumentation from the integration coverage run and spawned amux subprocesses
- cap integration coverage parallelism at 2 again to match the stable harness setting

## Root Cause
`Tests with coverage` regressed when `scripts/coverage.sh` changed the integration coverage invocation from `go test -parallel 2 -timeout 300s ./test/` to `AMUX_TEST_RACE=1 go test -race -timeout 900s ./test/`.

That made the coverage step build and run race-enabled amux subprocesses under `GOCOVERDIR`, which pushed the step from about 1m15s to about 10m21s in CI. The flake-detection step stayed flat at about 3m11s, so the slowdown was isolated to the coverage path.

## Testing
- `go test -race -coverprofile=unit-coverage.txt -covermode=atomic ./internal/... -timeout 60s`
- `GOCOVERDIR=$(mktemp -d) go test -parallel 2 -timeout 300s ./test/`
- `go test ./...`

Note: one rebased full-suite run hit an existing local flake in `TestNewWindowInheritsCwd`, `TestSplitInheritsCwd`, and `TestSplitWithinWindow`; a targeted rerun of those tests passed with `-count=3`.
