### PR TITLE
Document ANSI cursor debugging for app-drawn cursors

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,6 +168,8 @@ Use `amux capture --format json` to inspect composited output programmatically. 
 3. If the zoomed view is clean but the unzoomed view is corrupted, the bug is in the compositor or diff renderer (cell-grid boundary calculation, status bar overlay, or border compositing)
 4. If the zoomed view is also corrupted, the bug is in the terminal emulator or PTY output
 
+For cursor bugs in TUIs that may draw their own cursor (for example, Claude Code), compare `amux capture --format json` with `amux capture --ansi pane-N`. If ANSI shows a reverse-video block in pane content but JSON reports a stale cursor position, treat the app-drawn cursor as the visible source of truth and debug cursor-block detection separately from emulator cursor metadata.
+
 Trigger patterns for compositor bugs: long or truncated lines near pane boundaries, status bar overlays adjacent to wrapped content, and high-frequency output (for example, `htop` or progress bars).
 
 ### Hot-Reload


### PR DESCRIPTION
## Motivation
JSON capture is usually the fastest way to inspect cursor state, but TUIs like Claude Code can draw their own block cursor in pane content while emulator cursor metadata stays stale. The rendering-debugging guide should call out that mismatch so future debugging starts from the visible cursor, not just the reported coordinates.

## Summary
- add a cursor-specific note to the rendering-debugging section in `CLAUDE.md`
- document comparing `amux capture --format json` with `amux capture --ansi pane-N`
- explain how to interpret a visible app-drawn cursor when JSON metadata is stale

## Testing
- `git diff --check`

## Review focus
- Does the new note belong in the existing rendering-debugging section?
- Is the wording precise about the difference between app-drawn cursor blocks and emulator cursor metadata?
