### PR TITLE
Scope LAB-408 readiness to root split capture

### DIFF
--- a/test/headless_client_test.go
+++ b/test/headless_client_test.go
@@ -78,21 +78,22 @@ func newHeadlessClient(sockPath, session string, cols, rows int) (*headlessClien
 	go hc.readLoop()
 
 	// Block until the server sends the first layout, guaranteeing the
-	// window exists before any test code runs. Then require a successful
-	// command round-trip on the attached connection so the server has
-	// finished attach bootstrap and entered its per-client read loop.
+	// window and initial pane exist before any test code runs.
 	select {
 	case <-hc.ready:
 	case <-time.After(10 * time.Second):
 		hc.close()
 		return nil, fmt.Errorf("timeout waiting for first layout from server")
 	}
+	return hc, nil
+}
+
+func (hc *headlessClient) waitCommandReady() error {
 	msg := hc.runCommand("generation")
 	if msg.CmdErr != "" {
-		hc.close()
-		return nil, fmt.Errorf("headless client did not reach command-ready state: %s", msg.CmdErr)
+		return fmt.Errorf("headless client did not reach command-ready state: %s", msg.CmdErr)
 	}
-	return hc, nil
+	return nil
 }
 
 // resize sends a MsgTypeResize to the server, simulating a terminal resize.
@@ -277,6 +278,7 @@ func TestNewHeadlessClientWaitsForCommandReadyState(t *testing.T) {
 	go func() {
 		hc, err := newHeadlessClient(sockPath, "test", 80, 24)
 		if err == nil {
+			err = hc.waitCommandReady()
 			hc.close()
 		}
 		clientReady <- err

--- a/test/split_test.go
+++ b/test/split_test.go
@@ -179,6 +179,9 @@ func TestRootSplitHorizontal(t *testing.T) {
 
 	// Root horizontal split: top row (pane-1 + pane-2 side by side), bottom row (pane-3)
 	h.splitRootH()
+	if err := h.client.waitCommandReady(); err != nil {
+		t.Fatalf("headless client not command-ready before capture: %v", err)
+	}
 
 	c := h.captureJSON()
 	if len(c.Panes) != 3 {


### PR DESCRIPTION
## Motivation
`TestRootSplitHorizontal` was racing client-routed capture against a headless client that had seen an initial layout frame but was not yet command-ready. That made the failure show up as `amux capture: EOF` even though the root split logic itself was not the problem.

## Summary
- keep `newHeadlessClient()` at the original first-layout readiness boundary
- add an explicit `waitCommandReady()` helper plus a guard test for the attached-client command-ready transition
- call that explicit readiness wait only from `TestRootSplitHorizontal` before the client-routed capture that reproduces LAB-408

## Testing
- `env -u AMUX_SESSION -u TMUX go test ./test -run 'TestNewHeadlessClientWaitsForCommandReadyState|TestRootSplitHorizontal' -count=100`
- `env -u AMUX_SESSION -u TMUX scripts/coverage.sh --ci`
  - this still has unrelated failures later in `./test`, but the LAB-408 failure path did not recur during the run

## Review focus
- whether the new `waitCommandReady()` helper captures the exact attach-bootstrap boundary needed for LAB-408 without changing unrelated headless-client users
- whether `TestRootSplitHorizontal` is the right and only callsite for the explicit readiness wait

Closes LAB-408
