### PR TITLE
test: cover remaining client UI reducer edge cases

### DIFF
--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -704,6 +704,7 @@ func TestHandleRenderMsgEffects(t *testing.T) {
 				if !cr.ShowDisplayPanes() {
 					t.Fatal("ShowDisplayPanes should succeed")
 				}
+				cr.ShowPrefixMessage("No binding for C-a f")
 			},
 			msg: &RenderMsg{Typ: RenderMsgLayout, Layout: threePane80x23()},
 			wantKinds: []clientEffectKind{
@@ -712,11 +713,17 @@ func TestHandleRenderMsgEffects(t *testing.T) {
 				clientEffectStopScheduledRender,
 				clientEffectRenderNow,
 			},
-			wantUIEvents: []string{proto.UIEventDisplayPanesHidden},
+			wantUIEvents: []string{
+				proto.UIEventDisplayPanesHidden,
+				proto.UIEventPrefixMessageHidden,
+			},
 			assert: func(t *testing.T, cr *ClientRenderer, _ []clientEffect) {
 				t.Helper()
 				if cr.DisplayPanesActive() {
 					t.Fatal("display panes should be cleared after structural layout change")
+				}
+				if got := cr.prefixMessage(); got != "" {
+					t.Fatalf("structural layout change should clear prefix message, got %q", got)
 				}
 			},
 		},
@@ -775,6 +782,21 @@ func TestHandleRenderMsgEffects(t *testing.T) {
 				t.Helper()
 				if !cr.InCopyMode(1) {
 					t.Fatal("pane-1 should be in copy mode")
+				}
+			},
+		},
+		{
+			name: "additional copy-mode pane renders immediately without re-emitting shown",
+			prepare: func(_ *testing.T, cr *ClientRenderer) {
+				cr.EnterCopyMode(1)
+			},
+			msg:          &RenderMsg{Typ: RenderMsgCopyMode, PaneID: 2},
+			wantKinds:    []clientEffectKind{clientEffectStopScheduledRender, clientEffectRenderNow},
+			wantUIEvents: []string{},
+			assert: func(t *testing.T, cr *ClientRenderer, _ []clientEffect) {
+				t.Helper()
+				if !cr.InCopyMode(1) || !cr.InCopyMode(2) {
+					t.Fatal("both panes should be in copy mode after entering a second pane")
 				}
 			},
 		},

--- a/internal/client/ui_state_test.go
+++ b/internal/client/ui_state_test.go
@@ -97,6 +97,34 @@ func TestClientUIStateReduceTransitions(t *testing.T) {
 			wantEvents: []string{proto.UIEventPrefixMessageHidden},
 		},
 		{
+			name: "non-structural layout change preserves chooser and input state",
+			setup: func(st *clientUIState) {
+				st.chooser = &chooserState{mode: chooserModeTree}
+				st.message = "cannot minimize"
+				st.inputIdle = false
+			},
+			action: uiActionHandleLayout{structureChanged: false},
+			wantState: clientUIStateSnapshot{
+				dirty:           true,
+				chooser:         string(chooserModeTree),
+				copyModePaneIDs: []uint32{},
+				inputIdle:       false,
+			},
+			wantEvents: []string{proto.UIEventPrefixMessageHidden},
+		},
+		{
+			name: "layout update without transient UI only marks dirty",
+			setup: func(st *clientUIState) {
+				st.inputIdle = false
+			},
+			action: uiActionHandleLayout{structureChanged: false},
+			wantState: clientUIStateSnapshot{
+				dirty:           true,
+				copyModePaneIDs: []uint32{},
+				inputIdle:       false,
+			},
+		},
+		{
 			name: "pane output preserves message and marks dirty",
 			setup: func(st *clientUIState) {
 				st.message = "No binding for C-a f"
@@ -119,6 +147,32 @@ func TestClientUIStateReduceTransitions(t *testing.T) {
 				inputIdle:       true,
 			},
 			wantEvents: []string{proto.UIEventPrefixMessageShown},
+		},
+		{
+			name: "setting a new visible message replaces text without re-emitting shown",
+			setup: func(st *clientUIState) {
+				st.message = "No binding for C-a f"
+			},
+			action: uiActionSetMessage{message: "No binding for C-a g"},
+			wantState: clientUIStateSnapshot{
+				dirty:           true,
+				message:         "No binding for C-a g",
+				copyModePaneIDs: []uint32{},
+				inputIdle:       true,
+			},
+		},
+		{
+			name: "setting message empty hides prefix state",
+			setup: func(st *clientUIState) {
+				st.message = "cannot minimize"
+			},
+			action: uiActionSetMessage{message: ""},
+			wantState: clientUIStateSnapshot{
+				dirty:           true,
+				copyModePaneIDs: []uint32{},
+				inputIdle:       true,
+			},
+			wantEvents: []string{proto.UIEventPrefixMessageHidden},
 		},
 		{
 			name: "clear message removes text and marks dirty",
@@ -164,6 +218,14 @@ func TestClientUIStateReduceTransitions(t *testing.T) {
 				inputIdle:       true,
 			},
 			wantEvents: []string{proto.UIEventDisplayPanesHidden},
+		},
+		{
+			name:   "hide display panes is a no-op when already hidden",
+			action: uiActionHideDisplayPanes{},
+			wantState: clientUIStateSnapshot{
+				copyModePaneIDs: []uint32{},
+				inputIdle:       true,
+			},
 		},
 		{
 			name: "show chooser hides display panes and emits transitions",
@@ -224,6 +286,14 @@ func TestClientUIStateReduceTransitions(t *testing.T) {
 				inputIdle:       true,
 			},
 			wantEvents: []string{proto.UIEventChooseWindowHidden},
+		},
+		{
+			name:   "hide chooser is a no-op when already hidden",
+			action: uiActionHideChooser{},
+			wantState: clientUIStateSnapshot{
+				copyModePaneIDs: []uint32{},
+				inputIdle:       true,
+			},
 		},
 		{
 			name: "first copy mode enters active state",


### PR DESCRIPTION
## Summary
- add the remaining reducer edge cases for metadata-only layout updates, message replacement, and no-op overlay hides
- extend render-message coverage for structural prefix-message clearing and entering copy mode in a second pane
- keep the change scoped to the small LAB-297 delta left after #288 landed on `origin/main`

## Testing
- `go test ./internal/client/...`
- `go test ./test -run 'TestMinimizeFailureFeedbackClearsOnNextLocalInput|TestUnsupportedPrefixKeyShowsFeedback|TestUnsupportedPrefixKeyFeedbackClearsOnLiteralPrefix'
- `go test ./test -run 'TestWaitBusy_WaitsForChildProcessNotPromptEcho|TestWaitBusy_EventBased|TestCaptureJSON_AgentStatus_Transition'
- `go test ./...`

Refs LAB-297
