### PR TITLE
Use make targets in AGENTS.md build/test section

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,7 +63,8 @@ See [README.md -- Philosophy](README.md#philosophy) for the project thesis and t
 ```bash
 make setup                         # activate repo git hooks
 make build                         # build + install atomically (client hot-reloads automatically)
-go test ./...                      # run all tests
+make test                          # run all tests
+make coverage                      # merged unit + integration coverage (use this, not go test -coverprofile)
 ```
 
 ### Testing Live


### PR DESCRIPTION
## Summary
- Replace `go test ./...` with `make test` in the Build And Test section
- Add `make coverage` with a note not to use `go test -coverprofile` directly
- `make coverage` runs `scripts/coverage.sh` which merges unit + GOCOVERDIR-based integration coverage — running `go test -coverprofile` directly misses ~33 percentage points of coverage from integration tests

## Test plan
- [ ] Docs-only change; CI skips tests for docs-only diffs

🤖 Generated with [Claude Code](https://claude.com/claude-code)