### PR TITLE
Summarize postmortem findings in merge closeouts

### DIFF
--- a/.agents/skills/amux-pr-workflow/SKILL.md
+++ b/.agents/skills/amux-pr-workflow/SKILL.md
@@ -28,6 +28,7 @@ Use this skill when the task involves `git push`, `gh pr create`, `gh pr merge`,
 - After merge, any follow-up fix goes on a fresh branch and PR. Do not make extra commits on local `main`.
 - After merge, explicitly run `$postmortem`. A short manual summary does not count. Turn action items into issues or doc updates.
 - Do not say `$postmortem` ran unless you have the logged `~/.local/share/postmortems/...` path.
+- In the final merge closeout, include the `$postmortem` log path, summarize the key learnings and concrete action items, and say whether they were implemented now or left as follow-up work.
 - If `$postmortem` is skipped, say so explicitly and give the reason. Do not imply it was done.
 
 ## Workflow
@@ -46,6 +47,7 @@ Use this skill when the task involves `git push`, `gh pr create`, `gh pr merge`,
 12. If you discover a follow-up fix after merge, create a fresh branch before editing.
 13. After merge, explicitly run `$postmortem` to capture learnings, pain points, and follow-up actions. Do not substitute a brief ad hoc summary.
 14. In the final merge closeout, state either the logged `$postmortem` path or the explicit reason it was skipped.
+15. If `$postmortem` ran, summarize the main learnings and follow-up actions in the user-facing closeout so the user gets the result directly, not only via the log file.
 
 ## Output Checklist
 
@@ -63,3 +65,4 @@ Use this skill when the task involves `git push`, `gh pr create`, `gh pr merge`,
 - Follow-up fixes kept off local `main`.
 - `$postmortem` explicitly run after merge, or a clear skip reason is stated.
 - If `$postmortem` ran, the log path is reported.
+- If `$postmortem` ran, the key learnings and action items are also summarized in the final handoff.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,6 +140,8 @@ If a change in this repo is ready for review, open the PR proactively instead of
 
 Before stopping to wait for user input, suggest the next concrete action the user should take or approve. Do not end at "waiting on you" without a specific next step.
 
+If you ran `$postmortem`, provide the log path, summarize the key learnings, list the concrete action items, and say whether you already implemented them or left them for follow-up.
+
 ### Merge Conflict Resolution
 
 After resolving merge conflicts, run `go vet ./...` locally before committing. Git auto-merge can silently produce duplicate declarations (e.g., methods defined in both sides) that compile but fail vet.
@@ -151,6 +153,8 @@ GitHub PRs for this repo are squash-only. `gh pr merge --merge` and `gh pr merge
 After merging, verify local state explicitly: check that the checkout is on `main`, the worktree is clean, and `HEAD` matches `origin/main`. If you need another change after the merge, start a fresh branch and PR instead of committing follow-up fixes on local `main`.
 
 After merging, explicitly run `$postmortem`. A short manual recap is not a substitute for the postmortem workflow, and do not claim it ran unless you have the logged `~/.local/share/postmortems/...` path.
+
+In the final merge closeout, tell the user what the postmortem found and what follow-up actions, if any, came out of it, alongside the logged path.
 
 ### Include Baseline Numbers In Performance PRs
 


### PR DESCRIPTION
## Motivation
After PR #391, the merge closeout reported the `$postmortem` log path but did not surface the action items from the postmortem itself. This updates the repo workflow so future handoffs share the result directly with the user.

## Summary
- require final merge closeouts to include the `$postmortem` log path and a brief summary of learnings and follow-up actions
- add the same expectation to the repo instructions so it applies outside the skill body too
- keep the wording positively framed so the rule says what to include in the handoff

## Testing
- not run (docs/workflow-only change)

## Review focus
- check that the new wording is specific enough to prevent path-only postmortem handoffs without adding unnecessary merge workflow overhead

