### PR TITLE
Codify postmortem follow-up guidance

### DIFF
--- a/.agents/skills/amux-pr-workflow/SKILL.md
+++ b/.agents/skills/amux-pr-workflow/SKILL.md
@@ -20,7 +20,7 @@ Use this skill when the task involves `git push`, `gh pr create`, `gh pr merge`,
 - If a rebase triggers broad noisy local failures, verify with a targeted regression slice before making invasive code changes.
 - After merge, verify local state explicitly: confirm the checkout is on `main`, the worktree is clean, and `HEAD` matches `origin/main`.
 - After merge, any follow-up fix goes on a fresh branch and PR. Do not make extra commits on local `main`.
-- After merge, run the `postmortem` skill as an actual workflow, not just a brief retrospective in the final message.
+- After merge, explicitly invoke the `postmortem` skill workflow. A short manual summary does not count. Turn action items into issues or doc updates.
 - If the `postmortem` skill is skipped, say so explicitly and give the reason. Do not imply it was done.
 
 ## Workflow
@@ -37,7 +37,7 @@ Use this skill when the task involves `git push`, `gh pr create`, `gh pr merge`,
 10. Before merging, re-check the live PR state and mergeability after the latest green checks. If `main` moved, fetch and rebase again before merging.
 11. After merge, verify local state with `git branch --show-current`, `git status --short --branch`, and `git rev-parse HEAD origin/main`. If needed, run `git checkout main && git pull --ff-only`.
 12. If you discover a follow-up fix after merge, create a fresh branch before editing.
-13. After merge, explicitly invoke the `postmortem` skill to capture learnings, pain points, and follow-up actions.
+13. After merge, explicitly invoke the `postmortem` skill to capture learnings, pain points, and follow-up actions. Do not substitute a brief ad hoc summary.
 14. In the final merge closeout, state either the logged `postmortem` path or the explicit reason it was skipped.
 
 ## Output Checklist
@@ -52,5 +52,5 @@ Use this skill when the task involves `git push`, `gh pr create`, `gh pr merge`,
 - Benchmark baseline section added when relevant.
 - Local post-merge state verified.
 - Follow-up fixes kept off local `main`.
-- `postmortem` skill run after merge, or a clear skip reason is stated.
+- `postmortem` skill explicitly invoked after merge, or a clear skip reason is stated.
 - If `postmortem` ran, the log path is reported.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,10 @@ See [README.md -- Philosophy](README.md#philosophy) for the project thesis and t
 
 **Integration tests for end-to-end behavior.** The harness in `test/server_harness_test.go` drives amux directly over the Unix socket -- no tmux dependency. Tests run in ~6s total.
 
+**Tests that mutate package globals must stay serial.** If a test overrides package-level hooks or globals (for example `copyToClipboard`), do not call `t.Parallel()` in that test. Parallel siblings will race on shared state and produce misleading failures under `-race`.
+
+**Use the persistent harness when server lifetime matters.** Prefer `newServerHarnessPersistent()` for integration tests that must keep the server alive independent of client detach timing or transient attachment windows. Use the default harness when exit-on-unattached behavior is part of the behavior under test.
+
 **Guard against impossible states.** Minimize checks that at least one pane stays non-minimized. Restore caps height at available space. Focus fallback finds nearest pane when strict overlap matching fails.
 
 **Save/restore cursor state in copy mode motions.** Compound motions (word, paragraph, etc.) call `moveDown()`/`moveUp()` in scanning loops. These helpers mutate `cy`/`oy` on each call, so the caller must save both values before the loop and restore them when returning `ActionNone`. Otherwise the cursor drifts silently on failed motions.
@@ -107,6 +111,8 @@ After resolving merge conflicts, run `go vet ./...` locally before committing. G
 GitHub PRs for this repo are squash-only. `gh pr merge --merge` and `gh pr merge --rebase` will fail.
 
 After merging, verify local state explicitly: check that the checkout is on `main`, the worktree is clean, and `HEAD` matches `origin/main`. If you need another change after the merge, start a fresh branch and PR instead of committing follow-up fixes on local `main`.
+
+After merging, explicitly run the `postmortem` skill. A short manual recap is not a substitute for the postmortem workflow.
 
 ### Include Baseline Numbers In Performance PRs
 


### PR DESCRIPTION
## Summary
- require explicit `postmortem` skill invocation in the amux PR workflow
- document that tests mutating package globals must stay serial
- document when to use `newServerHarnessPersistent()` and that a manual post-merge recap is not enough

## Testing
- `git diff --check`
- no Go tests run; docs and skill guidance only
