### PR TITLE
Resync startup terminal size after attach

### DIFF
--- a/internal/client/attach.go
+++ b/internal/client/attach.go
@@ -23,12 +23,31 @@ import (
 	"golang.org/x/term"
 )
 
+var termGetSize = term.GetSize
+
 func handleDisplayPaneSelection(cr *ClientRenderer, sender *messageSender, b byte) {
 	paneID, ok := cr.ResolveDisplayPaneKey(b)
 	cr.HideDisplayPanes()
 	if ok {
 		sender.Command("focus", []string{fmt.Sprintf("%d", paneID)})
 	}
+}
+
+func syncTerminalSize(fd int, prevCols, prevRows int, cr *ClientRenderer, sender *messageSender) (int, int) {
+	c, r, _ := termGetSize(fd)
+	if c <= 0 || r <= 0 {
+		return prevCols, prevRows
+	}
+	if c == prevCols && r == prevRows {
+		return prevCols, prevRows
+	}
+	cr.Resize(c, r)
+	_ = sender.Send(&proto.Message{
+		Type: proto.MsgTypeResize,
+		Cols: c,
+		Rows: r,
+	})
+	return c, r
 }
 
 func terminalEnterSequence(caps proto.ClientCapabilities) string {
@@ -82,7 +101,7 @@ func RunSession(sessionName string) error {
 	defer sender.Close()
 
 	fd := int(os.Stdin.Fd())
-	cols, rows, _ := term.GetSize(fd)
+	cols, rows, _ := termGetSize(fd)
 	if cols <= 0 {
 		cols = server.DefaultTermCols
 	}
@@ -136,19 +155,16 @@ func RunSession(sessionName string) error {
 	// Forward SIGWINCH to server and update client renderer
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGWINCH)
+	defer signal.Stop(sigCh)
 	go func() {
+		lastCols, lastRows := cols, rows
 		for range sigCh {
-			c, r, _ := term.GetSize(fd)
-			if c > 0 && r > 0 {
-				cr.Resize(c, r)
-				sender.Send(&proto.Message{
-					Type: proto.MsgTypeResize,
-					Cols: c,
-					Rows: r,
-				})
-			}
+			lastCols, lastRows = syncTerminalSize(fd, lastCols, lastRows, cr, sender)
 		}
 	}()
+	// Recheck once after the handler is live so startup-time size changes
+	// (common on mobile/SSH clients) are not lost before the first SIGWINCH.
+	cols, rows = syncTerminalSize(fd, cols, rows, cr, sender)
 
 	// Channel for injecting keystrokes from type-keys (server → client).
 	injectCh := make(chan []byte, 16)

--- a/internal/client/attach_test.go
+++ b/internal/client/attach_test.go
@@ -1,11 +1,147 @@
 package client
 
 import (
+	"errors"
+	"net"
 	"testing"
+	"time"
 
 	"github.com/weill-labs/amux/internal/proto"
 	"github.com/weill-labs/amux/internal/render"
 )
+
+func stubTermGetSize(t *testing.T, fn func(int) (int, int, error)) {
+	t.Helper()
+	prev := termGetSize
+	termGetSize = fn
+	t.Cleanup(func() {
+		termGetSize = prev
+	})
+}
+
+func readResizeMessage(t *testing.T, conn net.Conn) *proto.Message {
+	t.Helper()
+	if err := conn.SetReadDeadline(time.Now().Add(2 * time.Second)); err != nil {
+		t.Fatalf("set read deadline: %v", err)
+	}
+	msg, err := proto.ReadMsg(conn)
+	if err != nil {
+		t.Fatalf("read resize message: %v", err)
+	}
+	return msg
+}
+
+func assertNoMessage(t *testing.T, conn net.Conn) {
+	t.Helper()
+	if err := conn.SetReadDeadline(time.Now().Add(100 * time.Millisecond)); err != nil {
+		t.Fatalf("set read deadline: %v", err)
+	}
+	msg, err := proto.ReadMsg(conn)
+	if err == nil {
+		t.Fatalf("unexpected message: %+v", msg)
+	}
+	if ne, ok := err.(net.Error); !ok || !ne.Timeout() {
+		t.Fatalf("read error = %v, want timeout", err)
+	}
+}
+
+func TestSyncTerminalSizeSendsResizeWhenSizeChanges(t *testing.T) {
+	clientConn, serverConn := net.Pipe()
+	t.Cleanup(func() {
+		_ = clientConn.Close()
+		_ = serverConn.Close()
+	})
+
+	sender := newMessageSender(clientConn)
+	t.Cleanup(sender.Close)
+
+	cr := NewClientRenderer(80, 24)
+	stubTermGetSize(t, func(int) (int, int, error) {
+		return 40, 12, nil
+	})
+
+	type sizeResult struct {
+		cols int
+		rows int
+	}
+	done := make(chan sizeResult, 1)
+	go func() {
+		cols, rows := syncTerminalSize(0, 80, 24, cr, sender)
+		done <- sizeResult{cols: cols, rows: rows}
+	}()
+
+	msg := readResizeMessage(t, serverConn)
+	if msg.Type != proto.MsgTypeResize {
+		t.Fatalf("message type = %d, want %d", msg.Type, proto.MsgTypeResize)
+	}
+	if msg.Cols != 40 || msg.Rows != 12 {
+		t.Fatalf("resize message = %dx%d, want 40x12", msg.Cols, msg.Rows)
+	}
+
+	result := <-done
+	if result.cols != 40 || result.rows != 12 {
+		t.Fatalf("syncTerminalSize returned %dx%d, want 40x12", result.cols, result.rows)
+	}
+
+	snap := cr.renderer.snapshot()
+	if snap.width != 40 || snap.height != 12 {
+		t.Fatalf("renderer size = %dx%d, want 40x12", snap.width, snap.height)
+	}
+}
+
+func TestSyncTerminalSizeSkipsUnchangedOrInvalidSizes(t *testing.T) {
+	tests := []struct {
+		name string
+		fn   func(int) (int, int, error)
+	}{
+		{
+			name: "unchanged",
+			fn: func(int) (int, int, error) {
+				return 80, 24, nil
+			},
+		},
+		{
+			name: "invalid dimensions",
+			fn: func(int) (int, int, error) {
+				return 0, 0, nil
+			},
+		},
+		{
+			name: "get size error",
+			fn: func(int) (int, int, error) {
+				return 0, 0, errors.New("boom")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clientConn, serverConn := net.Pipe()
+			t.Cleanup(func() {
+				_ = clientConn.Close()
+				_ = serverConn.Close()
+			})
+
+			sender := newMessageSender(clientConn)
+			t.Cleanup(sender.Close)
+
+			cr := NewClientRenderer(80, 24)
+			stubTermGetSize(t, tt.fn)
+
+			cols, rows := syncTerminalSize(0, 80, 24, cr, sender)
+			if cols != 80 || rows != 24 {
+				t.Fatalf("syncTerminalSize returned %dx%d, want 80x24", cols, rows)
+			}
+
+			assertNoMessage(t, serverConn)
+
+			snap := cr.renderer.snapshot()
+			if snap.width != 80 || snap.height != 24 {
+				t.Fatalf("renderer size = %dx%d, want 80x24", snap.width, snap.height)
+			}
+		})
+	}
+}
 
 func TestTerminalEnterSequence(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## Motivation
When attaching from an iPhone, panes could keep rendering at the stale startup size instead of the terminal's real post-attach size. The client read the terminal size once for the initial attach, but it did not re-check after installing the `SIGWINCH` handler, so an early mobile resize could be missed until a later resize event arrived.

## Summary
- add a small `syncTerminalSize` helper for the client attach path
- re-check terminal size once immediately after the `SIGWINCH` handler is live so startup-time resizes are not lost
- add focused client tests covering changed-size, unchanged-size, and invalid-size cases

## Testing
- `go test ./internal/client -run 'TestSyncTerminalSize' -count=100`
- `go test ./internal/client -run 'Test(SyncTerminalSize|TerminalEnterSequence|TerminalExitSequence)' -count=1`
- `go test ./test -run 'Test(ReattachResize|ReattachResizeShrink|AttachResyncsStaleCursorState|TerminalResize|MultiClientResizeRecalculates|MultiClientLatestClientShrinkRecalculates)' -count=1`
- manual repro: attach from iPhone and confirm panes redraw/wrap to the phone-sized layout

I also ran `env -u AMUX_SESSION -u TMUX make test`, but clean `origin/main` is already red in unrelated takeover / idle-status / agent-status / keybinding tests, so this PR relies on the targeted regression slices above.

## Review focus
- the startup race in `internal/client/attach.go`: initial attach size vs. the first real post-attach terminal size
- whether the one-time resync after `signal.Notify(SIGWINCH)` is the right place to close that gap without affecting steady-state resize behavior
- whether the new attach tests are the right level of coverage for this client-only fix
