### PR TITLE
Unify capture parsing across capture paths

### DIFF
--- a/internal/capture/capture.go
+++ b/internal/capture/capture.go
@@ -1,0 +1,107 @@
+package capture
+
+import (
+	"fmt"
+
+	"github.com/weill-labs/amux/internal/proto"
+)
+
+// Request is the parsed shape of amux capture flags.
+type Request struct {
+	IncludeANSI bool
+	ColorMap    bool
+	FormatJSON  bool
+	DisplayMode bool
+	HistoryMode bool
+	PaneRef     string
+}
+
+// ParseArgs parses capture flags while preserving the existing loose CLI
+// semantics: unknown positional args collapse to the last pane ref.
+func ParseArgs(args []string) Request {
+	var req Request
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--ansi":
+			req.IncludeANSI = true
+		case "--colors":
+			req.ColorMap = true
+		case "--display":
+			req.DisplayMode = true
+		case "--history":
+			req.HistoryMode = true
+		case "--format":
+			if i+1 < len(args) && args[i+1] == "json" {
+				req.FormatJSON = true
+				i++
+			}
+		default:
+			req.PaneRef = args[i]
+		}
+	}
+	return req
+}
+
+// ValidateScreenRequest applies the shared client-routed capture validation.
+func ValidateScreenRequest(req Request) error {
+	if (req.IncludeANSI && req.ColorMap) ||
+		(req.IncludeANSI && req.FormatJSON) ||
+		(req.ColorMap && req.FormatJSON) {
+		return fmt.Errorf("--ansi, --colors, and --format json are mutually exclusive")
+	}
+	if req.DisplayMode && (req.IncludeANSI || req.ColorMap || req.FormatJSON || req.HistoryMode || req.PaneRef != "") {
+		return fmt.Errorf("--display is mutually exclusive with other flags")
+	}
+	return nil
+}
+
+// ValidateHistoryRequest applies the shared server-owned history capture validation.
+func ValidateHistoryRequest(req Request) error {
+	if !req.HistoryMode {
+		return fmt.Errorf("internal error: captureHistory called without --history")
+	}
+	if req.IncludeANSI || req.ColorMap || req.DisplayMode {
+		return fmt.Errorf("--history is mutually exclusive with --ansi, --colors, and --display")
+	}
+	if req.PaneRef == "" {
+		return fmt.Errorf("--history requires a pane target")
+	}
+	return nil
+}
+
+// PaneInput holds the shared capture-pane fields assembled by both the client
+// and server capture paths.
+type PaneInput struct {
+	ID         uint32
+	Name       string
+	Active     bool
+	Minimized  bool
+	Zoomed     bool
+	Host       string
+	Task       string
+	Color      string
+	ConnStatus string
+	Cursor     proto.CaptureCursor
+	Content    []string
+	History    []string
+}
+
+// BuildPane builds the common proto.CapturePane shape shared by both capture paths.
+func BuildPane(input PaneInput, agentStatus map[uint32]proto.PaneAgentStatus) proto.CapturePane {
+	cp := proto.CapturePane{
+		ID:         input.ID,
+		Name:       input.Name,
+		Active:     input.Active,
+		Minimized:  input.Minimized,
+		Zoomed:     input.Zoomed,
+		Host:       input.Host,
+		Task:       input.Task,
+		Color:      input.Color,
+		ConnStatus: input.ConnStatus,
+		Cursor:     input.Cursor,
+		Content:    append([]string(nil), input.Content...),
+		History:    append([]string(nil), input.History...),
+	}
+	cp.ApplyAgentStatus(agentStatus)
+	return cp
+}

--- a/internal/capture/capture_test.go
+++ b/internal/capture/capture_test.go
@@ -1,0 +1,211 @@
+package capture
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/weill-labs/amux/internal/proto"
+)
+
+func TestParseArgs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		args []string
+		want Request
+	}{
+		{
+			name: "empty",
+			want: Request{},
+		},
+		{
+			name: "pane with ansi",
+			args: []string{"--ansi", "pane-1"},
+			want: Request{IncludeANSI: true, PaneRef: "pane-1"},
+		},
+		{
+			name: "format json pane",
+			args: []string{"--format", "json", "pane-2"},
+			want: Request{FormatJSON: true, PaneRef: "pane-2"},
+		},
+		{
+			name: "history pane",
+			args: []string{"--history", "pane-3"},
+			want: Request{HistoryMode: true, PaneRef: "pane-3"},
+		},
+		{
+			name: "display",
+			args: []string{"--display"},
+			want: Request{DisplayMode: true},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := ParseArgs(tt.args); got != tt.want {
+				t.Fatalf("ParseArgs(%v) = %+v, want %+v", tt.args, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidateScreenRequest(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		req     Request
+		wantErr string
+	}{
+		{
+			name: "plain pane",
+			req:  Request{PaneRef: "pane-1"},
+		},
+		{
+			name:    "ansi and colors",
+			req:     Request{IncludeANSI: true, ColorMap: true},
+			wantErr: "--ansi, --colors, and --format json are mutually exclusive",
+		},
+		{
+			name:    "display with pane",
+			req:     Request{DisplayMode: true, PaneRef: "pane-1"},
+			wantErr: "--display is mutually exclusive with other flags",
+		},
+		{
+			name:    "display with history",
+			req:     Request{DisplayMode: true, HistoryMode: true},
+			wantErr: "--display is mutually exclusive with other flags",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := ValidateScreenRequest(tt.req)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("ValidateScreenRequest(%+v) error = %v, want nil", tt.req, err)
+				}
+				return
+			}
+			if err == nil || err.Error() != tt.wantErr {
+				t.Fatalf("ValidateScreenRequest(%+v) error = %v, want %q", tt.req, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateHistoryRequest(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		req     Request
+		wantErr string
+	}{
+		{
+			name: "valid",
+			req:  Request{HistoryMode: true, PaneRef: "pane-1"},
+		},
+		{
+			name:    "missing history flag",
+			req:     Request{PaneRef: "pane-1"},
+			wantErr: "internal error: captureHistory called without --history",
+		},
+		{
+			name:    "ansi not allowed",
+			req:     Request{HistoryMode: true, IncludeANSI: true, PaneRef: "pane-1"},
+			wantErr: "--history is mutually exclusive with --ansi, --colors, and --display",
+		},
+		{
+			name:    "missing pane ref",
+			req:     Request{HistoryMode: true},
+			wantErr: "--history requires a pane target",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := ValidateHistoryRequest(tt.req)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("ValidateHistoryRequest(%+v) error = %v, want nil", tt.req, err)
+				}
+				return
+			}
+			if err == nil || err.Error() != tt.wantErr {
+				t.Fatalf("ValidateHistoryRequest(%+v) error = %v, want %q", tt.req, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestBuildPane(t *testing.T) {
+	t.Parallel()
+
+	input := PaneInput{
+		ID:         7,
+		Name:       "pane-7",
+		Active:     true,
+		Minimized:  false,
+		Zoomed:     true,
+		Host:       "local",
+		Task:       "task",
+		Color:      "f5e0dc",
+		ConnStatus: "connected",
+		Cursor: proto.CaptureCursor{
+			Col:    4,
+			Row:    2,
+			Hidden: true,
+		},
+		Content: []string{"screen-1", "screen-2"},
+		History: []string{"history-1"},
+	}
+	status := map[uint32]proto.PaneAgentStatus{
+		7: {
+			Idle:           true,
+			IdleSince:      "2026-03-20T12:00:00Z",
+			CurrentCommand: "bash",
+			ChildPIDs:      nil,
+		},
+	}
+
+	got := BuildPane(input, status)
+	want := proto.CapturePane{
+		ID:         7,
+		Name:       "pane-7",
+		Active:     true,
+		Minimized:  false,
+		Zoomed:     true,
+		Host:       "local",
+		Task:       "task",
+		Color:      "f5e0dc",
+		ConnStatus: "connected",
+		Cursor: proto.CaptureCursor{
+			Col:    4,
+			Row:    2,
+			Hidden: true,
+		},
+		Content:        []string{"screen-1", "screen-2"},
+		History:        []string{"history-1"},
+		Idle:           true,
+		IdleSince:      "2026-03-20T12:00:00Z",
+		CurrentCommand: "bash",
+		ChildPIDs:      []int{},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("BuildPane() = %+v, want %+v", got, want)
+	}
+
+	input.Content[0] = "mutated"
+	input.History[0] = "mutated"
+	if got.Content[0] != "screen-1" || got.History[0] != "history-1" {
+		t.Fatalf("BuildPane should copy slices, got content=%v history=%v", got.Content, got.History)
+	}
+}

--- a/internal/client/renderer.go
+++ b/internal/client/renderer.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"sync"
 
+	caputil "github.com/weill-labs/amux/internal/capture"
 	"github.com/weill-labs/amux/internal/mux"
 	"github.com/weill-labs/amux/internal/proto"
 	"github.com/weill-labs/amux/internal/render"
@@ -484,7 +485,7 @@ func (r *Renderer) buildCapturePaneLocked(paneID uint32, agentStatus map[uint32]
 		return proto.CapturePane{}, false
 	}
 	col, row := emu.CursorPosition()
-	cp := proto.CapturePane{
+	cp := caputil.BuildPane(caputil.PaneInput{
 		ID:         info.ID,
 		Name:       info.Name,
 		Active:     info.ID == r.activePaneID,
@@ -500,8 +501,7 @@ func (r *Renderer) buildCapturePaneLocked(paneID uint32, agentStatus map[uint32]
 			Hidden: emu.CursorHidden(),
 		},
 		Content: mux.EmulatorContentLines(emu),
-	}
-	cp.ApplyAgentStatus(agentStatus)
+	}, agentStatus)
 	return cp, true
 }
 
@@ -523,36 +523,13 @@ func (r *Renderer) paneLookupLocked(paneID uint32) render.PaneData {
 // with the rendered output. This is the shared implementation used by both
 // the live client (main package) and the headless test client.
 func (r *Renderer) HandleCaptureRequest(args []string, agentStatus map[uint32]proto.PaneAgentStatus) *proto.Message {
-	var includeANSI, colorMap, formatJSON, displayMode bool
-	var paneRef string
-	for i := 0; i < len(args); i++ {
-		switch args[i] {
-		case "--ansi":
-			includeANSI = true
-		case "--colors":
-			colorMap = true
-		case "--display":
-			displayMode = true
-		case "--format":
-			if i+1 < len(args) && args[i+1] == "json" {
-				formatJSON = true
-				i++ // consume "json"
-			}
-		default:
-			paneRef = args[i]
-		}
-	}
-
-	if (includeANSI && colorMap) || (includeANSI && formatJSON) || (colorMap && formatJSON) {
+	req := caputil.ParseArgs(args)
+	if err := caputil.ValidateScreenRequest(req); err != nil {
 		return &proto.Message{Type: proto.MsgTypeCaptureResponse,
-			CmdErr: "--ansi, --colors, and --format json are mutually exclusive"}
+			CmdErr: err.Error()}
 	}
 
-	if displayMode {
-		if includeANSI || colorMap || formatJSON || paneRef != "" {
-			return &proto.Message{Type: proto.MsgTypeCaptureResponse,
-				CmdErr: "--display is mutually exclusive with other flags"}
-		}
+	if req.DisplayMode {
 		out := r.CaptureDisplay()
 		if out == "" {
 			out = "(no previous grid — diff renderer has not run yet)"
@@ -560,32 +537,32 @@ func (r *Renderer) HandleCaptureRequest(args []string, agentStatus map[uint32]pr
 		return &proto.Message{Type: proto.MsgTypeCaptureResponse, CmdOutput: out + "\n"}
 	}
 
-	if paneRef != "" {
-		if colorMap {
+	if req.PaneRef != "" {
+		if req.ColorMap {
 			return &proto.Message{Type: proto.MsgTypeCaptureResponse,
 				CmdErr: "--colors is only supported for full screen capture"}
 		}
-		paneID := r.ResolvePaneID(paneRef)
+		paneID := r.ResolvePaneID(req.PaneRef)
 		if paneID == 0 {
 			return &proto.Message{Type: proto.MsgTypeCaptureResponse,
-				CmdErr: fmt.Sprintf("pane %q not found", paneRef)}
+				CmdErr: fmt.Sprintf("pane %q not found", req.PaneRef)}
 		}
 		var out string
-		if formatJSON {
+		if req.FormatJSON {
 			out = r.CapturePaneJSON(paneID, agentStatus)
 		} else {
-			out = r.CapturePaneText(paneID, includeANSI)
+			out = r.CapturePaneText(paneID, req.IncludeANSI)
 		}
 		return &proto.Message{Type: proto.MsgTypeCaptureResponse, CmdOutput: out + "\n"}
 	}
 
 	var out string
-	if formatJSON {
+	if req.FormatJSON {
 		out = r.CaptureJSON(agentStatus) + "\n"
-	} else if colorMap {
+	} else if req.ColorMap {
 		out = r.CaptureColorMap()
 	} else {
-		out = r.Capture(!includeANSI)
+		out = r.Capture(!req.IncludeANSI)
 	}
 	return &proto.Message{Type: proto.MsgTypeCaptureResponse, CmdOutput: out}
 }

--- a/internal/server/capture_history.go
+++ b/internal/server/capture_history.go
@@ -4,53 +4,15 @@ import (
 	"encoding/json"
 	"strings"
 
+	caputil "github.com/weill-labs/amux/internal/capture"
 	"github.com/weill-labs/amux/internal/mux"
 	"github.com/weill-labs/amux/internal/proto"
 )
 
-type captureHistoryArgs struct {
-	includeANSI bool
-	colorMap    bool
-	formatJSON  bool
-	displayMode bool
-	historyMode bool
-	paneRef     string
-}
-
-func parseCaptureArgs(args []string) captureHistoryArgs {
-	var req captureHistoryArgs
-	for i := 0; i < len(args); i++ {
-		switch args[i] {
-		case "--ansi":
-			req.includeANSI = true
-		case "--colors":
-			req.colorMap = true
-		case "--display":
-			req.displayMode = true
-		case "--history":
-			req.historyMode = true
-		case "--format":
-			if i+1 < len(args) && args[i+1] == "json" {
-				req.formatJSON = true
-				i++
-			}
-		default:
-			req.paneRef = args[i]
-		}
-	}
-	return req
-}
-
 func (s *Session) captureHistory(cc *ClientConn, args []string) *Message {
-	req := parseCaptureArgs(args)
-	if !req.historyMode {
-		return &Message{Type: MsgTypeCmdResult, CmdErr: "internal error: captureHistory called without --history"}
-	}
-	if req.includeANSI || req.colorMap || req.displayMode {
-		return &Message{Type: MsgTypeCmdResult, CmdErr: "--history is mutually exclusive with --ansi, --colors, and --display"}
-	}
-	if req.paneRef == "" {
-		return &Message{Type: MsgTypeCmdResult, CmdErr: "--history requires a pane target"}
+	req := caputil.ParseArgs(args)
+	if err := caputil.ValidateHistoryRequest(req); err != nil {
+		return &Message{Type: MsgTypeCmdResult, CmdErr: err.Error()}
 	}
 
 	type historySnapshot struct {
@@ -60,7 +22,7 @@ func (s *Session) captureHistory(cc *ClientConn, args []string) *Message {
 		zoomed   bool
 	}
 	snap, err := enqueueSessionQuery(s, func(s *Session) (historySnapshot, error) {
-		pane, w, err := cc.resolvePaneAcrossWindowsLocked(s, req.paneRef)
+		pane, w, err := cc.resolvePaneAcrossWindowsLocked(s, req.PaneRef)
 		if err != nil {
 			return historySnapshot{}, err
 		}
@@ -78,7 +40,7 @@ func (s *Session) captureHistory(cc *ClientConn, args []string) *Message {
 	pane := snap.pane
 	textSnap := pane.CaptureSnapshot()
 
-	capturePane := proto.CapturePane{
+	capturePane := caputil.BuildPane(caputil.PaneInput{
 		ID:         pane.ID,
 		Name:       pane.Meta.Name,
 		Active:     snap.active,
@@ -95,14 +57,13 @@ func (s *Session) captureHistory(cc *ClientConn, args []string) *Message {
 		},
 		Content: textSnap.Content,
 		History: textSnap.History,
-	}
+	}, s.captureAgentStatus([]*mux.Pane{pane}))
 	if !snap.inWindow {
 		capturePane.Active = false
 		capturePane.Zoomed = false
 	}
-	capturePane.ApplyAgentStatus(s.captureAgentStatus([]*mux.Pane{pane}))
 
-	if req.formatJSON {
+	if req.FormatJSON {
 		out, _ := json.MarshalIndent(capturePane, "", "  ")
 		return &Message{Type: MsgTypeCmdResult, CmdOutput: string(out) + "\n"}
 	}

--- a/internal/server/commands.go
+++ b/internal/server/commands.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	caputil "github.com/weill-labs/amux/internal/capture"
 	"github.com/weill-labs/amux/internal/config"
 	"github.com/weill-labs/amux/internal/hooks"
 	"github.com/weill-labs/amux/internal/mux"
@@ -268,7 +269,7 @@ func cmdFocus(ctx *CommandContext) {
 }
 
 func cmdCapture(ctx *CommandContext) {
-	if parseCaptureArgs(ctx.Args).historyMode {
+	if caputil.ParseArgs(ctx.Args).HistoryMode {
 		ctx.CC.Send(ctx.Sess.captureHistory(ctx.CC, ctx.Args))
 		return
 	}

--- a/test/capture_test.go
+++ b/test/capture_test.go
@@ -126,6 +126,19 @@ func TestCapturePaneHistoryWithoutAttachedClient(t *testing.T) {
 	}
 }
 
+func TestCapturePaneHistoryRejectsInvalidFlags(t *testing.T) {
+	t.Parallel()
+	h := newServerHarness(t)
+
+	if out := h.runCmd("capture", "--history", "--ansi", "pane-1"); !strings.Contains(out, "--history is mutually exclusive with --ansi, --colors, and --display") {
+		t.Fatalf("history capture with invalid flags should fail, got:\n%s", out)
+	}
+
+	if out := h.runCmd("capture", "--history"); !strings.Contains(out, "--history requires a pane target") {
+		t.Fatalf("history capture without pane should fail, got:\n%s", out)
+	}
+}
+
 func TestCapturePaneANSI(t *testing.T) {
 	t.Parallel()
 	h := newServerHarness(t)


### PR DESCRIPTION
## Summary
- add a shared `internal/capture` package for capture arg parsing, validation, and base `CapturePane` assembly
- switch the client renderer, history capture path, and command routing to the shared capture helpers
- add shared parser/builder tests and cover invalid `capture --history` flag combinations

## Testing
- `go test ./internal/capture ./internal/client ./internal/server ./test -run 'TestCapture|TestParseArgs|TestValidate|TestBuildPane'
- `go test ./test -run 'TestIdleStatus_BusyWhileRunning|TestCaptureJSON_AgentStatus_Transition' -count=5`
- `go test ./...`
  - two separate full-suite runs hit intermittent busy/idle timing flakes in `TestIdleStatus_BusyWhileRunning` and `TestCaptureJSON_AgentStatus_Transition`; direct reruns passed, and the focused capture slice above is green

Refs LAB-299
