### PR TITLE
Add v0.1.0 launch trajectory design doc

### DIFF
--- a/docs/designs/v010-launch.md
+++ b/docs/designs/v010-launch.md
@@ -53,7 +53,7 @@ Shipping v0.1.0 breaks the cycle and introduces real feedback.
 | # | Prerequisite | Owner | Depends on | Target |
 |---|-------------|-------|-----------|--------|
 | 1 | Merge PR #252 (v0.1.0 prep) | Agent | CI green | Day 1 |
-| 2 | Resolve open PRs (#283, #284, #285, #286 + any new) | Agents | Each PR's CI | Day 1-2 |
+| 2 | Resolve all open PRs (list shifts daily — check `gh pr list`) | Agents | Each PR's CI | Day 1-2 |
 | 3 | Flaky test stabilization | Agents (amux4, amux5, amux8) | — | Day 1-2 |
 | 4 | Create `weill-labs/homebrew-tap` repo + add `brews:` to `.goreleaser.yaml` | Agent | — | Day 2 |
 | 5 | Test full `brew install` flow end-to-end | Human | #4 | Day 2 |


### PR DESCRIPTION
## Summary

CEO-level strategic plan for shipping v0.1.0, produced by `/plan-ceo-review` with SELECTIVE EXPANSION mode.

- Defines the 12-month goal: Homebrew-installable tmux replacement
- Chooses "Ship Early, Iterate with Users" over feature-complete-first
- Accepts 4 launch cherry-picks: blog post, tmux compatibility checklist, Homebrew tap, flaky test stabilization
- Assigns owners and sequencing across 11 prerequisites with a 3-day timeline
- Includes no-go criteria, rollback plan, flake severity definitions, and post-launch plan (reduce to 3-4 agents)

## Motivation

The project has 9 parallel Codex agents generating ~30 PRs/day with no external user signal. This plan breaks the echo chamber by shipping a public release and letting user feedback drive prioritization.

## Testing

Design doc only — no code changes.

## Review focus

- Are the launch prerequisites complete and correctly sequenced?
- Are the no-go criteria the right gates?
- Is the post-launch plan (reduce agents, add diagnostics) reasonable?

Survived 2 rounds of adversarial spec review (12 issues caught and fixed, final score ~8/10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)