### PR TITLE
Add regressions for mixed-size replay scroll regions

### DIFF
--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -1885,3 +1885,29 @@ func TestRescaleLayoutForSmallerClientResizesEmulators(t *testing.T) {
 		t.Fatalf("pane cursor = (%d,%d), want (2,2)", got.Col, got.Row)
 	}
 }
+
+func TestRescaleLayoutForSmallerClientClampsOversizedScrollRegion(t *testing.T) {
+	t.Parallel()
+
+	// The larger client owns the server PTY size, but this client still replays
+	// the pane into its smaller local emulator.
+	cr := NewClientRenderer(40, 12)
+	cr.HandleLayout(twoPane80x23())
+
+	emu, ok := cr.Emulator(1)
+	if !ok {
+		t.Fatal("pane-1 emulator missing")
+	}
+	if w, h := emu.Size(); w != 19 || h != 10 {
+		t.Fatalf("pane-1 emulator size on smaller client = %dx%d, want 19x10", w, h)
+	}
+
+	cr.HandlePaneOutput(1, []byte("\x1b[1;23r\x1b[H\x1bMok"))
+
+	if !emu.ScreenContains("ok") {
+		t.Fatalf("ScreenContains(%q) = false\nrender:\n%s", "ok", emu.Render())
+	}
+	if got := cr.RenderDiff(); got == "" {
+		t.Fatal("RenderDiff after oversized scroll region should produce output")
+	}
+}

--- a/internal/mux/emulator_test.go
+++ b/internal/mux/emulator_test.go
@@ -88,6 +88,28 @@ func TestRenderWithCursor(t *testing.T) {
 	}
 }
 
+func TestVTEmulatorClampsOversizedVerticalMargins(t *testing.T) {
+	t.Parallel()
+
+	emu := NewVTEmulatorWithDrain(10, 4)
+	emu.Write([]byte("\x1b[1;24r\x1b[H\x1bMok"))
+
+	if !emu.ScreenContains("ok") {
+		t.Fatalf("ScreenContains(%q) = false\nrender:\n%s", "ok", emu.Render())
+	}
+}
+
+func TestVTEmulatorClampsOversizedHorizontalMargins(t *testing.T) {
+	t.Parallel()
+
+	emu := NewVTEmulatorWithDrain(5, 4)
+	emu.Write([]byte("\x1b[?69h\x1b[1;24s\x1b[H\x1b[@x"))
+
+	if !emu.ScreenContains("x") {
+		t.Fatalf("ScreenContains(%q) = false\nrender:\n%s", "x", emu.Render())
+	}
+}
+
 func TestRenderWithCursorRoundTrip(t *testing.T) {
 	t.Parallel()
 	// Verify that RenderWithCursor output replays correctly into a fresh


### PR DESCRIPTION
## Motivation
The underlying mixed-size replay fix already landed on `origin/main`, but the specific crash mode was still untested. This adds regressions for the case where a smaller attached client replays pane output containing scroll regions sized for a larger active client.

## Summary
- add emulator regressions for oversized vertical and horizontal margins
- add a client regression that reproduces the smaller-client replay path with an oversized scroll region followed by reverse index
- verify the new regressions are stable under repeated runs

## Testing
```bash
env -u AMUX_SESSION -u TMUX go test ./internal/mux -run 'TestVTEmulatorClampsOversized(Vertical|Horizontal)Margins$' -count=100
env -u AMUX_SESSION -u TMUX go test ./internal/client -run 'TestRescaleLayoutForSmallerClientClampsOversizedScrollRegion$' -count=100
```

## Review focus
The main thing to check is whether these regressions capture the actual mixed-size failure mode without overfitting to a specific implementation of the underlying `x/vt` clamp fix.
