### PR TITLE
Validate SSH takeover attach before splicing proxy panes

### DIFF
--- a/internal/remote/host_conn.go
+++ b/internal/remote/host_conn.go
@@ -202,7 +202,7 @@ func (hc *HostConn) doConnectWithAddr(sessionName, addr string) (*connectOutcome
 	}
 
 	// Ensure remote amux server is running
-	remoteSession := remoteSessionName(sessionName)
+	remoteSession := ManagedSessionName(sessionName)
 	sockPath := socketPath(remoteUID, remoteSession)
 	if err := ensureRemoteServer(sshClient, sockPath, remoteSession); err != nil {
 		sshClient.Close()
@@ -217,6 +217,11 @@ func (hc *HostConn) doConnectWithAddr(sessionName, addr string) (*connectOutcome
 	}
 
 	if err := attachAndWait(amuxConn, remoteSession, 10*time.Second); err != nil {
+		amuxConn.Close()
+		sshClient.Close()
+		return nil, err
+	}
+	if err := hc.validateRemoteSessionHasPanes(sshClient, sockPath, remoteSession); err != nil {
 		amuxConn.Close()
 		sshClient.Close()
 		return nil, err
@@ -259,6 +264,11 @@ func (hc *HostConn) doConnectTakeover(sessionName, remoteUID, sshAddr string) (*
 	}
 
 	if err := attachAndWait(amuxConn, sessionName, 10*time.Second); err != nil {
+		amuxConn.Close()
+		sshClient.Close()
+		return nil, err
+	}
+	if err := hc.validateRemoteSessionHasPanes(sshClient, remoteSock, sessionName); err != nil {
 		amuxConn.Close()
 		sshClient.Close()
 		return nil, err
@@ -380,7 +390,11 @@ func (hc *HostConn) runCommand(cmdName string, cmdArgs []string) (string, error)
 	}
 
 	remoteSock := socketPath(info.remoteUID, info.sessionName)
-	conn, err := hc.dialRemoteSocket(info.sshClient, remoteSock)
+	return hc.runSocketCommand(info.sshClient, remoteSock, cmdName, cmdArgs)
+}
+
+func (hc *HostConn) runSocketCommand(client *ssh.Client, sockPath, cmdName string, cmdArgs []string) (string, error) {
+	conn, err := hc.dialRemoteSocket(client, sockPath)
 	if err != nil {
 		return "", fmt.Errorf("dialing remote socket: %w", err)
 	}
@@ -402,6 +416,17 @@ func (hc *HostConn) runCommand(cmdName string, cmdArgs []string) (string, error)
 		return "", fmt.Errorf("%s", reply.CmdErr)
 	}
 	return reply.CmdOutput, nil
+}
+
+func (hc *HostConn) validateRemoteSessionHasPanes(client *ssh.Client, sockPath, sessionName string) error {
+	output, err := hc.runSocketCommand(client, sockPath, "list", nil)
+	if err != nil {
+		return fmt.Errorf("listing remote panes for %s: %w", sessionName, err)
+	}
+	if strings.TrimSpace(output) == "No panes." {
+		return fmt.Errorf("remote session %q has no panes", sessionName)
+	}
+	return nil
 }
 
 // readLoop reads messages from the persistent attach connection and dispatches
@@ -617,7 +642,7 @@ func socketPath(remoteUID, sessionName string) string {
 }
 
 // remoteSessionName returns the session name to use on the remote server.
-func remoteSessionName(localSessionName string) string {
+func ManagedSessionName(localSessionName string) string {
 	hostname, err := os.Hostname()
 	if err != nil {
 		hostname = "unknown"

--- a/internal/remote/host_conn_test.go
+++ b/internal/remote/host_conn_test.go
@@ -87,17 +87,17 @@ func TestNormalizeAddr(t *testing.T) {
 	}
 }
 
-func TestRemoteSessionName(t *testing.T) {
+func TestManagedSessionName(t *testing.T) {
 	t.Parallel()
 
-	name := remoteSessionName("default")
+	name := ManagedSessionName("default")
 	hostname, _ := os.Hostname()
 
 	if !strings.HasPrefix(name, "default@") {
-		t.Errorf("remoteSessionName should start with session name, got %q", name)
+		t.Errorf("ManagedSessionName should start with session name, got %q", name)
 	}
 	if !strings.HasSuffix(name, "@"+hostname) {
-		t.Errorf("remoteSessionName should end with @hostname, got %q", name)
+		t.Errorf("ManagedSessionName should end with @hostname, got %q", name)
 	}
 }
 

--- a/internal/server/session_remote.go
+++ b/internal/server/session_remote.go
@@ -56,8 +56,9 @@ func (s *Session) takeoverCallback(srv *Server) func(paneID uint32, req mux.Take
 // It runs asynchronously (called via goroutine from the readLoop callback).
 func (s *Session) handleTakeover(srv *Server, sshPaneID uint32, req mux.TakeoverRequest) {
 	type takeoverStart struct {
-		sshPane  *mux.Pane
-		hostname string
+		sshPane        *mux.Pane
+		hostname       string
+		managedSession string
 	}
 	type takeoverLayout struct {
 		cols  int
@@ -81,15 +82,25 @@ func (s *Session) handleTakeover(srv *Server, sshPaneID uint32, req mux.Takeover
 		if hostname == "" {
 			hostname = "remote"
 		}
-		return takeoverStart{sshPane: sshPane, hostname: hostname}, nil
+		return takeoverStart{
+			sshPane:        sshPane,
+			hostname:       hostname,
+			managedSession: remote.ManagedSessionName(s.Name),
+		}, nil
 	})
 	if err != nil || start.sshPane == nil {
 		return
 	}
+	clearTakeoverPending := func() {
+		s.enqueueCommandMutation(func(s *Session) commandMutationResult {
+			delete(s.takenOverPanes, sshPaneID)
+			return commandMutationResult{}
+		})
+	}
 
 	// Send ack through the SSH PTY's stdin — carries the agreed session name
 	// so the remote amux starts its server at the right socket path.
-	start.sshPane.Write([]byte(mux.FormatTakeoverAck(req.Session) + "\n"))
+	start.sshPane.Write([]byte(mux.FormatTakeoverAck(start.managedSession) + "\n"))
 
 	layout, err := enqueueSessionQuery(s, func(s *Session) (takeoverLayout, error) {
 		w := s.FindWindowByPaneID(sshPaneID)
@@ -139,8 +150,42 @@ func (s *Session) handleTakeover(srv *Server, sshPaneID uint32, req mux.Takeover
 		)
 		proxyPanes = append(proxyPanes, proxyPane)
 	}
+	removeRemoteMappings := func() {
+		if s.RemoteManager == nil {
+			return
+		}
+		for _, pp := range proxyPanes {
+			s.RemoteManager.RemovePane(pp.ID)
+		}
+	}
 
-	// Splice the proxy panes into the layout, replacing the SSH pane
+	// Wire bidirectional I/O: connect back to the remote amux server via SSH
+	// and register pane mappings so SendInput/FeedOutput flow correctly.
+	// Delay deploy and visible splice until the attach is established so a
+	// failed or stale remote session never replaces the raw SSH pane.
+	if s.RemoteManager == nil || req.SSHAddress == "" {
+		clearTakeoverPending()
+		return
+	}
+
+	paneMappings := make(map[uint32]uint32, len(proxyPanes))
+	for i, pp := range proxyPanes {
+		paneMappings[pp.ID] = remotePanes[i].ID
+	}
+	if err := s.RemoteManager.AttachForTakeover(
+		start.hostname, req.SSHAddress, req.SSHUser, req.UID, start.managedSession, paneMappings,
+	); err != nil {
+		fmt.Fprintf(os.Stderr, "amux: takeover AttachForTakeover: %v\n", err)
+		removeRemoteMappings()
+		clearTakeoverPending()
+		return
+	}
+	if needsInitialResize && len(proxyPanes) > 0 {
+		_ = s.RemoteManager.SendResize(proxyPanes[0].ID, layout.cols, mux.PaneContentHeight(layout.cellH))
+	}
+
+	// Splice the proxy panes into the layout only after the remote attach has
+	// been validated. This keeps the raw SSH pane visible on takeover failure.
 	res := s.enqueueCommandMutation(func(s *Session) commandMutationResult {
 		w := s.FindWindowByPaneID(sshPaneID)
 		if w == nil {
@@ -161,32 +206,15 @@ func (s *Session) handleTakeover(srv *Server, sshPaneID uint32, req mux.Takeover
 		return commandMutationResult{broadcastLayout: true}
 	})
 	if res.err != nil {
+		removeRemoteMappings()
+		clearTakeoverPending()
 		return
 	}
 	if res.broadcastLayout {
 		s.broadcastLayout()
 	}
 
-	// Wire bidirectional I/O: connect back to the remote amux server via SSH
-	// and register pane mappings so SendInput/FeedOutput flow correctly.
-	// Delay deploy until the attach is established so the running managed
-	// session is not perturbed during its first client attach.
-	if s.RemoteManager != nil && req.SSHAddress != "" {
-		paneMappings := make(map[uint32]uint32, len(proxyPanes))
-		for i, pp := range proxyPanes {
-			paneMappings[pp.ID] = remotePanes[i].ID
-		}
-		if err := s.RemoteManager.AttachForTakeover(
-			start.hostname, req.SSHAddress, req.SSHUser, req.UID, req.Session, paneMappings,
-		); err != nil {
-			fmt.Fprintf(os.Stderr, "amux: takeover AttachForTakeover: %v\n", err)
-		} else {
-			if needsInitialResize && len(proxyPanes) > 0 {
-				_ = s.RemoteManager.SendResize(proxyPanes[0].ID, layout.cols, mux.PaneContentHeight(layout.cellH))
-			}
-			go s.RemoteManager.DeployToAddress(start.hostname, req.SSHAddress, req.SSHUser)
-		}
-	}
+	go s.RemoteManager.DeployToAddress(start.hostname, req.SSHAddress, req.SSHUser)
 }
 
 // forwardCapture sends a capture request to the first attached interactive

--- a/test/takeover_test.go
+++ b/test/takeover_test.go
@@ -1,11 +1,16 @@
 package test
 
 import (
+	"encoding/json"
 	"fmt"
 	"net"
+	"os"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/weill-labs/amux/internal/proto"
+	"github.com/weill-labs/amux/internal/server"
 )
 
 // TestTakeoverBidirectionalIO verifies the full SSH takeover I/O pipeline:
@@ -66,6 +71,27 @@ func TestTakeoverFromInteractiveSSHShell(t *testing.T) {
 	h.waitForTimeout(proxyPaneName, "TAKEOVER_SHELL_OK", "5s")
 }
 
+func TestTakeoverAttachFailureLeavesSSHPaneVisible(t *testing.T) {
+	t.Parallel()
+
+	h := newServerHarness(t)
+	h.sendKeys("pane-1",
+		`printf '\033]999;amux-takeover;{"session":"default@badhost","host":"badhost","uid":"1","ssh_address":"127.0.0.1:1","ssh_user":"nobody","panes":[{"id":1,"name":"pane-1","cols":80,"rows":22}]}\007'`,
+		"Enter",
+	)
+	h.waitIdle("pane-1")
+
+	list := h.runCmd("list")
+	if strings.Contains(list, "@badhost") {
+		t.Fatalf("failed takeover should not splice proxy panes\nlist:\n%s", list)
+	}
+
+	c := h.captureJSON()
+	if len(c.Panes) != 1 || c.Panes[0].Name != "pane-1" {
+		t.Fatalf("failed takeover should leave only the raw SSH pane\ncapture:\n%s", h.capture())
+	}
+}
+
 func TestTakeoverReconnectAfterRemoteReload(t *testing.T) {
 	t.Parallel()
 
@@ -94,45 +120,27 @@ func TestTakeoverReconnectAfterRemoteReload(t *testing.T) {
 
 // TestTakeoverAfterServerReload is a regression test for the bug where
 // NewServerFromCheckpoint didn't call SetOnTakeover on restored panes.
-// Without the fix, pane.onTakeover == nil after a reload, so the readLoop
-// silently ignores all SSH takeover sequences (OSC 999) instead of calling
-// handleTakeover.
+// Without the fix, an SSH takeover emitted after a reload is silently ignored
+// instead of invoking handleTakeover.
 func TestTakeoverAfterServerReload(t *testing.T) {
 	t.Parallel()
-	h := newServerHarness(t)
 
-	// Trigger a server hot-reload (checkpoint + syscall.Exec — same PID,
-	// new process image). The headless client connection drops on exec;
-	// the new server inherits the listener FD so connections are queued
-	// in the OS backlog immediately.
+	addr, keyFile := setupTestSSH(t)
+	h := newServerHarnessWithConfig(t, 80, 24, remoteTestConfig(addr, keyFile))
+
 	h.runCmd("reload-server")
+	_ = h.generation()
 
-	// Capture generation immediately after reload (new server starts at 0).
-	// h.generation() also validates the server is accepting connections —
-	// if it can't connect it calls t.Fatalf.
-	gen := h.generation()
+	existingProxyPanes := map[string]struct{}{}
+	_, port, _ := net.SplitHostPort(addr)
+	sshCmd := fmt.Sprintf(
+		"ssh -i %s -p %s -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null 127.0.0.1 amux",
+		keyFile, port)
+	h.sendKeys("pane-1", sshCmd, "Enter")
 
-	// Have pane-1 emit an SSH takeover sequence. In production, the remote
-	// amux binary prints this to its stdout (the SSH PTY); here the local
-	// shell does the same thing. The server's readLoop detects the OSC 999
-	// sequence and calls handleTakeover.
-	const hostname = "testhost"
-	h.sendKeys("pane-1",
-		`printf '\033]999;amux-takeover;{"session":"s","host":"testhost","uid":"1","panes":[{"id":1,"name":"pane-1","cols":80,"rows":22}]}\007'`,
-		"Enter")
-
-	// The idle→busy pane-activity transition calls broadcastLayout, and
-	// handleTakeover calls it again after splicing — so we may see multiple
-	// layout bumps before the takeover completes. Loop until the proxy pane
-	// appears or no more layout changes arrive.
-	for h.waitLayoutOrTimeout(gen, "5s") {
-		list := h.runCmd("list")
-		if strings.Contains(list, hostname) {
-			return // takeover fired correctly
-		}
-		gen = h.generation()
-	}
-	t.Errorf("takeover after reload: expected pane@%s in list output\n%s", hostname, h.runCmd("list"))
+	proxyPaneName := waitForTakeoverProxyPane(t, h, existingProxyPanes)
+	h.sendKeys(proxyPaneName, "echo TAKEOVER_AFTER_RELOAD_OK", "Enter")
+	h.waitForTimeout(proxyPaneName, "TAKEOVER_AFTER_RELOAD_OK", "5s")
 }
 
 func waitForTakeoverProxyPane(t *testing.T, h *ServerHarness, existing map[string]struct{}) string {
@@ -146,27 +154,51 @@ func waitForTakeoverProxyPane(t *testing.T, h *ServerHarness, existing map[strin
 		gen = h.generation()
 	}
 
+	logPath := fmt.Sprintf("%s/%s.log", server.SocketDir(), h.session)
+	logData, _ := os.ReadFile(logPath)
 	t.Fatalf("takeover proxy pane did not appear\nlist:\n%s\npane-1:\n%s",
-		h.runCmd("list"), h.runCmd("capture", "pane-1"))
+		h.runCmd("list"), h.runCmd("capture", "pane-1")+"\nserver log:\n"+string(logData))
 	return ""
 }
 
 func firstNewTakeoverProxyPane(h *ServerHarness, existing map[string]struct{}) string {
-	for _, p := range h.captureJSON().Panes {
-		if !strings.Contains(p.Name, "@") {
+	capture, ok := takeoverCaptureJSON(h)
+	if ok {
+		for _, p := range capture.Panes {
+			if !strings.Contains(p.Name, "@") {
+				continue
+			}
+			if _, ok := existing[p.Name]; ok {
+				continue
+			}
+			return p.Name
+		}
+	}
+
+	for _, line := range strings.Split(h.runCmd("list"), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
 			continue
 		}
-		if _, ok := existing[p.Name]; ok {
+		name := fields[1]
+		if !strings.Contains(name, "@") {
 			continue
 		}
-		return p.Name
+		if _, ok := existing[name]; ok {
+			continue
+		}
+		return name
 	}
 	return ""
 }
 
 func takeoverProxyPaneNames(h *ServerHarness) map[string]struct{} {
 	names := make(map[string]struct{})
-	for _, p := range h.captureJSON().Panes {
+	capture, ok := takeoverCaptureJSON(h)
+	if !ok {
+		return names
+	}
+	for _, p := range capture.Panes {
 		if strings.Contains(p.Name, "@") {
 			names[p.Name] = struct{}{}
 		}
@@ -180,10 +212,11 @@ func waitForPaneConnStatus(t *testing.T, h *ServerHarness, paneName, wantStatus,
 	deadline := time.Now().Add(parseTestDuration(t, timeout))
 	gen := h.generation()
 	for time.Now().Before(deadline) {
-		c := h.captureJSON()
-		for _, p := range c.Panes {
-			if p.Name == paneName && p.ConnStatus == wantStatus {
-				return
+		if c, ok := takeoverCaptureJSON(h); ok {
+			for _, p := range c.Panes {
+				if p.Name == paneName && p.ConnStatus == wantStatus {
+					return
+				}
 			}
 		}
 
@@ -198,6 +231,21 @@ func waitForPaneConnStatus(t *testing.T, h *ServerHarness, paneName, wantStatus,
 	}
 
 	t.Fatalf("pane %s did not reach conn_status=%s\ncapture:\n%s", paneName, wantStatus, h.capture())
+}
+
+func takeoverCaptureJSON(h *ServerHarness) (proto.CaptureJSON, bool) {
+	h.tb.Helper()
+
+	out := h.runCmd("capture", "--format", "json")
+	if strings.Contains(out, "no client attached") {
+		return proto.CaptureJSON{}, false
+	}
+
+	var capture proto.CaptureJSON
+	if err := json.Unmarshal([]byte(out), &capture); err != nil {
+		h.tb.Fatalf("captureJSON: %v\nraw: %s", err, out)
+	}
+	return capture, true
 }
 
 func parseTestDuration(t *testing.T, s string) time.Duration {


### PR DESCRIPTION
## Summary

This makes SSH takeover fail safe instead of splicing in a blank dead proxy pane.

- derive the managed remote session name from the local session namespace instead of reusing the remote shell's default session name
- validate that the remote managed session actually has panes before treating attach as success
- only splice proxy panes into the local layout after takeover attach succeeds
- leave the raw SSH pane visible on attach failure
- add regression coverage for failed attach and post-reload interactive SSH takeover

## Testing

- `go test ./internal/remote ./test -run 'Test(ManagedSessionName|TakeoverAttachFailureLeavesSSHPaneVisible|TakeoverFromInteractiveSSHShell|TakeoverBidirectionalIO|TakeoverReconnectAfterRemoteReload|TakeoverAfterServerReload)'`
- `go test ./...`

## Live validation

Validated against `100.118.104.90` after the takeover fix:

- secure run: takeover stayed in the raw SSH pane and logged the real failure (`SSH host key verification failed`) instead of splicing a dead proxy
- `AMUX_SSH_INSECURE=1` run: takeover succeeded end to end, the proxy pane stayed connected, and `echo __LIVE_TAKEOVER_OK__` round-tripped successfully

## Follow-ups

Not included here:

- `LAB-302` Surface SSH takeover attach failures in the UI instead of only the session log
- `LAB-303` Handle cross-arch post-takeover deploy without noisy failure
