### PR TITLE
Fix smaller-client wrap/cursor sync on attach

### DIFF
--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -1576,3 +1576,38 @@ func TestRescaleLayoutForSmallerClient(t *testing.T) {
 		}
 	}
 }
+
+func TestRescaleLayoutForSmallerClientResizesEmulators(t *testing.T) {
+	t.Parallel()
+
+	cr := NewClientRenderer(40, 12)
+	cr.HandleLayout(twoPane80x23())
+
+	emu, ok := cr.Emulator(1)
+	if !ok {
+		t.Fatal("pane-1 emulator missing")
+	}
+	if w, h := emu.Size(); w != 19 || h != 10 {
+		t.Fatalf("pane-1 emulator size on smaller client = %dx%d, want 19x10", w, h)
+	}
+
+	const wideLine = "1234567890123456789012345678901234567890"
+	cr.HandlePaneOutput(1, []byte("\033[2J\033[H"+wideLine))
+
+	var pane proto.CapturePane
+	if err := json.Unmarshal([]byte(cr.CapturePaneJSON(1, nil)), &pane); err != nil {
+		t.Fatalf("CapturePaneJSON parse: %v", err)
+	}
+	wantLines := []string{wideLine[:19], wideLine[19:38], wideLine[38:]}
+	if len(pane.Content) < len(wantLines) {
+		t.Fatalf("pane content lines = %d, want at least %d", len(pane.Content), len(wantLines))
+	}
+	for i, want := range wantLines {
+		if got := pane.Content[i]; got != want {
+			t.Fatalf("pane line %d = %q, want %q", i, got, want)
+		}
+	}
+	if got := pane.Cursor; got.Col != 2 || got.Row != 2 {
+		t.Fatalf("pane cursor = (%d,%d), want (2,2)", got.Col, got.Row)
+	}
+}

--- a/internal/client/renderer.go
+++ b/internal/client/renderer.go
@@ -97,6 +97,14 @@ func (r *Renderer) HandleLayout(snap *proto.LayoutSnapshot) bool {
 		}
 
 		next.layout = mux.RebuildLayout(activeRoot)
+		clientLayoutH := next.height - render.GlobalBarHeight
+		if next.layout != nil && (snap.Width != next.width || snap.Height != clientLayoutH) {
+			// Rescale the client-side layout before resizing emulators so wrap
+			// and cursor metadata match this client's window, not the server's
+			// max-size snapshot.
+			next.layout.ResizeAll(next.width, clientLayoutH)
+		}
+
 		if next.layout != nil {
 			next.layout.Walk(func(cell *mux.LayoutCell) {
 				emu := next.emulators[cell.PaneID]
@@ -115,11 +123,6 @@ func (r *Renderer) HandleLayout(snap *proto.LayoutSnapshot) bool {
 					r.OnPaneResize(cell.PaneID, cell.W, contentH)
 				}
 			})
-		}
-
-		clientLayoutH := next.height - render.GlobalBarHeight
-		if next.layout != nil && (snap.Width != next.width || snap.Height != clientLayoutH) {
-			next.layout.ResizeAll(next.width, clientLayoutH)
 		}
 
 		st.compositor.SetSessionName(snap.SessionName)


### PR DESCRIPTION
## Summary
- resize the client-side layout before resizing pane emulators so a narrow attached client uses narrow pane dimensions for wrap and cursor state
- keep the change local to the client renderer without changing server-side multi-client sizing policy
- add a regression test covering smaller-client emulator size, wrapped content, and cursor position

## Testing
- `go test ./internal/client -run 'TestRescale(LayoutForSmallerClient|LayoutForSmallerClientResizesEmulators|ZoomedPaneForSmallerClient)' -count=100`
- `go test ./test -run 'Test(MultiClientSmallClientSeesAllPanes|ReattachResizeShrink|AttachResyncsStaleCursorState)' -count=1`

## Notes
- sanity-checked against tmux 3.6a with a 40-column pane: wrapped content follows the narrow pane width, which this change now matches on attach
