### PR TITLE
Display PR and issue metadata in pane status bars

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -717,6 +717,8 @@ func (c *clientPaneData) HasCursorBlock() bool {
 
 func (c *clientPaneData) ID() uint32         { return c.info.ID }
 func (c *clientPaneData) Name() string       { return c.info.Name }
+func (c *clientPaneData) PRs() []string      { return c.info.PRs }
+func (c *clientPaneData) Issues() []string   { return c.info.Issues }
 func (c *clientPaneData) Host() string       { return c.info.Host }
 func (c *clientPaneData) Task() string       { return c.info.Task }
 func (c *clientPaneData) Color() string      { return c.info.Color }

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -716,6 +716,26 @@ func TestCaptureDisplay(t *testing.T) {
 	}
 }
 
+func TestCaptureDisplayShowsPaneMetadata(t *testing.T) {
+	t.Parallel()
+
+	cr := NewClientRenderer(80, 24)
+	snap := singlePane20xN(23)
+	snap.Panes[0].PRs = []string{"42", "314"}
+	snap.Panes[0].Issues = []string{"LAB-339"}
+	snap.Windows[0].Panes[0].PRs = []string{"42", "314"}
+	snap.Windows[0].Panes[0].Issues = []string{"LAB-339"}
+
+	cr.HandleLayout(snap)
+	cr.HandlePaneOutput(1, []byte("metadata display"))
+	cr.RenderDiff()
+
+	display := cr.CaptureDisplay()
+	if !strings.Contains(display, "#42, #314, LAB-339") {
+		t.Fatalf("display should contain pane metadata, got:\n%s", display)
+	}
+}
+
 func TestCommandFeedbackAppearsInDisplayCapture(t *testing.T) {
 	t.Parallel()
 

--- a/internal/client/panedata.go
+++ b/internal/client/panedata.go
@@ -70,6 +70,8 @@ func (p *PaneData) CursorHidden() bool        { return p.Emu.CursorHidden() }
 func (p *PaneData) HasCursorBlock() bool      { return p.Emu.HasCursorBlock() }
 func (p *PaneData) ID() uint32                { return p.Info.ID }
 func (p *PaneData) Name() string              { return p.Info.Name }
+func (p *PaneData) PRs() []string             { return p.Info.PRs }
+func (p *PaneData) Issues() []string          { return p.Info.Issues }
 func (p *PaneData) Host() string              { return p.Info.Host }
 func (p *PaneData) Task() string              { return p.Info.Task }
 func (p *PaneData) Color() string             { return p.Info.Color }

--- a/internal/client/panedata_test.go
+++ b/internal/client/panedata_test.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"reflect"
 	"strings"
 	"testing"
 
@@ -132,6 +133,8 @@ func TestPaneDataAccessors(t *testing.T) {
 		Info: proto.PaneSnapshot{
 			ID:         7,
 			Name:       "pane-7",
+			PRs:        []string{"42", "314"},
+			Issues:     []string{"LAB-339"},
 			Host:       "buildbox",
 			Task:       "tail -f",
 			Color:      "89dceb",
@@ -146,6 +149,12 @@ func TestPaneDataAccessors(t *testing.T) {
 	}
 	if got := pane.Name(); got != "pane-7" {
 		t.Fatalf("Name() = %q, want pane-7", got)
+	}
+	if got := pane.PRs(); !reflect.DeepEqual(got, []string{"42", "314"}) {
+		t.Fatalf("PRs() = %v, want [42 314]", got)
+	}
+	if got := pane.Issues(); !reflect.DeepEqual(got, []string{"LAB-339"}) {
+		t.Fatalf("Issues() = %v, want [LAB-339]", got)
 	}
 	if got := pane.Host(); got != "buildbox" {
 		t.Fatalf("Host() = %q, want buildbox", got)

--- a/internal/mux/pane.go
+++ b/internal/mux/pane.go
@@ -25,18 +25,20 @@ func paneShellEnv(id uint32, sessionName string) []string {
 
 // PaneMeta holds amux metadata for a pane.
 type PaneMeta struct {
-	Name         string `json:"name"`
-	Host         string `json:"host"`
-	Task         string `json:"task,omitempty"`
-	Remote       string `json:"remote,omitempty"`
-	Color        string `json:"color"`
-	Minimized    bool   `json:"minimized,omitempty"`
-	RestoreH     int    `json:"restore_h,omitempty"`     // saved height before minimize
-	MinimizedSeq uint64 `json:"minimized_seq,omitempty"` // monotonic counter for LIFO restore ordering
-	Dormant      bool   `json:"dormant,omitempty"`       // pane is in Session.Panes but not in any window layout (e.g., SSH takeover host)
-	Dir          string `json:"dir,omitempty"`           // working directory override for new shell
-	GitBranch    string `json:"git_branch,omitempty"`    // cached git branch (auto-detected or manually set)
-	PR           string `json:"pr,omitempty"`            // PR number (set via escape sequence or CLI)
+	Name         string   `json:"name"`
+	Host         string   `json:"host"`
+	Task         string   `json:"task,omitempty"`
+	Remote       string   `json:"remote,omitempty"`
+	Color        string   `json:"color"`
+	Minimized    bool     `json:"minimized,omitempty"`
+	RestoreH     int      `json:"restore_h,omitempty"`     // saved height before minimize
+	MinimizedSeq uint64   `json:"minimized_seq,omitempty"` // monotonic counter for LIFO restore ordering
+	Dormant      bool     `json:"dormant,omitempty"`       // pane is in Session.Panes but not in any window layout (e.g., SSH takeover host)
+	Dir          string   `json:"dir,omitempty"`           // working directory override for new shell
+	GitBranch    string   `json:"git_branch,omitempty"`    // cached git branch (auto-detected or manually set)
+	PR           string   `json:"pr,omitempty"`            // PR number (set via escape sequence or CLI)
+	PRs          []string `json:"prs,omitempty"`           // PR numbers for status rendering
+	Issues       []string `json:"issues,omitempty"`        // issue IDs for status rendering
 }
 
 // Pane manages a PTY, its terminal emulator, and metadata.

--- a/internal/mux/snapshot.go
+++ b/internal/mux/snapshot.go
@@ -59,6 +59,8 @@ func (p *Pane) ToSnapshot() proto.PaneSnapshot {
 		ConnStatus: p.Meta.Remote,
 		GitBranch:  p.Meta.GitBranch,
 		PR:         p.Meta.PR,
+		PRs:        append([]string(nil), p.Meta.PRs...),
+		Issues:     append([]string(nil), p.Meta.Issues...),
 	}
 	if p.Meta.Minimized {
 		ps.EmuWidth, ps.EmuHeight = p.EmulatorSize()

--- a/internal/proto/types.go
+++ b/internal/proto/types.go
@@ -45,16 +45,18 @@ type CellSnapshot struct {
 
 // PaneSnapshot holds metadata for one pane.
 type PaneSnapshot struct {
-	ID         uint32 `json:"id"`
-	Name       string `json:"name"`
-	Host       string `json:"host"`
-	Task       string `json:"task"`
-	Color      string `json:"color"`
-	Minimized  bool   `json:"minimized"`
-	Idle       bool   `json:"idle"`
-	ConnStatus string `json:"conn_status,omitempty"` // "", "connected", "reconnecting", "disconnected" (remote panes only)
-	GitBranch  string `json:"git_branch,omitempty"`
-	PR         string `json:"pr,omitempty"`
+	ID         uint32   `json:"id"`
+	Name       string   `json:"name"`
+	Host       string   `json:"host"`
+	Task       string   `json:"task"`
+	Color      string   `json:"color"`
+	Minimized  bool     `json:"minimized"`
+	Idle       bool     `json:"idle"`
+	ConnStatus string   `json:"conn_status,omitempty"` // "", "connected", "reconnecting", "disconnected" (remote panes only)
+	GitBranch  string   `json:"git_branch,omitempty"`
+	PR         string   `json:"pr,omitempty"`
+	PRs        []string `json:"prs,omitempty"`
+	Issues     []string `json:"issues,omitempty"`
 
 	// EmuWidth/EmuHeight are set for minimized panes to record the
 	// pre-minimize emulator dimensions. Clients use these to create

--- a/internal/render/compositor_test.go
+++ b/internal/render/compositor_test.go
@@ -26,6 +26,8 @@ func (f *fakePaneData) CursorPos() (int, int)  { return 0, 0 }
 func (f *fakePaneData) CursorHidden() bool     { return f.cursorHidden }
 func (f *fakePaneData) ID() uint32             { return f.id }
 func (f *fakePaneData) Name() string           { return f.name }
+func (f *fakePaneData) PRs() []string          { return nil }
+func (f *fakePaneData) Issues() []string       { return nil }
 func (f *fakePaneData) Host() string           { return "local" }
 func (f *fakePaneData) Task() string           { return "" }
 func (f *fakePaneData) Color() string          { return "f5e0dc" }
@@ -82,6 +84,8 @@ func (e *cursorPaneData) CursorHidden() bool     { return e.emu.CursorHidden() }
 func (e *cursorPaneData) HasCursorBlock() bool   { return e.emu.HasCursorBlock() }
 func (e *cursorPaneData) ID() uint32             { return e.id }
 func (e *cursorPaneData) Name() string           { return e.name }
+func (e *cursorPaneData) PRs() []string          { return nil }
+func (e *cursorPaneData) Issues() []string       { return nil }
 func (e *cursorPaneData) Host() string           { return "local" }
 func (e *cursorPaneData) Task() string           { return "" }
 func (e *cursorPaneData) Color() string          { return e.color }

--- a/internal/render/overlay_status_test.go
+++ b/internal/render/overlay_status_test.go
@@ -12,6 +12,8 @@ import (
 type statusPaneData struct {
 	id           uint32
 	name         string
+	prs          []string
+	issues       []string
 	host         string
 	task         string
 	color        string
@@ -31,6 +33,8 @@ func (p *statusPaneData) CursorPos() (int, int)  { return 0, 0 }
 func (p *statusPaneData) CursorHidden() bool     { return p.cursorHidden }
 func (p *statusPaneData) ID() uint32             { return p.id }
 func (p *statusPaneData) Name() string           { return p.name }
+func (p *statusPaneData) PRs() []string          { return p.prs }
+func (p *statusPaneData) Issues() []string       { return p.issues }
 func (p *statusPaneData) Host() string           { return p.host }
 func (p *statusPaneData) Task() string           { return p.task }
 func (p *statusPaneData) Color() string          { return p.color }
@@ -104,6 +108,55 @@ func TestRenderPaneStatusVariants(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestRenderPaneStatusShowsMetadata(t *testing.T) {
+	t.Parallel()
+
+	cell := mux.NewLeaf(&mux.Pane{ID: 1}, 0, 0, 60, 3)
+	var buf strings.Builder
+	renderPaneStatus(&buf, cell, true, &statusPaneData{
+		id:     1,
+		name:   "pane-1",
+		prs:    []string{"42", "314"},
+		issues: []string{"LAB-339"},
+		host:   "gpu-box",
+		task:   "train",
+		color:  config.TextColorHex,
+	})
+
+	line := MaterializeGrid(buf.String(), cell.W, 1)
+	for _, want := range []string{"[pane-1]", "#42, #314, LAB-339", "@gpu-box", "train"} {
+		if !strings.Contains(line, want) {
+			t.Fatalf("status line %q missing %q", line, want)
+		}
+	}
+}
+
+func TestRenderPaneStatusTruncatesMetadata(t *testing.T) {
+	t.Parallel()
+
+	cell := mux.NewLeaf(&mux.Pane{ID: 1}, 0, 0, 34, 3)
+	var buf strings.Builder
+	renderPaneStatus(&buf, cell, false, &statusPaneData{
+		id:     1,
+		name:   "pane-1",
+		prs:    []string{"101", "202"},
+		issues: []string{"LAB-339", "LAB-340"},
+		host:   "gpu",
+		task:   "sync",
+		color:  config.TextColorHex,
+	})
+
+	line := strings.TrimRight(MaterializeGrid(buf.String(), cell.W, 1), " ")
+	for _, want := range []string{"#101", "…", "@gpu", "sync"} {
+		if !strings.Contains(line, want) {
+			t.Fatalf("status line %q missing %q", line, want)
+		}
+	}
+	if strings.Contains(line, ", …") {
+		t.Fatalf("status line %q should trim trailing separators before ellipsis", line)
 	}
 }
 
@@ -363,6 +416,38 @@ func TestBuildStatusCellsPreservesRemoteMetadata(t *testing.T) {
 	}
 	line := strings.TrimRight(row.String(), " ")
 	for _, want := range []string{"@remote-host", "sync", "⚡"} {
+		if !strings.Contains(line, want) {
+			t.Fatalf("status row %q missing %q", line, want)
+		}
+	}
+}
+
+func TestBuildStatusCellsShowsPaneMetadata(t *testing.T) {
+	t.Parallel()
+
+	cell := mux.NewLeaf(&mux.Pane{ID: 1}, 0, 0, 56, 4)
+	grid := NewScreenGrid(56, 4)
+	buildStatusCells(grid, cell, false, &statusPaneData{
+		id:         1,
+		name:       "pane-1",
+		prs:        []string{"42", "314"},
+		issues:     []string{"LAB-339"},
+		host:       "remote-host",
+		task:       "sync",
+		color:      config.TextColorHex,
+		connStatus: "connected",
+	})
+
+	var row strings.Builder
+	for x := 0; x < 56; x++ {
+		ch := grid.Get(x, 0).Char
+		if ch == "" {
+			ch = " "
+		}
+		row.WriteString(ch)
+	}
+	line := strings.TrimRight(row.String(), " ")
+	for _, want := range []string{"#42, #314, LAB-339", "@remote-host", "sync", "⚡"} {
 		if !strings.Contains(line, want) {
 			t.Fatalf("status row %q missing %q", line, want)
 		}

--- a/internal/render/panedata.go
+++ b/internal/render/panedata.go
@@ -20,6 +20,8 @@ type PaneData interface {
 	HasCursorBlock() bool
 	ID() uint32
 	Name() string
+	PRs() []string
+	Issues() []string
 	Host() string
 	Task() string
 	Color() string

--- a/internal/render/screen.go
+++ b/internal/render/screen.go
@@ -275,6 +275,8 @@ func buildStatusCells(g *ScreenGrid, cell *mux.LayoutCell, isActive bool, pd Pan
 	}
 	chars = appendStyledStr(chars, "["+pd.Name()+"]", nameStyle)
 
+	metaText := paneStatusMetadata(pd, availableMetadataWidth(cell.W, pd))
+
 	// Copy mode indicator
 	if pd.InCopyMode() {
 		chars = appendStyledStr(chars, " ", uv.Style{Bg: bg})
@@ -283,6 +285,11 @@ func buildStatusCells(g *ScreenGrid, cell *mux.LayoutCell, isActive bool, pd Pan
 			chars = appendStyledStr(chars, " ", uv.Style{Bg: bg})
 			chars = appendStyledStr(chars, search, yellowStyle)
 		}
+	}
+
+	if metaText != "" {
+		chars = appendStyledStr(chars, " ", uv.Style{Bg: bg})
+		chars = appendStyledStr(chars, metaText, textStyle)
 	}
 
 	// Host

--- a/internal/render/screen_test.go
+++ b/internal/render/screen_test.go
@@ -353,6 +353,8 @@ func (e *emuPaneData) CursorHidden() bool     { return e.cursorHidden }
 func (e *emuPaneData) HasCursorBlock() bool   { return false }
 func (e *emuPaneData) ID() uint32             { return e.id }
 func (e *emuPaneData) Name() string           { return e.name }
+func (e *emuPaneData) PRs() []string          { return nil }
+func (e *emuPaneData) Issues() []string       { return nil }
 func (e *emuPaneData) Host() string           { return "local" }
 func (e *emuPaneData) Task() string           { return "" }
 func (e *emuPaneData) Color() string          { return e.color }

--- a/internal/render/statusbar.go
+++ b/internal/render/statusbar.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"unicode/utf8"
 
+	"github.com/mattn/go-runewidth"
 	"github.com/weill-labs/amux/internal/mux"
 )
 
@@ -63,6 +64,8 @@ func renderPaneStatus(buf *strings.Builder, cell *mux.LayoutCell, isActive bool,
 	buf.WriteString("]")
 	buf.WriteString(NoBold)
 
+	metaText := paneStatusMetadata(pd, availableMetadataWidth(cell.W, pd))
+
 	// Copy mode indicator + search prompt
 	if pd.InCopyMode() {
 		buf.WriteString(" ")
@@ -73,6 +76,12 @@ func renderPaneStatus(buf *strings.Builder, cell *mux.LayoutCell, isActive bool,
 		} else {
 			buf.WriteString("[copy]")
 		}
+	}
+
+	if metaText != "" {
+		buf.WriteString(TextFg)
+		buf.WriteString(" ")
+		buf.WriteString(metaText)
 	}
 
 	// Host (only if not mux.DefaultHost)
@@ -105,21 +114,9 @@ func renderPaneStatus(buf *strings.Builder, cell *mux.LayoutCell, isActive bool,
 	}
 
 	// Fill remaining width with spaces
-	usedWidth := 2 + len(pd.Name()) + 2 // "● [name]"
-	if pd.InCopyMode() {
-		usedWidth += 7 // " [copy]"
-		if search := pd.CopyModeSearch(); search != "" {
-			usedWidth += 1 + len(search) // " /query"
-		}
-	}
-	if pd.Host() != "" && pd.Host() != mux.DefaultHost {
-		usedWidth += 2 + len(pd.Host())
-	}
-	if cs := pd.ConnStatus(); cs != "" {
-		usedWidth += 2 // " ⚡" or " ⟳" or " ✕" (space + 1 rune)
-	}
-	if pd.Task() != "" {
-		usedWidth += 1 + len(pd.Task())
+	usedWidth := paneStatusUsedWidthWithoutMetadata(pd)
+	if metaText != "" {
+		usedWidth += 1 + runewidth.StringWidth(metaText)
 	}
 	remaining := cell.W - usedWidth
 	if remaining > 0 {
@@ -141,6 +138,87 @@ func truncateRunes(s string, max int) string {
 		return string(runes[:1])
 	}
 	return string(runes[:max-1]) + "…"
+}
+
+func paneStatusMetadata(pd PaneData, maxWidth int) string {
+	items := paneStatusMetadataItems(pd.PRs(), pd.Issues())
+	if len(items) == 0 || maxWidth < 2 {
+		return ""
+	}
+
+	text := strings.Join(items, ", ")
+	if runewidth.StringWidth(text) <= maxWidth {
+		return text
+	}
+
+	var buf strings.Builder
+	usedWidth := 0
+	for _, r := range text {
+		runeWidth := runewidth.RuneWidth(r)
+		if runeWidth <= 0 {
+			runeWidth = 1
+		}
+		if usedWidth+runeWidth > maxWidth-1 {
+			break
+		}
+		buf.WriteRune(r)
+		usedWidth += runeWidth
+	}
+
+	prefix := strings.TrimRight(buf.String(), ", ")
+	if prefix == "" {
+		return ""
+	}
+	return prefix + "…"
+}
+
+func paneStatusMetadataItems(prs, issues []string) []string {
+	items := make([]string, 0, len(prs)+len(issues))
+	for _, pr := range prs {
+		pr = strings.TrimSpace(pr)
+		if pr == "" {
+			continue
+		}
+		if !strings.HasPrefix(pr, "#") {
+			pr = "#" + pr
+		}
+		items = append(items, pr)
+	}
+	for _, issue := range issues {
+		issue = strings.TrimSpace(issue)
+		if issue == "" {
+			continue
+		}
+		items = append(items, issue)
+	}
+	return items
+}
+
+func availableMetadataWidth(cellWidth int, pd PaneData) int {
+	if len(paneStatusMetadataItems(pd.PRs(), pd.Issues())) == 0 {
+		return 0
+	}
+	return cellWidth - paneStatusUsedWidthWithoutMetadata(pd) - 1
+}
+
+func paneStatusUsedWidthWithoutMetadata(pd PaneData) int {
+	usedWidth := 2 + runewidth.StringWidth(pd.Name()) + 2 // "● [name]"
+	if pd.InCopyMode() {
+		usedWidth += 7 // " [copy]"
+		if search := pd.CopyModeSearch(); search != "" {
+			usedWidth += 1 + runewidth.StringWidth(search)
+		}
+	}
+	if pd.Host() != "" && pd.Host() != mux.DefaultHost {
+		usedWidth += 2 + runewidth.StringWidth(pd.Host())
+	}
+	if cs := pd.ConnStatus(); cs != "" {
+		usedWidth += 2 // " ⚡" or " ⟳" or " ✕"
+	}
+	if pd.Task() != "" {
+		usedWidth += 1 + runewidth.StringWidth(pd.Task())
+	}
+	return usedWidth
 }
 
 func buildGlobalBarWindowTabs(windows []WindowInfo) []globalBarWindowTab {


### PR DESCRIPTION
## Motivation

Per-pane status lines currently stop at `[pane-N] @host task`, which means panes with associated reviews or tickets lose that context once the add-meta plumbing is available.
This change makes the status line display pane-level PR and issue metadata so the review or ticket context stays visible during day-to-day use.

## Summary

- add additive `prs`/`issues` pane metadata fields to `mux.PaneMeta` and `proto.PaneSnapshot` while leaving the existing singular `pr` field untouched
- extend the render pane-data adapters so both full ANSI rendering and diff/grid rendering can read PR and issue lists
- render comma-separated `#N`/`LAB-XXX` metadata after the pane name (and after `[copy]` when copy mode is active), truncating with `…` when space is tight
- add focused render and client tests covering display, truncation, and snapshot-to-render plumbing

## Testing

- `env -u AMUX_SESSION -u TMUX go test -race -count=100 ./internal/render -run 'TestRenderPaneStatusShowsMetadata|TestRenderPaneStatusTruncatesMetadata|TestBuildStatusCellsShowsPaneMetadata'`
- `env -u AMUX_SESSION -u TMUX go test -race -count=100 ./internal/client -run 'TestPaneDataAccessors|TestCaptureDisplayShowsPaneMetadata'`
- `env -u AMUX_SESSION -u TMUX go test ./internal/render -run 'TestRenderPaneStatusShowsMetadata|TestRenderPaneStatusTruncatesMetadata|TestBuildStatusCellsShowsPaneMetadata'`
- `env -u AMUX_SESSION -u TMUX go test ./test -run 'TestFocusUpFromFullWidthBottomPaneAfterVerticalPaneResize/grow-down' -timeout 120s`
- `env -u AMUX_SESSION -u TMUX make test` currently times out under the package-wide 120s cap in `github.com/weill-labs/amux/test`
- `env -u AMUX_SESSION -u TMUX go test ./... -timeout 300s` currently reproduces unrelated timing-sensitive failures in `TestMouseScrollWheel`, `TestMouseScrollWheelPassThroughAppMouse`, and `TestTypeKeysPacesEnterAfterText`

## Review focus

- the truncation helper is shared by the ANSI status line and the cell-grid status line so both render paths stay visually aligned
- the new metadata fields are additive snapshot plumbing for LAB-338/LAB-339 and do not change the existing singular `pr` capture or CLI behavior

Closes LAB-339
