### PR TITLE
Clarify user handoffs and postmortem closeout

### DIFF
--- a/.agents/skills/amux-pr-workflow/SKILL.md
+++ b/.agents/skills/amux-pr-workflow/SKILL.md
@@ -20,7 +20,8 @@ Use this skill when the task involves `git push`, `gh pr create`, `gh pr merge`,
 - If a rebase triggers broad noisy local failures, verify with a targeted regression slice before making invasive code changes.
 - After merge, verify local state explicitly: confirm the checkout is on `main`, the worktree is clean, and `HEAD` matches `origin/main`.
 - After merge, any follow-up fix goes on a fresh branch and PR. Do not make extra commits on local `main`.
-- After merge, run the `postmortem` skill and turn action items into issues or doc updates.
+- After merge, run the `postmortem` skill as an actual workflow, not just a brief retrospective in the final message.
+- If the `postmortem` skill is skipped, say so explicitly and give the reason. Do not imply it was done.
 
 ## Workflow
 
@@ -37,6 +38,7 @@ Use this skill when the task involves `git push`, `gh pr create`, `gh pr merge`,
 11. After merge, verify local state with `git branch --show-current`, `git status --short --branch`, and `git rev-parse HEAD origin/main`. If needed, run `git checkout main && git pull --ff-only`.
 12. If you discover a follow-up fix after merge, create a fresh branch before editing.
 13. After merge, explicitly invoke the `postmortem` skill to capture learnings, pain points, and follow-up actions.
+14. In the final merge closeout, state either the logged `postmortem` path or the explicit reason it was skipped.
 
 ## Output Checklist
 
@@ -50,4 +52,5 @@ Use this skill when the task involves `git push`, `gh pr create`, `gh pr merge`,
 - Benchmark baseline section added when relevant.
 - Local post-merge state verified.
 - Follow-up fixes kept off local `main`.
-- `postmortem` skill run after merge.
+- `postmortem` skill run after merge, or a clear skip reason is stated.
+- If `postmortem` ran, the log path is reported.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,6 +94,10 @@ Commit design specs and implementation plans to the feature branch, not main. Co
 
 After creating or updating a PR, run a review pass and a simplification pass before considering the work done. Claude Code gets hook reminders for this. Codex users should use the repo PR workflow skill or perform the steps explicitly.
 
+### User Handoffs
+
+Before stopping to wait for user input, suggest the next concrete action the user should take or approve. Do not end at "waiting on you" without a specific next step.
+
 ### Merge Conflict Resolution
 
 After resolving merge conflicts, run `go vet ./...` locally before committing. Git auto-merge can silently produce duplicate declarations (e.g., methods defined in both sides) that compile but fail vet.


### PR DESCRIPTION
## Summary
- add a `CLAUDE.md` rule that before waiting for user input, the agent should suggest the next concrete action for the user
- tighten the amux PR workflow skill so post-merge closeout requires a real `postmortem` run or an explicit skip reason
- require the final merge closeout to report the postmortem log path when it ran

## Testing
- Not run; docs/skill guidance only

## Review Pass
- Manual review completed on the rebased diff; the change is limited to agent guidance and does not affect runtime behavior.

## Simplification Pass
- Kept the guidance as two small targeted edits instead of adding broader workflow sections or redundant rules.
