### PR TITLE
Add PR title and description standards to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,6 +100,21 @@ If a PR is already open and `git fetch origin main` or `git pull` advances `orig
 
 Commit design specs and implementation plans to the feature branch, not main. Committing to main before creating the feature branch causes divergent branches on subsequent pulls.
 
+### PR Title And Description
+
+PR title and description are the permanent record of why a change was made. Write them for a reviewer seeing the diff for the first time.
+
+**Title**: State what changed in imperative mood, under 70 characters. Example: "Timestamp crash checkpoint filenames to prevent overwriting". Omit ticket prefixes like `LAB-314:` — link tickets in the description body instead.
+
+**Description** must include four sections:
+
+1. **Motivation** -- Why this change? What broke, what was missing, or what user need does it address? One to three sentences.
+2. **Summary** -- What changed? Bullet the key changes. Describe the PR as a complete unit, not per-commit.
+3. **Testing** -- How was it verified? Include the exact test commands a reviewer can copy-paste.
+4. **Review focus** -- What should reviewers look at? Call out non-obvious design decisions, edge cases, or areas where you are least confident.
+
+Use matter-of-fact language. State what the PR does, not how good it is. Avoid vague qualifiers like "robust", "comprehensive", "elegant", or "production-ready". If a Linear issue exists, add `Closes LAB-NNN` at the bottom.
+
 ### Review Before Done
 
 After creating or updating a PR, run a review pass and a simplification pass before considering the work done. Claude Code gets hook reminders for this. Codex users should use the repo PR workflow skill or perform the steps explicitly.


### PR DESCRIPTION
## Motivation

Agent-authored PRs (especially from Codex) often have minimal titles and descriptions that don't explain the motivation or review focus. Since `AGENTS.md` symlinks to `CLAUDE.md`, adding standards here teaches both Claude and Codex the same conventions.

## Summary

- Add a "PR Title And Description" section to CLAUDE.md requiring four sections: Motivation, Summary, Testing, Review focus
- Specify imperative mood titles under 70 characters, no ticket prefixes
- Ban vague qualifiers ("robust", "comprehensive", "elegant")

## Testing

Read the diff — this is a docs-only change.

## Review focus

- Is the four-section structure the right default, or should any sections be optional for trivial changes?
- The "no ticket prefix" rule matches the convention used in existing PRs but wasn't previously codified