### PR TITLE
Wait for server to process detach before closing connection

### DIFF
--- a/test/connection_log_test.go
+++ b/test/connection_log_test.go
@@ -21,8 +21,8 @@ func TestConnectionLogCLI(t *testing.T) {
 	if err := server.WriteMsg(conn, &server.Message{Type: server.MsgTypeDetach}); err != nil {
 		t.Fatalf("WriteMsg detach: %v", err)
 	}
-	_ = conn.Close()
 	h.waitLayout(gen)
+	_ = conn.Close()
 
 	out := h.runCmd("connection-log")
 	for _, want := range []string{


### PR DESCRIPTION
## Motivation

`TestConnectionLogCLI` intermittently fails in CI with `connection-log missing "client detach"`. The test sends `MsgTypeDetach` then immediately calls `conn.Close()`. When the TCP teardown reaches the server before it reads the detach message, the server logs reason `"connection closed"` instead of `"client detach"`.

## Summary

- Move `conn.Close()` after `h.waitLayout(gen)` in `TestConnectionLogCLI` so the server processes the detach event and broadcasts a layout update to the harness client before the connection is torn down.

## Testing

```bash
cd test && env -u AMUX_SESSION -u TMUX go test -run TestConnectionLogCLI -count=100 -parallel 2 -timeout 300s
```

100/100 passes locally.

## Review focus

The fix is a single two-line swap. `waitLayout(gen)` blocks until the harness's own client (client-1) receives a layout broadcast triggered by the server processing client-2's detach. This guarantees the detach reason is recorded before `conn.Close()` can race.

Closes LAB-375