### PR TITLE
test: cover remote connect auto-deploy

### DIFF
--- a/test/remote_hotreload_test.go
+++ b/test/remote_hotreload_test.go
@@ -1,26 +1,16 @@
 package test
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
 
-// TestRemotePaneViaSSH verifies that a remote proxy pane can be created
-// over a real SSH connection (in-process test server) and is functional.
-func TestRemotePaneViaSSH(t *testing.T) {
-	t.Parallel()
+func assertRemotePaneViaSSH(t *testing.T, h *ServerHarness) {
+	t.Helper()
 
-	addr, keyFile := setupTestSSH(t)
-	h := newServerHarnessWithConfig(t, 80, 24, remoteTestConfig(addr, keyFile))
-
-	// Create a remote pane
-	out := h.runCmd("split", "--host", "test-remote")
-	t.Logf("split --host test-remote: %s", strings.TrimSpace(out))
-	if strings.Contains(out, "error") || strings.Contains(out, "Error") {
-		t.Fatalf("remote split failed: %s", out)
-	}
-
-	// Verify remote pane exists with correct metadata
+	// Verify remote pane exists with correct metadata.
 	c := h.captureJSON()
 	if len(c.Panes) != 2 {
 		t.Fatalf("expected 2 panes, got %d", len(c.Panes))
@@ -30,9 +20,9 @@ func TestRemotePaneViaSSH(t *testing.T) {
 		t.Fatalf("pane-2 host = %q, want %q", p2.Host, "test-remote")
 	}
 
-	// Verify remote pane is functional (shell is running on localhost via SSH)
+	// Verify remote pane is functional (shell is running on localhost via SSH).
 	h.sendKeys("pane-2", "echo REMOTE_SHELL_OK", "Enter")
-	out = h.runCmd("wait-for", "pane-2", "REMOTE_SHELL_OK", "--timeout", "5s")
+	out := h.runCmd("wait-for", "pane-2", "REMOTE_SHELL_OK", "--timeout", "5s")
 	if strings.Contains(out, "timeout") {
 		t.Fatalf("remote pane should accept input: %s", out)
 	}
@@ -48,9 +38,49 @@ func TestRemotePaneViaSSH(t *testing.T) {
 		t.Fatalf("remote pane should resolve amux terminfo: %s", out)
 	}
 
-	// Verify host metadata is visible in list command
+	// Verify host metadata is visible in list command.
 	listOut := h.runCmd("list")
 	if !strings.Contains(listOut, "test-remote") {
 		t.Errorf("list should show test-remote, got:\n%s", listOut)
 	}
+}
+
+// TestRemotePaneViaSSH verifies that a remote proxy pane can be created
+// over a real SSH connection (in-process test server) and is functional.
+func TestRemotePaneViaSSH(t *testing.T) {
+	t.Parallel()
+
+	addr, keyFile := setupTestSSH(t)
+	h := newServerHarnessWithConfig(t, 80, 24, remoteTestConfig(addr, keyFile))
+
+	splitRemotePane(t, h)
+	assertRemotePaneViaSSH(t, h)
+}
+
+// TestRemotePaneViaSSHAutoDeploy verifies that the real remote connect path
+// auto-deploys amux when the remote host starts without AMUX_BIN and without
+// any usable amux in PATH.
+func TestRemotePaneViaSSHAutoDeploy(t *testing.T) {
+	t.Parallel()
+
+	fixture := setupTestSSHNoPreload(t)
+	remoteBin := filepath.Join(fixture.HomeDir, ".local", "bin", "amux")
+	if _, err := os.Stat(remoteBin); err == nil {
+		t.Fatalf("remote amux unexpectedly present before connect: %s", remoteBin)
+	} else if !os.IsNotExist(err) {
+		t.Fatalf("stat remote amux before connect: %v", err)
+	}
+
+	h := newServerHarnessWithConfig(t, 80, 24, remoteTestConfig(fixture.Addr, fixture.KeyFile))
+	splitRemotePane(t, h)
+
+	info, err := os.Stat(remoteBin)
+	if err != nil {
+		t.Fatalf("expected deployed remote amux at %s: %v", remoteBin, err)
+	}
+	if info.Mode()&0111 == 0 {
+		t.Fatalf("deployed remote amux should be executable, mode=%v", info.Mode())
+	}
+
+	assertRemotePaneViaSSH(t, h)
 }

--- a/test/test_sshd_test.go
+++ b/test/test_sshd_test.go
@@ -23,48 +23,34 @@ import (
 	"golang.org/x/term"
 )
 
+type testSSHServerOptions struct {
+	preloadAmux bool
+}
+
+type testSSHServer struct {
+	Addr    string
+	HomeDir string
+}
+
+type testSSHFixture struct {
+	Addr    string
+	KeyFile string
+	HomeDir string
+}
+
 // startTestSSHServer starts a lightweight in-process SSH server that:
 //   - Listens on localhost:0 (random port)
 //   - Accepts public key auth with the given authorized key
 //   - Handles "session"/"exec" requests by running commands via sh -c
 //   - Handles "direct-streamlocal@openssh.com" by dialing Unix sockets
 //
-// Returns the server address (host:port).
+// Returns the server address (host:port) and remote HOME directory.
 // The server is shut down via t.Cleanup.
-func startTestSSHServer(t *testing.T, authorizedKey ssh.PublicKey) string {
+func startTestSSHServer(t *testing.T, authorizedKey ssh.PublicKey, opts testSSHServerOptions) testSSHServer {
 	t.Helper()
 
-	// Build env for exec'd commands with the test amux binary in PATH.
-	// On CI runners the binary is in a temp dir not in PATH.
-	execEnv := os.Environ()
-	binDir := filepath.Dir(amuxBin)
 	homeDir := t.TempDir()
-	sawPath := false
-	sawHome := false
-	if !strings.Contains(os.Getenv("PATH"), binDir) {
-		for i, e := range execEnv {
-			if strings.HasPrefix(e, "PATH=") {
-				sawPath = true
-				execEnv[i] = "PATH=" + binDir + ":" + e[5:]
-				break
-			}
-		}
-	}
-	for i, e := range execEnv {
-		if strings.HasPrefix(e, "HOME=") {
-			sawHome = true
-			execEnv[i] = "HOME=" + homeDir
-		}
-	}
-	if !sawPath {
-		execEnv = append(execEnv, "PATH="+binDir+":"+os.Getenv("PATH"))
-	}
-	if !sawHome {
-		execEnv = append(execEnv, "HOME="+homeDir)
-	}
-	// Override the binary used by buildEnsureServerCmd so the remote server
-	// always uses the test binary, not a stale ~/.local/bin/amux.
-	execEnv = append(execEnv, "AMUX_BIN="+amuxBin)
+	execEnv := buildTestSSHExecEnv(homeDir, opts)
 
 	// Generate ed25519 host key
 	_, hostPriv, err := ed25519.GenerateKey(rand.Reader)
@@ -116,7 +102,39 @@ func startTestSSHServer(t *testing.T, authorizedKey ssh.PublicKey) string {
 		}
 	}()
 
-	return ln.Addr().String()
+	return testSSHServer{
+		Addr:    ln.Addr().String(),
+		HomeDir: homeDir,
+	}
+}
+
+func buildTestSSHExecEnv(homeDir string, opts testSSHServerOptions) []string {
+	execEnv := append([]string{}, os.Environ()...)
+	execEnv = upsertEnv(execEnv, "HOME", homeDir)
+
+	if !opts.preloadAmux {
+		// Keep only base system tools on PATH so the remote starts without any
+		// usable amux binary unless HostConn auto-deploy uploads one.
+		execEnv = upsertEnv(execEnv, "PATH", "/usr/bin:/bin")
+		return removeEnv(execEnv, "AMUX_BIN")
+	}
+
+	execEnv = upsertEnv(execEnv, "PATH", filepath.Dir(amuxBin)+":"+os.Getenv("PATH"))
+	// Force the happy-path fixture to use the freshly built test binary rather
+	// than any previously installed amux on the machine.
+	return upsertEnv(execEnv, "AMUX_BIN", amuxBin)
+}
+
+func removeEnv(env []string, key string) []string {
+	prefix := key + "="
+	filtered := env[:0]
+	for _, entry := range env {
+		if strings.HasPrefix(entry, prefix) {
+			continue
+		}
+		filtered = append(filtered, entry)
+	}
+	return filtered
 }
 
 func amuxServerPIDsForHome(homeDir string) []string {
@@ -449,9 +467,22 @@ func generateTestKeyPair(t *testing.T) (ssh.PublicKey, []byte) {
 // manipulation required — works identically on macOS and Linux.
 func setupTestSSH(t *testing.T) (addr string, keyFile string) {
 	t.Helper()
+	fixture := setupTestSSHWithOptions(t, testSSHServerOptions{preloadAmux: true})
+	return fixture.Addr, fixture.KeyFile
+}
 
+// setupTestSSHNoPreload starts the SSH fixture without AMUX_BIN and without
+// a preloaded amux in PATH. Remote connect must deploy ~/.local/bin/amux to
+// make the session functional.
+func setupTestSSHNoPreload(t *testing.T) testSSHFixture {
+	t.Helper()
+	return setupTestSSHWithOptions(t, testSSHServerOptions{})
+}
+
+func setupTestSSHWithOptions(t *testing.T, opts testSSHServerOptions) testSSHFixture {
+	t.Helper()
 	pubKey, privPEM := generateTestKeyPair(t)
-	addr = startTestSSHServer(t, pubKey)
+	server := startTestSSHServer(t, pubKey, opts)
 
 	// Write private key to a temp file for the amux identity_file config
 	keyPath := filepath.Join(t.TempDir(), "id_test")
@@ -459,7 +490,11 @@ func setupTestSSH(t *testing.T) (addr string, keyFile string) {
 		t.Fatalf("writing test key: %v", err)
 	}
 
-	return addr, keyPath
+	return testSSHFixture{
+		Addr:    server.Addr,
+		KeyFile: keyPath,
+		HomeDir: server.HomeDir,
+	}
 }
 
 // remoteTestConfig returns a TOML config with a "test-remote" host pointing


### PR DESCRIPTION
## Summary
- add a no-preload SSH fixture mode so remote integration tests can start without `AMUX_BIN` or a preinstalled `amux`
- add end-to-end coverage that `split --host` auto-deploys `amux` and brings up a functional remote pane
- reuse the existing remote pane assertions across the SSH happy-path and auto-deploy tests

## Testing
- `go test ./test -run 'TestRemotePaneViaSSH|TestRemotePaneViaSSHAutoDeploy|TestHostsCommand|TestDisconnectAndReconnect' -count=1`

## Notes
- `go test ./test -count=1` hung in the `go test` driver on this machine after the rebase, so the PR uses the targeted remote regression slice above instead of claiming a clean full-package run.

Refs LAB-308
