### PR TITLE
Drop frames instead of clients when write queue is full

### DIFF
--- a/internal/server/client_conn.go
+++ b/internal/server/client_conn.go
@@ -51,9 +51,7 @@ func newClientConn(conn net.Conn) *clientConn {
 		conn:      conn,
 		inputIdle: true,
 	}
-	cc.writer = newClientWriter(conn, func() {
-		cc.markDisconnectReason(disconnectReasonSlowClient)
-	})
+	cc.writer = newClientWriter(conn)
 	return cc
 }
 

--- a/internal/server/client_writer.go
+++ b/internal/server/client_writer.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 )
 
-const clientWriterQueueSize = 256
+const clientWriterQueueSize = 4096
 
 type clientWriterState struct {
 	closed          bool
@@ -24,7 +24,6 @@ type clientWriter struct {
 	paneCommands chan clientWriterCommand
 	stop         chan struct{}
 	done         chan struct{}
-	onSlowDrop   func()
 
 	closeOnce sync.Once
 	stopOnce  sync.Once
@@ -156,7 +155,7 @@ func (c clientWriterBootstrappingQuery) handle(state *clientWriterState, _ net.C
 	return state.closed
 }
 
-func newClientWriter(conn net.Conn, onSlowDrop func()) *clientWriter {
+func newClientWriter(conn net.Conn) *clientWriter {
 	if conn == nil {
 		return nil
 	}
@@ -166,7 +165,6 @@ func newClientWriter(conn net.Conn, onSlowDrop func()) *clientWriter {
 		paneCommands: make(chan clientWriterCommand, clientWriterQueueSize),
 		stop:         make(chan struct{}),
 		done:         make(chan struct{}),
-		onSlowDrop:   onSlowDrop,
 	}
 	go w.loop()
 	return w
@@ -267,10 +265,7 @@ func (w *clientWriter) sendBroadcast(msg *Message) {
 	if w == nil {
 		return
 	}
-	if !w.enqueueAsync(clientWriterBroadcastCommand{msg: msg}) {
-		w.dropSlowClient()
-		return
-	}
+	w.enqueueAsync(clientWriterBroadcastCommand{msg: msg})
 }
 
 func (w *clientWriter) sendBroadcastSync(msg *Message) {
@@ -279,7 +274,6 @@ func (w *clientWriter) sendBroadcastSync(msg *Message) {
 	}
 	reply := make(chan struct{}, 1)
 	if !w.enqueueAsync(clientWriterBroadcastCommand{msg: msg, reply: reply}) {
-		w.dropSlowClient()
 		return
 	}
 	<-reply
@@ -289,20 +283,14 @@ func (w *clientWriter) sendPaneOutput(msg *Message, paneID uint32, seq uint64) {
 	if w == nil {
 		return
 	}
-	if !w.enqueueAsyncPane(clientWriterPaneOutputCommand{msg: msg, paneID: paneID, seq: seq}) {
-		w.dropSlowClient()
-		return
-	}
+	w.enqueueAsyncPane(clientWriterPaneOutputCommand{msg: msg, paneID: paneID, seq: seq})
 }
 
 func (w *clientWriter) sendPaneMessage(msg *Message) {
 	if w == nil {
 		return
 	}
-	if !w.enqueueAsyncPane(clientWriterPaneMessageCommand{msg: msg}) {
-		w.dropSlowClient()
-		return
-	}
+	w.enqueueAsyncPane(clientWriterPaneMessageCommand{msg: msg})
 }
 
 func (w *clientWriter) startBootstrap() {
@@ -427,14 +415,6 @@ func (w *clientWriter) requestStop() {
 		return
 	}
 	w.stopOnce.Do(func() { close(w.stop) })
-}
-
-func (w *clientWriter) dropSlowClient() {
-	if w != nil && w.onSlowDrop != nil {
-		w.onSlowDrop()
-	}
-	w.forceCloseConn()
-	w.requestStop()
 }
 
 func writeClientMessage(state *clientWriterState, conn net.Conn, msg *Message) error {

--- a/internal/server/client_writer_test.go
+++ b/internal/server/client_writer_test.go
@@ -241,15 +241,10 @@ func TestClientWriterEnqueueReturnsFalseWhenStoppedOrDone(t *testing.T) {
 	}
 }
 
-func TestClientWriterSendPaneOutputDropsSlowClientWhenQueueFull(t *testing.T) {
+func TestClientWriterSendPaneOutputDropsFrameWhenQueueFull(t *testing.T) {
 	t.Parallel()
 
-	serverConn, peerConn := net.Pipe()
-	t.Cleanup(func() { serverConn.Close() })
-	t.Cleanup(func() { peerConn.Close() })
-
 	w := &clientWriter{
-		conn:         serverConn,
 		commands:     make(chan clientWriterCommand, 1),
 		paneCommands: make(chan clientWriterCommand, 1),
 		stop:         make(chan struct{}),
@@ -261,25 +256,15 @@ func TestClientWriterSendPaneOutputDropsSlowClientWhenQueueFull(t *testing.T) {
 
 	select {
 	case <-w.stop:
-	case <-time.After(time.Second):
-		t.Fatal("sendPaneOutput did not stop a slow client")
-	}
-
-	_, err := peerConn.Write([]byte("x"))
-	if err == nil {
-		t.Fatal("client connection remained open after dropping slow client")
+		t.Fatal("sendPaneOutput stopped the writer; want frame drop only")
+	default:
 	}
 }
 
-func TestClientWriterSendBroadcastDropsSlowClientWhenQueueFull(t *testing.T) {
+func TestClientWriterSendBroadcastDropsFrameWhenQueueFull(t *testing.T) {
 	t.Parallel()
 
-	serverConn, peerConn := net.Pipe()
-	t.Cleanup(func() { serverConn.Close() })
-	t.Cleanup(func() { peerConn.Close() })
-
 	w := &clientWriter{
-		conn:         serverConn,
 		commands:     make(chan clientWriterCommand, 1),
 		paneCommands: make(chan clientWriterCommand, 1),
 		stop:         make(chan struct{}),
@@ -291,25 +276,15 @@ func TestClientWriterSendBroadcastDropsSlowClientWhenQueueFull(t *testing.T) {
 
 	select {
 	case <-w.stop:
-	case <-time.After(time.Second):
-		t.Fatal("sendBroadcast did not stop a slow client")
-	}
-
-	_, err := peerConn.Write([]byte("x"))
-	if err == nil {
-		t.Fatal("client connection remained open after dropping slow client")
+		t.Fatal("sendBroadcast stopped the writer; want frame drop only")
+	default:
 	}
 }
 
-func TestClientWriterSendBroadcastSyncDropsSlowClientWhenQueueFull(t *testing.T) {
+func TestClientWriterSendBroadcastSyncDropsFrameWhenQueueFull(t *testing.T) {
 	t.Parallel()
 
-	serverConn, peerConn := net.Pipe()
-	t.Cleanup(func() { serverConn.Close() })
-	t.Cleanup(func() { peerConn.Close() })
-
 	w := &clientWriter{
-		conn:         serverConn,
 		commands:     make(chan clientWriterCommand, 1),
 		paneCommands: make(chan clientWriterCommand, 1),
 		stop:         make(chan struct{}),
@@ -317,17 +292,22 @@ func TestClientWriterSendBroadcastSyncDropsSlowClientWhenQueueFull(t *testing.T)
 	}
 	w.commands <- testClientWriterCommand{}
 
-	w.sendBroadcastSync(&Message{Type: MsgTypeServerReload})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		w.sendBroadcastSync(&Message{Type: MsgTypeServerReload})
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("sendBroadcastSync blocked instead of dropping frame")
+	}
 
 	select {
 	case <-w.stop:
-	case <-time.After(time.Second):
-		t.Fatal("sendBroadcastSync did not stop a slow client")
-	}
-
-	_, err := peerConn.Write([]byte("x"))
-	if err == nil {
-		t.Fatal("client connection remained open after dropping slow client")
+		t.Fatal("sendBroadcastSync stopped the writer; want frame drop only")
+	default:
 	}
 }
 
@@ -440,7 +420,6 @@ func TestClientWriterNilHelpersAreNoops(t *testing.T) {
 	var w *clientWriter
 	w.forceCloseConn()
 	w.requestStop()
-	w.dropSlowClient()
 }
 
 func TestClientWriterPrioritizesControlMessagesOverPaneOutput(t *testing.T) {


### PR DESCRIPTION
## Motivation

LAB-373: In multi-agent workloads with 8+ agents producing PTY output simultaneously, the clientWriter command queue saturates and `dropSlowClient()` disconnects the orchestrator client. The client is not actually slow — it's just bursty. A dropped frame causes temporary visual staleness; a dropped client kills the entire session.

PR #360 split the writer into two channels (`commands` + `paneCommands`), both independently calling `dropSlowClient()` on overflow. This effectively halved the queue tolerance for pane output.

## Summary

- Increase `clientWriterQueueSize` from 256 to 4096 (~160KB per client per channel, absorbs bursts)
- `sendBroadcast`: silently drop frame on queue full (layout snapshots are full state — the next broadcast replaces the missed one)
- `sendPaneOutput`: silently drop frame on queue full via `enqueueAsyncPane` (subsequent PTY output corrects the display)
- `sendPaneMessage`: silently drop frame on queue full via `enqueueAsyncPane`
- `sendBroadcastSync`: return immediately on queue full (only caller is server reload in `checkpoint.go`, which execs regardless — client detects the broken connection and re-execs)
- Remove `dropSlowClient()` and `onSlowDrop` callback — no callers remain
- Rewrite 3 tests to verify frame-dropping behavior; remove `dropSlowClient` from nil-helpers test

## Testing

```bash
go test ./internal/server/ -run 'TestClientWriter' -count=100 -race  # 0 failures, 14 tests
go test ./internal/... -timeout 120s                                  # all internal packages pass
```

## Review focus

- Frame dropping covers both channels: `enqueueAsync` (commands) and `enqueueAsyncPane` (pane output/messages). Both now silently drop instead of killing the client.
- The `sendBroadcastSync` change: when queue is full, the reload message is lost. This is safe because the server execs anyway and the client detects the broken socket.
- Whether 4096 is a reasonable queue size per channel. Memory cost is ~320KB per client total.

Closes LAB-373