### PR TITLE
Fix benchmark Pages subpath publish

### DIFF
--- a/.github/workflows/benchmark-publish.yml
+++ b/.github/workflows/benchmark-publish.yml
@@ -129,13 +129,22 @@ jobs:
           source: ./
           destination: ./site-root
 
+      - name: Prepare writable publish directory
+        id: publish_dir
+        if: steps.artifact.outputs.found == 'true'
+        run: |
+          set -euo pipefail
+          publish_dir=$(mktemp -d)
+          cp -R site-root/. "$publish_dir"/
+          echo "path=$publish_dir" >> "$GITHUB_OUTPUT"
+
       - name: Sync dashboard files
         id: site
         if: steps.artifact.outputs.found == 'true'
         run: |
           set -euo pipefail
           data_dir="${{ steps.data.outputs.path }}"
-          site_dir=site-root
+          site_dir="${{ steps.publish_dir.outputs.path }}"
 
           mkdir -p "$data_dir/benchmarks" "$site_dir/benchmarks"
 


### PR DESCRIPTION
## Summary
- fix `Publish Benchmark Trends` after the `/benchmarks/` move by copying the built Jekyll site into a writable temp publish directory before overlaying benchmark assets
- keep the homepage-at-root and benchmarks-at-subpath behavior unchanged; only the publish mechanics change

## Motivation
- the live publish workflow now fails in `Sync dashboard files` with `mkdir: cannot create directory `site-root/benchmarks`: Permission denied` because `actions/jekyll-build-pages` leaves `site-root` non-writable for the follow-up shell step

## Testing
- `actionlint .github/workflows/benchmark-publish.yml`
- `git diff --check`

## Review
- review pass completed
- simplification pass completed

## Testing Gap
- GitHub Actions was not run end-to-end locally; the next successful `Publish Benchmark Trends` run is the real verification
