### PR TITLE
Inject reload exec resolver instead of mutating package global

### DIFF
--- a/main.go
+++ b/main.go
@@ -27,8 +27,6 @@ var sessionName = "default"
 
 const reconnectEventType = "reconnect"
 
-var resolveReloadExecPath = reload.ResolveExecutable
-
 // BuildCommit can be set via -ldflags "-X main.BuildCommit=abc1234".
 // Falls back to VCS info from runtime/debug at startup.
 var BuildCommit string
@@ -896,7 +894,7 @@ func runServerCommand(cmdName string, args []string) {
 	defer conn.Close()
 
 	if cmdName == "reload-server" {
-		args = prependReloadExecPathArg(args)
+		args = prependReloadExecPathArg(reload.ResolveExecutable, args)
 	}
 
 	if err := server.WriteMsg(conn, newCommandMessage(cmdName, args)); err != nil {
@@ -917,8 +915,8 @@ func runServerCommand(cmdName string, args []string) {
 	fmt.Print(reply.CmdOutput)
 }
 
-func prependReloadExecPathArg(args []string) []string {
-	execPath, err := resolveReloadExecPath()
+func prependReloadExecPathArg(resolve func() (string, error), args []string) []string {
+	execPath, err := resolve()
 	if err != nil {
 		return args
 	}

--- a/main_reload_test.go
+++ b/main_reload_test.go
@@ -16,7 +16,7 @@ func TestPrependReloadExecPathArgIncludesResolvedExecutable(t *testing.T) {
 		t.Fatalf("ResolveExecutable() error = %v", err)
 	}
 
-	got := prependReloadExecPathArg([]string{"reload-server"})
+	got := prependReloadExecPathArg(reload.ResolveExecutable, []string{"reload-server"})
 	if len(got) != 3 {
 		t.Fatalf("len(prependReloadExecPathArg) = %d, want 3", len(got))
 	}
@@ -32,14 +32,12 @@ func TestPrependReloadExecPathArgIncludesResolvedExecutable(t *testing.T) {
 }
 
 func TestPrependReloadExecPathArgLeavesArgsUnchangedOnResolverError(t *testing.T) {
-	origResolve := resolveReloadExecPath
-	resolveReloadExecPath = func() (string, error) {
-		return "", errors.New("boom")
-	}
-	defer func() { resolveReloadExecPath = origResolve }()
+	t.Parallel()
 
 	args := []string{"reload-server"}
-	got := prependReloadExecPathArg(args)
+	got := prependReloadExecPathArg(func() (string, error) {
+		return "", errors.New("boom")
+	}, args)
 	if len(got) != 1 || got[0] != "reload-server" {
 		t.Fatalf("prependReloadExecPathArg() = %v, want %v", got, args)
 	}


### PR DESCRIPTION
## Motivation

`prependReloadExecPathArg` read from a package-level `var resolveReloadExecPath` — a mutable global that existed solely as a test seam. The error-path test swapped it via save/restore, making it incompatible with `t.Parallel()` and creating a latent data race with any parallel test that called the function.

## Summary

- Pass the resolver as a function parameter to `prependReloadExecPathArg` instead of reading a package global
- Remove the `resolveReloadExecPath` global entirely — the call site passes `reload.ResolveExecutable` directly
- Both reload tests are now `t.Parallel()`

## Testing

```
go test -run TestPrependReloadExecPathArg -count=100 -race ./...
```

100 runs, all green, race-clean.

## Review focus

The signature change to `prependReloadExecPathArg` is unexported, so no external callers are affected. The only call site in `main.go:899` now passes `reload.ResolveExecutable` directly.

Closes LAB-417