### PR TITLE
Ignore stale reverse-video blocks when focusing panes

### DIFF
--- a/internal/client/panedata.go
+++ b/internal/client/panedata.go
@@ -43,6 +43,10 @@ func stripCursorBlock(sc *render.ScreenCell, emu mux.TerminalEmulator, x, y int)
 	if sc.Char != " " {
 		return
 	}
+	cursorX, cursorY := emu.CursorPosition()
+	if x != cursorX || y != cursorY {
+		return
+	}
 	w, _ := emu.Size()
 	if x > 0 {
 		if left := emu.CellAt(x-1, y); left != nil && left.Style.Attrs&uv.AttrReverse != 0 {

--- a/internal/client/panedata_test.go
+++ b/internal/client/panedata_test.go
@@ -13,7 +13,7 @@ func TestPaneDataRenderScreen(t *testing.T) {
 	t.Parallel()
 
 	emu := mux.NewVTEmulator(20, 4)
-	if _, err := emu.Write([]byte("hello \033[7m \033[m")); err != nil {
+	if _, err := emu.Write([]byte("hello \033[7m \033[m\033[1D")); err != nil {
 		t.Fatalf("Write: %v", err)
 	}
 
@@ -33,7 +33,7 @@ func TestPaneDataCellAt(t *testing.T) {
 		t.Parallel()
 
 		emu := mux.NewVTEmulator(20, 4)
-		if _, err := emu.Write([]byte("hello \033[7m \033[m")); err != nil {
+		if _, err := emu.Write([]byte("hello \033[7m \033[m\033[1D")); err != nil {
 			t.Fatalf("Write: %v", err)
 		}
 
@@ -61,6 +61,24 @@ func TestPaneDataCellAt(t *testing.T) {
 		cell := pane.CellAt(1, 0, false)
 		if cell.Style.Attrs&uv.AttrReverse == 0 {
 			t.Fatal("inactive CellAt should preserve reverse-video for non-cursor highlights")
+		}
+	})
+
+	t.Run("inactive preserves isolated reverse video away from cursor", func(t *testing.T) {
+		t.Parallel()
+
+		emu := mux.NewVTEmulator(20, 4)
+		if _, err := emu.Write([]byte("hello \033[7m \033[m")); err != nil {
+			t.Fatalf("Write: %v", err)
+		}
+		if _, err := emu.Write([]byte("\033[1;1H")); err != nil {
+			t.Fatalf("Write cursor move: %v", err)
+		}
+
+		pane := &PaneData{Emu: emu}
+		cell := pane.CellAt(6, 0, false)
+		if cell.Style.Attrs&uv.AttrReverse == 0 {
+			t.Fatal("inactive CellAt should preserve off-cursor reverse-video space")
 		}
 	})
 }

--- a/internal/mux/emulator.go
+++ b/internal/mux/emulator.go
@@ -359,9 +359,9 @@ func (v *vtEmulator) ScreenContains(substr string) bool {
 }
 
 // isCursorBlock returns true if the cell at (x, y) is an isolated
-// reverse-video space — an app-rendered block cursor. "Isolated" means
-// neither the left nor right neighbor has the reverse-video attribute,
-// which distinguishes single-cell cursors from multi-cell highlights.
+// reverse-video space. "Isolated" means neither the left nor right neighbor
+// has the reverse-video attribute, which distinguishes single-cell cursors
+// from multi-cell highlights.
 func (v *vtEmulator) isCursorBlock(x, y, w int) bool {
 	cell := v.emu.CellAt(x, y)
 	if cell == nil || cell.Style.Attrs&uv.AttrReverse == 0 {
@@ -383,55 +383,40 @@ func (v *vtEmulator) isCursorBlock(x, y, w int) bool {
 	return true
 }
 
-func (v *vtEmulator) RenderWithoutCursorBlock() string {
+func (v *vtEmulator) currentCursorBlock() (x, y int, ok bool) {
 	v.mu.Lock()
 	w, h := v.w, v.h
 	v.mu.Unlock()
 
-	type savedCell struct {
-		x, y int
-		cell uv.Cell
+	x, y = v.CursorPosition()
+	if x < 0 || y < 0 || x >= w || y >= h {
+		return 0, 0, false
 	}
-	var saved []savedCell
-
-	for y := 0; y < h; y++ {
-		for x := 0; x < w; x++ {
-			if !v.isCursorBlock(x, y, w) {
-				continue
-			}
-			cell := v.emu.CellAt(x, y)
-			saved = append(saved, savedCell{x, y, *cell})
-			modified := cell.Clone()
-			modified.Style.Attrs &^= uv.AttrReverse
-			v.emu.SetCell(x, y, modified)
-		}
+	if !v.isCursorBlock(x, y, w) {
+		return 0, 0, false
 	}
+	return x, y, true
+}
 
-	if len(saved) == 0 {
+func (v *vtEmulator) RenderWithoutCursorBlock() string {
+	x, y, ok := v.currentCursorBlock()
+	if !ok {
 		return v.emu.Render()
 	}
 
+	cell := v.emu.CellAt(x, y)
+	saved := *cell
+	modified := cell.Clone()
+	modified.Style.Attrs &^= uv.AttrReverse
+	v.emu.SetCell(x, y, modified)
 	rendered := v.emu.Render()
-	for _, s := range saved {
-		c := s.cell
-		v.emu.SetCell(s.x, s.y, &c)
-	}
+	v.emu.SetCell(x, y, &saved)
 	return rendered
 }
 
 func (v *vtEmulator) HasCursorBlock() bool {
-	v.mu.Lock()
-	w, h := v.w, v.h
-	v.mu.Unlock()
-
-	for y := 0; y < h; y++ {
-		for x := 0; x < w; x++ {
-			if v.isCursorBlock(x, y, w) {
-				return true
-			}
-		}
-	}
-	return false
+	_, _, ok := v.currentCursorBlock()
+	return ok
 }
 
 // NewVTEmulatorWithDrain creates a terminal emulator that automatically

--- a/internal/mux/emulator_test.go
+++ b/internal/mux/emulator_test.go
@@ -130,7 +130,7 @@ func TestRenderWithoutCursorBlock(t *testing.T) {
 		t.Parallel()
 		emu := NewVTEmulator(40, 10)
 		// Write prompt, then a reverse-video space (simulating a block cursor)
-		emu.Write([]byte("hello \033[7m \033[m"))
+		emu.Write([]byte("hello \033[7m \033[m\033[1D"))
 
 		// Normal Render should contain reverse video
 		normal := emu.Render()
@@ -174,6 +174,18 @@ func TestRenderWithoutCursorBlock(t *testing.T) {
 			t.Error("RenderWithoutCursorBlock() should match Render() when no reverse video at cursor")
 		}
 	})
+
+	t.Run("preserves isolated reverse-video space away from cursor", func(t *testing.T) {
+		t.Parallel()
+		emu := NewVTEmulator(40, 10)
+		emu.Write([]byte("hello \033[7m \033[m"))
+		emu.Write([]byte("\033[1;1H"))
+
+		stripped := emu.RenderWithoutCursorBlock()
+		if !strings.Contains(stripped, "\033[7m") {
+			t.Fatal("RenderWithoutCursorBlock() should preserve off-cursor reverse video")
+		}
+	})
 }
 
 func TestHasCursorBlock(t *testing.T) {
@@ -182,7 +194,7 @@ func TestHasCursorBlock(t *testing.T) {
 	t.Run("true for isolated reverse-video space", func(t *testing.T) {
 		t.Parallel()
 		emu := NewVTEmulator(40, 10)
-		emu.Write([]byte("hello \033[7m \033[m"))
+		emu.Write([]byte("hello \033[7m \033[m\033[1D"))
 		if !emu.HasCursorBlock() {
 			t.Error("HasCursorBlock() = false, want true")
 		}
@@ -203,6 +215,16 @@ func TestHasCursorBlock(t *testing.T) {
 		emu.Write([]byte("hello"))
 		if emu.HasCursorBlock() {
 			t.Error("HasCursorBlock() = true with no reverse video, want false")
+		}
+	})
+
+	t.Run("false for isolated reverse-video space away from cursor", func(t *testing.T) {
+		t.Parallel()
+		emu := NewVTEmulator(40, 10)
+		emu.Write([]byte("hello \033[7m \033[m"))
+		emu.Write([]byte("\033[1;1H"))
+		if emu.HasCursorBlock() {
+			t.Error("HasCursorBlock() = true for off-cursor reverse video, want false")
 		}
 	})
 }

--- a/internal/render/compositor_test.go
+++ b/internal/render/compositor_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	uv "github.com/charmbracelet/ultraviolet"
 	"github.com/weill-labs/amux/internal/mux"
 )
 
@@ -34,6 +35,61 @@ func (f *fakePaneData) ConnStatus() string     { return "" }
 func (f *fakePaneData) InCopyMode() bool       { return false }
 func (f *fakePaneData) CopyModeSearch() string { return "" }
 func (f *fakePaneData) HasCursorBlock() bool   { return false }
+
+type cursorPaneData struct {
+	id    uint32
+	name  string
+	color string
+	emu   mux.TerminalEmulator
+}
+
+func (e *cursorPaneData) RenderScreen(active bool) string {
+	if !active {
+		return e.emu.RenderWithoutCursorBlock()
+	}
+	return e.emu.Render()
+}
+
+func (e *cursorPaneData) CellAt(col, row int, active bool) ScreenCell {
+	cell := CellFromUV(e.emu.CellAt(col, row))
+	if active {
+		return cell
+	}
+	cursorX, cursorY := e.emu.CursorPosition()
+	if col != cursorX || row != cursorY {
+		return cell
+	}
+	if cell.Style.Attrs&uv.AttrReverse == 0 || cell.Char != " " {
+		return cell
+	}
+	w, _ := e.emu.Size()
+	if col > 0 {
+		if left := e.emu.CellAt(col-1, row); left != nil && left.Style.Attrs&uv.AttrReverse != 0 {
+			return cell
+		}
+	}
+	if col < w-1 {
+		if right := e.emu.CellAt(col+1, row); right != nil && right.Style.Attrs&uv.AttrReverse != 0 {
+			return cell
+		}
+	}
+	cell.Style.Attrs &^= uv.AttrReverse
+	return cell
+}
+
+func (e *cursorPaneData) CursorPos() (int, int)  { return e.emu.CursorPosition() }
+func (e *cursorPaneData) CursorHidden() bool     { return e.emu.CursorHidden() }
+func (e *cursorPaneData) HasCursorBlock() bool   { return e.emu.HasCursorBlock() }
+func (e *cursorPaneData) ID() uint32             { return e.id }
+func (e *cursorPaneData) Name() string           { return e.name }
+func (e *cursorPaneData) Host() string           { return "local" }
+func (e *cursorPaneData) Task() string           { return "" }
+func (e *cursorPaneData) Color() string          { return e.color }
+func (e *cursorPaneData) Minimized() bool        { return false }
+func (e *cursorPaneData) Idle() bool             { return true }
+func (e *cursorPaneData) ConnStatus() string     { return "" }
+func (e *cursorPaneData) InCopyMode() bool       { return false }
+func (e *cursorPaneData) CopyModeSearch() string { return "" }
 
 func TestMinimizedPaneHidesCursor(t *testing.T) {
 	t.Parallel()
@@ -126,6 +182,32 @@ func TestRenderCursorEdgeCases(t *testing.T) {
 				t.Errorf("cursor visible = %v, want %v", hasCursor, tt.wantVisible)
 			}
 		})
+	}
+}
+
+func TestRenderCursorIgnoresOffCursorReverseVideoSpace(t *testing.T) {
+	t.Parallel()
+
+	width, height := 40, 5
+	root := mux.NewLeaf(&mux.Pane{ID: 1, Meta: mux.PaneMeta{Name: "pane-1"}}, 0, 0, width, height)
+	emu := mux.NewVTEmulator(width, height)
+	if _, err := emu.Write([]byte("hello \033[7m \033[m")); err != nil {
+		t.Fatalf("Write stale block: %v", err)
+	}
+	if _, err := emu.Write([]byte("\033[1;1H")); err != nil {
+		t.Fatalf("Write cursor move: %v", err)
+	}
+
+	comp := NewCompositor(width, height+GlobalBarHeight, "test")
+	output := comp.RenderFull(root, 1, func(id uint32) PaneData {
+		if id != 1 {
+			return nil
+		}
+		return &cursorPaneData{id: 1, name: "pane-1", color: "f5e0dc", emu: emu}
+	})
+
+	if !strings.Contains(output, ShowCursor) {
+		t.Fatal("cursor should remain visible when reverse-video space is away from the cursor")
 	}
 }
 


### PR DESCRIPTION
## Summary
- only treat an isolated reverse-video space as an app cursor when it is at the emulator's current cursor position
- preserve off-cursor reverse-video spaces so stale Claude prompt blocks do not hide the real terminal cursor after focusing a pane
- add regression coverage in emulator, pane-data, compositor, and focus-oriented integration tests

## Testing
- go test ./internal/mux ./internal/client ./internal/render -run 'Test(RenderWithoutCursorBlock|HasCursorBlock|PaneData|RenderCursorIgnoresOffCursorReverseVideoSpace)' -count=1
- go test ./test -run 'TestFocus|TestWindowSwitchResyncsStaleCursorState|TestAttachResyncsStaleCursorState' -count=1 -timeout 120s

## Notes
- `go test ./... -timeout 120s` hit one unrelated flaky failure in `TestWaitBusy_EventBased`; rerunning `go test ./test -run TestWaitBusy_EventBased -count=5 -timeout 120s` passed

## Review
- simplification pass completed
- review pass completed