### PR TITLE
Document clean-env CI reproduction under amux

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,8 @@ make test                          # run all tests
 make coverage                      # merged unit + integration coverage (use this, not go test -coverprofile)
 ```
 
+**Reproduce CI from a clean shell when running inside `amux`/tmux.** Clipboard and harness behavior can change when `AMUX_SESSION` or `TMUX` are set. For CI-style verification from an attached pane, prefer `env -u AMUX_SESSION -u TMUX scripts/coverage.sh --ci`, and prefix other CI-style test commands the same way when you need the same environment.
+
 ### Testing Live
 
 See [README.md -- CLI Reference](README.md#cli-reference) for the full command reference. Key commands for testing:


### PR DESCRIPTION
## Motivation

Running CI-style verification from inside a live `amux` or tmux pane can inherit `AMUX_SESSION` and `TMUX`, which changes clipboard and harness behavior. This note makes the clean-env repro command explicit in the repo guidance so future CI triage starts from the same environment as GitHub.

## Summary

- document the clean-env CI reproduction command in `CLAUDE.md`
- point contributors at `env -u AMUX_SESSION -u TMUX scripts/coverage.sh --ci` when reproducing CI from an attached pane

## Testing

- docs-only change; no tests run

## Review focus

- placement and wording of the new clean-env CI reproduction note in `CLAUDE.md`
