### PR TITLE
Lead README with pain, not mechanism

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,15 @@
 [![CI](https://github.com/weill-labs/amux/actions/workflows/ci.yml/badge.svg)](https://github.com/weill-labs/amux/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/weill-labs/amux/graph/badge.svg?token=RY0CPn9v7g)](https://codecov.io/gh/weill-labs/amux)
 
-A terminal multiplexer with a first-class agent API. Structured JSON capture, blocking waits, and push-based events — no polling, no screen-scraping.
+GUIs force screenshots and vision models. Headless APIs cut the human out. amux sits in between: a shared TUI where humans use keybindings and agents use CLI commands — same panes, same state.
+
+Structured JSON capture, blocking waits, and push-based events — no polling, no screen-scraping.
 
 ![amux demo](demo/hero.gif)
 
 ## How it works
 
-When humans and agents pair on terminal workflows, they need a shared screen. GUIs require screenshots and vision models. Headless APIs cut the human out. amux sits in between: the VT emulator's parsed state is the source of truth, rendered as ANSI for humans and structured JSON for agents.
+The VT emulator's parsed state is the single source of truth, rendered two ways:
 
 ```
 PTY output (raw bytes)
@@ -19,8 +21,6 @@ PTY output (raw bytes)
   ANSI rendering    structured output
   (for humans)      (for agents)
 ```
-
-Keybindings for humans, CLI commands for agents — same panes, same capabilities.
 
 ## Install
 


### PR DESCRIPTION
## Motivation

ChatGPT review flagged that the above-the-fold copy leads with mechanism ("A terminal multiplexer with a first-class agent API") rather than the pain it solves. The strongest lines were buried in the "How it works" section.

## Changes

- Move pain statement ("GUIs force screenshots... Headless APIs cut the human out") to be the first thing after the title
- Introduce "shared TUI" framing — concrete term technical users search for
- Fold "keybindings for humans, CLI commands for agents" into the positioning sentence
- Keep mechanism line ("Structured JSON capture, blocking waits...") as proof, not introduction
- Trim "How it works" prose since thesis is already stated above the fold

## Review focus

Read the first 15 lines of the README — does the hook land before the reader has to scroll?

🤖 Generated with [Claude Code](https://claude.com/claude-code)