### PR TITLE
Close client-side emulators when panes are removed from layout

### DIFF
--- a/internal/client/renderer.go
+++ b/internal/client/renderer.go
@@ -110,6 +110,15 @@ func (r *Renderer) HandleLayout(snap *proto.LayoutSnapshot) bool {
 			next.emulators[ps.ID] = emu
 		}
 
+		// Close emulators for panes that no longer exist in the layout.
+		// Each emulator has a drain goroutine that blocks on io.Pipe.Read;
+		// without Close() the goroutine and pipe FDs leak.
+		for id, emu := range prev.emulators {
+			if _, exists := next.emulators[id]; !exists {
+				_ = emu.Close()
+			}
+		}
+
 		next.layout = mux.RebuildLayout(activeRoot)
 		clientLayoutH := next.height - render.GlobalBarHeight
 		if next.layout != nil && (snap.Width != next.width || snap.Height != clientLayoutH) {

--- a/internal/client/renderer_close_test.go
+++ b/internal/client/renderer_close_test.go
@@ -26,3 +26,35 @@ func TestRendererCloseClosesPaneEmulators(t *testing.T) {
 		t.Fatalf("emu.Read after Close() = %v, want %v", err, io.EOF)
 	}
 }
+
+func TestHandleLayoutClosesRemovedPaneEmulators(t *testing.T) {
+	t.Parallel()
+	r := NewWithScrollback(80, 24, mux.DefaultScrollbackLines)
+
+	// Start with two panes.
+	r.HandleLayout(twoPane80x23())
+
+	emu2, ok := r.Emulator(2)
+	if !ok {
+		t.Fatal("expected pane-2 emulator after two-pane layout")
+	}
+
+	// Transition to single pane — pane 2 is removed.
+	r.HandleLayout(singlePane20x3())
+
+	// The removed emulator's pipe should be closed.
+	if _, err := emu2.Read(make([]byte, 1)); err != io.EOF {
+		t.Fatalf("removed emulator Read() = %v, want io.EOF", err)
+	}
+
+	// Surviving emulator should still work.
+	emu1, ok := r.Emulator(1)
+	if !ok {
+		t.Fatal("expected pane-1 emulator after layout transition")
+	}
+	if _, err := emu1.Write([]byte("\x1b[6n")); err != nil {
+		t.Fatalf("surviving emulator Write() = %v", err)
+	}
+
+	r.Close()
+}


### PR DESCRIPTION
## Motivation

The CI "Flake detection" step (`go test -count=3 -parallel 2 -timeout 300s ./test/`) consistently times out. Even successful runs take 300.6s — right at the limit. Goroutine dumps at timeout show leaked VT emulator drain goroutines stuck in `io.(*pipe).read`, accumulating across the 3 iterations.

## Summary

- `Renderer.HandleLayout()` builds a new emulators map from the incoming layout snapshot, but never closed emulators for panes that disappeared. Each leaked emulator retained a drain goroutine (blocked on `io.Pipe.Read`) and 2 pipe FDs
- Added a loop after building `next.emulators` that closes any emulator from `prev.emulators` not present in the new map
- Added regression test: creates two-pane layout, transitions to single-pane, verifies removed emulator returns `io.EOF`

## Testing

```bash
go test ./internal/client/ -run TestHandleLayoutClosesRemovedPaneEmulators -v
go test -count=10 -parallel 2 -timeout 3000s ./test/  # 3007 passes, no resource exhaustion
```

## Review focus

The 4-line fix in `renderer.go` `HandleLayout` — verify the cleanup loop runs at the right point (after `next.emulators` is fully populated, before layout rebuild).

🤖 Generated with [Claude Code](https://claude.com/claude-code)