### PR TITLE
test: kitty CSI-u half-page scroll in copy mode

### DIFF
--- a/internal/client/input_keys_test.go
+++ b/internal/client/input_keys_test.go
@@ -16,6 +16,16 @@ func TestNormalizeLocalInput(t *testing.T) {
 		want  []byte
 	}{
 		{
+			name:  "kitty ctrl-d c0",
+			input: []byte("\x1b[4;5u"),
+			want:  []byte{0x04},
+		},
+		{
+			name:  "kitty ctrl-u c0",
+			input: []byte("\x1b[21;5u"),
+			want:  []byte{0x15},
+		},
+		{
 			name:  "kitty ctrl-a",
 			input: []byte("\x1b[97;5u"),
 			want:  []byte{0x01},

--- a/test/copymode_test.go
+++ b/test/copymode_test.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -66,6 +67,40 @@ for i in $(seq -w 1 50); do echo "SCROLLTEST-$i"; done
 
 	// Exit copy mode
 	h.sendKeys("q")
+}
+
+func TestCopyModeKittyCtrlUDHalfPageScroll(t *testing.T) {
+	t.Parallel()
+	h := newAmuxHarness(t)
+
+	h.runCmd("resize-window", "80", "14")
+
+	scriptPath := filepath.Join(os.TempDir(), fmt.Sprintf("amux-kitty-half-page-%s.sh", h.session))
+	os.WriteFile(scriptPath, []byte(`#!/bin/bash
+for i in $(seq -w 1 40); do echo "KITTYHALF-$i"; done
+`), 0755)
+	t.Cleanup(func() { os.Remove(scriptPath) })
+
+	h.sendKeys(scriptPath, "Enter")
+	if !h.waitFor("KITTYHALF-40", 5*time.Second) {
+		t.Fatalf("expected KITTYHALF-40 in output\nScreen:\n%s", h.captureOuter())
+	}
+
+	h.sendKeys("C-a", "[")
+	h.waitUI(proto.UIEventCopyModeShown, 3*time.Second)
+
+	h.sendKeysHex(bytes.Repeat([]byte("\x1b[21;5u"), 10))
+	if !h.waitFor("KITTYHALF-01", 3*time.Second) {
+		t.Fatalf("expected KITTYHALF-01 after kitty Ctrl-u scrolls up\nScreen:\n%s", h.captureOuter())
+	}
+
+	h.sendKeysHex(bytes.Repeat([]byte("\x1b[4;5u"), 10))
+	if !h.waitFor("KITTYHALF-40", 3*time.Second) {
+		t.Fatalf("expected KITTYHALF-40 after kitty Ctrl-d scrolls down\nScreen:\n%s", h.captureOuter())
+	}
+
+	h.sendKeys("q")
+	h.waitUI(proto.UIEventCopyModeHidden, 3*time.Second)
 }
 
 func TestCopyModeSearch(t *testing.T) {


### PR DESCRIPTION
## Motivation

Kitty-protocol terminals encode `Ctrl-u` / `Ctrl-d` as CSI-u sequences (`ESC[21;5u`, `ESC[4;5u`). These must be normalized to C0 bytes so copy-mode half-page scroll works regardless of terminal protocol. This PR adds regression coverage for that path.

## Changes

- Add unit tests for kitty `Ctrl-d` (`\x1b[4;5u` → `0x04`) and `Ctrl-u` (`\x1b[21;5u` → `0x15`) normalization in `TestNormalizeLocalInput`
- Add end-to-end integration test (`TestCopyModeKittyCtrlUDHalfPageScroll`) that enters copy mode, sends raw kitty CSI-u sequences through the outer PTY, and verifies half-page scroll in both directions

## Testing

- `go test ./internal/client -run TestNormalizeLocalInput -count=100`
- `go test ./test -run TestCopyModeKittyCtrlUDHalfPageScroll -count=100`