### PR TITLE
docs: require logged $postmortem path

### DIFF
--- a/.agents/skills/amux-pr-workflow/SKILL.md
+++ b/.agents/skills/amux-pr-workflow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: amux-pr-workflow
-description: Use when creating, updating, reviewing, or merging a PR in this repo. Covers first-push rebases, review and simplification passes, benchmark baseline requirements, and post-merge postmortems.
+description: Use when creating, updating, reviewing, or merging a PR in this repo. Covers first-push rebases, review and simplification passes, benchmark baseline requirements, and post-merge `$postmortem` runs.
 ---
 
 # amux PR Workflow
@@ -25,8 +25,9 @@ Use this skill when the task involves `git push`, `gh pr create`, `gh pr merge`,
 - If a rebase triggers broad noisy local failures, verify with a targeted regression slice before making invasive code changes.
 - After merge, verify local state explicitly: confirm the checkout is on `main`, the worktree is clean, and `HEAD` matches `origin/main`.
 - After merge, any follow-up fix goes on a fresh branch and PR. Do not make extra commits on local `main`.
-- After merge, explicitly invoke the `postmortem` skill workflow. A short manual summary does not count. Turn action items into issues or doc updates.
-- If the `postmortem` skill is skipped, say so explicitly and give the reason. Do not imply it was done.
+- After merge, explicitly run `$postmortem`. A short manual summary does not count. Turn action items into issues or doc updates.
+- Do not say `$postmortem` ran unless you have the logged `~/.local/share/postmortems/...` path.
+- If `$postmortem` is skipped, say so explicitly and give the reason. Do not imply it was done.
 
 ## Workflow
 
@@ -42,8 +43,8 @@ Use this skill when the task involves `git push`, `gh pr create`, `gh pr merge`,
 10. Before merging, re-check the live PR state and mergeability after the latest green checks. If `main` moved, fetch and rebase again before merging.
 11. After merge, verify local state with `git branch --show-current`, `git status --short --branch`, and `git rev-parse HEAD origin/main`. If needed, run `git checkout main && git pull --ff-only`.
 12. If you discover a follow-up fix after merge, create a fresh branch before editing.
-13. After merge, explicitly invoke the `postmortem` skill to capture learnings, pain points, and follow-up actions. Do not substitute a brief ad hoc summary.
-14. In the final merge closeout, state either the logged `postmortem` path or the explicit reason it was skipped.
+13. After merge, explicitly run `$postmortem` to capture learnings, pain points, and follow-up actions. Do not substitute a brief ad hoc summary.
+14. In the final merge closeout, state either the logged `$postmortem` path or the explicit reason it was skipped.
 
 ## Output Checklist
 
@@ -58,5 +59,5 @@ Use this skill when the task involves `git push`, `gh pr create`, `gh pr merge`,
 - Benchmark baseline section added when relevant.
 - Local post-merge state verified.
 - Follow-up fixes kept off local `main`.
-- `postmortem` skill explicitly invoked after merge, or a clear skip reason is stated.
-- If `postmortem` ran, the log path is reported.
+- `$postmortem` explicitly run after merge, or a clear skip reason is stated.
+- If `$postmortem` ran, the log path is reported.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,7 +122,7 @@ GitHub PRs for this repo are squash-only. `gh pr merge --merge` and `gh pr merge
 
 After merging, verify local state explicitly: check that the checkout is on `main`, the worktree is clean, and `HEAD` matches `origin/main`. If you need another change after the merge, start a fresh branch and PR instead of committing follow-up fixes on local `main`.
 
-After merging, explicitly run the `postmortem` skill. A short manual recap is not a substitute for the postmortem workflow.
+After merging, explicitly run `$postmortem`. A short manual recap is not a substitute for the postmortem workflow, and do not claim it ran unless you have the logged `~/.local/share/postmortems/...` path.
 
 ### Include Baseline Numbers In Performance PRs
 


### PR DESCRIPTION
## Summary
- switch repo docs to use explicit `$postmortem` invocation
- require the saved `~/.local/share/postmortems/...` path before claiming it ran
- keep merge closeout guidance aligned between `CLAUDE.md` and the PR workflow skill

## Testing
- Docs only; no tests run
