### PR TITLE
Tell agents to set pane metadata after opening PRs

### DIFF
--- a/.agents/skills/amux/SKILL.md
+++ b/.agents/skills/amux/SKILL.md
@@ -214,6 +214,16 @@ git reset HEAD .claude/worktrees/ .context/ 2>/dev/null
 rm -rf .claude/worktrees/ .context/ 2>/dev/null
 ```
 
+## Post-PR Protocol
+
+After opening a PR with `gh pr create`, set pane metadata for the current amux pane:
+
+```bash
+amux add-meta "$AMUX_PANE" pr=NUMBER issue=LAB-XXX
+```
+
+`$AMUX_PANE` is already set in pane shells. Replace `NUMBER` with the new PR number and `LAB-XXX` with the Linear issue ID.
+
 ## JSON Capture Structure
 
 The `--format json` output looks like:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,15 @@ amux capture --format json        # structured JSON for agents
 amux capture --format json pane-1 # single pane JSON
 ```
 
+### Working In amux
+
+When working in an amux pane, set pane metadata when you start a Linear issue and update it again after opening a PR. Pane shells already have `$AMUX_PANE` set, so use that directly:
+
+```bash
+amux add-meta "$AMUX_PANE" issue=LAB-XXX
+amux add-meta "$AMUX_PANE" pr=NUMBER issue=LAB-XXX
+```
+
 ### TDD Workflow
 
 All development follows red-green-refactor with **separate commits** for each phase:


### PR DESCRIPTION
## Motivation

Agents working inside amux need a standard post-PR step so pane metadata tracks the Linear issue and PR number. This change documents that workflow in the shared amux skill and the repo-specific Claude/Codex instructions.

## Summary

- add a `Post-PR Protocol` section to `.agents/skills/amux/SKILL.md` with the `amux add-meta "$AMUX_PANE" pr=NUMBER issue=LAB-XXX` pattern
- add a `Working In amux` rule to `CLAUDE.md` for setting pane metadata when starting a Linear issue and after `gh pr create`
- rely on the existing `AGENTS.md -> CLAUDE.md` symlink so Codex gets the same rule without duplicating the file

## Testing

- `git diff --check`
- `env -u AMUX_SESSION -u TMUX make test`

## Review focus

- the docs intentionally describe the future `add-meta` / `issue` workflow ahead of the CLI implementation because LAB-337 is instruction-only
- `AGENTS.md` remains a symlink to `CLAUDE.md`, so the Codex instructions are updated through the shared source file

Closes LAB-337
