### PR TITLE
Use latest active client for session size

### DIFF
--- a/internal/server/client_conn.go
+++ b/internal/server/client_conn.go
@@ -129,6 +129,31 @@ func cloneMessage(msg *Message) *Message {
 	return &cp
 }
 
+func (cc *ClientConn) activeInputPaneForWrite(sess *Session) *mux.Pane {
+	pane := sess.inputTargetPane()
+	if pane == nil {
+		return nil
+	}
+	sizeClient := sess.currentSizeClient()
+	if sizeClient == nil || sizeClient == cc {
+		return pane
+	}
+
+	pane, err := enqueueSessionQuery(sess, func(sess *Session) (*mux.Pane, error) {
+		if s := sess.currentSizeClient(); s == nil || s != cc {
+			if sess.noteClientActivity(cc) {
+				sess.recalcSize()
+				sess.broadcastLayoutNow()
+			}
+		}
+		return sess.inputTargetPane(), nil
+	})
+	if err != nil {
+		return nil
+	}
+	return pane
+}
+
 // readLoop reads messages from the client and dispatches them to the session.
 func (cc *ClientConn) readLoop(srv *Server, sess *Session) {
 	defer func() {
@@ -144,7 +169,7 @@ func (cc *ClientConn) readLoop(srv *Server, sess *Session) {
 
 		switch msg.Type {
 		case MsgTypeInput:
-			if pane := sess.inputTargetPane(); pane != nil {
+			if pane := cc.activeInputPaneForWrite(sess); pane != nil {
 				pane.Write(msg.Input)
 			}
 
@@ -176,6 +201,7 @@ func (cc *ClientConn) readLoop(srv *Server, sess *Session) {
 
 // handleCommand dispatches CLI commands through the command registry.
 func (cc *ClientConn) handleCommand(srv *Server, sess *Session, msg *Message) {
+	sess.enqueueClientActivity(cc)
 	handler, ok := commandRegistry[msg.CmdName]
 	if !ok {
 		cc.Send(&Message{Type: MsgTypeCmdResult,

--- a/internal/server/client_conn_test.go
+++ b/internal/server/client_conn_test.go
@@ -252,6 +252,76 @@ func TestClientConnInputDoesNotBlockOnBusySessionActor(t *testing.T) {
 	}
 }
 
+func TestClientConnActiveInputPaneForWriteSwitchesSessionSizeToLatestClient(t *testing.T) {
+	t.Parallel()
+
+	sess := newSession("test-client-input-latest-size")
+	stopCrashCheckpointLoop(t, sess)
+	defer stopSessionBackgroundLoops(t, sess)
+
+	pane := newProxyPane(1, mux.PaneMeta{
+		Name:  "pane-1",
+		Host:  mux.DefaultHost,
+		Color: "f5e0dc",
+	}, 80, 23, nil, nil, func(data []byte) (int, error) {
+		return len(data), nil
+	})
+	w := mux.NewWindow(pane, 80, 23)
+	w.ID = 1
+	w.Name = "window-1"
+
+	owner := NewClientConn(discardConn{})
+	t.Cleanup(owner.Close)
+	owner.ID = "client-1"
+	owner.cols = 80
+	owner.rows = 24
+
+	cc := NewClientConn(discardConn{})
+	t.Cleanup(cc.Close)
+	cc.ID = "client-2"
+	cc.cols = 60
+	cc.rows = 20
+
+	res := sess.enqueueCommandMutation(func(sess *Session) commandMutationResult {
+		sess.Windows = []*mux.Window{w}
+		sess.ActiveWindowID = w.ID
+		sess.Panes = []*mux.Pane{pane}
+		sess.clients = []*ClientConn{owner, cc}
+		sess.sizeClient.Store(owner)
+		return commandMutationResult{}
+	})
+	if res.err != nil {
+		t.Fatalf("setup session: %v", res.err)
+	}
+
+	if got := cc.activeInputPaneForWrite(sess); got != pane {
+		t.Fatalf("activeInputPaneForWrite = %v, want pane-1", got)
+	}
+
+	state := mustSessionQuery(t, sess, func(sess *Session) struct {
+		width  int
+		height int
+		owner  *ClientConn
+	} {
+		w := sess.ActiveWindow()
+		return struct {
+			width  int
+			height int
+			owner  *ClientConn
+		}{
+			width:  w.Width,
+			height: w.Height,
+			owner:  sess.currentSizeClient(),
+		}
+	})
+	if state.width != 60 || state.height != 19 {
+		t.Fatalf("active window size = %dx%d, want 60x19", state.width, state.height)
+	}
+	if state.owner != cc {
+		t.Fatalf("size owner = %v, want client-2", state.owner)
+	}
+}
+
 func TestClientConnInputTargetTracksFocusAndWindowChanges(t *testing.T) {
 	t.Parallel()
 

--- a/internal/server/commands.go
+++ b/internal/server/commands.go
@@ -1423,9 +1423,13 @@ func cmdListClients(ctx *CommandContext) {
 	}
 
 	var output strings.Builder
-	output.WriteString(fmt.Sprintf("%-10s %-15s %-10s %s\n", "CLIENT", "DISPLAY_PANES", "CHOOSER", "CAPABILITIES"))
+	output.WriteString(fmt.Sprintf("%-10s %-8s %-15s %-10s %-10s %s\n", "CLIENT", "OWNER", "SIZE", "DISPLAY_PANES", "CHOOSER", "CAPABILITIES"))
 	for _, cc := range clients {
-		output.WriteString(fmt.Sprintf("%-10s %-15s %-10s %s\n", cc.id, cc.displayPanes, cc.chooser, cc.capabilities))
+		owner := ""
+		if cc.sizeOwner {
+			owner = "*"
+		}
+		output.WriteString(fmt.Sprintf("%-10s %-8s %-15s %-10s %-10s %s\n", cc.id, owner, cc.size, cc.displayPanes, cc.chooser, cc.capabilities))
 	}
 	ctx.reply(output.String())
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -39,6 +39,7 @@ type Session struct {
 	ActiveWindowID uint32        // which window is displayed
 	Panes          []*mux.Pane   // flat list of ALL panes across all windows
 	clients        []*ClientConn
+	sizeClient     atomic.Pointer[ClientConn] // latest active client whose terminal size owns the session
 	clientCounter  atomic.Uint32
 	counter        atomic.Uint32 // pane ID counter
 	windowCounter  atomic.Uint32 // window ID counter
@@ -266,14 +267,52 @@ func (s *Session) writeCrashCheckpoint() {
 	}
 }
 
+func (s *Session) hasClient(cc *ClientConn) bool {
+	for _, c := range s.clients {
+		if c == cc {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *Session) currentSizeClient() *ClientConn {
+	return s.sizeClient.Load()
+}
+
+func (s *Session) noteClientActivity(cc *ClientConn) bool {
+	if cc == nil || !s.hasClient(cc) || s.currentSizeClient() == cc {
+		return false
+	}
+	s.sizeClient.Store(cc)
+	return true
+}
+
+func (s *Session) effectiveSizeClient() *ClientConn {
+	if cc := s.currentSizeClient(); cc != nil && s.hasClient(cc) {
+		return cc
+	}
+	if len(s.clients) == 0 {
+		s.sizeClient.Store(nil)
+		return nil
+	}
+	// Fall back to the most recently attached remaining client.
+	cc := s.clients[len(s.clients)-1]
+	s.sizeClient.Store(cc)
+	return cc
+}
+
 // removeClient removes a client from the session and recalculates
-// the session size in case the largest client disconnected.
+// the session size if the active size owner disconnected.
 func (s *Session) removeClient(cc *ClientConn) {
 	for i, c := range s.clients {
 		if c == cc {
 			s.clients = append(s.clients[:i], s.clients[i+1:]...)
 			break
 		}
+	}
+	if s.currentSizeClient() == cc {
+		s.sizeClient.Store(nil)
 	}
 	shouldExit := s.exitServer != nil && s.exitServer.Env.ExitUnattached && s.hadClient && len(s.clients) == 0 && !s.shutdown.Load()
 	s.recalcSize()

--- a/internal/server/session_broadcast.go
+++ b/internal/server/session_broadcast.go
@@ -23,24 +23,19 @@ type hookResultRecord struct {
 	Error      string
 }
 
-// recalcSize resizes all windows to the maximum terminal dimensions across
-// connected clients ("largest client wins"). Smaller clients clip out-of-bounds
-// cells locally. Event-loop only.
+// recalcSize resizes all windows to the latest active client's terminal size,
+// matching tmux's "window-size latest" behavior. Event-loop only.
 func (s *Session) recalcSize() {
-	var maxCols, maxRows int
-	for _, c := range s.clients {
-		maxCols = max(maxCols, c.cols)
-		maxRows = max(maxRows, c.rows)
-	}
-	if maxCols == 0 || maxRows == 0 {
+	sizeClient := s.effectiveSizeClient()
+	if sizeClient == nil || sizeClient.cols == 0 || sizeClient.rows == 0 {
 		return
 	}
-	layoutH := maxRows - render.GlobalBarHeight
-	if aw := s.ActiveWindow(); aw != nil && maxCols == aw.Width && layoutH == aw.Height {
+	layoutH := sizeClient.rows - render.GlobalBarHeight
+	if aw := s.ActiveWindow(); aw != nil && sizeClient.cols == aw.Width && layoutH == aw.Height {
 		return
 	}
 	for _, w := range s.Windows {
-		w.Resize(maxCols, layoutH)
+		w.Resize(sizeClient.cols, layoutH)
 	}
 }
 

--- a/internal/server/session_events.go
+++ b/internal/server/session_events.go
@@ -110,6 +110,19 @@ type resizeClientEvent struct {
 func (e resizeClientEvent) handle(s *Session) {
 	e.cc.cols = e.cols
 	e.cc.rows = e.rows
+	s.noteClientActivity(e.cc)
+	s.recalcSize()
+	s.broadcastLayoutNow()
+}
+
+type clientActivityEvent struct {
+	cc *ClientConn
+}
+
+func (e clientActivityEvent) handle(s *Session) {
+	if !s.noteClientActivity(e.cc) {
+		return
+	}
 	s.recalcSize()
 	s.broadcastLayoutNow()
 }
@@ -487,11 +500,16 @@ type uiEventCmd struct {
 }
 
 func (e uiEventCmd) handle(s *Session) {
+	activityChanged := s.noteClientActivity(e.cc)
 	changed, err := e.cc.applyUIEvent(e.uiEvent)
 	clientID := e.cc.ID
 	if err != nil {
 		e.cc.Send(&Message{Type: MsgTypeCmdResult, CmdErr: err.Error()})
 		return
+	}
+	if activityChanged {
+		s.recalcSize()
+		s.broadcastLayoutNow()
 	}
 	if changed {
 		e.cc.uiGeneration++
@@ -595,6 +613,10 @@ func (s *Session) enqueueUIEvent(cc *ClientConn, uiEvent string) {
 	s.enqueueEvent(uiEventCmd{cc: cc, uiEvent: uiEvent})
 }
 
+func (s *Session) enqueueClientActivity(cc *ClientConn) {
+	s.enqueueEvent(clientActivityEvent{cc: cc})
+}
+
 func (s *Session) handleAttachEvent(srv *Server, cc *ClientConn, cols, rows int) attachResult {
 	idleSnap := s.snapshotIdleState()
 
@@ -612,6 +634,7 @@ func (s *Session) handleAttachEvent(srv *Server, cc *ClientConn, cols, rows int)
 
 	s.clients = append(s.clients, cc)
 	s.hadClient = true
+	s.noteClientActivity(cc)
 	s.recalcSize()
 
 	res.snap = s.snapshotLayout(idleSnap)

--- a/internal/server/session_queries.go
+++ b/internal/server/session_queries.go
@@ -49,6 +49,8 @@ type clientListEntry struct {
 	id           string
 	displayPanes string
 	chooser      string
+	size         string
+	sizeOwner    bool
 	capabilities string
 }
 
@@ -244,11 +246,19 @@ func (s *Session) queryWindowList() ([]windowListEntry, error) {
 func (s *Session) queryClientList() ([]clientListEntry, error) {
 	return enqueueSessionQuery(s, func(s *Session) ([]clientListEntry, error) {
 		entries := make([]clientListEntry, 0, len(s.clients))
+		sizeOwner := s.currentSizeClient()
+		if sizeOwner == nil || !s.hasClient(sizeOwner) {
+			if len(s.clients) > 0 {
+				sizeOwner = s.clients[len(s.clients)-1]
+			}
+		}
 		for _, cc := range s.clients {
 			entries = append(entries, clientListEntry{
 				id:           cc.ID,
 				displayPanes: cc.displayPanesState(),
 				chooser:      cc.chooserState(),
+				size:         fmt.Sprintf("%dx%d", cc.cols, cc.rows),
+				sizeOwner:    cc == sizeOwner,
 				capabilities: cc.capabilitySummary(),
 			})
 		}

--- a/internal/server/session_queries_test.go
+++ b/internal/server/session_queries_test.go
@@ -237,6 +237,12 @@ func TestQueryClientListIncludesCapabilities(t *testing.T) {
 			if len(clients) != 1 {
 				t.Fatalf("len(queryClientList) = %d, want 1", len(clients))
 			}
+			if got := clients[0].size; got != "0x0" {
+				t.Fatalf("size = %q, want 0x0", got)
+			}
+			if !clients[0].sizeOwner {
+				t.Fatal("sizeOwner = false, want true")
+			}
 			if got := clients[0].capabilities; got != tt.want {
 				t.Fatalf("capabilities = %q, want %q", got, tt.want)
 			}

--- a/test/events_test.go
+++ b/test/events_test.go
@@ -397,10 +397,10 @@ func TestListClientsShowsDisplayPanesState(t *testing.T) {
 	h.client.sendUIEvent(proto.UIEventChooseWindowShown)
 
 	out := h.runCmd("list-clients")
-	if !strings.Contains(out, "CLIENT") || !strings.Contains(out, "DISPLAY_PANES") || !strings.Contains(out, "CHOOSER") || !strings.Contains(out, "CAPABILITIES") {
+	if !strings.Contains(out, "CLIENT") || !strings.Contains(out, "OWNER") || !strings.Contains(out, "SIZE") || !strings.Contains(out, "DISPLAY_PANES") || !strings.Contains(out, "CHOOSER") || !strings.Contains(out, "CAPABILITIES") {
 		t.Fatalf("unexpected list-clients header: %s", out)
 	}
-	if !strings.Contains(out, "client-1") || !strings.Contains(out, "shown") || !strings.Contains(out, "window") || !strings.Contains(out, "hyperlinks") {
+	if !strings.Contains(out, "client-1") || !strings.Contains(out, "*") || !strings.Contains(out, "80x24") || !strings.Contains(out, "shown") || !strings.Contains(out, "window") || !strings.Contains(out, "hyperlinks") {
 		t.Fatalf("list-clients should report shown state, got: %s", out)
 	}
 }

--- a/test/multiclient_resize_test.go
+++ b/test/multiclient_resize_test.go
@@ -32,7 +32,7 @@ func (h *ServerHarness) assertLayoutSize(cols, rows, wantW, wantH int) {
 	}
 }
 
-func TestMultiClientLargestWins(t *testing.T) {
+func TestMultiClientLatestAttachWins(t *testing.T) {
 	t.Parallel()
 	h := newServerHarness(t) // 80×24
 
@@ -43,8 +43,8 @@ func TestMultiClientLargestWins(t *testing.T) {
 	gen := h.generation()
 	h.waitLayout(gen)
 
-	// Layout should stay at 80×23 (the larger client's dimensions).
-	h.assertLayoutSize(80, 24, 80, 23)
+	// Layout should follow the newly attached client.
+	h.assertLayoutSize(60, 20, 60, 19)
 	assertCaptureConsistent(t, h.captureJSON())
 
 	// Disconnect the small client — removeClient broadcasts layout.
@@ -114,18 +114,18 @@ func TestMultiClientResizeRecalculates(t *testing.T) {
 	h.waitLayout(gen)
 
 	// Send a resize from the primary (80×24) client, shrinking it to 70×20.
-	// The large client (120×40) is still the max, so layout stays at 120×39.
+	// The client with the latest activity should now own the session size.
 	gen = h.generation()
 	h.client.resize(70, 20)
 	h.waitLayout(gen)
 
-	h.assertLayoutSize(120, 40, 120, 39)
+	h.assertLayoutSize(70, 20, 70, 19)
 	assertCaptureConsistent(t, h.captureJSON())
 
 	large.close()
 }
 
-func TestMultiClientLargestClientShrinkRecalculates(t *testing.T) {
+func TestMultiClientLatestClientShrinkRecalculates(t *testing.T) {
 	t.Parallel()
 	h := newServerHarness(t) // 80x24
 
@@ -136,6 +136,6 @@ func TestMultiClientLargestClientShrinkRecalculates(t *testing.T) {
 	large.resize(70, 20)
 	h.waitLayout(gen)
 
-	h.assertLayoutSize(80, 24, 80, 23)
+	h.assertLayoutSize(70, 20, 70, 19)
 	assertCaptureConsistent(t, h.captureJSON())
 }

--- a/test/reattach_resize_test.go
+++ b/test/reattach_resize_test.go
@@ -160,20 +160,20 @@ func TestReattachResizeShrink(t *testing.T) {
 	// Initial session is 80×24. Split vertically.
 	h.splitV()
 
-	// Reattach at a smaller size (60×20). The primary headless client (80×24)
-	// is still connected, so "largest client wins" keeps the layout at 80×23.
+	// Reattach at a smaller size (60×20). The newly attached client should
+	// temporarily own the session size while it is active.
 	msg := h.attachAt(60, 20)
 	snap := msg.Layout
-	if snap.Width != 80 {
-		t.Errorf("shrink width: got %d, want 80 (largest client wins)", snap.Width)
+	if snap.Width != 60 {
+		t.Errorf("shrink width: got %d, want 60", snap.Width)
 	}
-	if snap.Height != 23 {
-		t.Errorf("shrink height: got %d, want 23 (largest client wins)", snap.Height)
+	if snap.Height != 19 {
+		t.Errorf("shrink height: got %d, want 19", snap.Height)
 	}
 
 	root := snap.Root
-	if root.W != 80 {
-		t.Errorf("root cell width: got %d, want 80", root.W)
+	if root.W != 60 {
+		t.Errorf("root cell width: got %d, want 60", root.W)
 	}
 
 	if len(root.Children) != 2 {
@@ -182,8 +182,8 @@ func TestReattachResizeShrink(t *testing.T) {
 	left := root.Children[0]
 	right := root.Children[1]
 	// Children sum to width-1 (1 col for the vertical border).
-	if left.W+right.W != 79 {
-		t.Errorf("children widths don't sum to 79: %d + %d", left.W, right.W)
+	if left.W+right.W != 59 {
+		t.Errorf("children widths don't sum to 59: %d + %d", left.W, right.W)
 	}
 }
 


### PR DESCRIPTION
## Summary
- switch shared session sizing from "largest attached client" to the latest active client, matching tmux's `window-size latest` behavior
- hand size ownership off before PTY input is written so app-side wrap/cursor state follows the client that just interacted
- show client sizes and the current size owner in `amux list-clients` to make multi-client sizing observable

## Testing
- `go test ./internal/server -run 'Test(ClientConnInputDoesNotBlockOnBusySessionActor|ClientConnActiveInputPaneForWriteSwitchesSessionSizeToLatestClient|HandleAttachStoresNegotiatedCapabilities|QueryClientListIncludesCapabilities|ClientWriterSendPaneOutputDropsSlowClientWhenQueueFull|HandleAttachAndResizeThroughSessionQueue)' -count=100`
- `go test ./test -run 'Test(ListClientsShowsDisplayPanesState|ReattachResizeShrink|MultiClientLatestAttachWins|MultiClientResizeRecalculates|MultiClientLatestClientShrinkRecalculates)' -count=100`
- `go test ./test -run 'TestMultiClientExpandOnLarger' -count=1`
- `go test ./test -run 'Test(ServerReloadCaptureRetry|ServerReloadPreservesGeneration)' -count=1`
- `go test ./internal/server -run 'Test(ClientConnInputDoesNotBlockOnBusySessionActor|ClientConnActiveInputPaneForWriteSwitchesSessionSizeToLatestClient|HandleAttachStoresNegotiatedCapabilities|QueryClientListIncludesCapabilities|HandleAttachAndResizeThroughSessionQueue)' -count=1`
- `go test ./test -run 'Test(ListClientsShowsDisplayPanesState|ReattachResizeShrink|MultiClientLatestAttachWins|MultiClientResizeRecalculates|MultiClientLatestClientShrinkRecalculates|MultiClientExpandOnLarger|ServerReloadCaptureRetry|ServerReloadPreservesGeneration)' -count=1`
