### PR TITLE
Make wait-busy wait for child processes

### DIFF
--- a/internal/server/commands.go
+++ b/internal/server/commands.go
@@ -1014,28 +1014,58 @@ func cmdWaitBusy(ctx *CommandContext) {
 		return
 	}
 	paneID := pane.ID
-	paneName := pane.Meta.Name
 	ctx.Sess.mu.Unlock()
 
-	res := ctx.Sess.enqueueEventSubscribe(eventFilter{Types: []string{EventBusy}, PaneName: paneName}, false)
-	if res.sub == nil {
+	checkBusy := func() (bool, error) {
+		ctx.Sess.mu.Lock()
+		pane := ctx.Sess.findPaneLocked(paneID)
+		ctx.Sess.mu.Unlock()
+		if pane == nil {
+			return false, fmt.Errorf("pane %q disappeared while waiting to become busy", paneRef)
+		}
+		return !pane.AgentStatus().Idle, nil
+	}
+
+	outputCh := ctx.Sess.enqueuePaneOutputSubscribe(paneID)
+	if outputCh == nil {
 		ctx.replyErr("session shutting down")
 		return
 	}
-	defer ctx.Sess.enqueueEventUnsubscribe(res.sub)
+	defer ctx.Sess.enqueuePaneOutputUnsubscribe(paneID, outputCh)
 
-	if !ctx.Sess.idle.IsIdle(paneID) {
+	busy, err := checkBusy()
+	if err != nil {
+		ctx.replyErr(err.Error())
+		return
+	}
+	if busy {
 		ctx.reply("busy\n")
 		return
 	}
 
-	timer := time.NewTimer(timeout)
-	defer timer.Stop()
-	select {
-	case <-res.sub.ch:
-		ctx.reply("busy\n")
-	case <-timer.C:
-		ctx.replyErr(fmt.Sprintf("timeout waiting for %s to become busy", paneRef))
+	timeoutTimer := time.NewTimer(timeout)
+	defer timeoutTimer.Stop()
+	ticker := time.NewTicker(50 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-outputCh:
+		case <-ticker.C:
+		case <-timeoutTimer.C:
+			ctx.replyErr(fmt.Sprintf("timeout waiting for %s to become busy", paneRef))
+			return
+		}
+
+		busy, err := checkBusy()
+		if err != nil {
+			ctx.replyErr(err.Error())
+			return
+		}
+		if busy {
+			ctx.reply("busy\n")
+			return
+		}
 	}
 }
 

--- a/test/idle_status_test.go
+++ b/test/idle_status_test.go
@@ -96,6 +96,29 @@ func TestWaitBusy_EventBased(t *testing.T) {
 	if pane.Idle {
 		t.Error("pane should be busy after waitBusy returns")
 	}
+	if len(pane.ChildPIDs) == 0 {
+		t.Error("waitBusy should return only after a child process exists")
+	}
+}
+
+func TestWaitBusy_WaitsForChildProcessNotPromptEcho(t *testing.T) {
+	t.Parallel()
+	h := newServerHarness(t)
+
+	h.sendKeys("pane-1", "echo READY", "Enter")
+	h.waitFor("pane-1", "READY")
+	h.waitIdle("pane-1")
+
+	h.sendKeys("pane-1", "sleep 300", "Enter")
+	h.waitBusy("pane-1")
+
+	pane := captureJSONPane(t, h, "pane-1")
+	if pane.Idle {
+		t.Error("pane should be busy after waitBusy returns")
+	}
+	if len(pane.ChildPIDs) == 0 {
+		t.Error("waitBusy should not return on prompt echo alone")
+	}
 }
 
 func TestWaitIdle_EventBased(t *testing.T) {

--- a/test/server_harness_test.go
+++ b/test/server_harness_test.go
@@ -298,7 +298,7 @@ func (h *ServerHarness) waitForTimeout(pane, substr, timeout string) {
 }
 
 // waitBusy blocks until the named pane has child processes (a command is running).
-// Uses the server's wait-busy command (blocking, zero polling).
+// Uses the server's process-based wait-busy command.
 func (h *ServerHarness) waitBusy(pane string) {
 	h.tb.Helper()
 	out := h.runCmd("wait-busy", pane, "--timeout", "5s")


### PR DESCRIPTION
## Summary
- make `wait-busy` check the pane process tree instead of the `busy` activity event so it only returns once a child process actually exists
- keep the event stream semantics unchanged and update the harness comment to describe `wait-busy` as process-based
- add regression coverage that asserts `wait-busy` returns with non-empty `child_pids` and does not wake on prompt echo alone

## Testing
- go test ./test -run 'TestWaitBusy' -count=20 -timeout 120s
- go test ./test -run 'TestWaitBusy|TestSendKeysSpecialKeys|TestIdleStatus' -count=1 -timeout 120s

## Notes
- `go test ./... -timeout 120s` hit an unrelated failure in `TestServerReloadTUIRedraw`

## Review
- simplification pass completed
- review pass completed