### PR TITLE
Harden benchmark execution and publishing

### DIFF
--- a/.github/workflows/benchmark-publish.yml
+++ b/.github/workflows/benchmark-publish.yml
@@ -1,0 +1,186 @@
+name: Publish Benchmark Trends
+
+on:
+  workflow_run:
+    workflows: ["Benchmarks"]
+    types: [completed]
+
+permissions:
+  actions: read
+  contents: write
+  pages: write
+  id-token: write
+
+concurrency:
+  group: benchmark-publish
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    if: github.event.workflow_run.event == 'push' && github.event.workflow_run.head_branch == 'main'
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v6.0.2
+
+      - name: Download benchmark artifact
+        id: download
+        continue-on-error: true
+        uses: actions/download-artifact@v5
+        with:
+          name: benchmark-results
+          path: benchmark-results
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+
+      - name: Check downloaded artifact
+        id: artifact
+        run: |
+          if [[ -f benchmark-results/benchmark-run.json ]]; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "found=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::No benchmark artifact found for workflow run ${{ github.event.workflow_run.id }}"
+          fi
+
+      - uses: actions/setup-go@v6.3.0
+        if: steps.artifact.outputs.found == 'true'
+        with:
+          go-version: "1.25"
+
+      - name: Install gobenchdata
+        if: steps.artifact.outputs.found == 'true'
+        run: go install go.bobheadxi.dev/gobenchdata@latest
+
+      - name: Read benchmark manifest
+        id: manifest
+        if: steps.artifact.outputs.found == 'true'
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+
+          with open("benchmark-results/benchmark-run.json", "r", encoding="utf-8") as fh:
+              data = json.load(fh)
+
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as out:
+              out.write(f"benchmark_success={'true' if data.get('benchmark_success') else 'false'}\n")
+              out.write(f"parse_ready={'true' if data.get('parse_ready') else 'false'}\n")
+              out.write(f"head_sha={data.get('head_sha', '')}\n")
+          PY
+
+      - name: Prepare benchmark data branch
+        id: data
+        if: steps.artifact.outputs.found == 'true'
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          data_dir=$(mktemp -d)
+          git -C "$data_dir" init -q
+          git -C "$data_dir" config user.name "github-actions[bot]"
+          git -C "$data_dir" config user.email "github-actions[bot]@users.noreply.github.com"
+          git -C "$data_dir" remote add origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+
+          if git -C "$data_dir" fetch --depth=1 origin benchmark-data; then
+            git -C "$data_dir" checkout -B benchmark-data FETCH_HEAD
+          else
+            git -C "$data_dir" checkout --orphan benchmark-data
+            find "$data_dir" -mindepth 1 -maxdepth 1 ! -name .git -exec rm -rf {} +
+          fi
+
+          echo "path=$data_dir" >> "$GITHUB_OUTPUT"
+
+      - name: Merge benchmark history
+        if: steps.artifact.outputs.found == 'true' && steps.manifest.outputs.parse_ready == 'true'
+        run: |
+          set -euo pipefail
+          data_dir="${{ steps.data.outputs.path }}"
+
+          if [[ -f "$data_dir/benchmarks.json" ]]; then
+            gobenchdata merge "$data_dir/benchmarks.json" benchmark-results/bench-current.json --json "$data_dir/benchmarks-merged.json"
+            mv "$data_dir/benchmarks-merged.json" "$data_dir/benchmarks.json"
+          else
+            cp benchmark-results/bench-current.json "$data_dir/benchmarks.json"
+          fi
+
+      - name: Sync dashboard files
+        id: site
+        if: steps.artifact.outputs.found == 'true'
+        run: |
+          set -euo pipefail
+          data_dir="${{ steps.data.outputs.path }}"
+          site_dir=$(mktemp -d)
+
+          cp docs/benchmark/index.html "$data_dir/index.html"
+          cp benchmark-results/benchmark-run.json "$data_dir/latest-run.json"
+          cp benchmark-results/bench-all.txt "$data_dir/bench-all.txt"
+          touch "$data_dir/.nojekyll"
+
+          if [[ ! -f "$data_dir/benchmarks.json" ]]; then
+            echo '[]' > "$data_dir/benchmarks.json"
+          fi
+
+          cp "$data_dir/index.html" "$site_dir/index.html"
+          cp "$data_dir/latest-run.json" "$site_dir/latest-run.json"
+          cp "$data_dir/bench-all.txt" "$site_dir/bench-all.txt"
+          cp "$data_dir/benchmarks.json" "$site_dir/benchmarks.json"
+          cp "$data_dir/.nojekyll" "$site_dir/.nojekyll"
+          echo "path=$site_dir" >> "$GITHUB_OUTPUT"
+
+      - name: Commit benchmark data
+        id: commit
+        if: steps.artifact.outputs.found == 'true'
+        continue-on-error: true
+        run: |
+          set -euo pipefail
+          data_dir="${{ steps.data.outputs.path }}"
+
+          git -C "$data_dir" add benchmarks.json latest-run.json bench-all.txt index.html .nojekyll
+          if git -C "$data_dir" diff --cached --quiet; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          git -C "$data_dir" commit -m "Update benchmark data for ${{ steps.manifest.outputs.head_sha }} [skip ci]"
+          git -C "$data_dir" push origin HEAD:benchmark-data
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Configure GitHub Pages
+        if: steps.artifact.outputs.found == 'true'
+        id: pages
+        continue-on-error: true
+        uses: actions/configure-pages@v5
+
+      - name: Upload GitHub Pages artifact
+        if: steps.artifact.outputs.found == 'true'
+        continue-on-error: true
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: ${{ steps.site.outputs.path }}
+
+      - name: Deploy to GitHub Pages
+        if: steps.artifact.outputs.found == 'true'
+        id: deploy
+        continue-on-error: true
+        uses: actions/deploy-pages@v4
+
+      - name: Publish summary
+        if: always()
+        run: |
+          {
+            echo "## Benchmark publish"
+            echo ""
+            if [[ "${{ steps.artifact.outputs.found }}" != "true" ]]; then
+              echo "- No benchmark artifact found for workflow run ${{ github.event.workflow_run.id }}."
+            else
+              echo "- Benchmark workflow conclusion: ${{ github.event.workflow_run.conclusion }}"
+              echo "- Benchmark execution success: ${{ steps.manifest.outputs.benchmark_success }}"
+              echo "- Normalized history update ready: ${{ steps.manifest.outputs.parse_ready }}"
+              echo "- Data branch updated: ${{ steps.commit.outputs.changed }}"
+              echo "- Pages deploy outcome: ${{ steps.deploy.outcome }}"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -5,7 +5,7 @@ on:
     branches: [main]
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   benchmark:
@@ -37,21 +37,59 @@ jobs:
         if: steps.changes.outputs.code_changed == 'true'
         run: brew install tmux
 
-      - name: Install benchstat
+      - name: Install benchmark tools
         if: steps.changes.outputs.code_changed == 'true'
-        run: go install golang.org/x/perf/cmd/benchstat@latest
+        run: |
+          go install golang.org/x/perf/cmd/benchstat@latest
+          go install go.bobheadxi.dev/gobenchdata@latest
 
-      - name: Microbenchmarks
+      - name: Run microbenchmarks
         if: steps.changes.outputs.code_changed == 'true'
-        run: go test -bench=. -benchmem -count=5 -run='^$' ./internal/... -timeout 120s | tee bench-micro.txt
+        run: |
+          scripts/run-benchmark-suite.sh bench-micro.txt bench-micro.exit \
+            go test -bench=. -benchmem -count=5 -run='^$' ./internal/... -timeout 120s
 
-      - name: Integration benchmarks
+      - name: Run integration benchmarks
         if: steps.changes.outputs.code_changed == 'true'
-        run: go test -bench=. -benchmem -count=7 -run='^$' ./test/ -timeout 300s | tee bench-integration.txt
+        run: |
+          scripts/run-benchmark-suite.sh bench-integration.txt bench-integration.exit \
+            go test -bench=. -benchmem -count=7 -run='^$' ./test/ -timeout 300s
 
-      - name: Combine results
-        if: steps.changes.outputs.code_changed == 'true'
+      - name: Combine benchmark outputs
+        if: always() && steps.changes.outputs.code_changed == 'true'
         run: cat bench-micro.txt bench-integration.txt > bench-all.txt
+
+      - name: Normalize benchmark data
+        id: normalize
+        if: always() && steps.changes.outputs.code_changed == 'true'
+        run: |
+          parse_ready=false
+          if [[ $(cat bench-micro.exit) == "0" && $(cat bench-integration.exit) == "0" ]]; then
+            if scripts/benchmark-normalize.sh bench-all.txt bench-current.json; then
+              parse_ready=true
+            else
+              echo "::warning::Skipping benchmark history update because normalization failed"
+            fi
+          else
+            echo "::warning::Skipping benchmark history update because one or more benchmark suites failed"
+          fi
+          echo "parse_ready=$parse_ready" >> "$GITHUB_OUTPUT"
+
+      - name: Write benchmark manifest
+        if: always() && steps.changes.outputs.code_changed == 'true'
+        env:
+          PARSE_READY: ${{ steps.normalize.outputs.parse_ready }}
+        run: |
+          go_version=$(go version | awk '{print $3}')
+          scripts/benchmark-manifest.sh benchmark-run.json \
+            "$GITHUB_SHA" \
+            "$GITHUB_RUN_ID" \
+            "$GITHUB_RUN_ATTEMPT" \
+            "$RUNNER_OS" \
+            "$go_version" \
+            "$(cat bench-micro.exit)" \
+            "$(cat bench-integration.exit)" \
+            "$PARSE_READY"
 
       - name: Upload benchmark results
         if: always() && steps.changes.outputs.code_changed == 'true'
@@ -62,173 +100,21 @@ jobs:
             bench-micro.txt
             bench-integration.txt
             bench-all.txt
+            bench-micro.exit
+            bench-integration.exit
+            bench-current.json
+            benchmark-run.json
 
       - name: Benchmark summary
         if: always() && steps.changes.outputs.code_changed == 'true'
         run: |
-          {
-            echo '## Benchmarks'
-            echo ''
-            echo '### Microbenchmarks'
-            echo '```'
-            benchstat bench-micro.txt
-            echo '```'
-            echo ''
-            echo '### Integration benchmarks'
-            echo '```'
-            benchstat bench-integration.txt
-            echo '```'
-          } >> "$GITHUB_STEP_SUMMARY"
+          scripts/benchmark-summary.sh bench-micro.txt bench-micro.exit bench-integration.txt bench-integration.exit >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Update trend data
-        if: steps.changes.outputs.code_changed == 'true'
+      - name: Fail if benchmark suites failed
+        if: always() && steps.changes.outputs.code_changed == 'true'
         run: |
-          go install go.bobheadxi.dev/gobenchdata@latest
-          # Strip harness noise and failed benchmark lines. gobenchdata expects
-          # only successful raw benchmark output on stdin.
-          grep -v -E '^(PASS|FAIL|ok[[:space:]]|\\?[[:space:]]|--- FAIL: )' bench-all.txt > bench-filtered.txt || true
-          if grep -q '^--- FAIL: Benchmark' bench-all.txt; then
-            echo "::warning::Skipping benchmark trend update because one or more benchmarks failed"
-          elif [ -s bench-filtered.txt ]; then
-            cat bench-filtered.txt | gobenchdata --json bench-current.json
+          micro_rc=$(cat bench-micro.exit)
+          integration_rc=$(cat bench-integration.exit)
+          if (( micro_rc != 0 || integration_rc != 0 )); then
+            exit 1
           fi
-
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
-          ORIGINAL_REF=$(git rev-parse HEAD)
-
-          mkdir -p /tmp/bench-data
-          cp bench-current.json /tmp/bench-data/ 2>/dev/null || true
-          cp bench-all.txt /tmp/bench-data/
-
-          if git fetch origin gh-pages 2>/dev/null; then
-            git checkout gh-pages
-          else
-            git checkout --orphan gh-pages
-            git rm -rf . 2>/dev/null || true
-          fi
-
-          cp /tmp/bench-data/bench-all.txt . 2>/dev/null || true
-          if [ -f /tmp/bench-data/bench-current.json ]; then
-            if [ -f benchmarks.json ]; then
-              gobenchdata merge benchmarks.json /tmp/bench-data/bench-current.json --json benchmarks-merged.json
-              mv benchmarks-merged.json benchmarks.json
-            else
-              cp /tmp/bench-data/bench-current.json benchmarks.json
-            fi
-          fi
-
-          # Generate dashboard HTML if it doesn't exist
-          if [ ! -f index.html ]; then
-            cat > index.html << 'HTMLEOF'
-          <!DOCTYPE html>
-          <html lang="en">
-          <head>
-            <meta charset="utf-8">
-            <meta name="viewport" content="width=device-width, initial-scale=1">
-            <title>amux benchmarks</title>
-            <script src="https://cdn.jsdelivr.net/npm/chart.js@4"></script>
-            <style>
-              * { margin: 0; padding: 0; box-sizing: border-box; }
-              body { font-family: system-ui, sans-serif; background: #1e1e2e; color: #cdd6f4; padding: 2rem; }
-              h1 { margin-bottom: 0.5rem; }
-              p.subtitle { color: #6c7086; margin-bottom: 2rem; }
-              .chart-container { background: #313244; border-radius: 8px; padding: 1rem; margin-bottom: 1.5rem; }
-              .chart-container h2 { font-size: 1rem; margin-bottom: 0.5rem; color: #89b4fa; }
-              canvas { max-height: 300px; }
-              .error { color: #f38ba8; padding: 2rem; }
-            </style>
-          </head>
-          <body>
-            <h1>amux benchmark trends</h1>
-            <p class="subtitle">Updated on each merge to main</p>
-            <div id="charts"></div>
-            <script>
-              const COLORS = ['#89b4fa','#a6e3a1','#f9e2af','#f38ba8','#cba6f7','#94e2d5','#fab387','#74c7ec'];
-
-              async function main() {
-                const container = document.getElementById('charts');
-                let data;
-                try {
-                  const res = await fetch('benchmarks.json');
-                  data = await res.json();
-                } catch (e) {
-                  container.innerHTML = '<p class="error">No benchmark data yet. Data appears after the first merge to main.</p>';
-                  return;
-                }
-                if (!data || !data.length) {
-                  container.innerHTML = '<p class="error">No benchmark data yet.</p>';
-                  return;
-                }
-
-                // Group benchmarks by suite (top-level name)
-                const suites = {};
-                for (const run of data) {
-                  for (const suite of (run.Suites || [])) {
-                    for (const bench of (suite.Benchmarks || [])) {
-                      const name = bench.Name;
-                      const parts = name.split('/');
-                      const suiteName = parts[0].replace(/^Benchmark/, '');
-                      if (!suites[suiteName]) suites[suiteName] = {};
-                      if (!suites[suiteName][name]) suites[suiteName][name] = [];
-                      suites[suiteName][name].push({
-                        date: run.Date ? new Date(run.Date * 1000).toLocaleDateString() : '?',
-                        nsOp: bench.NsPerOp || 0,
-                        allocsOp: bench.AllocsPerOp || 0,
-                        bytesOp: bench.Mem || 0,
-                      });
-                    }
-                  }
-                }
-
-                let colorIdx = 0;
-                for (const [suiteName, benchmarks] of Object.entries(suites)) {
-                  const div = document.createElement('div');
-                  div.className = 'chart-container';
-                  div.innerHTML = '<h2>' + suiteName + '</h2><canvas></canvas>';
-                  container.appendChild(div);
-
-                  const datasets = [];
-                  let labels = [];
-                  for (const [name, points] of Object.entries(benchmarks)) {
-                    const shortName = name.split('/').slice(1).join('/') || name;
-                    if (points.length > labels.length) labels = points.map(p => p.date);
-                    datasets.push({
-                      label: shortName,
-                      data: points.map(p => p.nsOp / 1e6),
-                      borderColor: COLORS[colorIdx % COLORS.length],
-                      backgroundColor: COLORS[colorIdx % COLORS.length] + '33',
-                      tension: 0.3,
-                      pointRadius: 3,
-                    });
-                    colorIdx++;
-                  }
-
-                  new Chart(div.querySelector('canvas'), {
-                    type: 'line',
-                    data: { labels, datasets },
-                    options: {
-                      responsive: true,
-                      plugins: { legend: { labels: { color: '#cdd6f4' } } },
-                      scales: {
-                        x: { ticks: { color: '#6c7086' }, grid: { color: '#45475a' } },
-                        y: { title: { display: true, text: 'ms/op', color: '#6c7086' },
-                             ticks: { color: '#6c7086' }, grid: { color: '#45475a' } },
-                      },
-                    },
-                  });
-                }
-              }
-              main();
-            </script>
-          </body>
-          </html>
-          HTMLEOF
-          fi
-
-          git add benchmarks.json bench-all.txt index.html 2>/dev/null || true
-          git diff --cached --quiet || git commit -m "Update benchmark data [skip ci]"
-          git push origin gh-pages || echo "::warning::Failed to push to gh-pages"
-
-          git checkout "$ORIGINAL_REF"

--- a/docs/benchmark/index.html
+++ b/docs/benchmark/index.html
@@ -1,0 +1,148 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>amux benchmarks</title>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4"></script>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      background: #1e1e2e;
+      color: #cdd6f4;
+      font-family: system-ui, sans-serif;
+      line-height: 1.5;
+      padding: 2rem;
+    }
+    h1 { margin-bottom: 0.25rem; }
+    p.subtitle { color: #6c7086; margin-bottom: 0.5rem; }
+    p.meta { color: #a6adc8; margin-bottom: 2rem; }
+    .chart-container {
+      background: #313244;
+      border-radius: 8px;
+      margin-bottom: 1.5rem;
+      padding: 1rem;
+    }
+    .chart-container h2 {
+      color: #89b4fa;
+      font-size: 1rem;
+      margin-bottom: 0.5rem;
+    }
+    canvas { max-height: 300px; }
+    .error { color: #f38ba8; padding: 2rem 0; }
+  </style>
+</head>
+<body>
+  <h1>amux benchmark trends</h1>
+  <p class="subtitle">Updated by the benchmark publish workflow on merges to main.</p>
+  <p id="meta" class="meta">Loading latest run metadata...</p>
+  <div id="charts"></div>
+  <script>
+    const COLORS = ["#89b4fa", "#a6e3a1", "#f9e2af", "#f38ba8", "#cba6f7", "#94e2d5", "#fab387", "#74c7ec"];
+
+    function renderMeta(run) {
+      const meta = document.getElementById("meta");
+      if (!run || !run.head_sha) {
+        meta.textContent = "No benchmark metadata yet.";
+        return;
+      }
+      const status = run.benchmark_success ? "successful benchmark run" : "benchmark run failed";
+      meta.textContent = `Latest run ${run.head_sha.slice(0, 7)} on ${run.runner_os}, ${status}.`;
+    }
+
+    async function fetchJSON(path) {
+      const res = await fetch(path);
+      if (!res.ok) {
+        throw new Error(`failed to fetch ${path}`);
+      }
+      return res.json();
+    }
+
+    function groupSuites(data) {
+      const suites = {};
+      for (const run of data) {
+        for (const suite of (run.Suites || [])) {
+          for (const bench of (suite.Benchmarks || [])) {
+            const name = bench.Name;
+            const parts = name.split("/");
+            const suiteName = parts[0].replace(/^Benchmark/, "");
+            if (!suites[suiteName]) suites[suiteName] = {};
+            if (!suites[suiteName][name]) suites[suiteName][name] = [];
+            suites[suiteName][name].push({
+              date: run.Date ? new Date(run.Date * 1000).toLocaleDateString() : "?",
+              nsOp: bench.NsPerOp || 0,
+            });
+          }
+        }
+      }
+      return suites;
+    }
+
+    async function main() {
+      const container = document.getElementById("charts");
+      try {
+        renderMeta(await fetchJSON("latest-run.json"));
+      } catch (_err) {
+        renderMeta(null);
+      }
+
+      let data;
+      try {
+        data = await fetchJSON("benchmarks.json");
+      } catch (_err) {
+        container.innerHTML = '<p class="error">No benchmark history published yet.</p>';
+        return;
+      }
+
+      if (!Array.isArray(data) || data.length === 0) {
+        container.innerHTML = '<p class="error">No benchmark history published yet.</p>';
+        return;
+      }
+
+      const suites = groupSuites(data);
+      let colorIdx = 0;
+      for (const [suiteName, benchmarks] of Object.entries(suites)) {
+        const div = document.createElement("div");
+        div.className = "chart-container";
+        div.innerHTML = `<h2>${suiteName}</h2><canvas></canvas>`;
+        container.appendChild(div);
+
+        const datasets = [];
+        let labels = [];
+        for (const [name, points] of Object.entries(benchmarks)) {
+          const shortName = name.split("/").slice(1).join("/") || name;
+          if (points.length > labels.length) labels = points.map((point) => point.date);
+          datasets.push({
+            label: shortName,
+            data: points.map((point) => point.nsOp / 1e6),
+            borderColor: COLORS[colorIdx % COLORS.length],
+            backgroundColor: `${COLORS[colorIdx % COLORS.length]}33`,
+            tension: 0.3,
+            pointRadius: 3,
+          });
+          colorIdx++;
+        }
+
+        new Chart(div.querySelector("canvas"), {
+          type: "line",
+          data: { labels, datasets },
+          options: {
+            responsive: true,
+            plugins: { legend: { labels: { color: "#cdd6f4" } } },
+            scales: {
+              x: { ticks: { color: "#6c7086" }, grid: { color: "#45475a" } },
+              y: {
+                title: { display: true, text: "ms/op", color: "#6c7086" },
+                ticks: { color: "#6c7086" },
+                grid: { color: "#45475a" },
+              },
+            },
+          },
+        });
+      }
+    }
+
+    main();
+  </script>
+</body>
+</html>

--- a/docs/specs/2026-03-15-benchmark-suite-design.md
+++ b/docs/specs/2026-03-15-benchmark-suite-design.md
@@ -123,23 +123,24 @@ Start pragmatic: `-count=5` for microbenchmarks, `-count=7` for integration benc
 
 ## CI Integration
 
-### `benchmark.yml` — runs on every push to `main` and every PR
+### `benchmark.yml` — runs on every push to `main`
 
 ```yaml
 # Pseudocode
-- apt-get install -y tmux
-- go test -bench=. -benchmem -count=5 ./internal/... > bench-micro.txt
-- go test -bench=. -benchmem -count=7 ./test/ -timeout 300s >> bench-micro.txt
+- run micro and integration benchmarks with real exit-code capture
+- upload raw outputs + benchmark-run.json manifest + normalized bench-current.json artifact
+- fail the workflow only for real benchmark failures
+```
 
-# On main: update trend data
-- gobenchdata merge bench-micro.txt → gh-pages JSON
-- commit to gh-pages
+### `benchmark-publish.yml` — runs after `benchmark.yml` completes on `main`
 
-# On PR: compare against main baseline
-- download main benchmark artifact
-- benchstat main.txt pr.txt > comparison.txt
-- post comparison as PR comment
-- fail check if regression >15% with p < 0.05
+```yaml
+# Pseudocode
+- download benchmark artifact from the triggering workflow_run
+- if benchmark-run.json says parse_ready=false, skip history update and exit successfully
+- merge bench-current.json into benchmark history on benchmark-data branch
+- build static dashboard artifact from benchmark-data contents
+- deploy GitHub Pages from uploaded artifact
 ```
 
 ### Regression threshold
@@ -170,6 +171,7 @@ benchstat old.txt new.txt
 | All-Go (`testing.B`) over shell scripts | Unified measurement, `benchstat` compatibility, reuses existing harnesses |
 | Everything in CI (including integration) | Ubuntu runners have tmux; `benchstat` handles variance statistically |
 | `gobenchdata` + GitHub Pages | Free, automated, visual trends, no infrastructure to maintain |
+| Separate publish workflow | Benchmark execution failures and publishing failures are independent, so `main` only goes red for real benchmark problems |
 | 15% regression threshold | Balances CI noise vs catching real regressions; tunable later |
 | Lightweight `TmuxBenchHarness` | Minimal code for comparison; not a full test harness |
 | `-count=7` for integration benchmarks | More samples to compensate for higher wall-clock variance |

--- a/scripts/benchmark-manifest.sh
+++ b/scripts/benchmark-manifest.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 9 ]]; then
+  echo "usage: $0 OUT HEAD_SHA RUN_ID RUN_ATTEMPT RUNNER_OS GO_VERSION MICRO_EXIT INTEGRATION_EXIT PARSE_READY" >&2
+  exit 2
+fi
+
+out=$1
+head_sha=$2
+run_id=$3
+run_attempt=$4
+runner_os=$5
+go_version=$6
+micro_exit=$7
+integration_exit=$8
+parse_ready=$9
+
+suite_status() {
+  if [[ $1 == "0" ]]; then
+    echo "success"
+  else
+    echo "failure"
+  fi
+}
+
+benchmark_success=false
+if [[ $micro_exit == "0" && $integration_exit == "0" ]]; then
+  benchmark_success=true
+fi
+
+cat > "$out" <<EOF
+{
+  "schema_version": 1,
+  "head_sha": "$head_sha",
+  "workflow_run_id": "$run_id",
+  "workflow_run_attempt": "$run_attempt",
+  "runner_os": "$runner_os",
+  "go_version": "$go_version",
+  "benchmark_success": $benchmark_success,
+  "parse_ready": $parse_ready,
+  "normalized_output": "bench-current.json",
+  "suites": [
+    {
+      "name": "micro",
+      "status": "$(suite_status "$micro_exit")",
+      "exit_code": $micro_exit,
+      "output_path": "bench-micro.txt"
+    },
+    {
+      "name": "integration",
+      "status": "$(suite_status "$integration_exit")",
+      "exit_code": $integration_exit,
+      "output_path": "bench-integration.txt"
+    }
+  ]
+}
+EOF

--- a/scripts/benchmark-normalize.sh
+++ b/scripts/benchmark-normalize.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+  echo "usage: $0 INPUT OUTPUT" >&2
+  exit 2
+fi
+
+input=$1
+output=$2
+filtered=$(mktemp)
+trap 'rm -f "$filtered"' EXIT
+
+if grep -q -- '--- FAIL: Benchmark' "$input"; then
+  echo "benchmark failure markers found in $input" >&2
+  exit 1
+fi
+
+# Drop package summary noise that gobenchdata cannot parse, but preserve
+# the standard PASS/ok footer that Go benchmark output normally includes.
+grep -v -E '^\?[[:space:]].*\[no test files\]$' "$input" > "$filtered" || true
+
+if ! grep -q '^Benchmark' "$filtered"; then
+  echo "no benchmark lines found in $input" >&2
+  exit 1
+fi
+
+cat "$filtered" | gobenchdata --json "$output"

--- a/scripts/benchmark-summary.sh
+++ b/scripts/benchmark-summary.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 4 ]]; then
+  echo "usage: $0 MICRO_TXT MICRO_EXIT INTEGRATION_TXT INTEGRATION_EXIT" >&2
+  exit 2
+fi
+
+micro_txt=$1
+micro_exit=$2
+integration_txt=$3
+integration_exit=$4
+
+render_suite() {
+  local title=$1
+  local txt=$2
+  local exit_file=$3
+  local rc
+
+  rc=$(cat "$exit_file")
+
+  echo "### $title"
+  echo '```'
+  if [[ $rc != "0" ]]; then
+    echo "suite failed with exit code $rc"
+    echo "see uploaded benchmark artifact for raw output"
+  elif [[ ! -s $txt ]]; then
+    echo "no benchmark output captured"
+  elif ! benchstat "$txt"; then
+    echo "benchstat could not summarize $txt"
+  fi
+  echo '```'
+  echo ""
+}
+
+echo "## Benchmarks"
+echo ""
+render_suite "Microbenchmarks" "$micro_txt" "$micro_exit"
+render_suite "Integration benchmarks" "$integration_txt" "$integration_exit"

--- a/scripts/run-benchmark-suite.sh
+++ b/scripts/run-benchmark-suite.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -lt 3 ]]; then
+  echo "usage: $0 OUTPUT EXIT_FILE CMD..." >&2
+  exit 2
+fi
+
+output=$1
+exit_file=$2
+shift 2
+
+if "$@" | tee "$output"; then
+  echo 0 > "$exit_file"
+else
+  rc=$?
+  echo "$rc" > "$exit_file"
+fi


### PR DESCRIPTION
## Summary
- split benchmark execution from benchmark publishing so `main` only goes red for real benchmark failures
- capture real benchmark exit codes, upload a benchmark manifest, and normalize history from explicit artifacts
- publish history and the dashboard from a separate workflow using a dedicated `benchmark-data` branch and Pages deploy

## Testing
- `actionlint .github/workflows/benchmark.yml .github/workflows/benchmark-publish.yml`
- `go test -bench=. -benchmem -count=1 -run='^$' ./internal/render -timeout 60s > /tmp/amux-bench.txt`
- `scripts/benchmark-normalize.sh /tmp/amux-bench.txt /tmp/amux-bench.json`
- failure-case normalization check on synthetic `--- FAIL: Benchmark...` input
- `scripts/run-benchmark-suite.sh` exit-code capture smoke test
- `scripts/benchmark-manifest.sh` JSON smoke test
- `scripts/benchmark-summary.sh` smoke test with `benchstat`

## Notes
This replaces the old inline `Update trend data` path, which was coupling benchmark execution, raw-output parsing, branch mutation, and publishing into one fragile job. The new shape makes benchmark execution authoritative and treats publishing as a follow-up concern.

The remaining unknown is the first real GitHub Actions run, especially Pages configuration in the repository settings. The workflows are designed so publishing problems stay visible without making `main` red for the wrong reason.
