### PR TITLE
Add tests for high-yield coverage gaps

### DIFF
--- a/internal/client/helpers_extra_test.go
+++ b/internal/client/helpers_extra_test.go
@@ -1,0 +1,173 @@
+package client
+
+import (
+	"testing"
+
+	"github.com/weill-labs/amux/internal/proto"
+)
+
+func TestAdvertisedAttachCapabilitiesUsesProcessEnv(t *testing.T) {
+	t.Setenv("TERM", "xterm-kitty")
+	t.Setenv("TERM_PROGRAM", "")
+	t.Setenv("KITTY_WINDOW_ID", "42")
+	t.Setenv("AMUX_CLIENT_CAPABILITIES", "-graphics_placeholder,prompt_markers")
+
+	got := advertisedAttachCapabilities()
+	want := &proto.ClientCapabilities{
+		KittyKeyboard:  true,
+		Hyperlinks:     true,
+		RichUnderline:  true,
+		PromptMarkers:  true,
+		CursorMetadata: false,
+	}
+
+	if got == nil {
+		t.Fatal("advertisedAttachCapabilities returned nil")
+	}
+	if got.KittyKeyboard != want.KittyKeyboard ||
+		got.Hyperlinks != want.Hyperlinks ||
+		got.RichUnderline != want.RichUnderline ||
+		got.PromptMarkers != want.PromptMarkers ||
+		got.GraphicsPlaceholder != want.GraphicsPlaceholder {
+		t.Fatalf("advertisedAttachCapabilities() = %+v, want %+v", *got, *want)
+	}
+}
+
+func TestRendererOverlayStateCommandFeedbackAndActiveCopyMode(t *testing.T) {
+	t.Parallel()
+
+	cr := buildMultiWindowRenderer(t)
+	if !cr.ShowDisplayPanes() {
+		t.Fatal("ShowDisplayPanes should succeed")
+	}
+
+	overlay := cr.overlayState()
+	if len(overlay.PaneLabels) == 0 {
+		t.Fatal("overlayState should include pane labels")
+	}
+	if overlay.Chooser != nil || overlay.Message != "" {
+		t.Fatalf("overlayState = %+v, want labels only", overlay)
+	}
+
+	cr.ShowPrefixMessage("prefix message")
+	overlay = cr.overlayState()
+	if overlay.Message != "prefix message" {
+		t.Fatalf("overlay message = %q, want prefix message", overlay.Message)
+	}
+	if !cr.ClearCommandFeedback() {
+		t.Fatal("ClearCommandFeedback should report a change")
+	}
+	if cr.ClearCommandFeedback() {
+		t.Fatal("second ClearCommandFeedback should be a no-op")
+	}
+
+	activePaneID := cr.ActivePaneID()
+	cr.EnterCopyMode(activePaneID)
+	if cr.ActiveCopyMode() == nil {
+		t.Fatal("ActiveCopyMode should return the active pane's copy mode")
+	}
+	cr.ExitCopyMode(activePaneID)
+	if cr.ActiveCopyMode() != nil {
+		t.Fatal("ActiveCopyMode should be nil after ExitCopyMode")
+	}
+}
+
+func TestChooserHelpersAndInputBranches(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		mode       chooserMode
+		wantTitle  string
+		wantShown  string
+		wantHidden string
+	}{
+		{mode: chooserModeTree, wantTitle: "choose-tree", wantShown: proto.UIEventChooseTreeShown, wantHidden: proto.UIEventChooseTreeHidden},
+		{mode: chooserModeWindow, wantTitle: "choose-window", wantShown: proto.UIEventChooseWindowShown, wantHidden: proto.UIEventChooseWindowHidden},
+		{mode: chooserMode("custom"), wantTitle: "chooser"},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(string(tt.mode), func(t *testing.T) {
+			t.Parallel()
+			if got := tt.mode.title(); got != tt.wantTitle {
+				t.Fatalf("title() = %q, want %q", got, tt.wantTitle)
+			}
+			if got := tt.mode.shownEvent(); got != tt.wantShown {
+				t.Fatalf("shownEvent() = %q, want %q", got, tt.wantShown)
+			}
+			if got := tt.mode.hiddenEvent(); got != tt.wantHidden {
+				t.Fatalf("hiddenEvent() = %q, want %q", got, tt.wantHidden)
+			}
+		})
+	}
+
+	cr := buildMultiWindowRenderer(t)
+	if cr.ChooserActive() {
+		t.Fatal("ChooserActive should be false before ShowChooser")
+	}
+	if !cr.ShowChooser(chooserModeTree) {
+		t.Fatal("ShowChooser tree should succeed")
+	}
+	if !cr.ChooserActive() {
+		t.Fatal("ChooserActive should be true after ShowChooser")
+	}
+
+	overlay := cr.chooserOverlay()
+	if overlay == nil || overlay.Title != "choose-tree" {
+		t.Fatalf("chooserOverlay = %+v, want choose-tree overlay", overlay)
+	}
+
+	if cmd := cr.HandleChooserInput([]byte{0x1b, '[', 'B'}); cmd.bell || cmd.command != "" {
+		t.Fatalf("down-arrow command = %+v, want movement only", cmd)
+	}
+	if cmd := cr.HandleChooserInput([]byte{0x01}); !cmd.bell {
+		t.Fatalf("invalid control byte should ring bell, got %+v", cmd)
+	}
+
+	cr.HandleChooserInput([]byte("gpu"))
+	if got := cr.chooserOverlay().Query; got != "gpu" {
+		t.Fatalf("query after printable input = %q, want gpu", got)
+	}
+	cr.HandleChooserInput([]byte("q"))
+	if got := cr.chooserOverlay().Query; got != "gpuq" {
+		t.Fatalf("query after q with non-empty query = %q, want gpuq", got)
+	}
+	cr.HandleChooserInput([]byte{0x7f})
+	if got := cr.chooserOverlay().Query; got != "gpu" {
+		t.Fatalf("query after backspace = %q, want gpu", got)
+	}
+
+	cr.HandleChooserInput([]byte{0x1b})
+	if cr.ChooserActive() {
+		t.Fatal("escape should hide chooser")
+	}
+
+	if !cr.ShowChooser(chooserModeWindow) {
+		t.Fatal("ShowChooser window should succeed")
+	}
+	cr.HandleChooserInput([]byte("q"))
+	if cr.ChooserActive() {
+		t.Fatal("q should hide chooser when the query is empty")
+	}
+}
+
+func TestMoveAndSelectChooserBellPaths(t *testing.T) {
+	t.Parallel()
+
+	cr := NewClientRenderer(20, 8)
+	cr.updateState(func(next *clientSnapshot) clientUIResult {
+		next.ui.chooser = &chooserState{
+			mode: chooserModeWindow,
+			rows: []chooserItem{{text: "header", selectable: false}},
+		}
+		return clientUIResult{}
+	})
+
+	if got := cr.moveChooser(1); !got.bell {
+		t.Fatalf("moveChooser should bell when no rows are selectable, got %+v", got)
+	}
+	if got := cr.selectChooser(); !got.bell {
+		t.Fatalf("selectChooser should bell when selected row is not selectable, got %+v", got)
+	}
+}

--- a/internal/mux/helpers_extra_test.go
+++ b/internal/mux/helpers_extra_test.go
@@ -1,0 +1,133 @@
+package mux
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/charmbracelet/x/ansi"
+	"github.com/weill-labs/amux/internal/mouse"
+)
+
+func TestLayoutCellIDHelpers(t *testing.T) {
+	t.Parallel()
+
+	leafByID := NewLeafByID(7, 1, 2, 10, 4)
+	if got := leafByID.CellPaneID(); got != 7 {
+		t.Fatalf("CellPaneID() = %d, want 7", got)
+	}
+	if leafByID.Pane != nil || !leafByID.IsLeaf() {
+		t.Fatalf("NewLeafByID() = %+v, want client-side leaf", leafByID)
+	}
+
+	leafWithPane := NewLeaf(&Pane{ID: 9}, 0, 0, 8, 4)
+	root := &LayoutCell{
+		Dir:      SplitVertical,
+		Children: []*LayoutCell{leafByID, leafWithPane},
+	}
+	leafByID.Parent = root
+	leafWithPane.Parent = root
+
+	if got := root.CellPaneID(); got != 0 {
+		t.Fatalf("internal CellPaneID() = %d, want 0", got)
+	}
+	if got := root.FindByPaneID(7); got != leafByID {
+		t.Fatalf("FindByPaneID(7) = %+v, want leafByID", got)
+	}
+	if got := root.FindByPaneID(9); got != leafWithPane {
+		t.Fatalf("FindByPaneID(9) = %+v, want leafWithPane", got)
+	}
+	if got := root.FindByPaneID(99); got != nil {
+		t.Fatalf("FindByPaneID(99) = %+v, want nil", got)
+	}
+	if got := leafByID.indexInParent(); got != 0 {
+		t.Fatalf("indexInParent(first child) = %d, want 0", got)
+	}
+	if got := leafWithPane.indexInParent(); got != 1 {
+		t.Fatalf("indexInParent(second child) = %d, want 1", got)
+	}
+	if got := (&LayoutCell{}).indexInParent(); got != -1 {
+		t.Fatalf("indexInParent(rootless) = %d, want -1", got)
+	}
+}
+
+func TestPaneEnvironmentAndCreatedAt(t *testing.T) {
+	base := []string{
+		"TERM=screen-256color",
+		"AMUX_PANE=old",
+		"AMUX_SESSION=old-session",
+		"NO_COLOR=1",
+		"CODEX_CI=1",
+		"PATH=/bin",
+		"ODDENTRY",
+	}
+
+	env := paneCommandEnv(base, 7, "session-a")
+	joined := strings.Join(env, "\n")
+	for _, forbidden := range []string{"TERM=screen-256color", "AMUX_PANE=old", "AMUX_SESSION=old-session", "NO_COLOR=1", "CODEX_CI=1"} {
+		if strings.Contains(joined, forbidden) {
+			t.Fatalf("paneCommandEnv leaked %q:\n%s", forbidden, joined)
+		}
+	}
+	for _, required := range []string{"TERM=amux", "AMUX_PANE=7", "AMUX_SESSION=session-a", "PATH=/bin", "ODDENTRY"} {
+		if !strings.Contains(joined, required) {
+			t.Fatalf("paneCommandEnv missing %q:\n%s", required, joined)
+		}
+	}
+
+	t.Setenv("TERM", "xterm-256color")
+	t.Setenv("AMUX_PANE", "old-pane")
+	t.Setenv("AMUX_SESSION", "old-session")
+	t.Setenv("NO_COLOR", "1")
+	t.Setenv("CODEX_CI", "1")
+	shellEnv := strings.Join(paneShellEnv(8, "session-b"), "\n")
+	for _, required := range []string{"TERM=amux", "AMUX_PANE=8", "AMUX_SESSION=session-b"} {
+		if !strings.Contains(shellEnv, required) {
+			t.Fatalf("paneShellEnv missing %q:\n%s", required, shellEnv)
+		}
+	}
+	for _, forbidden := range []string{"NO_COLOR=1", "CODEX_CI=1", "AMUX_PANE=old-pane", "AMUX_SESSION=old-session"} {
+		if strings.Contains(shellEnv, forbidden) {
+			t.Fatalf("paneShellEnv leaked %q:\n%s", forbidden, shellEnv)
+		}
+	}
+
+	pane := &Pane{}
+	want := time.Unix(1234, 5678)
+	pane.SetCreatedAt(want)
+	if got := pane.CreatedAt(); !got.Equal(want) {
+		t.Fatalf("CreatedAt() = %v, want %v", got, want)
+	}
+}
+
+func TestEncodeMouseButton(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		btn  mouse.Button
+		want ansi.MouseButton
+		ok   bool
+	}{
+		{name: "left", btn: mouse.ButtonLeft, want: ansi.MouseLeft, ok: true},
+		{name: "middle", btn: mouse.ButtonMiddle, want: ansi.MouseMiddle, ok: true},
+		{name: "right", btn: mouse.ButtonRight, want: ansi.MouseRight, ok: true},
+		{name: "none", btn: mouse.ButtonNone, want: ansi.MouseNone, ok: true},
+		{name: "scroll up", btn: mouse.ScrollUp, want: ansi.MouseWheelUp, ok: true},
+		{name: "scroll down", btn: mouse.ScrollDown, want: ansi.MouseWheelDown, ok: true},
+		{name: "scroll left", btn: mouse.ScrollLeft, want: ansi.MouseWheelLeft, ok: true},
+		{name: "scroll right", btn: mouse.ScrollRight, want: ansi.MouseWheelRight, ok: true},
+		{name: "invalid", btn: mouse.Button(99), ok: false},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, ok := encodeMouseButton(tt.btn)
+			if ok != tt.ok || got != tt.want {
+				t.Fatalf("encodeMouseButton(%v) = (%v, %t), want (%v, %t)", tt.btn, got, ok, tt.want, tt.ok)
+			}
+		})
+	}
+}

--- a/internal/render/overlay_extra_test.go
+++ b/internal/render/overlay_extra_test.go
@@ -1,0 +1,391 @@
+package render
+
+import (
+	"reflect"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/weill-labs/amux/internal/config"
+	"github.com/weill-labs/amux/internal/mux"
+)
+
+type statusPaneData struct {
+	fakePaneData
+	host       string
+	task       string
+	color      string
+	connStatus string
+	idle       bool
+	inCopyMode bool
+	search     string
+}
+
+func (p *statusPaneData) Host() string           { return p.host }
+func (p *statusPaneData) Task() string           { return p.task }
+func (p *statusPaneData) Color() string          { return p.color }
+func (p *statusPaneData) Idle() bool             { return p.idle }
+func (p *statusPaneData) ConnStatus() string     { return p.connStatus }
+func (p *statusPaneData) InCopyMode() bool       { return p.inCopyMode }
+func (p *statusPaneData) CopyModeSearch() string { return p.search }
+
+func TestChooserOverlayLayoutGuardsAndWindowing(t *testing.T) {
+	t.Parallel()
+
+	t.Run("guards", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []struct {
+			name    string
+			width   int
+			height  int
+			overlay *ChooserOverlay
+		}{
+			{name: "nil overlay", width: 20, height: 10},
+			{name: "non-positive width", width: 0, height: 10, overlay: &ChooserOverlay{Title: "x"}},
+			{name: "tiny width", width: 8, height: 10, overlay: &ChooserOverlay{Title: "x"}},
+			{name: "tiny height", width: 20, height: 4, overlay: &ChooserOverlay{Title: "x"}},
+		}
+
+		for _, tt := range tests {
+			tt := tt
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
+				lines, styles, x, y := chooserOverlayLayout(tt.width, tt.height, tt.overlay)
+				if lines != nil || styles != nil || x != 0 || y != 0 {
+					t.Fatalf("chooserOverlayLayout(%d, %d, %+v) = (%v, %v, %d, %d), want nil layout", tt.width, tt.height, tt.overlay, lines, styles, x, y)
+				}
+			})
+		}
+	})
+
+	t.Run("windows selected row into view", func(t *testing.T) {
+		t.Parallel()
+
+		rows := make([]ChooserOverlayRow, 10)
+		for i := range rows {
+			rows[i] = ChooserOverlayRow{Text: "row-" + string(rune('0'+i)), Selectable: true}
+		}
+		overlay := &ChooserOverlay{
+			Title:    "choose-tree",
+			Query:    "pane",
+			Rows:     rows,
+			Selected: 8,
+		}
+
+		lines, styles, x, y := chooserOverlayLayout(30, 12, overlay)
+		if len(lines) != 8 {
+			t.Fatalf("len(lines) = %d, want 8", len(lines))
+		}
+		if x <= 0 || y <= 0 {
+			t.Fatalf("layout origin = (%d, %d), want centered positive coordinates", x, y)
+		}
+		if !strings.Contains(lines[2], "row-5") || !strings.Contains(lines[6], "row-9") {
+			t.Fatalf("visible rows = %q .. %q, want rows 5 through 9", lines[2], lines[6])
+		}
+		if styles[5] != chooserRowSelected {
+			t.Fatalf("selected row style = %q, want %q", styles[5], chooserRowSelected)
+		}
+	})
+}
+
+func TestChooserOverlayRenderAndCells(t *testing.T) {
+	t.Parallel()
+
+	overlay := &ChooserOverlay{
+		Title: "choose-window",
+		Query: "pane",
+		Rows: []ChooserOverlayRow{
+			{Text: "0:main", Selectable: true},
+			{Text: "section", Selectable: false},
+			{Text: "1:logs", Selectable: true},
+		},
+		Selected: 2,
+	}
+
+	lines, _, x, y := chooserOverlayLayout(32, 12, overlay)
+	if len(lines) == 0 {
+		t.Fatal("chooserOverlayLayout returned no lines")
+	}
+
+	grid := NewScreenGrid(32, 12)
+	buildChooserOverlayCells(grid, overlay)
+	text := gridToText(grid)
+	for _, line := range lines {
+		if !strings.Contains(text, line) {
+			t.Fatalf("grid text missing overlay line %q:\n%s", line, text)
+		}
+	}
+	if got := grid.Get(x+1, y+2).Char; got != string(lines[2][1]) {
+		t.Fatalf("grid cell at selected row = %q, want %q", got, string(lines[2][1]))
+	}
+
+	var buf strings.Builder
+	renderChooserOverlay(&buf, 32, 12, overlay)
+	rendered := buf.String()
+	for row, line := range lines {
+		if !strings.Contains(rendered, line) {
+			t.Fatalf("rendered overlay missing line %q:\n%s", line, rendered)
+		}
+		if !strings.Contains(rendered, cursorPos(y+row+1, x+1)) {
+			t.Fatalf("rendered overlay missing cursor position for row %d", row)
+		}
+	}
+}
+
+func TestPadOrTrim(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		s     string
+		width int
+		want  string
+	}{
+		{name: "non-positive width", s: "hello", width: 0, want: ""},
+		{name: "pads shorter strings", s: "hi", width: 4, want: "hi  "},
+		{name: "returns exact width", s: "word", width: 4, want: "word"},
+		{name: "trims longer strings", s: "abcdef", width: 3, want: "abc"},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := padOrTrim(tt.s, tt.width); got != tt.want {
+				t.Fatalf("padOrTrim(%q, %d) = %q, want %q", tt.s, tt.width, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPaneOverlayPlacementAndRendering(t *testing.T) {
+	t.Parallel()
+
+	t.Run("placement", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []struct {
+			name  string
+			cell  *mux.LayoutCell
+			label string
+			want  string
+		}{
+			{name: "nil cell", label: "a", want: ""},
+			{name: "empty label", cell: mkLeaf(1, 0, 0, 8, 4), want: ""},
+			{name: "narrow cell uses first rune", cell: mkLeaf(1, 4, 3, 2, 4), label: "zoom", want: "z"},
+			{name: "wide cell uses badge", cell: mkLeaf(1, 0, 0, 8, 4), label: "b", want: "[b]"},
+		}
+
+		for _, tt := range tests {
+			tt := tt
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
+				got, _, _ := paneOverlayPlacement(tt.cell, tt.label)
+				if got != tt.want {
+					t.Fatalf("paneOverlayPlacement(%v, %q) badge = %q, want %q", tt.cell, tt.label, got, tt.want)
+				}
+			})
+		}
+	})
+
+	t.Run("builds grid cells and ansi output", func(t *testing.T) {
+		t.Parallel()
+
+		root := buildFourPane(19, 9)
+		labels := []PaneOverlayLabel{
+			{PaneID: 3, Label: "x"},
+			{PaneID: 99, Label: "ignored"},
+			{PaneID: 4, Label: ""},
+		}
+		lookup := func(paneID uint32) PaneData {
+			if paneID != 3 {
+				return nil
+			}
+			return &statusPaneData{
+				fakePaneData: fakePaneData{id: 3, name: "pane-3"},
+				color:        config.TextColorHex,
+			}
+		}
+
+		grid := NewScreenGrid(19, 9)
+		buildPaneOverlayCells(grid, root, lookup, labels)
+		badge, x, y := paneOverlayPlacement(root.FindByPaneID(3), "x")
+		if got := grid.Get(x, y).Char + grid.Get(x+1, y).Char + grid.Get(x+2, y).Char; got != badge {
+			t.Fatalf("badge text = %q, want %q", got, badge)
+		}
+
+		var buf strings.Builder
+		renderPaneOverlay(&buf, root, lookup, labels)
+		rendered := buf.String()
+		if !strings.Contains(rendered, cursorPos(y+1, x+1)) {
+			t.Fatalf("rendered pane overlay missing cursor position: %q", rendered)
+		}
+		if !strings.Contains(rendered, badge) {
+			t.Fatalf("rendered pane overlay missing badge %q: %q", badge, rendered)
+		}
+	})
+}
+
+func TestRenderPaneStatusVariants(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		active   bool
+		pd       *statusPaneData
+		contains []string
+	}{
+		{
+			name:   "active copy mode remote connected",
+			active: true,
+			pd: &statusPaneData{
+				fakePaneData: fakePaneData{id: 1, name: "pane-1"},
+				host:         "gpu",
+				task:         "tail -f",
+				color:        config.CatppuccinMocha[0],
+				connStatus:   "connected",
+				inCopyMode:   true,
+				search:       "/panic",
+			},
+			contains: []string{"●", "[pane-1]", "[copy] /panic", "@gpu", "⚡", "tail -f"},
+		},
+		{
+			name:   "inactive idle disconnected",
+			active: false,
+			pd: &statusPaneData{
+				fakePaneData: fakePaneData{id: 2, name: "pane-2"},
+				host:         "edge",
+				color:        config.CatppuccinMocha[1],
+				connStatus:   "disconnected",
+				idle:         true,
+			},
+			contains: []string{"◇", "[pane-2]", "@edge", "✕"},
+		},
+		{
+			name:   "inactive busy reconnecting",
+			active: false,
+			pd: &statusPaneData{
+				fakePaneData: fakePaneData{id: 3, name: "pane-3"},
+				host:         mux.DefaultHost,
+				task:         "htop",
+				color:        config.CatppuccinMocha[2],
+				connStatus:   "reconnecting",
+			},
+			contains: []string{"○", "[pane-3]", "⟳", "htop"},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var buf strings.Builder
+			renderPaneStatus(&buf, mkLeaf(tt.pd.id, 0, 0, 48, 4), tt.active, tt.pd)
+			rendered := buf.String()
+			for _, want := range tt.contains {
+				if !strings.Contains(rendered, want) {
+					t.Fatalf("renderPaneStatus missing %q:\n%s", want, rendered)
+				}
+			}
+		})
+	}
+}
+
+func TestRenderGlobalBarAndTruncateRunes(t *testing.T) {
+	frozen := time.Date(2026, time.March, 22, 9, 41, 0, 0, time.UTC)
+	prevTimeNow := timeNow
+	timeNow = func() time.Time { return frozen }
+	defer func() { timeNow = prevTimeNow }()
+
+	if got := truncateRunes("abcdef", 4); got != "abc…" {
+		t.Fatalf("truncateRunes = %q, want %q", got, "abc…")
+	}
+
+	var buf strings.Builder
+	renderGlobalBar(&buf, "main", 3, 36, 8, []WindowInfo{
+		{Index: 1, Name: "dev", IsActive: true},
+		{Index: 2, Name: "logs", IsActive: false},
+	}, "very long command feedback that must truncate")
+	rendered := buf.String()
+	for _, want := range []string{"[1:dev]", "2:logs", "very lon…"} {
+		if !strings.Contains(rendered, want) {
+			t.Fatalf("renderGlobalBar missing %q:\n%s", want, rendered)
+		}
+	}
+
+	buf.Reset()
+	renderGlobalBar(&buf, "main", 7, 30, 8, nil, "")
+	rendered = buf.String()
+	for _, want := range []string{" main ", "7 panes", "09:41"} {
+		if !strings.Contains(rendered, want) {
+			t.Fatalf("renderGlobalBar missing %q:\n%s", want, rendered)
+		}
+	}
+}
+
+func TestCompositorHelpersAndClipLine(t *testing.T) {
+	t.Parallel()
+
+	c := NewCompositor(12, 6, "alpha")
+	if got := c.LayoutHeight(); got != 5 {
+		t.Fatalf("LayoutHeight = %d, want 5", got)
+	}
+
+	windows := []WindowInfo{{Index: 1, Name: "main", IsActive: true, Panes: 1}}
+	c.SetWindows(windows)
+	c.SetSessionName("beta")
+	if c.sessionName != "beta" {
+		t.Fatalf("sessionName = %q, want beta", c.sessionName)
+	}
+	if !reflect.DeepEqual(c.windows, windows) {
+		t.Fatalf("windows = %+v, want %+v", c.windows, windows)
+	}
+
+	root := mkLeaf(1, 0, 0, 12, 5)
+	emu := mux.NewVTEmulatorWithScrollback(12, 4, mux.DefaultScrollbackLines)
+	if _, err := emu.Write([]byte("hello")); err != nil {
+		t.Fatalf("emu.Write: %v", err)
+	}
+	pd := &cursorPaneData{id: 1, name: "pane-1", color: config.CatppuccinMocha[0], emu: emu}
+	rendered := c.RenderDiff(root, 1, func(uint32) PaneData { return pd })
+	if rendered == "" {
+		t.Fatal("RenderDiff returned empty output")
+	}
+	if got := c.PrevGridText(); !strings.Contains(got, "hello") {
+		t.Fatalf("PrevGridText = %q, want pane content", got)
+	}
+	c.ClearPrevGrid()
+	if got := c.PrevGridText(); got != "" {
+		t.Fatalf("PrevGridText after ClearPrevGrid = %q, want empty", got)
+	}
+
+	tests := []struct {
+		name     string
+		line     string
+		maxWidth int
+		want     string
+	}{
+		{name: "plain text", line: "hello", maxWidth: 3, want: "hel"},
+		{name: "preserves ansi prefix", line: "\x1b[31mhello", maxWidth: 3, want: "\x1b[31mhel"},
+		{name: "skips control chars", line: "a\tbcd", maxWidth: 2, want: "a\tb"},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := clipLine(tt.line, tt.maxWidth); got != tt.want {
+				t.Fatalf("clipLine(%q, %d) = %q, want %q", tt.line, tt.maxWidth, got, tt.want)
+			}
+		})
+	}
+}
+
+func cursorPos(row, col int) string {
+	return "\x1b[" + strconv.Itoa(row) + ";" + strconv.Itoa(col) + "H"
+}

--- a/internal/server/commands_extra_test.go
+++ b/internal/server/commands_extra_test.go
@@ -1,0 +1,431 @@
+package server
+
+import (
+	"encoding/json"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/weill-labs/amux/internal/config"
+	"github.com/weill-labs/amux/internal/mux"
+	"github.com/weill-labs/amux/internal/proto"
+)
+
+func runOneShotCommand(t *testing.T, sess *Session, args []string, fn func(*CommandContext)) *Message {
+	t.Helper()
+
+	serverConn, clientConn := net.Pipe()
+	cc := NewClientConn(serverConn)
+	cc.ID = "cmd-client"
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		fn(&CommandContext{CC: cc, Sess: sess, Args: args})
+	}()
+
+	msg := readMsgWithTimeout(t, clientConn)
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("command did not return after reply")
+	}
+
+	cc.Close()
+	_ = clientConn.Close()
+	_ = serverConn.Close()
+	return msg
+}
+
+func readCmdResultEvent(t *testing.T, conn net.Conn) Event {
+	t.Helper()
+
+	msg := readMsgWithTimeout(t, conn)
+	if msg.Type != MsgTypeCmdResult {
+		t.Fatalf("message type = %v, want cmd result", msg.Type)
+	}
+
+	var ev Event
+	if err := json.Unmarshal([]byte(strings.TrimSpace(msg.CmdOutput)), &ev); err != nil {
+		t.Fatalf("json.Unmarshal(%q): %v", msg.CmdOutput, err)
+	}
+	return ev
+}
+
+func TestHookCommandsRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	sess := newSession("test-hook-commands")
+	stopCrashCheckpointLoop(t, sess)
+	defer stopSessionBackgroundLoops(t, sess)
+
+	msg := runOneShotCommand(t, sess, []string{"on-idle", "echo", "one"}, cmdSetHook)
+	if got := msg.CmdOutput; got != "Hook added: on-idle → echo one\n" {
+		t.Fatalf("set-hook output = %q", got)
+	}
+
+	msg = runOneShotCommand(t, sess, []string{"on-idle", "echo", "two"}, cmdSetHook)
+	if got := msg.CmdOutput; got != "Hook added: on-idle → echo two\n" {
+		t.Fatalf("second set-hook output = %q", got)
+	}
+
+	msg = runOneShotCommand(t, sess, nil, cmdListHooks)
+	for _, want := range []string{"on-idle:", "0: echo one", "1: echo two"} {
+		if !strings.Contains(msg.CmdOutput, want) {
+			t.Fatalf("list-hooks missing %q:\n%s", want, msg.CmdOutput)
+		}
+	}
+
+	msg = runOneShotCommand(t, sess, []string{"on-idle", "0"}, cmdUnsetHook)
+	if got := msg.CmdOutput; got != "Removed hook 0 for on-idle\n" {
+		t.Fatalf("unset-hook index output = %q", got)
+	}
+
+	msg = runOneShotCommand(t, sess, nil, cmdListHooks)
+	if strings.Contains(msg.CmdOutput, "echo one") || !strings.Contains(msg.CmdOutput, "echo two") {
+		t.Fatalf("list-hooks after indexed removal = %q", msg.CmdOutput)
+	}
+
+	msg = runOneShotCommand(t, sess, []string{"on-idle"}, cmdUnsetHook)
+	if got := msg.CmdOutput; got != "Removed all hooks for on-idle\n" {
+		t.Fatalf("unset-hook all output = %q", got)
+	}
+
+	msg = runOneShotCommand(t, sess, nil, cmdListHooks)
+	if got := msg.CmdOutput; got != "No hooks registered.\n" {
+		t.Fatalf("list-hooks empty output = %q", got)
+	}
+}
+
+func TestCmdWaitUIUnknownImmediateAndTimeout(t *testing.T) {
+	t.Parallel()
+
+	t.Run("unknown event", func(t *testing.T) {
+		t.Parallel()
+
+		sess := newSession("test-wait-ui-unknown")
+		stopCrashCheckpointLoop(t, sess)
+		defer stopSessionBackgroundLoops(t, sess)
+
+		msg := runOneShotCommand(t, sess, []string{"not-a-ui-event"}, cmdWaitUI)
+		if !strings.Contains(msg.CmdErr, "unknown ui event") {
+			t.Fatalf("cmdWaitUI error = %q, want unknown ui event", msg.CmdErr)
+		}
+	})
+
+	t.Run("current match returns immediately", func(t *testing.T) {
+		t.Parallel()
+
+		sess := newSession("test-wait-ui-current")
+		stopCrashCheckpointLoop(t, sess)
+		defer stopSessionBackgroundLoops(t, sess)
+
+		serverConn, clientConn := net.Pipe()
+		cc := NewClientConn(serverConn)
+		cc.ID = "client-1"
+		cc.copyModeShown = true
+		cc.uiGeneration = 3
+		mustSessionQuery(t, sess, func(sess *Session) struct{} {
+			sess.clients = []*ClientConn{cc}
+			return struct{}{}
+		})
+
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			cmdWaitUI(&CommandContext{CC: cc, Sess: sess, Args: []string{"copy-mode-shown", "--after", "2"}})
+		}()
+
+		msg := readMsgWithTimeout(t, clientConn)
+		if got := msg.CmdOutput; got != "copy-mode-shown\n" {
+			t.Fatalf("cmdWaitUI immediate output = %q", got)
+		}
+
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+			t.Fatal("cmdWaitUI immediate case did not return")
+		}
+
+		cc.Close()
+		_ = clientConn.Close()
+		_ = serverConn.Close()
+	})
+
+	t.Run("timeout", func(t *testing.T) {
+		t.Parallel()
+
+		sess := newSession("test-wait-ui-timeout")
+		stopCrashCheckpointLoop(t, sess)
+		defer stopSessionBackgroundLoops(t, sess)
+
+		serverConn, clientConn := net.Pipe()
+		cc := NewClientConn(serverConn)
+		cc.ID = "client-2"
+		cc.inputIdle = true
+		mustSessionQuery(t, sess, func(sess *Session) struct{} {
+			sess.clients = []*ClientConn{cc}
+			return struct{}{}
+		})
+
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			cmdWaitUI(&CommandContext{CC: cc, Sess: sess, Args: []string{"input-busy", "--timeout", "20ms"}})
+		}()
+
+		msg := readMsgWithTimeout(t, clientConn)
+		if got := msg.CmdErr; got != "timeout waiting for input-busy on client-2" {
+			t.Fatalf("cmdWaitUI timeout error = %q", got)
+		}
+
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+			t.Fatal("cmdWaitUI timeout case did not return")
+		}
+
+		cc.Close()
+		_ = clientConn.Close()
+		_ = serverConn.Close()
+	})
+}
+
+func TestCmdListClientsFormatsClientsAndEmptyState(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty", func(t *testing.T) {
+		t.Parallel()
+
+		sess := newSession("test-list-clients-empty")
+		stopCrashCheckpointLoop(t, sess)
+		defer stopSessionBackgroundLoops(t, sess)
+
+		msg := runOneShotCommand(t, sess, nil, cmdListClients)
+		if got := msg.CmdOutput; got != "No clients attached.\n" {
+			t.Fatalf("cmdListClients empty output = %q", got)
+		}
+	})
+
+	t.Run("formats active clients", func(t *testing.T) {
+		t.Parallel()
+
+		sess := newSession("test-list-clients-full")
+		stopCrashCheckpointLoop(t, sess)
+		defer stopSessionBackgroundLoops(t, sess)
+
+		cc1 := &ClientConn{
+			ID:                "client-1",
+			displayPanesShown: true,
+			cols:              80,
+			rows:              24,
+			capabilities:      proto.ClientCapabilities{Hyperlinks: true},
+			inputIdle:         true,
+		}
+		cc2 := &ClientConn{
+			ID:          "client-2",
+			chooserMode: chooserWindow,
+			cols:        60,
+			rows:        20,
+			inputIdle:   true,
+		}
+		mustSessionQuery(t, sess, func(sess *Session) struct{} {
+			sess.clients = []*ClientConn{cc1, cc2}
+			sess.sizeClient.Store(cc2)
+			return struct{}{}
+		})
+
+		msg := runOneShotCommand(t, sess, nil, cmdListClients)
+		for _, want := range []string{"CLIENT", "client-1", "client-2", "80x24", "60x20", "shown", "window", "hyperlinks", "*"} {
+			if !strings.Contains(msg.CmdOutput, want) {
+				t.Fatalf("cmdListClients missing %q:\n%s", want, msg.CmdOutput)
+			}
+		}
+	})
+}
+
+func TestRemoteHostCommandsReportConfiguredAndErrorStates(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{
+		Hosts: map[string]config.Host{
+			"dev":   {Type: "remote", Address: "example.com:22"},
+			"local": {Type: "local"},
+		},
+	}
+
+	t.Run("hosts without manager", func(t *testing.T) {
+		t.Parallel()
+
+		sess := newSession("test-hosts-none")
+		stopCrashCheckpointLoop(t, sess)
+		defer stopSessionBackgroundLoops(t, sess)
+
+		msg := runOneShotCommand(t, sess, nil, cmdHosts)
+		if got := msg.CmdOutput; got != "No remote hosts configured.\n" {
+			t.Fatalf("cmdHosts without manager = %q", got)
+		}
+	})
+
+	t.Run("hosts with configured manager", func(t *testing.T) {
+		t.Parallel()
+
+		sess := newSession("test-hosts-configured")
+		stopCrashCheckpointLoop(t, sess)
+		defer stopSessionBackgroundLoops(t, sess)
+		sess.SetupRemoteManager(cfg, "")
+		defer sess.RemoteManager.Shutdown()
+
+		msg := runOneShotCommand(t, sess, nil, cmdHosts)
+		for _, want := range []string{"HOST", "STATUS", "dev", "disconnected"} {
+			if !strings.Contains(msg.CmdOutput, want) {
+				t.Fatalf("cmdHosts missing %q:\n%s", want, msg.CmdOutput)
+			}
+		}
+	})
+
+	t.Run("disconnect and reconnect error paths", func(t *testing.T) {
+		t.Parallel()
+
+		noMgr := newSession("test-host-commands-no-manager")
+		stopCrashCheckpointLoop(t, noMgr)
+		defer stopSessionBackgroundLoops(t, noMgr)
+
+		msg := runOneShotCommand(t, noMgr, nil, cmdDisconnect)
+		if got := msg.CmdErr; got != "usage: disconnect <host>" {
+			t.Fatalf("disconnect usage error = %q", got)
+		}
+
+		msg = runOneShotCommand(t, noMgr, []string{"dev"}, cmdDisconnect)
+		if got := msg.CmdErr; got != "no remote hosts configured" {
+			t.Fatalf("disconnect no-manager error = %q", got)
+		}
+
+		msg = runOneShotCommand(t, noMgr, nil, cmdReconnect)
+		if got := msg.CmdErr; got != "usage: reconnect <host>" {
+			t.Fatalf("reconnect usage error = %q", got)
+		}
+
+		msg = runOneShotCommand(t, noMgr, []string{"dev"}, cmdReconnect)
+		if got := msg.CmdErr; got != "no remote hosts configured" {
+			t.Fatalf("reconnect no-manager error = %q", got)
+		}
+
+		withMgr := newSession("test-host-commands-configured")
+		stopCrashCheckpointLoop(t, withMgr)
+		defer stopSessionBackgroundLoops(t, withMgr)
+		withMgr.SetupRemoteManager(cfg, "")
+		defer withMgr.RemoteManager.Shutdown()
+
+		msg = runOneShotCommand(t, withMgr, []string{"dev"}, cmdDisconnect)
+		if got := msg.CmdErr; got != "host \"dev\" not connected" {
+			t.Fatalf("disconnect configured error = %q", got)
+		}
+
+		msg = runOneShotCommand(t, withMgr, []string{"dev"}, cmdReconnect)
+		if got := msg.CmdErr; got != "host \"dev\" not known" {
+			t.Fatalf("reconnect configured error = %q", got)
+		}
+	})
+}
+
+func TestCmdEventsStreamsAndThrottlesOutput(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no throttle streams output immediately", func(t *testing.T) {
+		t.Parallel()
+
+		sess := newSession("test-events-immediate")
+		stopCrashCheckpointLoop(t, sess)
+		defer stopSessionBackgroundLoops(t, sess)
+
+		pane := newProxyPane(1, mux.PaneMeta{Name: "pane-1", Host: mux.DefaultHost, Color: config.CatppuccinMocha[0]}, 80, 23, nil, nil, func(data []byte) (int, error) {
+			return len(data), nil
+		})
+		sess.Panes = []*mux.Pane{pane}
+
+		serverConn, clientConn := net.Pipe()
+		cc := NewClientConn(serverConn)
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			cmdEvents(&CommandContext{CC: cc, Sess: sess, Args: []string{"--throttle", "0s"}})
+		}()
+
+		for i := 0; i < 2; i++ {
+			_ = readCmdResultEvent(t, clientConn)
+		}
+
+		sess.paneOutputCallback()(pane.ID, []byte("hello"), 1)
+		ev := readCmdResultEvent(t, clientConn)
+		if ev.Type != EventOutput || ev.PaneID != pane.ID || ev.PaneName != "pane-1" {
+			t.Fatalf("output event = %+v", ev)
+		}
+
+		_ = clientConn.Close()
+		sess.paneOutputCallback()(pane.ID, []byte("again"), 2)
+
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+			t.Fatal("cmdEvents immediate stream did not exit after client disconnect")
+		}
+
+		cc.Close()
+		_ = serverConn.Close()
+	})
+
+	t.Run("throttle coalesces and sorts output events", func(t *testing.T) {
+		t.Parallel()
+
+		sess := newSession("test-events-throttle")
+		stopCrashCheckpointLoop(t, sess)
+		defer stopSessionBackgroundLoops(t, sess)
+
+		pane1 := newProxyPane(1, mux.PaneMeta{Name: "pane-1", Host: mux.DefaultHost, Color: config.CatppuccinMocha[0]}, 80, 23, nil, nil, func(data []byte) (int, error) {
+			return len(data), nil
+		})
+		pane2 := newProxyPane(2, mux.PaneMeta{Name: "pane-2", Host: mux.DefaultHost, Color: config.CatppuccinMocha[1]}, 80, 23, nil, nil, func(data []byte) (int, error) {
+			return len(data), nil
+		})
+		sess.Panes = []*mux.Pane{pane1, pane2}
+
+		serverConn, clientConn := net.Pipe()
+		cc := NewClientConn(serverConn)
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			cmdEvents(&CommandContext{CC: cc, Sess: sess, Args: []string{"--throttle", "20ms"}})
+		}()
+
+		for i := 0; i < 3; i++ {
+			_ = readCmdResultEvent(t, clientConn)
+		}
+
+		sess.paneOutputCallback()(pane2.ID, []byte("pane2"), 1)
+		sess.paneOutputCallback()(pane1.ID, []byte("pane1"), 1)
+		sess.paneOutputCallback()(pane1.ID, []byte("pane1 again"), 2)
+
+		first := readCmdResultEvent(t, clientConn)
+		second := readCmdResultEvent(t, clientConn)
+		if first.Type != EventOutput || second.Type != EventOutput {
+			t.Fatalf("expected output events, got %+v and %+v", first, second)
+		}
+		if first.PaneID != pane1.ID || second.PaneID != pane2.ID {
+			t.Fatalf("throttled pane order = [%d %d], want [%d %d]", first.PaneID, second.PaneID, pane1.ID, pane2.ID)
+		}
+
+		_ = clientConn.Close()
+		sess.paneOutputCallback()(pane1.ID, []byte("final"), 3)
+
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+			t.Fatal("cmdEvents throttled stream did not exit after client disconnect")
+		}
+
+		cc.Close()
+		_ = serverConn.Close()
+	})
+}


### PR DESCRIPTION
## Motivation
The coverage hotspots in `internal/server`, `internal/render`, `internal/client`, and `internal/mux` were still leaving large helper and command surfaces untested. This adds focused tests in those areas to raise confidence around edge cases while keeping patch coverage comfortably above the repo target.

## Summary
- add render tests for chooser overlays, pane overlays, status bars, compositor helpers, and ANSI clipping paths
- add client tests for attach-capability detection, chooser input branches, overlay aggregation, command feedback, and active copy-mode helpers
- add server command tests for hook management, UI waits, client/host listing, and throttled `events` streaming
- add mux helper tests for client-side layout leaf IDs, pane env rewriting, created-at accessors, and mouse-button encoding
- raise package coverage in the target areas: `internal/render` 65.6% -> 85.0%, `internal/server` 48.7% -> 52.8%, `internal/client` 63.3% -> 65.6%, `internal/mux` 69.2% -> 70.8%

## Testing
- `env -u AMUX_SESSION -u TMUX go test ./internal/render -run 'TestChooserOverlayLayoutGuardsAndWindowing|TestChooserOverlayRenderAndCells|TestPadOrTrim|TestPaneOverlayPlacementAndRendering|TestRenderPaneStatusVariants|TestRenderGlobalBarAndTruncateRunes|TestCompositorHelpersAndClipLine' -count=100`
- `env -u AMUX_SESSION -u TMUX go test ./internal/client -run 'TestAdvertisedAttachCapabilitiesUsesProcessEnv|TestRendererOverlayStateCommandFeedbackAndActiveCopyMode|TestChooserHelpersAndInputBranches|TestMoveAndSelectChooserBellPaths' -count=100`
- `env -u AMUX_SESSION -u TMUX go test ./internal/server -run 'TestHookCommandsRoundTrip|TestCmdWaitUIUnknownImmediateAndTimeout|TestCmdListClientsFormatsClientsAndEmptyState|TestRemoteHostCommandsReportConfiguredAndErrorStates|TestCmdEventsStreamsAndThrottlesOutput' -count=100`
- `env -u AMUX_SESSION -u TMUX go test ./internal/mux -run 'TestLayoutCellIDHelpers|TestPaneEnvironmentAndCreatedAt|TestEncodeMouseButton' -count=100`
- `env -u AMUX_SESSION -u TMUX go test ./... -count=1`
- `env -u AMUX_SESSION -u TMUX go test ./... -coverprofile=/tmp/cover.out -count=1`
- `go tool cover -func=/tmp/cover.out | tail -1`

## Review focus
- The new `internal/server/commands_extra_test.go` coverage is concentrated on direct command execution over `net.Pipe`, especially the streaming `events` command and `wait-ui` behavior.
- The render coverage leans on helper-level assertions for overlays and status bars rather than golden files; check that those expectations still match the intended rendering contracts.
