### PR TITLE
Wait for zoom layout before asserting screen state

### DIFF
--- a/test/mouse_test.go
+++ b/test/mouse_test.go
@@ -56,13 +56,15 @@ func TestMouseClickInsideZoomedPaneDoesNotUnzoom(t *testing.T) {
 	h := newAmuxHarness(t)
 
 	h.splitH()
+	gen := h.generation()
 	h.runCmd("zoom", "pane-2")
+	h.waitLayout(gen)
 
 	h.assertScreen("pane-2 should be zoomed before click", func(s string) bool {
 		return strings.Contains(s, "[pane-2]") && !strings.Contains(s, "[pane-1]")
 	})
 
-	gen := h.generation()
+	gen = h.generation()
 	h.clickAt(40, 3)
 
 	if h.waitLayoutOrTimeout(gen, "500ms") {


### PR DESCRIPTION
## Motivation

`TestMouseClickInsideZoomedPaneDoesNotUnzoom` was flaky in CI (seen in PR #254 run). The test called `runCmd("zoom", "pane-2")` then immediately asserted the screen showed only pane-2, but the layout change hadn't propagated yet on slow CI runners.

## Testing

- `go test -run TestMouseClickInsideZoomedPaneDoesNotUnzoom -count=5 ./test/` — 5/5 pass
- `go test -run TestMouseClickInsideZoomedPaneDoesNotUnzoom -count=3 -parallel 2 ./test/` — matches CI flags, 3/3 pass

## Review focus

The three-line change: snapshot generation before zoom, waitLayout after, reuse `gen` variable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)