### PR TITLE
Add comment for firebase-debug.log in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,4 +33,6 @@ coverage-summary.txt
 merged-coverage.txt
 unit-coverage.txt
 tmux-src/
+
+# Firebase MCP plugin debug log (written to CWD on session start)
 firebase-debug.log


### PR DESCRIPTION
## Summary
- Adds an explanatory comment above the `firebase-debug.log` entry in `.gitignore` noting it comes from the Firebase MCP plugin on session start

## Test plan
- [x] `git diff` shows only the comment addition, no functional change

🤖 Generated with [Claude Code](https://claude.com/claude-code)