### PR TITLE
LAB-239: add happy-path tests for remote deploy

### DIFF
--- a/internal/remote/deploy.go
+++ b/internal/remote/deploy.go
@@ -14,8 +14,6 @@ import (
 
 const remoteInstallPath = "$HOME/.local/bin/amux"
 
-type commandFactory func(name string, args ...string) *exec.Cmd
-
 // DeployBinary ensures the remote host has a matching amux binary.
 // Strategy:
 //  1. Remote hash matches local → skip (already up to date)
@@ -97,12 +95,12 @@ func parseUnameArch(unameSM string) (goos, goarch string, err error) {
 }
 
 func crossCompileAndUpload(client *ssh.Client, goos, goarch string) error {
-	return crossCompileAndUploadWith(client, goos, goarch, os.Executable, exec.Command)
+	return crossCompileAndUploadWith(client, goos, goarch, os.Executable)
 }
 
 // crossCompileAndUploadWith builds amux for the target OS/arch via `go build`
-// and uploads it using injectable dependencies for testing.
-func crossCompileAndUploadWith(client *ssh.Client, goos, goarch string, executablePath func() (string, error), makeCmd commandFactory) error {
+// and uploads it using an injectable executable-path lookup for testing.
+func crossCompileAndUploadWith(client *ssh.Client, goos, goarch string, executablePath func() (string, error)) error {
 	// Find the module root (where go.mod lives)
 	localExe, err := executablePath()
 	if err != nil {
@@ -121,7 +119,7 @@ func crossCompileAndUploadWith(client *ssh.Client, goos, goarch string, executab
 	tmpFile.Close()
 	defer os.Remove(tmpBin)
 
-	cmd := makeCmd("go", "build", "-o", tmpBin, ".")
+	cmd := exec.Command("go", "build", "-o", tmpBin, ".")
 	cmd.Dir = modRoot
 	cmd.Env = append(os.Environ(),
 		"GOOS="+goos,
@@ -150,12 +148,12 @@ func findModuleRoot(dir string) string {
 }
 
 func downloadReleaseBinary(client *ssh.Client, goos, goarch, version string) error {
-	return downloadReleaseBinaryWith(client, goos, goarch, version, releaseBinaryURL, exec.Command)
+	return downloadReleaseBinaryWith(client, goos, goarch, version, releaseBinaryURL)
 }
 
 // downloadReleaseBinaryWith downloads a pre-built binary from a release URL.
 // Tries remote curl first (fastest), falls back to local download + upload.
-func downloadReleaseBinaryWith(client *ssh.Client, goos, goarch, version string, releaseURL func(version, goos, goarch string) string, makeCmd commandFactory) error {
+func downloadReleaseBinaryWith(client *ssh.Client, goos, goarch, version string, releaseURL func(version, goos, goarch string) string) error {
 	archiveName := fmt.Sprintf("amux_%s_%s_%s.tar.gz", version, goos, goarch)
 	url := releaseURL(version, goos, goarch)
 
@@ -173,13 +171,13 @@ func downloadReleaseBinaryWith(client *ssh.Client, goos, goarch, version string,
 	defer os.RemoveAll(tmpDir)
 
 	archivePath := filepath.Join(tmpDir, archiveName)
-	dlCmd := makeCmd("curl", "-fsSL", url, "-o", archivePath)
+	dlCmd := exec.Command("curl", "-fsSL", url, "-o", archivePath)
 	if out, err := dlCmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("downloading release: %w: %s", err, out)
 	}
 
 	binPath := filepath.Join(tmpDir, "amux")
-	extractCmd := makeCmd("tar", "xzf", archivePath, "-C", tmpDir, "amux")
+	extractCmd := exec.Command("tar", "xzf", archivePath, "-C", tmpDir, "amux")
 	if out, err := extractCmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("extracting release: %w: %s", err, out)
 	}

--- a/internal/remote/deploy_test.go
+++ b/internal/remote/deploy_test.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"runtime"
 	"testing"
@@ -248,7 +247,6 @@ func TestCrossCompileAndUploadBuildsAndUploadsBinary(t *testing.T) {
 	targetOS, targetArch := testCrossCompileTarget()
 	err := crossCompileAndUploadWith(ts.Client, targetOS, targetArch,
 		func() (string, error) { return fakeExe, nil },
-		exec.Command,
 	)
 	if err != nil {
 		t.Fatalf("crossCompileAndUploadWith error: %v", err)
@@ -300,7 +298,6 @@ func TestDownloadReleaseBinaryInstallsRemoteArchive(t *testing.T) {
 		func(version, goos, goarch string) string {
 			return fmt.Sprintf("%s/downloads/v%s/amux_%s_%s_%s.tar.gz", server.URL, version, version, goos, goarch)
 		},
-		exec.Command,
 	)
 	if err != nil {
 		t.Fatalf("downloadReleaseBinaryWith error: %v", err)


### PR DESCRIPTION
## Summary
- add happy-path coverage for `crossCompileAndUpload` using a temporary Go module and the in-process SSH harness
- add happy-path coverage for `downloadReleaseBinary` using an `httptest.Server` that serves a fake release tarball
- keep the production seam narrow by injecting only executable-path lookup and release URL construction for tests

## Testing
- `go test ./internal/remote`
- `make test`
- `go test ./test -run TestUnsupportedPrefixKeyFeedbackClearsOnLiteralPrefix -count=1`

## Review Pass
- manual diff review against `origin/main`
- note: attempted `codex review --base origin/main`, but the sandboxed review environment hit localhost bind restrictions in the SSH-backed remote tests and did not surface concrete code findings on this change

## Simplification Pass
- removed the extra injected `exec.Command` factory and kept only the test seams actually needed for stable happy-path coverage
