### PR TITLE
Strip com.apple.provenance xattr before codesigning on macOS

### DIFF
--- a/scripts/build-install.sh
+++ b/scripts/build-install.sh
@@ -38,6 +38,10 @@ trap cleanup EXIT
 go build -o "$tmp" .
 
 if [[ $(uname -s) == Darwin ]]; then
+	# Strip com.apple.provenance xattr that macOS Sequoia sets on files
+	# created in SSH sessions. Without this, taskgated rejects ad-hoc
+	# signed binaries at launch (SIGKILL "Code Signature Invalid").
+	xattr -d com.apple.provenance "$tmp" 2>/dev/null || true
 	if ! codesign -f -s - "$tmp" >/dev/null 2>&1; then
 		echo "amux build: codesign failed for $tmp" >&2
 		exit 1


### PR DESCRIPTION
## Motivation

On macOS Sequoia, files created in SSH sessions are automatically tagged with `com.apple.provenance`. When the Go linker's ad-hoc signature (`linker-signed` flag) is present alongside this xattr, macOS's `taskgated` rejects the binary at launch with SIGKILL ("Code Signature Invalid"). This produced 38+ crash reports over 2 days.

The `codesign -f -s -` step in the build script replaces the linker signature with a proper ad-hoc one (which taskgated accepts), but stripping the provenance xattr first provides defense-in-depth against evolving Sequoia trust policies.

## Testing

1. Built via `make build` in an SSH session — binary runs without SIGKILL
2. Verified `codesign -dvvv` shows `flags=0x2(adhoc)` (not `0x20002(adhoc,linker-signed)`)
3. Confirmed `xattr -d` is no-op on non-SSH builds (`|| true` handles missing xattr)

## Review focus

The single `xattr -d` line before the existing `codesign` call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)