### PR TITLE
docs: codify PR refresh and review fallback

### DIFF
--- a/.agents/skills/amux-pr-workflow/SKILL.md
+++ b/.agents/skills/amux-pr-workflow/SKILL.md
@@ -10,6 +10,7 @@ Use this skill when the task involves `git push`, `gh pr create`, `gh pr merge`,
 ## Rules
 
 - Rebase onto `origin/main` before the first push: `git fetch origin main && git rebase origin/main`.
+- If `git fetch origin main` or `git pull` advances `origin/main` while a PR branch is open, refresh that branch onto `origin/main` before treating the PR as current again.
 - If the PR drifts after opening and you rebase or resolve conflicts, rerun the review pass and simplification pass on the rebased diff before calling the PR ready again.
 - In non-interactive sessions, prefer `GIT_EDITOR=true git rebase --continue` so rebase continuation does not stall in `vim`.
 - This repo is squash-only on GitHub. Use `gh pr merge --squash`; merge and rebase merges will fail.
@@ -17,6 +18,7 @@ Use this skill when the task involves `git push`, `gh pr create`, `gh pr merge`,
 - Prefer `gh pr create --body-file ...` for multiline PR descriptions, especially when they include backticks or code fences.
 - In `amux`, if the change is ready for review, open the PR proactively instead of asking whether to make one.
 - Do not present a PR as done until it has had both a review pass and a simplification pass.
+- If `codex review` or other external review tooling stalls, fall back to a manual diff review and say so explicitly.
 - If benchmarks changed, add a `Baseline numbers` section to the PR description with representative results and hardware.
 - If a rebase triggers broad noisy local failures, verify with a targeted regression slice before making invasive code changes.
 - After merge, verify local state explicitly: confirm the checkout is on `main`, the worktree is clean, and `HEAD` matches `origin/main`.
@@ -27,9 +29,9 @@ Use this skill when the task involves `git push`, `gh pr create`, `gh pr merge`,
 ## Workflow
 
 1. Confirm the relevant tests ran and note any gaps.
-2. If this is the first push for the branch, rebase onto `origin/main`.
+2. If this is the first push for the branch, rebase onto `origin/main`. If the PR is already open and a fetch/pull advanced `origin/main`, refresh the branch onto `origin/main` before continuing.
 3. Create or update the PR as soon as the branch is ready for review. Use `gh pr create --body-file ...` when the body is multiline.
-4. Run a review pass. Prefer `codex review` when available.
+4. Run a review pass. Prefer `codex review` when available, but if it stalls, do a manual diff review and state that explicitly.
 5. Run a simplification pass focused on unnecessary complexity and cleanup opportunities.
 6. If the branch had to be rebased or conflict-resolved after the PR was open, rerun both passes on that rebased diff before pushing again.
 7. If the change affects layout math or resize behavior, compare against tmux before adding new layout state or diverging from tmux semantics.
@@ -45,6 +47,7 @@ Use this skill when the task involves `git push`, `gh pr create`, `gh pr merge`,
 
 - Tests run, or an explicit testing gap is called out.
 - Rebase-before-first-push handled or explicitly not needed.
+- Open PR branches refreshed after any fetch/pull that advanced `origin/main`.
 - Review pass completed.
 - Simplification pass completed.
 - Review/simplification rerun after any post-open rebase or conflict resolution.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,6 +90,8 @@ Regenerate goldens after intentional rendering changes: `cd test && go test -run
 
 Rebase onto `origin/main` before the first push (`git fetch origin main && git rebase origin/main`). Multiple features often land in parallel; rebasing before push avoids repeated merge conflict resolution after the PR is open.
 
+If a PR is already open and `git fetch origin main` or `git pull` advances `origin/main`, refresh that PR branch onto `origin/main` before treating it as current again. After the refresh, rerun verification on the rebased branch before pushing.
+
 ### Specs And Plans On Feature Branches
 
 Commit design specs and implementation plans to the feature branch, not main. Committing to main before creating the feature branch causes divergent branches on subsequent pulls.
@@ -97,6 +99,8 @@ Commit design specs and implementation plans to the feature branch, not main. Co
 ### Review Before Done
 
 After creating or updating a PR, run a review pass and a simplification pass before considering the work done. Claude Code gets hook reminders for this. Codex users should use the repo PR workflow skill or perform the steps explicitly.
+
+Prefer external review tooling like `codex review` when it returns promptly, but do not block the PR on it. If the tool stalls or is unavailable, do a manual diff review and say that explicitly.
 
 If a change in this repo is ready for review, open the PR proactively instead of asking whether to make one.
 


### PR DESCRIPTION
Follow-up from the LAB-295 postmortem.

## Summary
- codify that open PR branches should be refreshed onto `origin/main` after a fetch/pull advances `origin/main`
- codify that `codex review` should not block the PR path; manual diff review is the fallback when it stalls
- update the repo PR workflow skill to reflect both rules in the checklist and workflow steps

## Tests
- not run; documentation-only change
