### PR TITLE
Add Unicode grapheme tests for emulator and JSON capture

### DIFF
--- a/internal/mux/emulator_test.go
+++ b/internal/mux/emulator_test.go
@@ -333,6 +333,78 @@ func TestScreenLineTextWideChars(t *testing.T) {
 	}
 }
 
+func TestScreenLineTextGraphemeClusters(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		input         []byte
+		wantLine      string
+		wantCell0     string
+		wantCell0Wide int
+	}{
+		{
+			name:          "combining mark cluster",
+			input:         []byte("Λ\u030A1"),
+			wantLine:      "Λ\u030A1",
+			wantCell0:     "Λ\u030A",
+			wantCell0Wide: 1,
+		},
+		{
+			name:          "emoji modifier cluster",
+			input:         []byte("👍🏻2"),
+			wantLine:      "👍🏻2",
+			wantCell0:     "👍🏻",
+			wantCell0Wide: 2,
+		},
+		{
+			name:          "zwj emoji cluster",
+			input:         []byte("🤷‍♂️3"),
+			wantLine:      "🤷‍♂️3",
+			wantCell0:     "🤷‍♂️",
+			wantCell0Wide: 2,
+		},
+		{
+			name:          "regional indicator flag cluster",
+			input:         []byte("🇸🇪4"),
+			wantLine:      "🇸🇪4",
+			wantCell0:     "🇸🇪",
+			wantCell0Wide: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			emu := NewVTEmulatorWithDrain(20, 5)
+			emu.Write(tt.input)
+
+			if got := emu.ScreenLineText(0); got != tt.wantLine {
+				t.Fatalf("ScreenLineText(0) = %q, want %q", got, tt.wantLine)
+			}
+
+			cell0 := emu.CellAt(0, 0)
+			if cell0 == nil {
+				t.Fatal("CellAt(0, 0) = nil, want grapheme cluster")
+			}
+			if cell0.Content != tt.wantCell0 || cell0.Width != tt.wantCell0Wide {
+				t.Fatalf("CellAt(0, 0) = {content:%q width:%d}, want {content:%q width:%d}",
+					cell0.Content, cell0.Width, tt.wantCell0, tt.wantCell0Wide)
+			}
+
+			if tt.wantCell0Wide == 2 {
+				cont := emu.CellAt(1, 0)
+				if cont == nil {
+					t.Fatal("CellAt(1, 0) = nil, want continuation cell")
+				}
+				if cont.Width != 0 {
+					t.Fatalf("CellAt(1, 0).Width = %d, want 0 continuation", cont.Width)
+				}
+			}
+		})
+	}
+}
+
 func TestScreenLineTextTrailingSpaces(t *testing.T) {
 	t.Parallel()
 	emu := NewVTEmulatorWithDrain(80, 24)

--- a/test/capture_json_test.go
+++ b/test/capture_json_test.go
@@ -220,6 +220,27 @@ func TestCaptureJSON_RoundTrip(t *testing.T) {
 	}
 }
 
+func TestCaptureJSON_PreservesGraphemeClusters(t *testing.T) {
+	t.Parallel()
+	h := newServerHarness(t)
+
+	line := "GRAPHEMES: Λ̊ 👍🏻 🤷‍♂️ 🇸🇪"
+	h.sendKeys("pane-1", "clear; printf '"+line+"\\n'", "Enter")
+	h.waitFor("pane-1", "GRAPHEMES:")
+
+	pane := captureJSONPane(t, h, "pane-1")
+	found := false
+	for _, got := range pane.Content {
+		if strings.Contains(got, line) {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("capture JSON should preserve grapheme clusters %q, got: %v", line, pane.Content)
+	}
+}
+
 func TestCaptureJSON_AgentStatus_Busy(t *testing.T) {
 	t.Parallel()
 	h := newServerHarness(t)


### PR DESCRIPTION
Part of LAB-269.

## Summary
- add emulator tests for combining-mark, emoji-modifier, ZWJ emoji, and flag grapheme clusters
- assert cell content and continuation-width behavior at the VT layer
- add an end-to-end JSON capture test that verifies those clusters survive the server/client path

## Testing
- go test ./internal/mux
- go test ./test -run 'TestCaptureJSON_|TestCapture'
- go test ./internal/mux ./test -run 'TestScreenLineTextGraphemeClusters|TestCaptureJSON_PreservesGraphemeClusters|TestCapture|TestCaptureJSON_'

## Notes
- review pass completed
- simplification pass completed
- malformed UTF-8 replacement is not included here because the current stack drops invalid bytes rather than surfacing U+FFFD; that needs a deliberate production change before it can be asserted as test behavior
