### PR TITLE
Stabilize takeover reconnect after deploy

### DIFF
--- a/internal/remote/deploy.go
+++ b/internal/remote/deploy.go
@@ -12,6 +12,8 @@ import (
 	"golang.org/x/crypto/ssh"
 )
 
+const remoteInstallPath = "$HOME/.local/bin/amux"
+
 // DeployBinary ensures the remote host has a matching amux binary.
 // Strategy:
 //  1. Remote hash matches local → skip (already up to date)
@@ -152,10 +154,7 @@ func downloadReleaseBinary(client *ssh.Client, goos, goarch, version string) err
 	url := fmt.Sprintf("https://github.com/weill-labs/amux/releases/download/v%s/%s", version, archiveName)
 
 	// Try remote curl: download directly on the remote host
-	remoteCmd := fmt.Sprintf(
-		`mkdir -p ~/.local/bin && cd /tmp && curl -fsSL %q -o %q && tar xzf %q amux && mv amux ~/.local/bin/amux && chmod +x ~/.local/bin/amux && rm -f %q`,
-		url, archiveName, archiveName, archiveName,
-	)
+	remoteCmd := remoteReleaseInstallCmd(url, archiveName)
 	if err := sshRunErr(client, remoteCmd); err == nil {
 		return nil
 	}
@@ -199,8 +198,6 @@ func uploadBinary(client *ssh.Client, localPath string) error {
 		return fmt.Errorf("reading local binary: %w", err)
 	}
 
-	sshRun(client, "mkdir -p ~/.local/bin")
-
 	sess, err := client.NewSession()
 	if err != nil {
 		return err
@@ -208,11 +205,25 @@ func uploadBinary(client *ssh.Client, localPath string) error {
 	defer sess.Close()
 
 	sess.Stdin = bytes.NewReader(data)
-	if err := sess.Run("cat > ~/.local/bin/amux && chmod +x ~/.local/bin/amux"); err != nil {
+	if err := sess.Run(remoteInstallStdinCmd(remoteInstallPath)); err != nil {
 		return fmt.Errorf("uploading binary: %w", err)
 	}
 
 	return nil
+}
+
+func remoteInstallStdinCmd(destPath string) string {
+	return fmt.Sprintf(
+		`set -eu; dir=$(dirname %q); mkdir -p "$dir"; tmp=$(mktemp "$dir/.amux.tmp.XXXXXX"); cleanup() { rm -f "$tmp"; }; trap cleanup EXIT; cat > "$tmp"; chmod +x "$tmp"; mv "$tmp" %q; trap - EXIT`,
+		destPath, destPath,
+	)
+}
+
+func remoteReleaseInstallCmd(url, archiveName string) string {
+	return fmt.Sprintf(
+		`set -eu; dir=$(dirname %q); mkdir -p "$dir"; tmp=$(mktemp "$dir/.amux.tmp.XXXXXX"); archive=$(mktemp "/tmp/%s.XXXXXX"); extract=$(mktemp -d "/tmp/amux-extract.XXXXXX"); cleanup() { rm -f "$tmp" "$archive"; rm -rf "$extract"; }; trap cleanup EXIT; curl -fsSL %q -o "$archive"; tar xzf "$archive" -C "$extract" amux; chmod +x "$extract/amux"; mv "$extract/amux" "$tmp"; mv "$tmp" %q; trap - EXIT`,
+		remoteInstallPath, archiveName, url, remoteInstallPath,
+	)
 }
 
 // sshOutput runs a command on the remote and returns trimmed stdout.

--- a/internal/remote/deploy_test.go
+++ b/internal/remote/deploy_test.go
@@ -216,6 +216,14 @@ func TestUploadBinary(t *testing.T) {
 	if info.Mode()&0111 == 0 {
 		t.Error("uploaded binary should be executable")
 	}
+
+	matches, err := filepath.Glob(filepath.Join(ts.HomeDir, ".local", "bin", ".amux.tmp.*"))
+	if err != nil {
+		t.Fatalf("glob temp files: %v", err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("temp upload files left behind: %v", matches)
+	}
 }
 
 func TestUploadBinaryFileNotFound(t *testing.T) {
@@ -313,5 +321,13 @@ func TestDeployBinarySameArch(t *testing.T) {
 	uploaded := filepath.Join(ts.HomeDir, ".local", "bin", "amux")
 	if _, err := os.Stat(uploaded); err != nil {
 		t.Errorf("expected binary at %s after deploy: %v", uploaded, err)
+	}
+
+	matches, err := filepath.Glob(filepath.Join(ts.HomeDir, ".local", "bin", ".amux.tmp.*"))
+	if err != nil {
+		t.Fatalf("glob temp files: %v", err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("temp deploy files left behind: %v", matches)
 	}
 }

--- a/internal/remote/host_conn.go
+++ b/internal/remote/host_conn.go
@@ -44,6 +44,7 @@ type HostConn struct {
 	// Session name for the remote amux server (includes local hostname)
 	sessionName  string
 	remoteUID    string // UID of the remote user (for socket path)
+	connectAddr  string // normalized SSH address used by the current connection
 	takeoverMode bool   // true when established via takeover
 
 	// Pending connect waiters — replied when connectDoneEvent arrives.
@@ -153,16 +154,19 @@ func (hc *HostConn) EnsureConnectedForTakeover(sessionName, remoteUID, sshAddr s
 // Runs outside the actor in a spawned goroutine. Only reads immutable fields;
 // returns all results for the actor to apply.
 func (hc *HostConn) doConnect(sessionName string) (*connectOutcome, error) {
+	return hc.doConnectWithAddr(sessionName, "")
+}
+
+// doConnectWithAddr performs the SSH dial, deploy, server start, and amux attach
+// using the supplied address. If addr is empty, the configured host address or
+// HostConn name is used.
+func (hc *HostConn) doConnectWithAddr(sessionName, addr string) (*connectOutcome, error) {
 	sshCfg, err := hc.buildSSHConfig()
 	if err != nil {
 		return nil, fmt.Errorf("building SSH config: %w", err)
 	}
 
-	addr := hc.config.Address
-	if addr == "" {
-		addr = hc.name
-	}
-	addr = normalizeAddr(addr)
+	addr = normalizedDialAddr(hc.name, addr, hc.config.Address)
 
 	sshClient, err := ssh.Dial("tcp", addr, sshCfg)
 	if err != nil {
@@ -206,6 +210,7 @@ func (hc *HostConn) doConnect(sessionName string) (*connectOutcome, error) {
 		amuxConn:    amuxConn,
 		sessionName: remoteSession,
 		remoteUID:   remoteUID,
+		connectAddr: addr,
 	}, nil
 }
 
@@ -247,6 +252,7 @@ func (hc *HostConn) doConnectTakeover(sessionName, remoteUID, sshAddr string) (*
 		amuxConn:    amuxConn,
 		sessionName: sessionName,
 		remoteUID:   remoteUID,
+		connectAddr: sshAddr,
 		takeover:    true,
 	}, nil
 }
@@ -649,4 +655,21 @@ func normalizeAddr(addr string) string {
 		return addr + ":22"
 	}
 	return addr
+}
+
+func addrOrFallback(values ...string) string {
+	for _, value := range values {
+		if value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func normalizedDialAddr(hostName string, candidates ...string) string {
+	addr := addrOrFallback(candidates...)
+	if addr == "" {
+		addr = hostName
+	}
+	return normalizeAddr(addr)
 }

--- a/internal/remote/host_conn_events.go
+++ b/internal/remote/host_conn_events.go
@@ -26,6 +26,7 @@ type connectOutcome struct {
 	amuxConn    net.Conn
 	sessionName string
 	remoteUID   string
+	connectAddr string
 	takeover    bool
 }
 
@@ -174,7 +175,7 @@ func (e reconnectCmd) handle(hc *HostConn) {
 
 	// Start a new connect.
 	hc.startConnect(e.reply, func() (*connectOutcome, error) {
-		return hc.doConnect(e.sessionName)
+		return hc.doConnectWithAddr(e.sessionName, hc.connectAddr)
 	})
 }
 
@@ -243,11 +244,7 @@ func (e readDisconnectEvent) handle(hc *HostConn) {
 	hc.closeConns()
 
 	// Capture reconnect parameters before spawning the goroutine.
-	sessionName := hc.sessionName
-	remoteUID := hc.remoteUID
-	isTakeover := hc.takeoverMode
-	sshAddr := normalizeAddr(hc.config.Address)
-	go hc.reconnectLoop(sessionName, remoteUID, isTakeover, sshAddr)
+	go hc.reconnectLoop(hc.reconnectTarget())
 }
 
 // reconnectDoneEvent is sent by the reconnect goroutine on success.
@@ -277,6 +274,7 @@ func (hc *HostConn) applyOutcome(o *connectOutcome) {
 	hc.amuxConn = o.amuxConn
 	hc.sessionName = o.sessionName
 	hc.remoteUID = o.remoteUID
+	hc.connectAddr = o.connectAddr
 	if o.takeover {
 		hc.takeoverMode = true
 	}
@@ -299,6 +297,26 @@ func (hc *HostConn) disconnectAndDrainPending() {
 	hc.closeConns()
 	hc.setState(Disconnected)
 	hc.drainPendingReplies(errHostConnClosed)
+}
+
+type reconnectTarget struct {
+	sessionName string
+	remoteUID   string
+	connectAddr string
+	takeover    bool
+}
+
+func (hc *HostConn) reconnectTarget() reconnectTarget {
+	connectAddr := hc.connectAddr
+	if connectAddr == "" {
+		connectAddr = normalizedDialAddr(hc.name, hc.config.Address)
+	}
+	return reconnectTarget{
+		sessionName: hc.sessionName,
+		remoteUID:   hc.remoteUID,
+		connectAddr: connectAddr,
+		takeover:    hc.takeoverMode,
+	}
 }
 
 // --- Event loop ---

--- a/internal/remote/host_conn_test.go
+++ b/internal/remote/host_conn_test.go
@@ -183,6 +183,48 @@ func TestHostConnStateTransitions(t *testing.T) {
 	}
 }
 
+func TestReconnectTargetUsesStoredConnectAddr(t *testing.T) {
+	t.Parallel()
+
+	hc := NewHostConn("test-remote", config.Host{Address: "wrong-host"}, "hash", nil, nil, nil)
+	defer hc.Close()
+
+	testInActor(hc, func(hc *HostConn) {
+		hc.sessionName = "default@test"
+		hc.remoteUID = "1000"
+		hc.connectAddr = "127.0.0.1:2222"
+		hc.takeoverMode = true
+
+		target := hc.reconnectTarget()
+		if target.sessionName != "default@test" {
+			t.Fatalf("target.sessionName = %q, want default@test", target.sessionName)
+		}
+		if target.remoteUID != "1000" {
+			t.Fatalf("target.remoteUID = %q, want 1000", target.remoteUID)
+		}
+		if target.connectAddr != "127.0.0.1:2222" {
+			t.Fatalf("target.connectAddr = %q, want 127.0.0.1:2222", target.connectAddr)
+		}
+		if !target.takeover {
+			t.Fatal("target.takeover = false, want true")
+		}
+	})
+}
+
+func TestReconnectTargetFallsBackToHostName(t *testing.T) {
+	t.Parallel()
+
+	hc := NewHostConn("test-remote", config.Host{}, "hash", nil, nil, nil)
+	defer hc.Close()
+
+	testInActor(hc, func(hc *HostConn) {
+		target := hc.reconnectTarget()
+		if target.connectAddr != "test-remote:22" {
+			t.Fatalf("target.connectAddr = %q, want test-remote:22", target.connectAddr)
+		}
+	})
+}
+
 func TestRemovePane(t *testing.T) {
 	t.Parallel()
 

--- a/internal/remote/reconnect.go
+++ b/internal/remote/reconnect.go
@@ -15,7 +15,7 @@ const (
 // It attempts to reconnect with exponential backoff, posting the result
 // to the actor on success. Exits when the actor state changes away from
 // Reconnecting (e.g., explicit Disconnect).
-func (hc *HostConn) reconnectLoop(sessionName, remoteUID string, isTakeover bool, sshAddr string) {
+func (hc *HostConn) reconnectLoop(target reconnectTarget) {
 	delay := initialBackoff
 	for attempt := 0; ; attempt++ {
 		time.Sleep(delay)
@@ -27,10 +27,10 @@ func (hc *HostConn) reconnectLoop(sessionName, remoteUID string, isTakeover bool
 
 		var outcome *connectOutcome
 		var err error
-		if isTakeover {
-			outcome, err = hc.doConnectTakeover(sessionName, remoteUID, sshAddr)
+		if target.takeover {
+			outcome, err = hc.doConnectTakeover(target.sessionName, target.remoteUID, target.connectAddr)
 		} else {
-			outcome, err = hc.doConnect(sessionName)
+			outcome, err = hc.doConnectWithAddr(target.sessionName, target.connectAddr)
 		}
 
 		if err == nil {

--- a/internal/server/session_remote.go
+++ b/internal/server/session_remote.go
@@ -169,10 +169,9 @@ func (s *Session) handleTakeover(srv *Server, sshPaneID uint32, req mux.Takeover
 
 	// Wire bidirectional I/O: connect back to the remote amux server via SSH
 	// and register pane mappings so SendInput/FeedOutput flow correctly.
-	// Also deploy the updated binary so the remote amux hot-reloads.
+	// Delay deploy until the attach is established so the running managed
+	// session is not perturbed during its first client attach.
 	if s.RemoteManager != nil && req.SSHAddress != "" {
-		go s.RemoteManager.DeployToAddress(start.hostname, req.SSHAddress, req.SSHUser)
-
 		paneMappings := make(map[uint32]uint32, len(proxyPanes))
 		for i, pp := range proxyPanes {
 			paneMappings[pp.ID] = remotePanes[i].ID
@@ -181,8 +180,11 @@ func (s *Session) handleTakeover(srv *Server, sshPaneID uint32, req mux.Takeover
 			start.hostname, req.SSHAddress, req.SSHUser, req.UID, req.Session, paneMappings,
 		); err != nil {
 			fmt.Fprintf(os.Stderr, "amux: takeover AttachForTakeover: %v\n", err)
-		} else if needsInitialResize && len(proxyPanes) > 0 {
-			_ = s.RemoteManager.SendResize(proxyPanes[0].ID, layout.cols, mux.PaneContentHeight(layout.cellH))
+		} else {
+			if needsInitialResize && len(proxyPanes) > 0 {
+				_ = s.RemoteManager.SendResize(proxyPanes[0].ID, layout.cols, mux.PaneContentHeight(layout.cellH))
+			}
+			go s.RemoteManager.DeployToAddress(start.hostname, req.SSHAddress, req.SSHUser)
 		}
 	}
 }

--- a/test/takeover_test.go
+++ b/test/takeover_test.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"strings"
 	"testing"
+	"time"
 )
 
 // TestTakeoverBidirectionalIO verifies the full SSH takeover I/O pipeline:
@@ -63,6 +64,32 @@ func TestTakeoverFromInteractiveSSHShell(t *testing.T) {
 	proxyPaneName := waitForTakeoverProxyPane(t, h, existingProxyPanes)
 	h.sendKeys(proxyPaneName, "echo TAKEOVER_SHELL_OK", "Enter")
 	h.waitForTimeout(proxyPaneName, "TAKEOVER_SHELL_OK", "5s")
+}
+
+func TestTakeoverReconnectAfterRemoteReload(t *testing.T) {
+	t.Parallel()
+
+	addr, keyFile := setupTestSSH(t)
+	h := newServerHarnessWithConfig(t, 80, 24, remoteTestConfig(addr, keyFile))
+	existingProxyPanes := takeoverProxyPaneNames(h)
+
+	_, port, _ := net.SplitHostPort(addr)
+	sshCmd := fmt.Sprintf(
+		"ssh -i %s -p %s -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null 127.0.0.1 amux",
+		keyFile, port)
+	h.sendKeys("pane-1", sshCmd, "Enter")
+
+	proxyPaneName := waitForTakeoverProxyPane(t, h, existingProxyPanes)
+	h.sendKeys(proxyPaneName, "echo TAKEOVER_BEFORE_RELOAD", "Enter")
+	h.waitForTimeout(proxyPaneName, "TAKEOVER_BEFORE_RELOAD", "5s")
+
+	gen := h.generation()
+	h.sendKeys(proxyPaneName, "amux reload-server", "Enter")
+	h.waitLayoutTimeout(gen, "10s")
+	waitForPaneConnStatus(t, h, proxyPaneName, "connected", "10s")
+
+	h.sendKeys(proxyPaneName, "echo TAKEOVER_AFTER_RELOAD", "Enter")
+	h.waitForTimeout(proxyPaneName, "TAKEOVER_AFTER_RELOAD", "10s")
 }
 
 // TestTakeoverAfterServerReload is a regression test for the bug where
@@ -145,4 +172,40 @@ func takeoverProxyPaneNames(h *ServerHarness) map[string]struct{} {
 		}
 	}
 	return names
+}
+
+func waitForPaneConnStatus(t *testing.T, h *ServerHarness, paneName, wantStatus, timeout string) {
+	t.Helper()
+
+	deadline := time.Now().Add(parseTestDuration(t, timeout))
+	gen := h.generation()
+	for time.Now().Before(deadline) {
+		c := h.captureJSON()
+		for _, p := range c.Panes {
+			if p.Name == paneName && p.ConnStatus == wantStatus {
+				return
+			}
+		}
+
+		waitFor := time.Until(deadline)
+		if waitFor > 250*time.Millisecond {
+			waitFor = 250 * time.Millisecond
+		}
+		if !h.waitLayoutOrTimeout(gen, waitFor.String()) {
+			continue
+		}
+		gen = h.generation()
+	}
+
+	t.Fatalf("pane %s did not reach conn_status=%s\ncapture:\n%s", paneName, wantStatus, h.capture())
+}
+
+func parseTestDuration(t *testing.T, s string) time.Duration {
+	t.Helper()
+
+	d, err := time.ParseDuration(s)
+	if err != nil {
+		t.Fatalf("ParseDuration(%q): %v", s, err)
+	}
+	return d
 }


### PR DESCRIPTION
## Summary
- make remote deploy install atomic so takeover-managed sessions are not overwritten in place
- reconnect takeover hosts using the actual SSH address that originally attached, not just config address fallback
- delay post-takeover deploy until the remote attach is established and cover remote reload/reconnect in tests

## Testing
- go test ./...
- attempted live repro in `amux` against `ssh 100.118.104.90`, but Tailscale SSH required browser auth (`https://login.tailscale.com/a/l10c82eaf395f3d`) so real-host acceptance remains blocked on that interactive step