### PR TITLE
test: add client UI reducer transition specs

### DIFF
--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -210,6 +210,16 @@ func assertClientEffectKinds(t *testing.T, effects []clientEffect, want []client
 	}
 }
 
+func collectClientEffectUIEvents(effects []clientEffect) []string {
+	var uiEvents []string
+	for _, effect := range effects {
+		if effect.kind == clientEffectEmitUIEvents {
+			uiEvents = append(uiEvents, effect.uiEvents...)
+		}
+	}
+	return uiEvents
+}
+
 func multiWindow80x23Zoomed(windowID, paneID uint32) *proto.LayoutSnapshot {
 	snap := multiWindow80x23()
 	for i := range snap.Windows {
@@ -628,90 +638,160 @@ func TestHandleLayoutClearsCommandFeedback(t *testing.T) {
 	}
 }
 
-func TestHandleRenderMsgLayoutReturnsEffects(t *testing.T) {
+func TestHandleRenderMsgEffects(t *testing.T) {
 	t.Parallel()
 
-	cr := buildTestRenderer(t)
-	if !cr.ShowDisplayPanes() {
-		t.Fatal("ShowDisplayPanes should succeed")
+	tests := []struct {
+		name         string
+		prepare      func(*testing.T, *ClientRenderer)
+		msg          *RenderMsg
+		wantKinds    []clientEffectKind
+		wantUIEvents []string
+		assert       func(*testing.T, *ClientRenderer, []clientEffect)
+	}{
+		{
+			name: "structural layout change clears overlay and repaints immediately",
+			prepare: func(t *testing.T, cr *ClientRenderer) {
+				if !cr.ShowDisplayPanes() {
+					t.Fatal("ShowDisplayPanes should succeed")
+				}
+			},
+			msg: &RenderMsg{Typ: RenderMsgLayout, Layout: threePane80x23()},
+			wantKinds: []clientEffectKind{
+				clientEffectEmitUIEvents,
+				clientEffectClearPrevGrid,
+				clientEffectStopScheduledRender,
+				clientEffectRenderNow,
+			},
+			wantUIEvents: []string{proto.UIEventDisplayPanesHidden},
+			assert: func(t *testing.T, cr *ClientRenderer, _ []clientEffect) {
+				t.Helper()
+				if cr.DisplayPanesActive() {
+					t.Fatal("display panes should be cleared after structural layout change")
+				}
+			},
+		},
+		{
+			name: "non-structural layout change preserves overlay and skips grid clear",
+			prepare: func(t *testing.T, cr *ClientRenderer) {
+				if !cr.ShowDisplayPanes() {
+					t.Fatal("ShowDisplayPanes should succeed")
+				}
+				cr.ShowCommandError("cannot minimize")
+			},
+			msg: &RenderMsg{Typ: RenderMsgLayout, Layout: twoPane80x23()},
+			wantKinds: []clientEffectKind{
+				clientEffectEmitUIEvents,
+				clientEffectStopScheduledRender,
+				clientEffectRenderNow,
+			},
+			wantUIEvents: []string{proto.UIEventPrefixMessageHidden},
+			assert: func(t *testing.T, cr *ClientRenderer, _ []clientEffect) {
+				t.Helper()
+				if !cr.DisplayPanesActive() {
+					t.Fatal("display panes should survive a non-structural layout change")
+				}
+				if got := cr.prefixMessage(); got != "" {
+					t.Fatalf("layout update should clear command feedback, got %q", got)
+				}
+			},
+		},
+		{
+			name: "pane output preserves message and schedules render",
+			prepare: func(_ *testing.T, cr *ClientRenderer) {
+				cr.ShowPrefixMessage("No binding for C-a f")
+			},
+			msg:       &RenderMsg{Typ: RenderMsgPaneOutput, PaneID: 1, Data: []byte("more output")},
+			wantKinds: []clientEffectKind{clientEffectScheduleRender},
+			assert: func(t *testing.T, cr *ClientRenderer, _ []clientEffect) {
+				t.Helper()
+				if got := cr.prefixMessage(); got != "No binding for C-a f" {
+					t.Fatalf("pane output should preserve the prefix message, got %q", got)
+				}
+				if !cr.IsDirty() {
+					t.Fatal("pane output should leave the renderer dirty until the scheduled render runs")
+				}
+			},
+		},
+		{
+			name: "copy mode returns immediate render effects",
+			msg:  &RenderMsg{Typ: RenderMsgCopyMode, PaneID: 1},
+			wantKinds: []clientEffectKind{
+				clientEffectEmitUIEvents,
+				clientEffectStopScheduledRender,
+				clientEffectRenderNow,
+			},
+			wantUIEvents: []string{proto.UIEventCopyModeShown},
+			assert: func(t *testing.T, cr *ClientRenderer, _ []clientEffect) {
+				t.Helper()
+				if !cr.InCopyMode(1) {
+					t.Fatal("pane-1 should be in copy mode")
+				}
+			},
+		},
+		{
+			name: "command error trims text and rings bell",
+			msg:  &RenderMsg{Typ: RenderMsgCmdError, Text: "  cannot minimize  \n"},
+			wantKinds: []clientEffectKind{
+				clientEffectStopScheduledRender,
+				clientEffectBell,
+				clientEffectRenderNow,
+			},
+			assert: func(t *testing.T, cr *ClientRenderer, _ []clientEffect) {
+				t.Helper()
+				if got := cr.prefixMessage(); got != "cannot minimize" {
+					t.Fatalf("command feedback = %q, want %q", got, "cannot minimize")
+				}
+			},
+		},
+		{
+			name:      "blank command error is ignored",
+			msg:       &RenderMsg{Typ: RenderMsgCmdError, Text: " \t "},
+			wantKinds: []clientEffectKind{},
+			assert: func(t *testing.T, cr *ClientRenderer, _ []clientEffect) {
+				t.Helper()
+				if got := cr.prefixMessage(); got != "" {
+					t.Fatalf("blank command error should not set command feedback, got %q", got)
+				}
+			},
+		},
+		{
+			name: "dirty exit renders before exiting",
+			msg:  &RenderMsg{Typ: RenderMsgExit},
+			wantKinds: []clientEffectKind{
+				clientEffectRenderNow,
+				clientEffectExit,
+			},
+		},
+		{
+			name: "clean exit skips the final render",
+			prepare: func(_ *testing.T, cr *ClientRenderer) {
+				cr.RenderDiff()
+			},
+			msg:       &RenderMsg{Typ: RenderMsgExit},
+			wantKinds: []clientEffectKind{clientEffectExit},
+		},
 	}
 
-	effects := cr.handleRenderMsg(&RenderMsg{Typ: RenderMsgLayout, Layout: threePane80x23()})
-	assertClientEffectKinds(t, effects, []clientEffectKind{
-		clientEffectEmitUIEvents,
-		clientEffectClearPrevGrid,
-		clientEffectStopScheduledRender,
-		clientEffectRenderNow,
-	})
-	if !reflect.DeepEqual(effects[0].uiEvents, []string{proto.UIEventDisplayPanesHidden}) {
-		t.Fatalf("ui events = %v, want [%q]", effects[0].uiEvents, proto.UIEventDisplayPanesHidden)
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cr := buildTestRenderer(t)
+			if tt.prepare != nil {
+				tt.prepare(t, cr)
+			}
+
+			effects := cr.handleRenderMsg(tt.msg)
+
+			assertClientEffectKinds(t, effects, tt.wantKinds)
+			assertUIEvents(t, collectClientEffectUIEvents(effects), tt.wantUIEvents)
+			if tt.assert != nil {
+				tt.assert(t, cr, effects)
+			}
+		})
 	}
-	if cr.DisplayPanesActive() {
-		t.Fatal("display panes should be cleared after structural layout change")
-	}
-}
-
-func TestHandleRenderMsgPaneOutputSchedulesRender(t *testing.T) {
-	t.Parallel()
-
-	cr := buildTestRenderer(t)
-
-	effects := cr.handleRenderMsg(&RenderMsg{Typ: RenderMsgPaneOutput, PaneID: 1, Data: []byte("more output")})
-	assertClientEffectKinds(t, effects, []clientEffectKind{clientEffectScheduleRender})
-}
-
-func TestHandleRenderMsgCopyModeReturnsImmediateRenderEffects(t *testing.T) {
-	t.Parallel()
-
-	cr := buildTestRenderer(t)
-
-	effects := cr.handleRenderMsg(&RenderMsg{Typ: RenderMsgCopyMode, PaneID: 1})
-	assertClientEffectKinds(t, effects, []clientEffectKind{
-		clientEffectEmitUIEvents,
-		clientEffectStopScheduledRender,
-		clientEffectRenderNow,
-	})
-	if !reflect.DeepEqual(effects[0].uiEvents, []string{proto.UIEventCopyModeShown}) {
-		t.Fatalf("ui events = %v, want [%q]", effects[0].uiEvents, proto.UIEventCopyModeShown)
-	}
-	if !cr.InCopyMode(1) {
-		t.Fatal("pane-1 should be in copy mode")
-	}
-}
-
-func TestHandleRenderMsgCommandErrorReturnsBellAndRenderEffects(t *testing.T) {
-	t.Parallel()
-
-	cr := buildTestRenderer(t)
-
-	effects := cr.handleRenderMsg(&RenderMsg{Typ: RenderMsgCmdError, Text: "cannot minimize: pane has no stacked siblings"})
-	assertClientEffectKinds(t, effects, []clientEffectKind{
-		clientEffectStopScheduledRender,
-		clientEffectBell,
-		clientEffectRenderNow,
-	})
-
-	effects = cr.handleRenderMsg(&RenderMsg{Typ: RenderMsgCmdError, Text: " \t "})
-	if len(effects) != 0 {
-		t.Fatalf("blank command error should produce no effects, got %v", effects)
-	}
-}
-
-func TestHandleRenderMsgExitRendersOnlyWhenDirty(t *testing.T) {
-	t.Parallel()
-
-	cr := buildTestRenderer(t)
-
-	effects := cr.handleRenderMsg(&RenderMsg{Typ: RenderMsgExit})
-	assertClientEffectKinds(t, effects, []clientEffectKind{
-		clientEffectRenderNow,
-		clientEffectExit,
-	})
-
-	cr.RenderDiff()
-
-	effects = cr.handleRenderMsg(&RenderMsg{Typ: RenderMsgExit})
-	assertClientEffectKinds(t, effects, []clientEffectKind{clientEffectExit})
 }
 
 func TestToggleMinimizeBlockedReasonVerticalSplit(t *testing.T) {

--- a/internal/client/ui_state_test.go
+++ b/internal/client/ui_state_test.go
@@ -1,123 +1,387 @@
 package client
 
 import (
+	"reflect"
+	"sort"
 	"testing"
 
 	"github.com/weill-labs/amux/internal/copymode"
 	"github.com/weill-labs/amux/internal/proto"
 )
 
-func TestClientUIStateReduceLayoutStructureChangeClearsTransientUI(t *testing.T) {
-	t.Parallel()
+type clientUIStateSnapshot struct {
+	dirty           bool
+	message         string
+	displayPanes    bool
+	chooser         string
+	copyModePaneIDs []uint32
+	inputIdle       bool
+}
 
-	st := newClientUIState()
-	st.displayPanes = &displayPanesState{}
-	st.chooser = &chooserState{mode: chooserModeWindow}
-	st.message = "cannot minimize"
-
-	effects := st.reduce(uiActionHandleLayout{structureChanged: true})
-
-	if st.displayPanes != nil {
-		t.Fatal("display panes should be cleared on structural layout change")
+func snapshotClientUIState(st clientUIState) clientUIStateSnapshot {
+	paneIDs := make([]uint32, 0, len(st.copyModes))
+	for paneID := range st.copyModes {
+		paneIDs = append(paneIDs, paneID)
 	}
+	sort.Slice(paneIDs, func(i, j int) bool { return paneIDs[i] < paneIDs[j] })
+
+	chooser := ""
 	if st.chooser != nil {
-		t.Fatal("chooser should be cleared on structural layout change")
+		chooser = string(st.chooser.mode)
 	}
-	if st.message != "" {
-		t.Fatalf("message = %q, want empty", st.message)
+
+	return clientUIStateSnapshot{
+		dirty:           st.dirty,
+		message:         st.message,
+		displayPanes:    st.displayPanes != nil,
+		chooser:         chooser,
+		copyModePaneIDs: paneIDs,
+		inputIdle:       st.inputIdle,
 	}
-	if !st.dirty {
-		t.Fatal("layout change should mark state dirty")
+}
+
+func assertClientUIState(t *testing.T, st clientUIState, want clientUIStateSnapshot) {
+	t.Helper()
+
+	got := snapshotClientUIState(st)
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("state = %+v, want %+v", got, want)
 	}
-	assertUIEvents(t, effects.uiEvents, []string{
-		proto.UIEventDisplayPanesHidden,
-		proto.UIEventChooseWindowHidden,
-		proto.UIEventPrefixMessageHidden,
+}
+
+func TestClientUIStateReduceTransitions(t *testing.T) {
+	t.Parallel()
+
+	existingCopyMode := new(copymode.CopyMode)
+
+	tests := []struct {
+		name       string
+		setup      func(*clientUIState)
+		action     any
+		wantState  clientUIStateSnapshot
+		wantEvents []string
+		assert     func(*testing.T, *clientUIState)
+	}{
+		{
+			name: "structural layout change clears transient UI",
+			setup: func(st *clientUIState) {
+				st.displayPanes = &displayPanesState{}
+				st.chooser = &chooserState{mode: chooserModeWindow}
+				st.message = "cannot minimize"
+			},
+			action: uiActionHandleLayout{structureChanged: true},
+			wantState: clientUIStateSnapshot{
+				dirty:           true,
+				copyModePaneIDs: []uint32{},
+				inputIdle:       true,
+			},
+			wantEvents: []string{
+				proto.UIEventDisplayPanesHidden,
+				proto.UIEventChooseWindowHidden,
+				proto.UIEventPrefixMessageHidden,
+			},
+		},
+		{
+			name: "non-structural layout change preserves overlays but clears message",
+			setup: func(st *clientUIState) {
+				st.displayPanes = &displayPanesState{}
+				st.message = "cannot minimize"
+			},
+			action: uiActionHandleLayout{structureChanged: false},
+			wantState: clientUIStateSnapshot{
+				dirty:           true,
+				displayPanes:    true,
+				copyModePaneIDs: []uint32{},
+				inputIdle:       true,
+			},
+			wantEvents: []string{proto.UIEventPrefixMessageHidden},
+		},
+		{
+			name: "pane output preserves message and marks dirty",
+			setup: func(st *clientUIState) {
+				st.message = "No binding for C-a f"
+			},
+			action: uiActionPaneOutput{},
+			wantState: clientUIStateSnapshot{
+				dirty:           true,
+				message:         "No binding for C-a f",
+				copyModePaneIDs: []uint32{},
+				inputIdle:       true,
+			},
+		},
+		{
+			name:   "set message stores text and marks dirty",
+			action: uiActionSetMessage{message: "cannot minimize"},
+			wantState: clientUIStateSnapshot{
+				dirty:           true,
+				message:         "cannot minimize",
+				copyModePaneIDs: []uint32{},
+				inputIdle:       true,
+			},
+			wantEvents: []string{proto.UIEventPrefixMessageShown},
+		},
+		{
+			name: "clear message removes text and marks dirty",
+			setup: func(st *clientUIState) {
+				st.message = "cannot minimize"
+			},
+			action: uiActionClearMessage{},
+			wantState: clientUIStateSnapshot{
+				dirty:           true,
+				copyModePaneIDs: []uint32{},
+				inputIdle:       true,
+			},
+			wantEvents: []string{proto.UIEventPrefixMessageHidden},
+		},
+		{
+			name:   "clear message is a no-op when already empty",
+			action: uiActionClearMessage{},
+			wantState: clientUIStateSnapshot{
+				copyModePaneIDs: []uint32{},
+				inputIdle:       true,
+			},
+		},
+		{
+			name:   "show display panes emits shown once",
+			action: uiActionShowDisplayPanes{displayPanes: &displayPanesState{}},
+			wantState: clientUIStateSnapshot{
+				dirty:           true,
+				displayPanes:    true,
+				copyModePaneIDs: []uint32{},
+				inputIdle:       true,
+			},
+			wantEvents: []string{proto.UIEventDisplayPanesShown},
+		},
+		{
+			name: "hide display panes emits hidden",
+			setup: func(st *clientUIState) {
+				st.displayPanes = &displayPanesState{}
+			},
+			action: uiActionHideDisplayPanes{},
+			wantState: clientUIStateSnapshot{
+				dirty:           true,
+				copyModePaneIDs: []uint32{},
+				inputIdle:       true,
+			},
+			wantEvents: []string{proto.UIEventDisplayPanesHidden},
+		},
+		{
+			name: "show chooser hides display panes and emits transitions",
+			setup: func(st *clientUIState) {
+				st.displayPanes = &displayPanesState{}
+			},
+			action: uiActionShowChooser{chooser: &chooserState{mode: chooserModeWindow}},
+			wantState: clientUIStateSnapshot{
+				dirty:           true,
+				chooser:         string(chooserModeWindow),
+				copyModePaneIDs: []uint32{},
+				inputIdle:       true,
+			},
+			wantEvents: []string{
+				proto.UIEventDisplayPanesHidden,
+				proto.UIEventChooseWindowShown,
+			},
+		},
+		{
+			name: "switch chooser modes emits hide then show",
+			setup: func(st *clientUIState) {
+				st.chooser = &chooserState{mode: chooserModeWindow}
+			},
+			action: uiActionShowChooser{chooser: &chooserState{mode: chooserModeTree}},
+			wantState: clientUIStateSnapshot{
+				dirty:           true,
+				chooser:         string(chooserModeTree),
+				copyModePaneIDs: []uint32{},
+				inputIdle:       true,
+			},
+			wantEvents: []string{
+				proto.UIEventChooseWindowHidden,
+				proto.UIEventChooseTreeShown,
+			},
+		},
+		{
+			name: "re-showing same chooser mode stays silent but dirty",
+			setup: func(st *clientUIState) {
+				st.chooser = &chooserState{mode: chooserModeTree}
+			},
+			action: uiActionShowChooser{chooser: &chooserState{mode: chooserModeTree}},
+			wantState: clientUIStateSnapshot{
+				dirty:           true,
+				chooser:         string(chooserModeTree),
+				copyModePaneIDs: []uint32{},
+				inputIdle:       true,
+			},
+		},
+		{
+			name: "hide chooser emits hidden event",
+			setup: func(st *clientUIState) {
+				st.chooser = &chooserState{mode: chooserModeWindow}
+			},
+			action: uiActionHideChooser{},
+			wantState: clientUIStateSnapshot{
+				dirty:           true,
+				copyModePaneIDs: []uint32{},
+				inputIdle:       true,
+			},
+			wantEvents: []string{proto.UIEventChooseWindowHidden},
+		},
+		{
+			name: "first copy mode enters active state",
+			action: uiActionEnterCopyMode{
+				paneID: 1,
+				mode:   new(copymode.CopyMode),
+			},
+			wantState: clientUIStateSnapshot{
+				dirty:           true,
+				copyModePaneIDs: []uint32{1},
+				inputIdle:       true,
+			},
+			wantEvents: []string{proto.UIEventCopyModeShown},
+		},
+		{
+			name: "additional copy-mode pane keeps visibility active without event",
+			setup: func(st *clientUIState) {
+				st.copyModes[1] = new(copymode.CopyMode)
+			},
+			action: uiActionEnterCopyMode{
+				paneID: 2,
+				mode:   new(copymode.CopyMode),
+			},
+			wantState: clientUIStateSnapshot{
+				dirty:           true,
+				copyModePaneIDs: []uint32{1, 2},
+				inputIdle:       true,
+			},
+		},
+		{
+			name: "re-entering copy mode for the same pane is a no-op",
+			setup: func(st *clientUIState) {
+				st.copyModes[1] = existingCopyMode
+			},
+			action: uiActionEnterCopyMode{
+				paneID: 1,
+				mode:   new(copymode.CopyMode),
+			},
+			wantState: clientUIStateSnapshot{
+				copyModePaneIDs: []uint32{1},
+				inputIdle:       true,
+			},
+			assert: func(t *testing.T, st *clientUIState) {
+				t.Helper()
+				if st.copyModes[1] != existingCopyMode {
+					t.Fatal("re-entering copy mode should keep the existing copy-mode state")
+				}
+			},
+		},
+		{
+			name: "exiting one of multiple copy-mode panes stays visible",
+			setup: func(st *clientUIState) {
+				st.copyModes[1] = new(copymode.CopyMode)
+				st.copyModes[2] = new(copymode.CopyMode)
+			},
+			action: uiActionExitCopyMode{paneID: 1},
+			wantState: clientUIStateSnapshot{
+				dirty:           true,
+				copyModePaneIDs: []uint32{2},
+				inputIdle:       true,
+			},
+		},
+		{
+			name: "exiting last copy-mode pane hides active state",
+			setup: func(st *clientUIState) {
+				st.copyModes[2] = new(copymode.CopyMode)
+			},
+			action: uiActionExitCopyMode{paneID: 2},
+			wantState: clientUIStateSnapshot{
+				dirty:           true,
+				copyModePaneIDs: []uint32{},
+				inputIdle:       true,
+			},
+			wantEvents: []string{proto.UIEventCopyModeHidden},
+		},
+		{
+			name:   "input busy emits event only on change",
+			action: uiActionSetInputIdle{idle: false},
+			wantState: clientUIStateSnapshot{
+				copyModePaneIDs: []uint32{},
+				inputIdle:       false,
+			},
+			wantEvents: []string{proto.UIEventInputBusy},
+		},
+		{
+			name: "setting input busy again is a no-op",
+			setup: func(st *clientUIState) {
+				st.inputIdle = false
+			},
+			action: uiActionSetInputIdle{idle: false},
+			wantState: clientUIStateSnapshot{
+				copyModePaneIDs: []uint32{},
+				inputIdle:       false,
+			},
+		},
+		{
+			name: "returning to input idle emits idle event",
+			setup: func(st *clientUIState) {
+				st.inputIdle = false
+			},
+			action: uiActionSetInputIdle{idle: true},
+			wantState: clientUIStateSnapshot{
+				copyModePaneIDs: []uint32{},
+				inputIdle:       true,
+			},
+			wantEvents: []string{proto.UIEventInputIdle},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			st := newClientUIState()
+			if tt.setup != nil {
+				tt.setup(&st)
+			}
+
+			result := st.reduce(tt.action)
+
+			assertClientUIState(t, st, tt.wantState)
+			assertUIEvents(t, result.uiEvents, tt.wantEvents)
+			if tt.assert != nil {
+				tt.assert(t, &st)
+			}
+		})
+	}
+}
+
+func TestClientUIStateDirtyLifecycle(t *testing.T) {
+	t.Parallel()
+
+	st := newClientUIState()
+	assertClientUIState(t, st, clientUIStateSnapshot{
+		copyModePaneIDs: []uint32{},
+		inputIdle:       true,
 	})
-}
 
-func TestClientUIStateReduceSetInputIdleEmitsOnlyOnChange(t *testing.T) {
-	t.Parallel()
-
-	st := newClientUIState()
-
-	effects := st.reduce(uiActionSetInputIdle{idle: false})
-	assertUIEvents(t, effects.uiEvents, []string{proto.UIEventInputBusy})
-
-	effects = st.reduce(uiActionSetInputIdle{idle: false})
-	assertUIEvents(t, effects.uiEvents, nil)
-
-	effects = st.reduce(uiActionSetInputIdle{idle: true})
-	assertUIEvents(t, effects.uiEvents, []string{proto.UIEventInputIdle})
-}
-
-func TestClientUIStateReducePaneOutputPreservesMessage(t *testing.T) {
-	t.Parallel()
-
-	st := newClientUIState()
-	st.message = "cannot minimize"
-
-	effects := st.reduce(uiActionPaneOutput{})
-
-	if st.message != "cannot minimize" {
-		t.Fatalf("message = %q, want preserved command feedback", st.message)
+	st.reduce(uiActionSetMessage{message: "cannot minimize"})
+	if !st.dirty {
+		t.Fatal("set message should mark state dirty")
 	}
+
+	st.markRendered()
+	if st.dirty {
+		t.Fatal("markRendered should clear dirty state")
+	}
+
+	st.reduce(uiActionPaneOutput{})
 	if !st.dirty {
 		t.Fatal("pane output should mark state dirty")
 	}
-	assertUIEvents(t, effects.uiEvents, nil)
-}
 
-func TestClientUIStateReduceShowChooserHidesDisplayPanesAndEmitsTransitions(t *testing.T) {
-	t.Parallel()
-
-	st := newClientUIState()
-	st.displayPanes = &displayPanesState{}
-
-	effects := st.reduce(uiActionShowChooser{
-		chooser: &chooserState{mode: chooserModeWindow},
-	})
-	assertUIEvents(t, effects.uiEvents, []string{
-		proto.UIEventDisplayPanesHidden,
-		proto.UIEventChooseWindowShown,
-	})
-
-	effects = st.reduce(uiActionShowChooser{
-		chooser: &chooserState{mode: chooserModeTree},
-	})
-	assertUIEvents(t, effects.uiEvents, []string{
-		proto.UIEventChooseWindowHidden,
-		proto.UIEventChooseTreeShown,
-	})
-
-	effects = st.reduce(uiActionShowChooser{
-		chooser: &chooserState{mode: chooserModeTree},
-	})
-	assertUIEvents(t, effects.uiEvents, nil)
-}
-
-func TestClientUIStateReduceCopyModeVisibilityTransitions(t *testing.T) {
-	t.Parallel()
-
-	st := newClientUIState()
-
-	effects := st.reduce(uiActionEnterCopyMode{
-		paneID: 1,
-		mode:   new(copymode.CopyMode),
-	})
-	assertUIEvents(t, effects.uiEvents, []string{proto.UIEventCopyModeShown})
-
-	effects = st.reduce(uiActionEnterCopyMode{
-		paneID: 2,
-		mode:   new(copymode.CopyMode),
-	})
-	assertUIEvents(t, effects.uiEvents, nil)
-
-	effects = st.reduce(uiActionExitCopyMode{paneID: 1})
-	assertUIEvents(t, effects.uiEvents, nil)
-
-	effects = st.reduce(uiActionExitCopyMode{paneID: 2})
-	assertUIEvents(t, effects.uiEvents, []string{proto.UIEventCopyModeHidden})
+	st.markRendered()
+	if st.dirty {
+		t.Fatal("markRendered should clear dirty state after pane output")
+	}
 }
 
 func assertUIEvents(t *testing.T, got, want []string) {


### PR DESCRIPTION
Fixes LAB-297.

## Summary
- expand `clientUIState` coverage into a table-driven reducer/state-transition matrix
- collapse render-loop assertions into a table-driven `handleRenderMsg` effect matrix
- add dirty lifecycle coverage for `markRendered()` and pane-output/message clearing

## Testing
- `go test ./internal/client -run 'TestClientUIState|TestHandleRenderMsg|TestRenderCoalesced' -count=1`
- `go test ./test -run 'Test(DisplayPanes|Chooser|Events|WaitUI|TypeKeys|HeadlessClient|CopyMode)' -count=1`

## Review
- manual diff review completed
- simplification pass completed
