### PR TITLE
LAB-280: add client capability negotiation and kitty keyboard support

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,6 +327,12 @@ Default prefix: `Ctrl-a`. Configurable via `~/.config/amux/config.toml` (see [Co
 
 Config file: `~/.config/amux/config.toml` (or set `AMUX_CONFIG` env var).
 
+For attach-time terminal capability negotiation, you can override auto-detection
+with `AMUX_CLIENT_CAPABILITIES`. Use a comma-separated list of capability names:
+`kitty_keyboard`, `hyperlinks`, `rich_underline`, `cursor_metadata`,
+`prompt_markers`, `graphics_placeholder`. Special values: `all`,
+`legacy`/`none`, and `-name` or `!name` to disable a specific capability.
+
 ### Session
 
 ```toml

--- a/internal/client/ansi_filter.go
+++ b/internal/client/ansi_filter.go
@@ -1,0 +1,60 @@
+package client
+
+import (
+	"strings"
+
+	"github.com/weill-labs/amux/internal/proto"
+)
+
+// filterRenderedANSI strips escape sequences the attached client did not
+// negotiate support for, while preserving visible text content.
+func filterRenderedANSI(rendered string, caps proto.ClientCapabilities) string {
+	if caps.Hyperlinks {
+		return rendered
+	}
+	return stripOSC8Hyperlinks(rendered)
+}
+
+// stripOSC8Hyperlinks removes OSC 8 hyperlink open/close sequences while
+// leaving the linked text intact.
+func stripOSC8Hyperlinks(s string) string {
+	var out strings.Builder
+	out.Grow(len(s))
+
+	for i := 0; i < len(s); {
+		if s[i] == '\033' && i+1 < len(s) && s[i+1] == ']' {
+			end, payload, ok := parseOSCSequence(s, i)
+			if ok {
+				if strings.HasPrefix(payload, "8;") {
+					i = end
+					continue
+				}
+				out.WriteString(s[i:end])
+				i = end
+				continue
+			}
+		}
+
+		out.WriteByte(s[i])
+		i++
+	}
+
+	return out.String()
+}
+
+// parseOSCSequence parses one OSC sequence starting at s[i]=='\033' and
+// s[i+1]==']'. It returns the end index (exclusive), payload, and whether a
+// complete OSC terminator was found.
+func parseOSCSequence(s string, i int) (int, string, bool) {
+	j := i + 2
+	for j < len(s) {
+		if s[j] == '\007' {
+			return j + 1, s[i+2 : j], true
+		}
+		if s[j] == '\033' && j+1 < len(s) && s[j+1] == '\\' {
+			return j + 2, s[i+2 : j], true
+		}
+		j++
+	}
+	return 0, "", false
+}

--- a/internal/client/ansi_filter_test.go
+++ b/internal/client/ansi_filter_test.go
@@ -1,0 +1,33 @@
+package client
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/weill-labs/amux/internal/proto"
+)
+
+func TestFilterRenderedANIOSC8Hyperlinks(t *testing.T) {
+	t.Parallel()
+
+	rendered := "\033]8;https://example.com;\alink\033]8;;\a plain"
+
+	t.Run("preserves hyperlinks when supported", func(t *testing.T) {
+		t.Parallel()
+		got := filterRenderedANSI(rendered, proto.ClientCapabilities{Hyperlinks: true})
+		if got != rendered {
+			t.Fatalf("filterRenderedANSI() = %q, want unchanged", got)
+		}
+	})
+
+	t.Run("strips hyperlinks when unsupported", func(t *testing.T) {
+		t.Parallel()
+		got := filterRenderedANSI(rendered, proto.ClientCapabilities{})
+		if strings.Contains(got, "\033]8;") {
+			t.Fatalf("filtered output should not contain OSC 8 sequences, got %q", got)
+		}
+		if !strings.Contains(got, "link plain") {
+			t.Fatalf("filtered output should preserve visible text, got %q", got)
+		}
+	})
+}

--- a/internal/client/attach.go
+++ b/internal/client/attach.go
@@ -12,6 +12,7 @@ import (
 	"syscall"
 	"time"
 
+	uv "github.com/charmbracelet/ultraviolet"
 	"github.com/weill-labs/amux/internal/config"
 	"github.com/weill-labs/amux/internal/copymode"
 	"github.com/weill-labs/amux/internal/mouse"
@@ -29,6 +30,27 @@ func handleDisplayPaneSelection(cr *ClientRenderer, sender *messageSender, b byt
 	if ok {
 		sender.Command("focus", []string{fmt.Sprintf("%d", paneID)})
 	}
+}
+
+func terminalEnterSequence(caps proto.ClientCapabilities) string {
+	var b strings.Builder
+	b.WriteString(render.AltScreenEnter)
+	b.WriteString(render.MouseEnable)
+	if caps.KittyKeyboard {
+		b.WriteString(render.KittyKeyboardEnable)
+	}
+	return b.String()
+}
+
+func terminalExitSequence(caps proto.ClientCapabilities) string {
+	var b strings.Builder
+	if caps.KittyKeyboard {
+		b.WriteString(render.KittyKeyboardDisable)
+	}
+	b.WriteString(render.MouseDisable)
+	b.WriteString(render.AltScreenExit)
+	b.WriteString(render.ResetTitle)
+	return b.String()
 }
 
 // RunSession connects to an existing server or starts one, then enters raw
@@ -70,11 +92,14 @@ func RunSession(sessionName string) error {
 	}
 
 	// Send attach
+	attachCaps := advertisedAttachCapabilities()
+	negotiatedAttachCaps := proto.NegotiateClientCapabilities(attachCaps)
 	if err := sender.Send(&proto.Message{
-		Type:    proto.MsgTypeAttach,
-		Session: sessionName,
-		Cols:    cols,
-		Rows:    rows,
+		Type:               proto.MsgTypeAttach,
+		Session:            sessionName,
+		Cols:               cols,
+		Rows:               rows,
+		AttachCapabilities: attachCaps,
 	}); err != nil {
 		return fmt.Errorf("sending attach: %w", err)
 	}
@@ -84,17 +109,15 @@ func RunSession(sessionName string) error {
 	if err != nil {
 		return fmt.Errorf("raw mode: %w", err)
 	}
-	os.Stdout.Write([]byte(render.AltScreenEnter))
-	os.Stdout.Write([]byte(render.MouseEnable))
+	os.Stdout.Write([]byte(terminalEnterSequence(negotiatedAttachCaps)))
 	defer func() {
-		os.Stdout.Write([]byte(render.MouseDisable))
-		os.Stdout.Write([]byte(render.AltScreenExit))
-		os.Stdout.Write([]byte(render.ResetTitle))
+		os.Stdout.Write([]byte(terminalExitSequence(negotiatedAttachCaps)))
 		term.Restore(fd, oldState)
 	}()
 
 	// Client-side renderer with per-pane emulators
 	cr := NewClientRendererWithScrollback(cols, rows, scrollbackLines)
+	cr.SetCapabilities(negotiatedAttachCaps)
 	cr.OnUIEvent = func(name string) {
 		_ = sender.Send(&proto.Message{
 			Type:    proto.MsgTypeUIEvent,
@@ -426,6 +449,36 @@ func RunSession(sessionName string) error {
 			return false
 		}
 
+		shouldHandleKeyLocally := func(key byte) bool {
+			if prefix || repeatKey != 0 {
+				return true
+			}
+			if key == kb.Prefix {
+				return true
+			}
+			_, ok := altHJKL[key]
+			return altEsc && ok
+		}
+
+		processKeyBytes := func(data []byte, forward *[]byte) bool {
+			for _, b := range data {
+				if processKeyByte(b, forward) {
+					return true
+				}
+			}
+			return false
+		}
+
+		shouldHandleDecodedKeyLocally := func(key uv.KeyPressEvent) bool {
+			if prefix || repeatKey != 0 {
+				return true
+			}
+			if keyPressMatchesByte(key, kb.Prefix) {
+				return true
+			}
+			return key.MatchString("alt+h", "alt+j", "alt+k", "alt+l")
+		}
+
 		// Read stdin in a dedicated goroutine, sending chunks on stdinCh.
 		// This allows the main input loop to select between stdin and
 		// injected keystrokes from type-keys.
@@ -511,7 +564,7 @@ func RunSession(sessionName string) error {
 			}
 
 			if cr.ChooserActive() {
-				action := cr.HandleChooserInput(raw)
+				action := cr.HandleChooserInput(normalizeLocalInput(raw))
 				if action.bell {
 					io.WriteString(os.Stdout, "\a")
 				}
@@ -546,22 +599,50 @@ func RunSession(sessionName string) error {
 				}
 
 				// Process flushed bytes (normal input that passed through parser)
-				for _, fb := range flushed {
+				for _, decoded := range decodeInputEvents(flushed) {
+					normalized := normalizeLocalInput(decoded.raw)
+					if len(normalized) == 0 {
+						normalized = decoded.raw
+					}
+
 					if cr.DisplayPanesActive() {
-						handleDisplayPaneSelection(cr, sender, fb)
+						if len(normalized) > 0 {
+							handleDisplayPaneSelection(cr, sender, normalized[0])
+						} else {
+							cr.HideDisplayPanes()
+						}
 						if data := cr.RenderDiff(); data != "" {
 							io.WriteString(os.Stdout, data)
 						}
 						continue
 					}
+
 					if cr.ActiveCopyMode() != nil {
-						copyInput = append(copyInput, fb)
+						copyInput = append(copyInput, normalized...)
 						continue
 					}
-					if processKeyByte(fb, &forward) {
-						shouldExit = true
-						break
+
+					if key, ok := decoded.event.(uv.KeyPressEvent); ok {
+						if shouldHandleDecodedKeyLocally(key) {
+							if processKeyBytes(normalized, &forward) {
+								shouldExit = true
+								break
+							}
+							continue
+						}
+						forward = append(forward, decoded.raw...)
+						continue
 					}
+
+					if len(decoded.raw) == 1 && shouldHandleKeyLocally(decoded.raw[0]) {
+						if processKeyByte(decoded.raw[0], &forward) {
+							shouldExit = true
+							break
+						}
+						continue
+					}
+
+					forward = append(forward, decoded.raw...)
 				}
 			}
 
@@ -571,7 +652,7 @@ func RunSession(sessionName string) error {
 			}
 
 			if cr.ActiveCopyMode() != nil {
-				copyInput = append(copyInput, mouseParser.FlushPending()...)
+				copyInput = append(copyInput, normalizeLocalInput(mouseParser.FlushPending())...)
 			}
 			flushCopyInput()
 
@@ -590,7 +671,7 @@ func RunSession(sessionName string) error {
 		return nil
 	case <-triggerReload:
 		if execPath != "" {
-			ExecSelf(execPath, sender, fd, oldState)
+			ExecSelf(execPath, sender, fd, oldState, negotiatedAttachCaps)
 		}
 		// ExecSelf replaces the process; if we get here, exec failed fatally
 		return nil
@@ -635,7 +716,7 @@ func formatKeyName(b byte) string {
 
 // ExecSelf replaces the current process with the binary at execPath.
 // Pre-validates the binary before tearing down the connection.
-func ExecSelf(execPath string, sender *messageSender, fd int, oldState *term.State) {
+func ExecSelf(execPath string, sender *messageSender, fd int, oldState *term.State, caps proto.ClientCapabilities) {
 	// Pre-validate: binary must exist and be accessible
 	if _, err := os.Stat(execPath); err != nil {
 		return
@@ -647,9 +728,7 @@ func ExecSelf(execPath string, sender *messageSender, fd int, oldState *term.Sta
 
 	// Restore terminal state
 	term.Restore(fd, oldState)
-	os.Stdout.Write([]byte(render.MouseDisable))
-	os.Stdout.Write([]byte(render.AltScreenExit))
-	os.Stdout.Write([]byte(render.ResetTitle))
+	os.Stdout.Write([]byte(terminalExitSequence(caps)))
 
 	// Flush coverage data before exec (which replaces the process image
 	// without running atexit handlers). No-op if not built with -cover.

--- a/internal/client/attach_test.go
+++ b/internal/client/attach_test.go
@@ -1,0 +1,68 @@
+package client
+
+import (
+	"testing"
+
+	"github.com/weill-labs/amux/internal/proto"
+	"github.com/weill-labs/amux/internal/render"
+)
+
+func TestTerminalEnterSequence(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		caps proto.ClientCapabilities
+		want string
+	}{
+		{
+			name: "legacy",
+			want: render.AltScreenEnter + render.MouseEnable,
+		},
+		{
+			name: "kitty keyboard",
+			caps: proto.ClientCapabilities{KittyKeyboard: true},
+			want: render.AltScreenEnter + render.MouseEnable + render.KittyKeyboardEnable,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := terminalEnterSequence(tt.caps); got != tt.want {
+				t.Fatalf("terminalEnterSequence() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTerminalExitSequence(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		caps proto.ClientCapabilities
+		want string
+	}{
+		{
+			name: "legacy",
+			want: render.MouseDisable + render.AltScreenExit + render.ResetTitle,
+		},
+		{
+			name: "kitty keyboard",
+			caps: proto.ClientCapabilities{KittyKeyboard: true},
+			want: render.KittyKeyboardDisable + render.MouseDisable + render.AltScreenExit + render.ResetTitle,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := terminalExitSequence(tt.caps); got != tt.want {
+				t.Fatalf("terminalExitSequence() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/client/capabilities.go
+++ b/internal/client/capabilities.go
@@ -1,0 +1,150 @@
+package client
+
+import (
+	"os"
+	"strings"
+
+	"github.com/weill-labs/amux/internal/proto"
+)
+
+type envLookup func(string) (string, bool)
+
+const (
+	terminalUnknown = iota
+	terminalKitty
+	terminalGhostty
+	terminalWezTerm
+	terminalITerm2
+)
+
+// advertisedAttachCapabilities detects terminal support for the attach-time
+// capability registry. This is intentionally conservative: if a feature cannot
+// be inferred reliably from the client environment, we leave it disabled.
+func advertisedAttachCapabilities() *proto.ClientCapabilities {
+	caps := detectAttachCapabilitiesFromEnv(os.LookupEnv)
+	return &caps
+}
+
+func detectAttachCapabilitiesFromEnv(lookup envLookup) proto.ClientCapabilities {
+	caps := detectedAttachCapabilities(detectTerminalFlavor(lookup))
+	if raw, ok := lookup("AMUX_CLIENT_CAPABILITIES"); ok {
+		caps = applyCapabilityOverride(caps, raw)
+	}
+	return caps
+}
+
+func detectedAttachCapabilities(flavor int) proto.ClientCapabilities {
+	switch flavor {
+	case terminalKitty:
+		return proto.ClientCapabilities{
+			KittyKeyboard:       true,
+			Hyperlinks:          true,
+			RichUnderline:       true,
+			PromptMarkers:       true,
+			GraphicsPlaceholder: true,
+		}
+	case terminalGhostty:
+		return proto.ClientCapabilities{
+			KittyKeyboard:       true,
+			Hyperlinks:          true,
+			RichUnderline:       true,
+			CursorMetadata:      true,
+			PromptMarkers:       true,
+			GraphicsPlaceholder: true,
+		}
+	case terminalWezTerm:
+		// WezTerm supports kitty keyboard protocol, but its docs describe it as
+		// config-gated rather than on by default, so we do not advertise it here.
+		return proto.ClientCapabilities{
+			Hyperlinks:          true,
+			RichUnderline:       true,
+			CursorMetadata:      true,
+			PromptMarkers:       true,
+			GraphicsPlaceholder: true,
+		}
+	case terminalITerm2:
+		return proto.ClientCapabilities{
+			KittyKeyboard:  true,
+			Hyperlinks:     true,
+			CursorMetadata: true,
+			PromptMarkers:  true,
+		}
+	default:
+		return proto.ClientCapabilities{}
+	}
+}
+
+func applyCapabilityOverride(base proto.ClientCapabilities, raw string) proto.ClientCapabilities {
+	caps := base
+	for _, token := range strings.Split(raw, ",") {
+		token = strings.ToLower(strings.TrimSpace(token))
+		if token == "" {
+			continue
+		}
+
+		switch token {
+		case "all":
+			caps = proto.KnownClientCapabilities()
+			continue
+		case "legacy", "none":
+			caps = proto.ClientCapabilities{}
+			continue
+		}
+
+		enabled := true
+		if strings.HasPrefix(token, "-") || strings.HasPrefix(token, "!") {
+			enabled = false
+			token = strings.TrimSpace(token[1:])
+		}
+		setCapability(&caps, token, enabled)
+	}
+	return caps
+}
+
+func setCapability(caps *proto.ClientCapabilities, name string, enabled bool) bool {
+	switch name {
+	case "kitty_keyboard":
+		caps.KittyKeyboard = enabled
+	case "hyperlinks":
+		caps.Hyperlinks = enabled
+	case "rich_underline":
+		caps.RichUnderline = enabled
+	case "cursor_metadata":
+		caps.CursorMetadata = enabled
+	case "prompt_markers":
+		caps.PromptMarkers = enabled
+	case "graphics_placeholder":
+		caps.GraphicsPlaceholder = enabled
+	default:
+		return false
+	}
+	return true
+}
+
+func detectTerminalFlavor(lookup envLookup) int {
+	termProgram := envValue(lookup, "TERM_PROGRAM")
+	term := envValue(lookup, "TERM")
+
+	switch {
+	case envSet(lookup, "KITTY_WINDOW_ID") || strings.Contains(term, "kitty") || strings.EqualFold(termProgram, "kitty"):
+		return terminalKitty
+	case envSet(lookup, "GHOSTTY_RESOURCES_DIR") || strings.EqualFold(termProgram, "ghostty") || strings.Contains(term, "ghostty"):
+		return terminalGhostty
+	case envSet(lookup, "WEZTERM_EXECUTABLE") || envSet(lookup, "WEZTERM_PANE") || termProgram == "WezTerm":
+		return terminalWezTerm
+	case envSet(lookup, "ITERM_SESSION_ID") || termProgram == "iTerm.app":
+		return terminalITerm2
+	default:
+		return terminalUnknown
+	}
+}
+
+func envValue(lookup envLookup, key string) string {
+	value, _ := lookup(key)
+	return value
+}
+
+func envSet(lookup envLookup, key string) bool {
+	value, ok := lookup(key)
+	return ok && value != ""
+}

--- a/internal/client/capabilities_test.go
+++ b/internal/client/capabilities_test.go
@@ -1,0 +1,173 @@
+package client
+
+import (
+	"testing"
+
+	"github.com/weill-labs/amux/internal/proto"
+)
+
+func TestDetectAttachCapabilitiesFromEnv(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		env  map[string]string
+		want proto.ClientCapabilities
+	}{
+		{
+			name: "unknown terminal defaults to legacy",
+			env: map[string]string{
+				"TERM":         "screen-256color",
+				"TERM_PROGRAM": "tmux",
+			},
+			want: proto.ClientCapabilities{},
+		},
+		{
+			name: "kitty",
+			env: map[string]string{
+				"TERM": "xterm-kitty",
+			},
+			want: proto.ClientCapabilities{
+				KittyKeyboard:       true,
+				Hyperlinks:          true,
+				RichUnderline:       true,
+				PromptMarkers:       true,
+				GraphicsPlaceholder: true,
+			},
+		},
+		{
+			name: "ghostty",
+			env: map[string]string{
+				"TERM_PROGRAM": "ghostty",
+			},
+			want: proto.ClientCapabilities{
+				KittyKeyboard:       true,
+				Hyperlinks:          true,
+				RichUnderline:       true,
+				CursorMetadata:      true,
+				PromptMarkers:       true,
+				GraphicsPlaceholder: true,
+			},
+		},
+		{
+			name: "wezterm",
+			env: map[string]string{
+				"WEZTERM_EXECUTABLE": "/Applications/WezTerm.app/Contents/MacOS/wezterm",
+			},
+			want: proto.ClientCapabilities{
+				Hyperlinks:          true,
+				RichUnderline:       true,
+				CursorMetadata:      true,
+				PromptMarkers:       true,
+				GraphicsPlaceholder: true,
+			},
+		},
+		{
+			name: "iterm2",
+			env: map[string]string{
+				"ITERM_SESSION_ID": "w0t0p0:ABC123",
+			},
+			want: proto.ClientCapabilities{
+				KittyKeyboard:  true,
+				Hyperlinks:     true,
+				CursorMetadata: true,
+				PromptMarkers:  true,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := detectAttachCapabilitiesFromEnv(mapLookup(tt.env)); got != tt.want {
+				t.Fatalf("detectAttachCapabilitiesFromEnv() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDetectAttachCapabilitiesFromEnvOverride(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		env  map[string]string
+		want proto.ClientCapabilities
+	}{
+		{
+			name: "override unknown terminal",
+			env: map[string]string{
+				"TERM_PROGRAM":             "tmux",
+				"AMUX_CLIENT_CAPABILITIES": "hyperlinks,prompt_markers",
+			},
+			want: proto.ClientCapabilities{
+				Hyperlinks:    true,
+				PromptMarkers: true,
+			},
+		},
+		{
+			name: "disable detected capability",
+			env: map[string]string{
+				"TERM":                     "xterm-kitty",
+				"AMUX_CLIENT_CAPABILITIES": "-kitty_keyboard,-graphics_placeholder",
+			},
+			want: proto.ClientCapabilities{
+				Hyperlinks:    true,
+				RichUnderline: true,
+				PromptMarkers: true,
+			},
+		},
+		{
+			name: "legacy then selective enable",
+			env: map[string]string{
+				"TERM_PROGRAM":             "ghostty",
+				"AMUX_CLIENT_CAPABILITIES": "legacy,hyperlinks,cursor_metadata",
+			},
+			want: proto.ClientCapabilities{
+				Hyperlinks:     true,
+				CursorMetadata: true,
+			},
+		},
+		{
+			name: "all then disable one",
+			env: map[string]string{
+				"TERM_PROGRAM":             "tmux",
+				"AMUX_CLIENT_CAPABILITIES": "all,-graphics_placeholder",
+			},
+			want: proto.ClientCapabilities{
+				KittyKeyboard:  true,
+				Hyperlinks:     true,
+				RichUnderline:  true,
+				CursorMetadata: true,
+				PromptMarkers:  true,
+			},
+		},
+		{
+			name: "ignore unknown token",
+			env: map[string]string{
+				"TERM_PROGRAM":             "tmux",
+				"AMUX_CLIENT_CAPABILITIES": "hyperlinks,not_real,prompt_markers",
+			},
+			want: proto.ClientCapabilities{
+				Hyperlinks:    true,
+				PromptMarkers: true,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := detectAttachCapabilitiesFromEnv(mapLookup(tt.env)); got != tt.want {
+				t.Fatalf("detectAttachCapabilitiesFromEnv() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func mapLookup(values map[string]string) envLookup {
+	return func(key string) (string, bool) {
+		value, ok := values[key]
+		return value, ok
+	}
+}

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -43,6 +43,21 @@ func NewClientRendererWithScrollback(width, height, scrollbackLines int) *Client
 	return cr
 }
 
+func (cr *ClientRenderer) SetCapabilities(caps proto.ClientCapabilities) {
+	cr.renderer.SetCapabilities(caps)
+}
+
+func (cr *ClientRenderer) Capabilities() proto.ClientCapabilities {
+	return cr.renderer.Capabilities()
+}
+
+// HandleLayout processes a layout snapshot from the server. Returns true if the
+// layout structure changed (panes moved/resized/added/removed).
+func (cr *ClientRenderer) HandleLayout(snap *proto.LayoutSnapshot) bool {
+	structureChanged, result := cr.handleLayoutResult(snap)
+	cr.emitUIEvents(result.uiEvents)
+	return structureChanged
+}
 func (cr *ClientRenderer) handleLayoutResult(snap *proto.LayoutSnapshot) (bool, clientUIResult) {
 	structureChanged := cr.renderer.HandleLayout(snap)
 	validPanes := make(map[uint32]bool)
@@ -146,7 +161,7 @@ func (cr *ClientRenderer) paneLookup(state *clientSnapshot) func(uint32) render.
 			return nil
 		}
 		cm := state.ui.copyModes[paneID]
-		return &clientPaneData{emu: emu, info: info, cm: cm}
+		return &clientPaneData{emu: emu, info: info, cm: cm, caps: rendererState.capabilities}
 	}
 }
 
@@ -607,16 +622,19 @@ type clientPaneData struct {
 	emu  mux.TerminalEmulator
 	info proto.PaneSnapshot
 	cm   *copymode.CopyMode // nil when not in copy mode
+	caps proto.ClientCapabilities
 }
 
 func (c *clientPaneData) RenderScreen(active bool) string {
+	var rendered string
 	if c.cm != nil {
-		return c.cm.RenderViewport()
+		rendered = c.cm.RenderViewport()
+	} else if !active {
+		rendered = c.emu.RenderWithoutCursorBlock()
+	} else {
+		rendered = c.emu.Render()
 	}
-	if !active {
-		return c.emu.RenderWithoutCursorBlock()
-	}
-	return c.emu.Render()
+	return filterRenderedANSI(rendered, c.caps)
 }
 
 func (c *clientPaneData) CellAt(col, row int, active bool) render.ScreenCell {

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -108,6 +108,24 @@ func buildTestRenderer(t *testing.T) *ClientRenderer {
 	return cr
 }
 
+func TestClientRendererCapabilities(t *testing.T) {
+	t.Parallel()
+
+	caps := proto.ClientCapabilities{
+		KittyKeyboard:  true,
+		Hyperlinks:     true,
+		PromptMarkers:  true,
+		CursorMetadata: true,
+	}
+
+	cr := NewClientRenderer(80, 24)
+	cr.SetCapabilities(caps)
+
+	if got := cr.Capabilities(); got != caps {
+		t.Fatalf("Capabilities() = %+v, want %+v", got, caps)
+	}
+}
+
 func twoPane80x23Zoomed(paneID uint32) *proto.LayoutSnapshot {
 	snap := twoPane80x23()
 	snap.ZoomedPaneID = paneID
@@ -373,6 +391,36 @@ func TestClientRendererCapturePaneText(t *testing.T) {
 	empty := cr.CapturePaneText(999, false)
 	if empty != "" {
 		t.Error("nonexistent pane should return empty")
+	}
+}
+
+func TestClientRendererCapturePaneTextStripsHyperlinksWhenUnsupported(t *testing.T) {
+	t.Parallel()
+
+	cr := NewClientRenderer(80, 24)
+	cr.HandleLayout(twoPane80x23())
+	cr.HandlePaneOutput(1, []byte("\033]8;;https://example.com\033\\test-link\033]8;;\033\\"))
+
+	ansi := cr.CapturePaneText(1, true)
+	if strings.Contains(ansi, "\033]8;") {
+		t.Fatalf("CapturePaneText should strip OSC 8 when hyperlinks are unsupported, got %q", ansi)
+	}
+	if !strings.Contains(ansi, "test-link") {
+		t.Fatalf("CapturePaneText should preserve visible link text, got %q", ansi)
+	}
+}
+
+func TestClientRendererCapturePaneTextPreservesHyperlinksWhenSupported(t *testing.T) {
+	t.Parallel()
+
+	cr := NewClientRenderer(80, 24)
+	cr.SetCapabilities(proto.ClientCapabilities{Hyperlinks: true})
+	cr.HandleLayout(twoPane80x23())
+	cr.HandlePaneOutput(1, []byte("\033]8;;https://example.com\033\\test-link\033]8;;\033\\"))
+
+	ansi := cr.CapturePaneText(1, true)
+	if !strings.Contains(ansi, "\033]8;") {
+		t.Fatalf("CapturePaneText should preserve OSC 8 when hyperlinks are supported, got %q", ansi)
 	}
 }
 

--- a/internal/client/client_test_helpers_test.go
+++ b/internal/client/client_test_helpers_test.go
@@ -1,18 +1,9 @@
 package client
 
-import (
-	"github.com/weill-labs/amux/internal/mux"
-	"github.com/weill-labs/amux/internal/proto"
-)
+import "github.com/weill-labs/amux/internal/mux"
 
 func NewClientRenderer(width, height int) *ClientRenderer {
 	return NewClientRendererWithScrollback(width, height, mux.DefaultScrollbackLines)
-}
-
-func (cr *ClientRenderer) HandleLayout(snap *proto.LayoutSnapshot) bool {
-	structureChanged, result := cr.handleLayoutResult(snap)
-	cr.emitUIEvents(result.uiEvents)
-	return structureChanged
 }
 
 func (cr *ClientRenderer) Capture(stripANSI bool) string {

--- a/internal/client/input_keys.go
+++ b/internal/client/input_keys.go
@@ -1,0 +1,177 @@
+package client
+
+import (
+	"unicode"
+	"unicode/utf8"
+
+	uv "github.com/charmbracelet/ultraviolet"
+)
+
+type decodedInputEvent struct {
+	raw   []byte
+	event uv.Event
+}
+
+func decodeInputEvents(raw []byte) []decodedInputEvent {
+	decoder := uv.EventDecoder{}
+	events := make([]decodedInputEvent, 0, len(raw))
+	for len(raw) > 0 {
+		n, event := decoder.Decode(raw)
+		if n <= 0 {
+			n = 1
+		}
+		events = append(events, decodedInputEvent{
+			raw:   append([]byte(nil), raw[:n]...),
+			event: event,
+		})
+		raw = raw[n:]
+	}
+	return events
+}
+
+func normalizeLocalInput(raw []byte) []byte {
+	var out []byte
+	for _, decoded := range decodeInputEvents(raw) {
+		if key, ok := decoded.event.(uv.KeyPressEvent); ok {
+			if legacy := legacyBytesForKeyPress(key); len(legacy) > 0 {
+				out = append(out, legacy...)
+				continue
+			}
+		}
+		out = append(out, decoded.raw...)
+	}
+	return out
+}
+
+func keyPressMatchesByte(key uv.KeyPressEvent, want byte) bool {
+	legacy := legacyBytesForKeyPress(key)
+	return len(legacy) == 1 && legacy[0] == want
+}
+
+func legacyBytesForKeyPress(key uv.KeyPressEvent) []byte {
+	k := key.Key()
+
+	// Shifted printable keys should still behave like their textual byte form
+	// for local bindings such as prefix + M.
+	if k.Text != "" && k.Mod&^(uv.ModShift|uv.ModCapsLock) == 0 {
+		if ascii := asciiTextBytes(k.Text); len(ascii) > 0 {
+			return ascii
+		}
+	}
+
+	switch k.Mod {
+	case 0:
+		if seq := legacySpecialKeySequence(k.Code); len(seq) > 0 {
+			return seq
+		}
+	case uv.ModAlt:
+		if seq := legacySpecialKeySequence(k.Code); len(seq) > 0 {
+			return append([]byte{0x1b}, seq...)
+		}
+		if ascii, ok := asciiRuneByte(k.Code); ok {
+			return []byte{0x1b, ascii}
+		}
+	case uv.ModCtrl:
+		if b, ok := legacyCtrlByte(k.Code); ok {
+			return []byte{b}
+		}
+	case uv.ModCtrl | uv.ModAlt:
+		if b, ok := legacyCtrlByte(k.Code); ok {
+			return []byte{0x1b, b}
+		}
+	}
+
+	return nil
+}
+
+func asciiTextBytes(text string) []byte {
+	if text == "" {
+		return nil
+	}
+	buf := make([]byte, 0, len(text))
+	for len(text) > 0 {
+		r, size := utf8.DecodeRuneInString(text)
+		if r == utf8.RuneError || r > unicode.MaxASCII {
+			return nil
+		}
+		buf = append(buf, byte(r))
+		text = text[size:]
+	}
+	return buf
+}
+
+func asciiRuneByte(r rune) (byte, bool) {
+	if r < 0 || r > unicode.MaxASCII {
+		return 0, false
+	}
+	return byte(r), true
+}
+
+func legacyCtrlByte(code rune) (byte, bool) {
+	switch {
+	case code >= 'a' && code <= 'z':
+		return byte(code-'a') + 1, true
+	case code >= 'A' && code <= 'Z':
+		return byte(code-'A') + 1, true
+	}
+
+	switch code {
+	case '@', uv.KeySpace:
+		return 0x00, true
+	case '[', uv.KeyEscape:
+		return 0x1b, true
+	case '\\':
+		return 0x1c, true
+	case ']':
+		return 0x1d, true
+	case '^':
+		return 0x1e, true
+	case '_':
+		return 0x1f, true
+	case '?':
+		return 0x7f, true
+	case uv.KeyTab:
+		return '\t', true
+	case uv.KeyEnter:
+		return '\r', true
+	case uv.KeyBackspace:
+		return 0x08, true
+	default:
+		return 0, false
+	}
+}
+
+func legacySpecialKeySequence(code rune) []byte {
+	switch code {
+	case uv.KeyEnter:
+		return []byte{'\r'}
+	case uv.KeyTab:
+		return []byte{'\t'}
+	case uv.KeyEscape:
+		return []byte{0x1b}
+	case uv.KeyBackspace:
+		return []byte{0x7f}
+	case uv.KeyUp:
+		return []byte{0x1b, '[', 'A'}
+	case uv.KeyDown:
+		return []byte{0x1b, '[', 'B'}
+	case uv.KeyRight:
+		return []byte{0x1b, '[', 'C'}
+	case uv.KeyLeft:
+		return []byte{0x1b, '[', 'D'}
+	case uv.KeyHome:
+		return []byte{0x1b, '[', 'H'}
+	case uv.KeyEnd:
+		return []byte{0x1b, '[', 'F'}
+	case uv.KeyPgUp:
+		return []byte{0x1b, '[', '5', '~'}
+	case uv.KeyPgDown:
+		return []byte{0x1b, '[', '6', '~'}
+	case uv.KeyDelete:
+		return []byte{0x1b, '[', '3', '~'}
+	case uv.KeyInsert:
+		return []byte{0x1b, '[', '2', '~'}
+	default:
+		return nil
+	}
+}

--- a/internal/client/input_keys_test.go
+++ b/internal/client/input_keys_test.go
@@ -1,0 +1,71 @@
+package client
+
+import (
+	"bytes"
+	"testing"
+
+	uv "github.com/charmbracelet/ultraviolet"
+)
+
+func TestNormalizeLocalInput(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input []byte
+		want  []byte
+	}{
+		{
+			name:  "kitty ctrl-a",
+			input: []byte("\x1b[97;5u"),
+			want:  []byte{0x01},
+		},
+		{
+			name:  "kitty alt-h",
+			input: []byte("\x1b[104;3u"),
+			want:  []byte{0x1b, 'h'},
+		},
+		{
+			name:  "kitty escape",
+			input: []byte("\x1b[27u"),
+			want:  []byte{0x1b},
+		},
+		{
+			name:  "kitty shifted printable",
+			input: []byte("\x1b[97;2;65u"),
+			want:  []byte("A"),
+		},
+		{
+			name:  "unmapped kitty super key stays raw",
+			input: []byte("\x1b[97;9u"),
+			want:  []byte("\x1b[97;9u"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := normalizeLocalInput(tt.input); !bytes.Equal(got, tt.want) {
+				t.Fatalf("normalizeLocalInput(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDecodeInputEventsKittyCtrlA(t *testing.T) {
+	t.Parallel()
+
+	events := decodeInputEvents([]byte("\x1b[97;5u"))
+	if len(events) != 1 {
+		t.Fatalf("len(events) = %d, want 1", len(events))
+	}
+
+	key, ok := events[0].event.(uv.KeyPressEvent)
+	if !ok {
+		t.Fatalf("event type = %T, want uv.KeyPressEvent", events[0].event)
+	}
+	if !key.MatchString("ctrl+a") {
+		t.Fatalf("decoded key = %q, want ctrl+a", key.Keystroke())
+	}
+}

--- a/internal/client/panedata.go
+++ b/internal/client/panedata.go
@@ -14,15 +14,19 @@ var _ render.PaneData = (*PaneData)(nil)
 // interface. This is the basic adapter without copy mode support — the main
 // package wraps this with copy mode overlay.
 type PaneData struct {
-	Emu  mux.TerminalEmulator
-	Info proto.PaneSnapshot
+	Emu          mux.TerminalEmulator
+	Info         proto.PaneSnapshot
+	Capabilities proto.ClientCapabilities
 }
 
 func (p *PaneData) RenderScreen(active bool) string {
+	var rendered string
 	if !active {
-		return p.Emu.RenderWithoutCursorBlock()
+		rendered = p.Emu.RenderWithoutCursorBlock()
+	} else {
+		rendered = p.Emu.Render()
 	}
-	return p.Emu.Render()
+	return filterRenderedANSI(rendered, p.Capabilities)
 }
 
 func (p *PaneData) CellAt(col, row int, active bool) render.ScreenCell {

--- a/internal/client/panedata_test.go
+++ b/internal/client/panedata_test.go
@@ -30,6 +30,42 @@ func TestPaneDataRenderScreen(t *testing.T) {
 	}
 }
 
+func TestPaneDataRenderScreenStripsOSC8HyperlinksWhenUnsupported(t *testing.T) {
+	t.Parallel()
+
+	emu := newTestVTEmulator(40, 4)
+	if _, err := emu.Write([]byte("\033]8;;https://example.com\033\\test-link\033]8;;\033\\")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	pane := &PaneData{Emu: emu}
+	got := pane.RenderScreen(true)
+	if strings.Contains(got, "\033]8;") {
+		t.Fatalf("RenderScreen should strip OSC 8 when hyperlinks are unsupported, got %q", got)
+	}
+	if !strings.Contains(got, "test-link") {
+		t.Fatalf("RenderScreen should preserve visible link text, got %q", got)
+	}
+}
+
+func TestPaneDataRenderScreenPreservesOSC8HyperlinksWhenSupported(t *testing.T) {
+	t.Parallel()
+
+	emu := newTestVTEmulator(40, 4)
+	if _, err := emu.Write([]byte("\033]8;;https://example.com\033\\test-link\033]8;;\033\\")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	pane := &PaneData{
+		Emu:          emu,
+		Capabilities: proto.ClientCapabilities{Hyperlinks: true},
+	}
+	got := pane.RenderScreen(true)
+	if !strings.Contains(got, "\033]8;") {
+		t.Fatalf("RenderScreen should preserve OSC 8 when hyperlinks are supported, got %q", got)
+	}
+}
+
 func TestPaneDataCellAt(t *testing.T) {
 	t.Parallel()
 

--- a/internal/client/renderer.go
+++ b/internal/client/renderer.go
@@ -58,6 +58,7 @@ func (r *Renderer) HandleLayout(snap *proto.LayoutSnapshot) bool {
 			paneInfo:        make(map[uint32]proto.PaneSnapshot),
 			sessionName:     snap.SessionName,
 			sessionNotice:   snap.Notice,
+			capabilities:    prev.capabilities,
 			activePaneID:    snap.ActivePaneID,
 			zoomedPaneID:    snap.ZoomedPaneID,
 			width:           prev.width,
@@ -169,6 +170,21 @@ func (r *Renderer) Resize(width, height int) {
 		st.snapshot = &next
 		r.publishSnapshot(&next)
 	})
+}
+
+// SetCapabilities stores the negotiated attach capabilities for this client.
+func (r *Renderer) SetCapabilities(caps proto.ClientCapabilities) {
+	r.withActor(func(st *rendererActorState) {
+		next := *st.snapshot
+		next.capabilities = caps
+		st.snapshot = &next
+		r.publishSnapshot(&next)
+	})
+}
+
+// Capabilities returns the negotiated attach capabilities for this client.
+func (r *Renderer) Capabilities() proto.ClientCapabilities {
+	return r.loadSnapshot().capabilities
 }
 
 // ClearPrevGrid forces a full repaint on the next RenderDiff call.
@@ -325,7 +341,7 @@ func (r *Renderer) CapturePaneText(paneID uint32, includeANSI bool) string {
 		return ""
 	}
 	if includeANSI {
-		return emu.Render()
+		return filterRenderedANSI(emu.Render(), snap.capabilities)
 	}
 	return strings.Join(mux.EmulatorContentLines(emu), "\n")
 }
@@ -443,7 +459,7 @@ func (r *Renderer) paneLookupSnapshot(snap *rendererSnapshot, paneID uint32) ren
 	if !ok {
 		return nil
 	}
-	return &PaneData{Emu: emu, Info: info}
+	return &PaneData{Emu: emu, Info: info, Capabilities: snap.capabilities}
 }
 
 func (r *Renderer) mergeOverlay(snap *rendererSnapshot, overlay render.OverlayState) render.OverlayState {

--- a/internal/client/renderer_state.go
+++ b/internal/client/renderer_state.go
@@ -17,6 +17,7 @@ type rendererSnapshot struct {
 	zoomedPaneID    uint32
 	sessionName     string
 	sessionNotice   string
+	capabilities    proto.ClientCapabilities
 	width           int
 	height          int
 	windows         []proto.WindowSnapshot

--- a/internal/mouse/mouse.go
+++ b/internal/mouse/mouse.go
@@ -90,6 +90,7 @@ const (
 	stateEsc                // saw \033
 	stateBracket            // saw \033[
 	stateLt                 // saw \033[<
+	stateCSI                // saw \033[ and a non-mouse CSI sequence
 	stateParams             // accumulating digits and semicolons
 )
 
@@ -124,8 +125,33 @@ func (p *Parser) Feed(b byte) (Event, bool, []byte) {
 			p.buf = append(p.buf, b)
 			return Event{}, false, nil
 		}
-		// CSI but not mouse — flush
+		if isCSIFinalByte(b) {
+			p.buf = append(p.buf, b)
+			saved := p.flush(0)
+			return Event{}, false, saved
+		}
+		if isCSIIntermediateByte(b) || isCSIParamByte(b) {
+			p.state = stateCSI
+			p.buf = append(p.buf, b)
+			return Event{}, false, nil
+		}
 		saved := p.flush(b)
+		return Event{}, false, saved
+
+	case stateCSI:
+		p.buf = append(p.buf, b)
+		if len(p.buf) > 64 {
+			saved := p.flush(0)
+			return Event{}, false, saved
+		}
+		if isCSIFinalByte(b) {
+			saved := p.flush(0)
+			return Event{}, false, saved
+		}
+		if isCSIIntermediateByte(b) || isCSIParamByte(b) {
+			return Event{}, false, nil
+		}
+		saved := p.flush(0)
 		return Event{}, false, saved
 
 	case stateLt:
@@ -260,4 +286,16 @@ func splitSemicolons(b []byte) [][]byte {
 	}
 	parts = append(parts, b[start:])
 	return parts
+}
+
+func isCSIParamByte(b byte) bool {
+	return b >= 0x30 && b <= 0x3f
+}
+
+func isCSIIntermediateByte(b byte) bool {
+	return b >= 0x20 && b <= 0x2f
+}
+
+func isCSIFinalByte(b byte) bool {
+	return b >= 0x40 && b <= 0x7e
 }

--- a/internal/mouse/mouse_test.go
+++ b/internal/mouse/mouse_test.go
@@ -135,6 +135,19 @@ func TestNonMouseEscapeFlushes(t *testing.T) {
 	}
 }
 
+func TestNonMouseCSIUFlushesAsSingleSequence(t *testing.T) {
+	p := &Parser{}
+
+	events, flushed := feedAll(t, p, []byte("\033[97;5u"))
+
+	if len(events) != 0 {
+		t.Errorf("expected 0 events, got %d", len(events))
+	}
+	if string(flushed) != "\033[97;5u" {
+		t.Errorf("flushed: got %q, want %q", flushed, "\033[97;5u")
+	}
+}
+
 func TestNormalInputFlushes(t *testing.T) {
 	p := &Parser{}
 	events, flushed := feedAll(t, p, []byte("hello"))

--- a/internal/proto/capabilities.go
+++ b/internal/proto/capabilities.go
@@ -1,0 +1,83 @@
+package proto
+
+import "strings"
+
+// ClientCapabilities describes attach-time feature support for an amux client.
+// These flags let the server gate modern terminal features explicitly instead
+// of assuming every attached client supports the same escape semantics.
+type ClientCapabilities struct {
+	KittyKeyboard       bool `json:"kitty_keyboard,omitempty"`
+	Hyperlinks          bool `json:"hyperlinks,omitempty"`
+	RichUnderline       bool `json:"rich_underline,omitempty"`
+	CursorMetadata      bool `json:"cursor_metadata,omitempty"`
+	PromptMarkers       bool `json:"prompt_markers,omitempty"`
+	GraphicsPlaceholder bool `json:"graphics_placeholder,omitempty"`
+}
+
+// KnownClientCapabilities returns the capability set understood by this build.
+// Negotiation intersects an attach's advertised set with this registry.
+func KnownClientCapabilities() ClientCapabilities {
+	return ClientCapabilities{
+		KittyKeyboard:       true,
+		Hyperlinks:          true,
+		RichUnderline:       true,
+		CursorMetadata:      true,
+		PromptMarkers:       true,
+		GraphicsPlaceholder: true,
+	}
+}
+
+// NegotiateClientCapabilities returns the capability set enabled for an
+// attached client. A nil advertisement means the client is using the legacy
+// attach path and negotiates an empty capability set.
+func NegotiateClientCapabilities(advertised *ClientCapabilities) ClientCapabilities {
+	if advertised == nil {
+		return ClientCapabilities{}
+	}
+	return advertised.Intersect(KnownClientCapabilities())
+}
+
+// Intersect keeps only capabilities enabled in both sets.
+func (c ClientCapabilities) Intersect(other ClientCapabilities) ClientCapabilities {
+	return ClientCapabilities{
+		KittyKeyboard:       c.KittyKeyboard && other.KittyKeyboard,
+		Hyperlinks:          c.Hyperlinks && other.Hyperlinks,
+		RichUnderline:       c.RichUnderline && other.RichUnderline,
+		CursorMetadata:      c.CursorMetadata && other.CursorMetadata,
+		PromptMarkers:       c.PromptMarkers && other.PromptMarkers,
+		GraphicsPlaceholder: c.GraphicsPlaceholder && other.GraphicsPlaceholder,
+	}
+}
+
+// EnabledNames returns enabled capability names in stable display order.
+func (c ClientCapabilities) EnabledNames() []string {
+	names := make([]string, 0, 6)
+	if c.KittyKeyboard {
+		names = append(names, "kitty_keyboard")
+	}
+	if c.Hyperlinks {
+		names = append(names, "hyperlinks")
+	}
+	if c.RichUnderline {
+		names = append(names, "rich_underline")
+	}
+	if c.CursorMetadata {
+		names = append(names, "cursor_metadata")
+	}
+	if c.PromptMarkers {
+		names = append(names, "prompt_markers")
+	}
+	if c.GraphicsPlaceholder {
+		names = append(names, "graphics_placeholder")
+	}
+	return names
+}
+
+// Summary returns a compact stable string for logs, tests, and `list-clients`.
+func (c ClientCapabilities) Summary() string {
+	names := c.EnabledNames()
+	if len(names) == 0 {
+		return "legacy"
+	}
+	return strings.Join(names, ",")
+}

--- a/internal/proto/capabilities_test.go
+++ b/internal/proto/capabilities_test.go
@@ -1,0 +1,93 @@
+package proto
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestNegotiateClientCapabilities(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		advertised *ClientCapabilities
+		want       ClientCapabilities
+	}{
+		{
+			name:       "legacy attach omits capabilities",
+			advertised: nil,
+			want:       ClientCapabilities{},
+		},
+		{
+			name: "partial modern attach",
+			advertised: &ClientCapabilities{
+				Hyperlinks:     true,
+				PromptMarkers:  true,
+				CursorMetadata: true,
+			},
+			want: ClientCapabilities{
+				Hyperlinks:     true,
+				PromptMarkers:  true,
+				CursorMetadata: true,
+			},
+		},
+		{
+			name:       "all known capabilities",
+			advertised: ptrClientCaps(KnownClientCapabilities()),
+			want:       KnownClientCapabilities(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := NegotiateClientCapabilities(tt.advertised); got != tt.want {
+				t.Fatalf("NegotiateClientCapabilities() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestClientCapabilitiesEnabledNamesAndSummary(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		caps ClientCapabilities
+		want []string
+		text string
+	}{
+		{
+			name: "legacy",
+			caps: ClientCapabilities{},
+			want: []string{},
+			text: "legacy",
+		},
+		{
+			name: "stable ordering",
+			caps: ClientCapabilities{
+				GraphicsPlaceholder: true,
+				Hyperlinks:          true,
+				KittyKeyboard:       true,
+			},
+			want: []string{"kitty_keyboard", "hyperlinks", "graphics_placeholder"},
+			text: "kitty_keyboard,hyperlinks,graphics_placeholder",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := tt.caps.EnabledNames(); !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("EnabledNames() = %v, want %v", got, tt.want)
+			}
+			if got := tt.caps.Summary(); got != tt.text {
+				t.Fatalf("Summary() = %q, want %q", got, tt.text)
+			}
+		})
+	}
+}
+
+func ptrClientCaps(c ClientCapabilities) *ClientCapabilities {
+	return &c
+}

--- a/internal/proto/wire.go
+++ b/internal/proto/wire.go
@@ -60,6 +60,9 @@ type Message struct {
 
 	// MsgTypeAttach
 	Session string
+	// AttachCapabilities is optional. Nil means the client used the legacy
+	// attach path and did not advertise explicit capability support.
+	AttachCapabilities *ClientCapabilities
 
 	// MsgTypeCommand
 	CmdName string

--- a/internal/render/ansi.go
+++ b/internal/render/ansi.go
@@ -37,6 +37,15 @@ const (
 	MouseDisable = "\033[?1006l\033[?1002l"
 )
 
+// Kitty keyboard protocol mode sequences.
+const (
+	// KittyKeyboardEnable enables the kitty keyboard protocol in level 1 mode.
+	KittyKeyboardEnable = "\033[>1u"
+
+	// KittyKeyboardDisable restores legacy keyboard reporting.
+	KittyKeyboardDisable = "\033[<u"
+)
+
 // OSC (Operating System Command) sequences for terminal title.
 const (
 	AltScreenEnter = "\033[?1049h"

--- a/internal/server/attach_capabilities_test.go
+++ b/internal/server/attach_capabilities_test.go
@@ -1,0 +1,103 @@
+package server
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/weill-labs/amux/internal/mux"
+	"github.com/weill-labs/amux/internal/proto"
+	"github.com/weill-labs/amux/internal/render"
+)
+
+func TestHandleAttachStoresNegotiatedCapabilities(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		caps *proto.ClientCapabilities
+		want string
+	}{
+		{
+			name: "legacy attach",
+			caps: nil,
+			want: "legacy",
+		},
+		{
+			name: "partial modern attach",
+			caps: &proto.ClientCapabilities{
+				Hyperlinks:     true,
+				PromptMarkers:  true,
+				CursorMetadata: true,
+			},
+			want: "hyperlinks,cursor_metadata,prompt_markers",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			sess := newSession("test-attach-capabilities")
+			stopCrashCheckpointLoop(t, sess)
+			defer stopSessionBackgroundLoops(t, sess)
+
+			pane := newProxyPane(1, mux.PaneMeta{
+				Name:  "pane-1",
+				Host:  mux.DefaultHost,
+				Color: "f5e0dc",
+			}, 80, 23, nil, nil, func(data []byte) (int, error) { return len(data), nil })
+			pane.FeedOutput([]byte("hello from pane"))
+
+			w := mux.NewWindow(pane, 80, 24-render.GlobalBarHeight)
+			w.ID = 1
+			w.Name = "window-1"
+			sess.Windows = []*mux.Window{w}
+			sess.ActiveWindowID = w.ID
+			sess.Panes = []*mux.Pane{pane}
+
+			srv := &Server{sessions: map[string]*Session{sess.Name: sess}}
+			serverConn, clientConn := net.Pipe()
+			defer clientConn.Close()
+
+			done := make(chan struct{})
+			go func() {
+				defer close(done)
+				srv.handleAttach(serverConn, &Message{
+					Type:               MsgTypeAttach,
+					Session:            sess.Name,
+					Cols:               80,
+					Rows:               24,
+					AttachCapabilities: tt.caps,
+				})
+			}()
+
+			readMsgWithTimeout(t, clientConn)
+			readMsgWithTimeout(t, clientConn)
+			readUntil(t, clientConn, func(msg *Message) bool {
+				return msg.Type == MsgTypeLayout
+			})
+
+			clients, err := sess.queryClientList()
+			if err != nil {
+				t.Fatalf("queryClientList: %v", err)
+			}
+			if len(clients) != 1 {
+				t.Fatalf("len(queryClientList) = %d, want 1", len(clients))
+			}
+			if got := clients[0].capabilities; got != tt.want {
+				t.Fatalf("capabilities = %q, want %q", got, tt.want)
+			}
+
+			if err := WriteMsg(clientConn, &Message{Type: MsgTypeDetach}); err != nil {
+				t.Fatalf("WriteMsg detach: %v", err)
+			}
+
+			select {
+			case <-done:
+			case <-time.After(time.Second):
+				t.Fatal("handleAttach did not exit after detach")
+			}
+		})
+	}
+}

--- a/internal/server/client_conn.go
+++ b/internal/server/client_conn.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/weill-labs/amux/internal/mux"
+	"github.com/weill-labs/amux/internal/proto"
 )
 
 // ClientConn manages a single client connection to the server.
@@ -24,6 +25,7 @@ type ClientConn struct {
 	rows               int // last reported terminal height
 	writer             *clientWriter
 	typeKeyQueue       *pacedInputQueue
+	capabilities       proto.ClientCapabilities
 }
 
 type pendingMessage struct {
@@ -39,6 +41,14 @@ func NewClientConn(conn net.Conn) *ClientConn {
 		inputIdle: true,
 		writer:    newClientWriter(conn),
 	}
+}
+
+func (cc *ClientConn) setNegotiatedCapabilities(caps proto.ClientCapabilities) {
+	cc.capabilities = caps
+}
+
+func (cc *ClientConn) capabilitySummary() string {
+	return cc.capabilities.Summary()
 }
 
 // Send writes a message to the client. Thread-safe.

--- a/internal/server/commands.go
+++ b/internal/server/commands.go
@@ -1423,9 +1423,9 @@ func cmdListClients(ctx *CommandContext) {
 	}
 
 	var output strings.Builder
-	output.WriteString(fmt.Sprintf("%-10s %-15s %-10s\n", "CLIENT", "DISPLAY_PANES", "CHOOSER"))
+	output.WriteString(fmt.Sprintf("%-10s %-15s %-10s %s\n", "CLIENT", "DISPLAY_PANES", "CHOOSER", "CAPABILITIES"))
 	for _, cc := range clients {
-		output.WriteString(fmt.Sprintf("%-10s %-15s %-10s\n", cc.id, cc.displayPanes, cc.chooser))
+		output.WriteString(fmt.Sprintf("%-10s %-15s %-10s %s\n", cc.id, cc.displayPanes, cc.chooser, cc.capabilities))
 	}
 	ctx.reply(output.String())
 }

--- a/internal/server/protocol_test.go
+++ b/internal/server/protocol_test.go
@@ -2,7 +2,10 @@ package server
 
 import (
 	"bytes"
+	"reflect"
 	"testing"
+
+	"github.com/weill-labs/amux/internal/proto"
 )
 
 func TestWriteReadMsg(t *testing.T) {
@@ -21,7 +24,17 @@ func TestWriteReadMsg(t *testing.T) {
 		},
 		{
 			name: "attach message",
-			msg:  Message{Type: MsgTypeAttach, Session: "test-session", Cols: 80, Rows: 24},
+			msg: Message{
+				Type:    MsgTypeAttach,
+				Session: "test-session",
+				Cols:    80,
+				Rows:    24,
+				AttachCapabilities: &proto.ClientCapabilities{
+					Hyperlinks:     true,
+					PromptMarkers:  true,
+					CursorMetadata: true,
+				},
+			},
 		},
 		{
 			name: "detach message",
@@ -86,6 +99,9 @@ func TestWriteReadMsg(t *testing.T) {
 			}
 			if got.Session != tt.msg.Session {
 				t.Errorf("Session = %q, want %q", got.Session, tt.msg.Session)
+			}
+			if !reflect.DeepEqual(got.AttachCapabilities, tt.msg.AttachCapabilities) {
+				t.Errorf("AttachCapabilities = %+v, want %+v", got.AttachCapabilities, tt.msg.AttachCapabilities)
 			}
 			if got.CmdName != tt.msg.CmdName {
 				t.Errorf("CmdName = %q, want %q", got.CmdName, tt.msg.CmdName)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -12,6 +12,7 @@ import (
 	"github.com/weill-labs/amux/internal/config"
 	"github.com/weill-labs/amux/internal/hooks"
 	"github.com/weill-labs/amux/internal/mux"
+	"github.com/weill-labs/amux/internal/proto"
 	"github.com/weill-labs/amux/internal/remote"
 )
 
@@ -600,6 +601,7 @@ func (s *Server) handleAttach(conn net.Conn, msg *Message) {
 	cc := NewClientConn(conn)
 	cc.ID = fmt.Sprintf("client-%d", sess.clientCounter.Add(1))
 	cc.initTypeKeyQueue()
+	cc.setNegotiatedCapabilities(proto.NegotiateClientCapabilities(msg.AttachCapabilities))
 	cc.startBootstrap()
 
 	cols, rows := msg.Cols, msg.Rows

--- a/internal/server/session_queries.go
+++ b/internal/server/session_queries.go
@@ -49,6 +49,7 @@ type clientListEntry struct {
 	id           string
 	displayPanes string
 	chooser      string
+	capabilities string
 }
 
 type uiClientSnapshot struct {
@@ -248,6 +249,7 @@ func (s *Session) queryClientList() ([]clientListEntry, error) {
 				id:           cc.ID,
 				displayPanes: cc.displayPanesState(),
 				chooser:      cc.chooserState(),
+				capabilities: cc.capabilitySummary(),
 			})
 		}
 		return entries, nil

--- a/internal/server/session_queries_test.go
+++ b/internal/server/session_queries_test.go
@@ -189,3 +189,57 @@ func TestEnqueueUIWaitSubscribeErrors(t *testing.T) {
 		}
 	})
 }
+
+func TestQueryClientListIncludesCapabilities(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		cc   *ClientConn
+		want string
+	}{
+		{
+			name: "legacy client",
+			cc: &ClientConn{
+				ID:        "client-1",
+				inputIdle: true,
+			},
+			want: "legacy",
+		},
+		{
+			name: "modern client",
+			cc: &ClientConn{
+				ID:           "client-2",
+				inputIdle:    true,
+				capabilities: proto.ClientCapabilities{Hyperlinks: true, PromptMarkers: true},
+			},
+			want: "hyperlinks,prompt_markers",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			sess := newSession("test-query-client-list-capabilities")
+			stopCrashCheckpointLoop(t, sess)
+			defer stopSessionBackgroundLoops(t, sess)
+
+			mustSessionQuery(t, sess, func(sess *Session) struct{} {
+				sess.clients = []*ClientConn{tt.cc}
+				return struct{}{}
+			})
+
+			clients, err := sess.queryClientList()
+			if err != nil {
+				t.Fatalf("queryClientList: %v", err)
+			}
+			if len(clients) != 1 {
+				t.Fatalf("len(queryClientList) = %d, want 1", len(clients))
+			}
+			if got := clients[0].capabilities; got != tt.want {
+				t.Fatalf("capabilities = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/test/amux_harness_test.go
+++ b/test/amux_harness_test.go
@@ -125,6 +125,15 @@ func (h *AmuxHarness) sendKeys(keys ...string) {
 	h.outer.runCmd(args...)
 }
 
+func (h *AmuxHarness) sendKeysHex(data []byte) {
+	h.tb.Helper()
+	var hexParts []string
+	for _, b := range data {
+		hexParts = append(hexParts, fmt.Sprintf("%02x", b))
+	}
+	h.outer.runCmd("send-keys", "pane-1", "--hex", strings.Join(hexParts, ""))
+}
+
 // ---------------------------------------------------------------------------
 // Synchronization — zero-polling primitives on the inner server
 // ---------------------------------------------------------------------------

--- a/test/events_test.go
+++ b/test/events_test.go
@@ -397,10 +397,10 @@ func TestListClientsShowsDisplayPanesState(t *testing.T) {
 	h.client.sendUIEvent(proto.UIEventChooseWindowShown)
 
 	out := h.runCmd("list-clients")
-	if !strings.Contains(out, "CLIENT") || !strings.Contains(out, "DISPLAY_PANES") || !strings.Contains(out, "CHOOSER") {
+	if !strings.Contains(out, "CLIENT") || !strings.Contains(out, "DISPLAY_PANES") || !strings.Contains(out, "CHOOSER") || !strings.Contains(out, "CAPABILITIES") {
 		t.Fatalf("unexpected list-clients header: %s", out)
 	}
-	if !strings.Contains(out, "client-1") || !strings.Contains(out, "shown") || !strings.Contains(out, "window") {
+	if !strings.Contains(out, "client-1") || !strings.Contains(out, "shown") || !strings.Contains(out, "window") || !strings.Contains(out, "hyperlinks") {
 		t.Fatalf("list-clients should report shown state, got: %s", out)
 	}
 }

--- a/test/headless_client_test.go
+++ b/test/headless_client_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/weill-labs/amux/internal/client"
 	"github.com/weill-labs/amux/internal/mux"
+	"github.com/weill-labs/amux/internal/proto"
 	"github.com/weill-labs/amux/internal/server"
 )
 
@@ -41,11 +42,13 @@ func newHeadlessClient(sockPath, session string, cols, rows int) (*headlessClien
 		return nil, err
 	}
 
+	caps := proto.KnownClientCapabilities()
 	if err := server.WriteMsg(conn, &server.Message{
-		Type:    server.MsgTypeAttach,
-		Session: session,
-		Cols:    cols,
-		Rows:    rows,
+		Type:               server.MsgTypeAttach,
+		Session:            session,
+		Cols:               cols,
+		Rows:               rows,
+		AttachCapabilities: &caps,
 	}); err != nil {
 		conn.Close()
 		return nil, err
@@ -57,6 +60,7 @@ func newHeadlessClient(sockPath, session string, cols, rows int) (*headlessClien
 		done:     make(chan struct{}),
 		ready:    make(chan struct{}),
 	}
+	hc.renderer.SetCapabilities(proto.NegotiateClientCapabilities(&caps))
 
 	go hc.readLoop()
 

--- a/test/kitty_keyboard_pty_test.go
+++ b/test/kitty_keyboard_pty_test.go
@@ -1,0 +1,76 @@
+package test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/weill-labs/amux/internal/render"
+)
+
+func rawReadCommand(byteCount int) string {
+	return fmt.Sprintf(`old=$(stty -g); stty raw -echo; printf 'READY\n'; dd bs=1 count=%d 2>/dev/null | od -An -tx1 | tr -d ' \n'; printf '\n'; stty "$old"`, byteCount)
+}
+
+func TestPTYClientKittyKeyboardChangesPaneBytes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		env       string
+		wantKitty bool
+		readBytes int
+		wantHex   string
+	}{
+		{
+			name:      "legacy",
+			env:       "AMUX_CLIENT_CAPABILITIES=legacy",
+			wantKitty: false,
+			readBytes: 1,
+			wantHex:   "02",
+		},
+		{
+			name:      "kitty keyboard",
+			env:       "AMUX_CLIENT_CAPABILITIES=kitty_keyboard",
+			wantKitty: true,
+			readBytes: 7,
+			wantHex:   "1b5b39383b3575",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := newServerHarness(t)
+			client := newPTYClientHarness(t, h, tt.env)
+
+			if got := client.kittyKeyboardEnabled(); got != tt.wantKitty {
+				t.Fatalf("kittyKeyboardEnabled() = %v, want %v\nOutput:\n%s", got, tt.wantKitty, client.outputString())
+			}
+
+			h.sendKeys("pane-1", rawReadCommand(tt.readBytes), "Enter")
+			h.waitFor("pane-1", "READY")
+
+			client.sendCtrl('b')
+			h.waitForTimeout("pane-1", tt.wantHex, "5s")
+
+			client.detach()
+			if !client.waitExited(5 * time.Second) {
+				t.Fatalf("PTY client did not exit after detach\nOutput:\n%s", client.outputString())
+			}
+			if err := client.waitError(); err != nil {
+				t.Fatalf("PTY client exited with error: %v\nOutput:\n%s", err, client.outputString())
+			}
+
+			if tt.wantKitty {
+				if !client.waitForOutput(render.KittyKeyboardDisable, 2*time.Second) {
+					t.Fatalf("expected kitty disable sequence on exit\nOutput:\n%s", client.outputString())
+				}
+				return
+			}
+			if strings.Contains(client.outputString(), render.KittyKeyboardDisable) {
+				t.Fatalf("legacy client should not emit kitty disable\nOutput:\n%s", client.outputString())
+			}
+		})
+	}
+}

--- a/test/kitty_keyboard_test.go
+++ b/test/kitty_keyboard_test.go
@@ -1,0 +1,62 @@
+package test
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/weill-labs/amux/internal/proto"
+)
+
+func TestKittyKeyboardPrefixSplit(t *testing.T) {
+	t.Parallel()
+
+	h := newAmuxHarness(t, "AMUX_CLIENT_CAPABILITIES=kitty_keyboard")
+
+	gen := h.generation()
+	h.sendKeysHex([]byte("\x1b[97;5u"))
+	h.sendKeys("-")
+	h.waitLayout(gen)
+
+	out := h.runCmd("status")
+	if !strings.Contains(out, "2 total") {
+		t.Fatalf("expected 2 panes after kitty ctrl-a prefix split, got: %s", out)
+	}
+}
+
+func TestKittyKeyboardAltFocus(t *testing.T) {
+	t.Parallel()
+
+	h := newAmuxHarness(t, "AMUX_CLIENT_CAPABILITIES=kitty_keyboard")
+	h.splitV()
+	h.assertActive("pane-2")
+
+	h.sendKeysHex([]byte("\x1b[104;3u"))
+	if !h.waitForActive("pane-1", 3*time.Second) {
+		t.Fatalf("expected kitty alt-h to focus pane-1\nScreen:\n%s", h.captureOuter())
+	}
+
+	h.sendKeysHex([]byte("\x1b[108;3u"))
+	if !h.waitForActive("pane-2", 3*time.Second) {
+		t.Fatalf("expected kitty alt-l to focus pane-2\nScreen:\n%s", h.captureOuter())
+	}
+}
+
+func TestKittyKeyboardChooserEscape(t *testing.T) {
+	t.Parallel()
+
+	h := newAmuxHarness(t, "AMUX_CLIENT_CAPABILITIES=kitty_keyboard")
+
+	h.sendKeysHex([]byte("\x1b[97;5u"))
+	h.sendKeys("s")
+	out := h.runCmd("wait-ui", proto.UIEventChooseTreeShown, "--timeout", "3s")
+	if !strings.Contains(out, proto.UIEventChooseTreeShown) {
+		t.Fatalf("expected chooser shown event, got: %s", out)
+	}
+
+	h.sendKeysHex([]byte("\x1b[27u"))
+	out = h.runCmd("wait-ui", proto.UIEventChooseTreeHidden, "--timeout", "3s")
+	if !strings.Contains(out, proto.UIEventChooseTreeHidden) {
+		t.Fatalf("expected chooser hidden event after kitty escape, got: %s", out)
+	}
+}

--- a/test/pty_client_harness_test.go
+++ b/test/pty_client_harness_test.go
@@ -1,0 +1,191 @@
+package test
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/creack/pty"
+	"github.com/weill-labs/amux/internal/render"
+)
+
+// ptyClientHarness runs a real interactive amux client in a PTY so tests can
+// observe terminal mode sequences and decide how a terminal would encode
+// logical keypresses in response.
+type ptyClientHarness struct {
+	tb   testing.TB
+	cmd  *exec.Cmd
+	ptmx *os.File
+
+	mu       sync.Mutex
+	output   []byte
+	waitErr  error
+	updateCh chan struct{}
+	exited   chan struct{}
+}
+
+func newPTYClientHarness(tb testing.TB, server *ServerHarness, envVars ...string) *ptyClientHarness {
+	tb.Helper()
+
+	cmd := exec.Command(amuxBin, "-s", server.session)
+	env := upsertEnv(os.Environ(), "HOME", server.home)
+	env = upsertEnv(env, "TERM", "xterm-256color")
+	env = upsertEnv(env, "AMUX_NO_WATCH", "1")
+	if server.coverDir != "" {
+		env = upsertEnv(env, "GOCOVERDIR", server.coverDir)
+	}
+	env = append(env, envVars...)
+	cmd.Env = env
+
+	ptmx, err := pty.StartWithSize(cmd, &pty.Winsize{Cols: 80, Rows: 24})
+	if err != nil {
+		tb.Fatalf("starting PTY client: %v", err)
+	}
+
+	h := &ptyClientHarness{
+		tb:       tb,
+		cmd:      cmd,
+		ptmx:     ptmx,
+		updateCh: make(chan struct{}, 1),
+		exited:   make(chan struct{}),
+	}
+
+	go h.readLoop()
+	go func() {
+		err := cmd.Wait()
+		h.mu.Lock()
+		h.waitErr = err
+		h.mu.Unlock()
+		close(h.exited)
+	}()
+
+	tb.Cleanup(h.cleanup)
+
+	if !h.waitForOutput("[pane-1]", 10*time.Second) {
+		tb.Fatalf("PTY client did not render initial pane\nOutput:\n%s", h.outputString())
+	}
+
+	return h
+}
+
+func (h *ptyClientHarness) cleanup() {
+	select {
+	case <-h.exited:
+	default:
+		h.detach()
+		if !h.waitExited(3*time.Second) && h.cmd.Process != nil {
+			_ = h.cmd.Process.Kill()
+			<-h.exited
+		}
+	}
+	_ = h.ptmx.Close()
+}
+
+func (h *ptyClientHarness) readLoop() {
+	buf := make([]byte, 4096)
+	for {
+		n, err := h.ptmx.Read(buf)
+		if n > 0 {
+			h.mu.Lock()
+			h.output = append(h.output, buf[:n]...)
+			h.mu.Unlock()
+			select {
+			case h.updateCh <- struct{}{}:
+			default:
+			}
+		}
+		if err != nil {
+			return
+		}
+	}
+}
+
+func (h *ptyClientHarness) outputBytes() []byte {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return append([]byte(nil), h.output...)
+}
+
+func (h *ptyClientHarness) outputString() string {
+	return string(h.outputBytes())
+}
+
+func (h *ptyClientHarness) waitError() error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.waitErr
+}
+
+func (h *ptyClientHarness) waitForOutput(substr string, timeout time.Duration) bool {
+	h.tb.Helper()
+
+	deadline := time.Now().Add(timeout)
+	for {
+		if bytes.Contains(h.outputBytes(), []byte(substr)) {
+			return true
+		}
+		wait := time.Until(deadline)
+		if wait <= 0 {
+			return false
+		}
+		if wait > 50*time.Millisecond {
+			wait = 50 * time.Millisecond
+		}
+		select {
+		case <-h.updateCh:
+		case <-h.exited:
+			return bytes.Contains(h.outputBytes(), []byte(substr))
+		case <-time.After(wait):
+		}
+	}
+}
+
+func (h *ptyClientHarness) kittyKeyboardEnabled() bool {
+	out := h.outputBytes()
+	enableAt := bytes.LastIndex(out, []byte(render.KittyKeyboardEnable))
+	disableAt := bytes.LastIndex(out, []byte(render.KittyKeyboardDisable))
+	return enableAt >= 0 && enableAt > disableAt
+}
+
+func (h *ptyClientHarness) write(data []byte) {
+	h.tb.Helper()
+	if _, err := h.ptmx.Write(data); err != nil {
+		h.tb.Fatalf("writing to PTY client: %v", err)
+	}
+}
+
+func (h *ptyClientHarness) sendText(text string) {
+	h.write([]byte(text))
+}
+
+func (h *ptyClientHarness) sendCtrl(letter byte) {
+	h.tb.Helper()
+	if letter < 'a' || letter > 'z' {
+		h.tb.Fatalf("sendCtrl only supports lowercase ASCII letters, got %q", letter)
+	}
+	if h.kittyKeyboardEnabled() {
+		h.write([]byte(fmt.Sprintf("\x1b[%d;5u", letter)))
+		return
+	}
+	h.write([]byte{letter - 'a' + 1})
+}
+
+func (h *ptyClientHarness) detach() {
+	h.tb.Helper()
+	h.sendCtrl('a')
+	h.sendText("d")
+}
+
+func (h *ptyClientHarness) waitExited(timeout time.Duration) bool {
+	h.tb.Helper()
+	select {
+	case <-h.exited:
+		return true
+	case <-time.After(timeout):
+		return false
+	}
+}


### PR DESCRIPTION
## Summary
- add attach-time client capability negotiation plus capability summaries in `list-clients`
- detect and override client capabilities, gate hyperlink rendering, and enable kitty keyboard mode only when negotiated
- decode locally consumed kitty CSI-u input, keep richer raw bytes for pane apps, and add PTY-backed verification that legacy vs kitty mode changes pane-facing bytes

## Testing
- `go vet ./...`
- `go test ./internal/client ./internal/mouse ./internal/proto ./internal/server ./test`
- `go test ./test -run TestPTYClientKittyKeyboardChangesPaneBytes -count=1 -v`
- `make test`

## Linear
- LAB-280
- LAB-282
