### PR TITLE
Document concurrency contracts and enforce single-owner access

### DIFF
--- a/internal/client/attach.go
+++ b/internal/client/attach.go
@@ -148,15 +148,26 @@ func readAttachBootstrap(conn net.Conn, cr *ClientRenderer) error {
 	return readImmediateAttachCorrection(conn, cr, defaultBootstrapCorrectionWindow)
 }
 
-func handleDisplayPaneSelection(cr *ClientRenderer, sender *messageSender, b byte) {
-	paneID, ok := cr.ResolveDisplayPaneKey(b)
-	cr.HideDisplayPanes()
-	if ok {
-		sender.Command("focus", []string{fmt.Sprintf("%d", paneID)})
+type displayPaneSelectionResult struct {
+	paneID uint32
+	ok     bool
+}
+
+func handleDisplayPaneSelection(cr *ClientRenderer, sender *messageSender, b byte, msgCh chan<- *RenderMsg) {
+	result := callLocalRenderAction[displayPaneSelectionResult](cr, msgCh, func(cr *ClientRenderer) localRenderResult {
+		paneID, ok := cr.ResolveDisplayPaneKey(b)
+		cr.HideDisplayPanes()
+		return localRenderResult{
+			effects: overlayRenderNowResult().effects,
+			value:   displayPaneSelectionResult{paneID: paneID, ok: ok},
+		}
+	})
+	if result.ok {
+		sender.Command("focus", []string{fmt.Sprintf("%d", result.paneID)})
 	}
 }
 
-func syncTerminalSize(fd int, prevCols, prevRows int, cr *ClientRenderer, sender *messageSender, getSize func(int) (int, int, error)) (int, int) {
+func syncTerminalSize(fd int, prevCols, prevRows int, cr *ClientRenderer, sender *messageSender, getSize func(int) (int, int, error), msgCh chan<- *RenderMsg) (int, int) {
 	c, r, _ := getSize(fd)
 	if c <= 0 || r <= 0 {
 		return prevCols, prevRows
@@ -164,7 +175,10 @@ func syncTerminalSize(fd int, prevCols, prevRows int, cr *ClientRenderer, sender
 	if c == prevCols && r == prevRows {
 		return prevCols, prevRows
 	}
-	cr.Resize(c, r)
+	_ = callLocalRenderAction[struct{}](cr, msgCh, func(cr *ClientRenderer) localRenderResult {
+		cr.Resize(c, r)
+		return localRenderResult{}
+	})
 	_ = sender.Send(&proto.Message{
 		Type: proto.MsgTypeResize,
 		Cols: c,
@@ -279,23 +293,6 @@ func RunSession(sessionName string, getTermSize func(int) (int, int, error)) err
 	triggerReload := make(chan struct{}, 1)
 	execPath, _ := reload.ResolveExecutable()
 
-	// Forward SIGWINCH to server and update client renderer
-	sigCh := make(chan os.Signal, 1)
-	signal.Notify(sigCh, syscall.SIGWINCH)
-	defer signal.Stop(sigCh)
-	// Capture initial size for the SIGWINCH goroutine to avoid racing
-	// with the recheck on line below.
-	initCols, initRows := cols, rows
-	go func() {
-		lastCols, lastRows := initCols, initRows
-		for range sigCh {
-			lastCols, lastRows = syncTerminalSize(fd, lastCols, lastRows, cr, sender, getTermSize)
-		}
-	}()
-	// Recheck once after the handler is live so startup-time size changes
-	// (common on mobile/SSH clients) are not lost before the first SIGWINCH.
-	cols, rows = syncTerminalSize(fd, cols, rows, cr, sender, getTermSize)
-
 	// Channel for injecting keystrokes from type-keys (server → client).
 	injectCh := make(chan []byte, 16)
 
@@ -335,7 +332,9 @@ func RunSession(sessionName string, getTermSize func(int) (int, int, error)) err
 			case proto.MsgTypeCaptureRequest:
 				// Server is forwarding a capture request — render from
 				// client-side emulators and send the result back.
-				resp := cr.HandleCaptureRequest(msg.CmdArgs, msg.AgentStatus)
+				resp := callLocalRenderAction[*proto.Message](cr, msgCh, func(cr *ClientRenderer) localRenderResult {
+					return localRenderResult{value: cr.HandleCaptureRequest(msg.CmdArgs, msg.AgentStatus)}
+				})
 				sender.Send(resp)
 			case proto.MsgTypeTypeKeys:
 				select {
@@ -360,6 +359,22 @@ func RunSession(sessionName string, getTermSize func(int) (int, int, error)) err
 			io.WriteString(os.Stdout, data)
 		})
 	}()
+
+	// Forward SIGWINCH to server and update client renderer.
+	// The render loop is live before we start queueing local resize actions.
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGWINCH)
+	defer signal.Stop(sigCh)
+	initCols, initRows := cols, rows
+	go func() {
+		lastCols, lastRows := initCols, initRows
+		for range sigCh {
+			lastCols, lastRows = syncTerminalSize(fd, lastCols, lastRows, cr, sender, getTermSize, msgCh)
+		}
+	}()
+	// Recheck once after the handler is live so startup-time size changes
+	// (common on mobile/SSH clients) are not lost before the first SIGWINCH.
+	cols, rows = syncTerminalSize(fd, cols, rows, cr, sender, getTermSize, msgCh)
 
 	// Terminal → server: read input with mouse parsing + Ctrl-a prefix handling
 	go func() {
@@ -423,24 +438,18 @@ func RunSession(sessionName string, getTermSize func(int) (int, int, error)) err
 					io.WriteString(os.Stdout, "\a")
 					return
 				}
-				if data := cr.RenderDiff(); data != "" {
-					io.WriteString(os.Stdout, data)
-				}
+				runLocalRenderAction(cr, msgCh, func(*ClientRenderer) localRenderResult { return overlayRenderNowResult() })
 			}
 			showPrefixMessage := func(key byte) {
 				cr.ShowPrefixMessage(formatUnboundPrefixMessage(kb.Prefix, key))
 				io.WriteString(os.Stdout, "\a")
-				if data := cr.RenderDiff(); data != "" {
-					io.WriteString(os.Stdout, data)
-				}
+				runLocalRenderAction(cr, msgCh, func(*ClientRenderer) localRenderResult { return overlayRenderNowResult() })
 			}
 			clearPrefixMessage := func() {
 				if !cr.ClearPrefixMessage() {
 					return
 				}
-				if data := cr.RenderDiff(); data != "" {
-					io.WriteString(os.Stdout, data)
-				}
+				runLocalRenderAction(cr, msgCh, func(*ClientRenderer) localRenderResult { return overlayRenderNowResult() })
 			}
 
 			// Pressing the prefix key again sends the literal prefix byte
@@ -475,10 +484,10 @@ func RunSession(sessionName string, getTermSize func(int) (int, int, error)) err
 					default:
 					}
 				case "copy-mode":
-					cr.EnterCopyMode(cr.ActivePaneID())
-					if data := cr.RenderDiff(); data != "" {
-						io.WriteString(os.Stdout, data)
-					}
+					_ = callLocalRenderAction[struct{}](cr, msgCh, func(cr *ClientRenderer) localRenderResult {
+						cr.EnterCopyMode(cr.ActivePaneID())
+						return renderNowResult()
+					})
 				case "display-panes":
 					if cr.DisplayPanesActive() {
 						cr.HideDisplayPanes()
@@ -486,9 +495,7 @@ func RunSession(sessionName string, getTermSize func(int) (int, int, error)) err
 						io.WriteString(os.Stdout, "\a")
 						break
 					}
-					if data := cr.RenderDiff(); data != "" {
-						io.WriteString(os.Stdout, data)
-					}
+					runLocalRenderAction(cr, msgCh, func(*ClientRenderer) localRenderResult { return overlayRenderNowResult() })
 				case "choose-tree":
 					showChooser(chooserModeTree)
 				case "choose-window":
@@ -497,9 +504,7 @@ func RunSession(sessionName string, getTermSize func(int) (int, int, error)) err
 					if reason := cr.toggleMinimizeBlockedReason(); reason != "" {
 						cr.ShowCommandError(reason)
 						io.WriteString(os.Stdout, "\a")
-						if data := cr.RenderDiff(); data != "" {
-							io.WriteString(os.Stdout, data)
-						}
+						runLocalRenderAction(cr, msgCh, func(*ClientRenderer) localRenderResult { return overlayRenderNowResult() })
 					}
 					sender.Command(binding.Action, binding.Args)
 				case "compat-bell":
@@ -664,13 +669,13 @@ func RunSession(sessionName string, getTermSize func(int) (int, int, error)) err
 				raw = data
 			case <-wordCopyTimer:
 				if drag.PendingWordCopyPaneID != 0 {
-					cr.CopyModeCopySelection(drag.PendingWordCopyPaneID)
+					_ = callLocalRenderAction[struct{}](cr, msgCh, func(cr *ClientRenderer) localRenderResult {
+						cr.CopyModeCopySelection(drag.PendingWordCopyPaneID)
+						return renderNowResult()
+					})
 					drag.PendingWordCopyPaneID = 0
 					drag.PendingWordCopyAt = time.Time{}
 					drag.ClickCount = 0
-					if data := cr.RenderDiff(); data != "" {
-						io.WriteString(os.Stdout, data)
-					}
 				}
 				continue
 			}
@@ -700,9 +705,7 @@ func RunSession(sessionName string, getTermSize func(int) (int, int, error)) err
 			}
 
 			if localActivity && cr.ClearCommandFeedback() {
-				if data := cr.RenderDiff(); data != "" {
-					io.WriteString(os.Stdout, data)
-				}
+				runLocalRenderAction(cr, msgCh, func(*ClientRenderer) localRenderResult { return overlayRenderNowResult() })
 			}
 
 			var forward []byte
@@ -713,23 +716,23 @@ func RunSession(sessionName string, getTermSize func(int) (int, int, error)) err
 				if len(copyInput) == 0 {
 					return
 				}
-				cm := cr.ActiveCopyMode()
-				if cm == nil {
-					copyInput = nil
-					return
-				}
-				action := cm.HandleInput(copyInput)
-				paneID := cr.ActivePaneID()
+				input := append([]byte(nil), copyInput...)
 				copyInput = nil
-				switch action {
-				case copymode.ActionExit:
-					cr.ExitCopyMode(paneID)
-				case copymode.ActionYank:
-					cr.CopyModeCopySelection(paneID)
-				}
-				if data := cr.RenderDiff(); data != "" {
-					io.WriteString(os.Stdout, data)
-				}
+				_ = callLocalRenderAction[struct{}](cr, msgCh, func(cr *ClientRenderer) localRenderResult {
+					cm := cr.ActiveCopyMode()
+					if cm == nil {
+						return localRenderResult{}
+					}
+					action := cm.HandleInput(input)
+					paneID := cr.ActivePaneID()
+					switch action {
+					case copymode.ActionExit:
+						cr.ExitCopyMode(paneID)
+					case copymode.ActionYank:
+						cr.CopyModeCopySelection(paneID)
+					}
+					return renderNowResult()
+				})
 			}
 
 			// dispatchDecoded routes one decoded input event through local
@@ -753,12 +756,10 @@ func RunSession(sessionName string, getTermSize func(int) (int, int, error)) err
 
 				if cr.DisplayPanesActive() {
 					if len(normalized) > 0 {
-						handleDisplayPaneSelection(cr, sender, normalized[0])
+						handleDisplayPaneSelection(cr, sender, normalized[0], msgCh)
 					} else {
 						cr.HideDisplayPanes()
-					}
-					if data := cr.RenderDiff(); data != "" {
-						io.WriteString(os.Stdout, data)
+						runLocalRenderAction(cr, msgCh, func(*ClientRenderer) localRenderResult { return overlayRenderNowResult() })
 					}
 					return false
 				}
@@ -809,9 +810,7 @@ func RunSession(sessionName string, getTermSize func(int) (int, int, error)) err
 				if action.bell {
 					io.WriteString(os.Stdout, "\a")
 				}
-				if data := cr.RenderDiff(); data != "" {
-					io.WriteString(os.Stdout, data)
-				}
+				runLocalRenderAction(cr, msgCh, func(*ClientRenderer) localRenderResult { return overlayRenderNowResult() })
 				if action.command != "" {
 					sender.Command(action.command, action.args)
 				}
@@ -830,12 +829,7 @@ func RunSession(sessionName string, getTermSize func(int) (int, int, error)) err
 						})
 						forward = nil
 					}
-					handleMouseEvent(ev, cr, sender, &drag)
-					if cr.IsDirty() {
-						if data := cr.RenderDiff(); data != "" {
-							io.WriteString(os.Stdout, data)
-						}
-					}
+					handleMouseEvent(ev, cr, sender, &drag, msgCh)
 					continue
 				}
 

--- a/internal/client/attach_test.go
+++ b/internal/client/attach_test.go
@@ -57,7 +57,7 @@ func TestSyncTerminalSizeSendsResizeWhenSizeChanges(t *testing.T) {
 	}
 	done := make(chan sizeResult, 1)
 	go func() {
-		cols, rows := syncTerminalSize(0, 80, 24, cr, sender, getSize)
+		cols, rows := syncTerminalSize(0, 80, 24, cr, sender, getSize, nil)
 		done <- sizeResult{cols: cols, rows: rows}
 	}()
 
@@ -118,7 +118,7 @@ func TestSyncTerminalSizeSkipsUnchangedOrInvalidSizes(t *testing.T) {
 
 			cr := NewClientRenderer(80, 24)
 
-			cols, rows := syncTerminalSize(0, 80, 24, cr, sender, tt.fn)
+			cols, rows := syncTerminalSize(0, 80, 24, cr, sender, tt.fn, nil)
 			if cols != 80 || rows != 24 {
 				t.Fatalf("syncTerminalSize returned %dx%d, want 80x24", cols, rows)
 			}

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -38,13 +38,6 @@ func NewClientRendererWithScrollback(width, height, scrollbackLines int) *Client
 		scrollbackLines: scrollbackLines,
 	}
 	cr.state.Store(newClientSnapshot())
-	// Resize copy modes when the renderer resizes emulators during layout.
-	cr.renderer.OnPaneResize = func(paneID uint32, w, h int) {
-		cm := cr.CopyModeForPane(paneID)
-		if cm != nil {
-			cm.Resize(w, h)
-		}
-	}
 	return cr
 }
 
@@ -65,6 +58,7 @@ func (cr *ClientRenderer) HandleLayout(snap *proto.LayoutSnapshot) bool {
 }
 func (cr *ClientRenderer) handleLayoutResult(snap *proto.LayoutSnapshot) (bool, clientUIResult) {
 	structureChanged := cr.renderer.HandleLayout(snap)
+	cr.syncCopyModeSizes()
 	validPanes := make(map[uint32]bool)
 	for _, ps := range snap.Panes {
 		validPanes[ps.ID] = true
@@ -214,6 +208,7 @@ func (cr *ClientRenderer) IsDirty() bool {
 // Resize updates the client's terminal dimensions.
 func (cr *ClientRenderer) Resize(width, height int) {
 	cr.renderer.Resize(width, height)
+	cr.syncCopyModeSizes()
 }
 
 // CaptureJSON renders a structured JSON capture from client-side emulators.
@@ -262,6 +257,7 @@ const (
 	RenderMsgExit
 	RenderMsgCopyMode
 	RenderMsgCmdError
+	RenderMsgLocalAction
 )
 
 // RenderMsg is an internal message type for the render coalescing loop.
@@ -271,6 +267,15 @@ type RenderMsg struct {
 	PaneID uint32
 	Data   []byte
 	Text   string
+	Local  localRenderFunc
+	Reply  chan any
+}
+
+type localRenderFunc func(*ClientRenderer) localRenderResult
+
+type localRenderResult struct {
+	effects []clientEffect
+	value   any
 }
 
 type clientEffectKind int
@@ -402,6 +407,23 @@ func (cr *ClientRenderer) handleRenderMsg(msg *RenderMsg) []clientEffect {
 	}
 }
 
+func (cr *ClientRenderer) handleLocalRenderMsg(state *clientRenderLoopState, msg *RenderMsg, write func(string)) bool {
+	if msg.Local == nil {
+		if msg.Reply != nil {
+			msg.Reply <- nil
+		}
+		return false
+	}
+	result := msg.Local(cr)
+	if cr.executeRenderEffects(state, result.effects, write) {
+		return true
+	}
+	if msg.Reply != nil {
+		msg.Reply <- result.value
+	}
+	return false
+}
+
 func (cr *ClientRenderer) executeRenderEffects(state *clientRenderLoopState, effects []clientEffect, write func(string)) bool {
 	for _, effect := range effects {
 		switch effect.kind {
@@ -484,12 +506,30 @@ func (cr *ClientRenderer) RenderCoalesced(msgCh <-chan *RenderMsg, write func(st
 			if !ok {
 				return
 			}
+			if msg.Typ == RenderMsgLocalAction {
+				if cr.handleLocalRenderMsg(state, msg, write) {
+					return
+				}
+				continue
+			}
 			if cr.executeRenderEffects(state, cr.handleRenderMsg(msg), write) {
 				return
 			}
 		case <-state.renderC:
 			cr.renderNow(state, write)
 		}
+	}
+}
+
+func (cr *ClientRenderer) syncCopyModeSizes() {
+	state := cr.loadState()
+	for paneID, cm := range state.ui.copyModes {
+		emu, ok := cr.renderer.Emulator(paneID)
+		if !ok || cm == nil {
+			continue
+		}
+		w, h := emu.Size()
+		cm.Resize(w, h)
 	}
 }
 

--- a/internal/client/input_dispatch_test.go
+++ b/internal/client/input_dispatch_test.go
@@ -28,6 +28,22 @@ func readCommandMessage(t *testing.T, conn net.Conn) *proto.Message {
 	return msg
 }
 
+func startTestRenderLoop(t *testing.T, cr *ClientRenderer) chan *RenderMsg {
+	t.Helper()
+
+	msgCh := make(chan *RenderMsg, 64)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		cr.RenderCoalesced(msgCh, func(string) {})
+	}()
+	t.Cleanup(func() {
+		msgCh <- &RenderMsg{Typ: RenderMsgExit}
+		<-done
+	})
+	return msgCh
+}
+
 func buildMultiWindowRendererAt(t *testing.T, activeWindowID uint32) *ClientRenderer {
 	t.Helper()
 
@@ -88,7 +104,7 @@ func TestHandleDisplayPaneSelectionSendsFocusCommand(t *testing.T) {
 	sender := newMessageSender(clientConn)
 	done := make(chan struct{})
 	go func() {
-		handleDisplayPaneSelection(cr, sender, '2')
+		handleDisplayPaneSelection(cr, sender, '2', nil)
 		close(done)
 	}()
 
@@ -128,7 +144,7 @@ func TestHandleMouseEventClickSendsFocusCommand(t *testing.T) {
 			Button: mouse.ButtonLeft,
 			X:      60,
 			Y:      5,
-		}, cr, sender, &drag)
+		}, cr, sender, &drag, nil)
 		close(done)
 	}()
 
@@ -195,7 +211,7 @@ func TestHandleMouseEventGlobalBarClickSendsSelectWindowCommand(t *testing.T) {
 					Button: mouse.ButtonLeft,
 					X:      x,
 					Y:      y,
-				}, cr, sender, &drag)
+				}, cr, sender, &drag, nil)
 				close(done)
 			}()
 
@@ -237,7 +253,7 @@ func TestHandleMouseEventGlobalBarClickOutsideTabsDoesNothing(t *testing.T) {
 		Button: mouse.ButtonLeft,
 		X:      x,
 		Y:      y,
-	}, cr, sender, &drag)
+	}, cr, sender, &drag, nil)
 
 	assertNoMessage(t, serverConn)
 }
@@ -265,7 +281,7 @@ func TestHandleMouseEventGlobalBarClickSingleWindowDoesNothing(t *testing.T) {
 		Button: mouse.ButtonLeft,
 		X:      x,
 		Y:      y,
-	}, cr, sender, &drag)
+	}, cr, sender, &drag, nil)
 
 	assertNoMessage(t, serverConn)
 }
@@ -353,7 +369,7 @@ func TestHandleMouseEventBorderPressClearsCopyDragState(t *testing.T) {
 		Button: mouse.ButtonLeft,
 		X:      borderX,
 		Y:      5,
-	}, cr, nil, &drag)
+	}, cr, nil, &drag, nil)
 
 	if !drag.Active {
 		t.Fatal("border press should start a resize drag")
@@ -389,7 +405,7 @@ func TestHandleMouseEventDragStartsCopyModeAndCopiesSelection(t *testing.T) {
 		Button: mouse.ButtonLeft,
 		X:      0,
 		Y:      y,
-	}, cr, sender, &drag)
+	}, cr, sender, &drag, nil)
 
 	if cr.InCopyMode(1) {
 		t.Fatal("pane-1 should not enter copy mode until the drag moves")
@@ -402,7 +418,7 @@ func TestHandleMouseEventDragStartsCopyModeAndCopiesSelection(t *testing.T) {
 		Y:      y,
 		LastX:  0,
 		LastY:  y,
-	}, cr, sender, &drag)
+	}, cr, sender, &drag, nil)
 
 	cm := cr.CopyModeForPane(1)
 	if cm == nil {
@@ -419,13 +435,63 @@ func TestHandleMouseEventDragStartsCopyModeAndCopiesSelection(t *testing.T) {
 		Y:      y,
 		LastX:  4,
 		LastY:  y,
-	}, cr, sender, &drag)
+	}, cr, sender, &drag, nil)
 
 	if copied != "hello" {
 		t.Fatalf("copied text = %q, want %q", copied, "hello")
 	}
 	if cr.InCopyMode(1) {
 		t.Fatal("pane-1 should exit copy mode after mouse drag copy")
+	}
+}
+
+func TestHandleMouseEventQueuedDragStartsCopyModeAndCopiesSelection(t *testing.T) {
+	cr := buildTestRenderer(t)
+	msgCh := startTestRenderLoop(t, cr)
+
+	clientConn, serverConn := net.Pipe()
+	t.Cleanup(func() {
+		clientConn.Close()
+		serverConn.Close()
+	})
+
+	sender := newMessageSender(clientConn)
+	var drag dragState
+
+	var copied string
+	stubCopyToClipboard(cr, func(text string) {
+		copied = text
+	})
+
+	y := mux.StatusLineRows
+	handleMouseEvent(mouse.Event{
+		Action: mouse.Press,
+		Button: mouse.ButtonLeft,
+		X:      0,
+		Y:      y,
+	}, cr, sender, &drag, msgCh)
+	handleMouseEvent(mouse.Event{
+		Action: mouse.Motion,
+		Button: mouse.ButtonLeft,
+		X:      4,
+		Y:      y,
+		LastX:  0,
+		LastY:  y,
+	}, cr, sender, &drag, msgCh)
+	handleMouseEvent(mouse.Event{
+		Action: mouse.Release,
+		Button: mouse.ButtonLeft,
+		X:      4,
+		Y:      y,
+		LastX:  4,
+		LastY:  y,
+	}, cr, sender, &drag, msgCh)
+
+	if copied != "hello" {
+		t.Fatalf("copied text = %q, want %q", copied, "hello")
+	}
+	if cr.InCopyMode(1) {
+		t.Fatal("pane-1 should exit copy mode after queued mouse drag copy")
 	}
 }
 
@@ -452,7 +518,7 @@ func TestHandleMouseEventDragMotionWithMissingPaneDoesNotEnterCopyMode(t *testin
 		Button: mouse.ButtonLeft,
 		X:      1,
 		Y:      mux.StatusLineRows,
-	}, cr, nil, &drag)
+	}, cr, nil, &drag, nil)
 
 	if cr.InCopyMode(99) {
 		t.Fatal("missing pane should not enter copy mode on mouse drag")
@@ -486,7 +552,7 @@ func TestHandleMouseEventCopyModeDragCopiesSelectionAndExits(t *testing.T) {
 		Button: mouse.ButtonLeft,
 		X:      0,
 		Y:      y,
-	}, cr, sender, &drag)
+	}, cr, sender, &drag, nil)
 	handleMouseEvent(mouse.Event{
 		Action: mouse.Motion,
 		Button: mouse.ButtonLeft,
@@ -494,7 +560,7 @@ func TestHandleMouseEventCopyModeDragCopiesSelectionAndExits(t *testing.T) {
 		Y:      y,
 		LastX:  0,
 		LastY:  y,
-	}, cr, sender, &drag)
+	}, cr, sender, &drag, nil)
 	handleMouseEvent(mouse.Event{
 		Action: mouse.Release,
 		Button: mouse.ButtonLeft,
@@ -502,7 +568,7 @@ func TestHandleMouseEventCopyModeDragCopiesSelectionAndExits(t *testing.T) {
 		Y:      y,
 		LastX:  4,
 		LastY:  y,
-	}, cr, sender, &drag)
+	}, cr, sender, &drag, nil)
 
 	if copied != "hello" {
 		t.Fatalf("copied text = %q, want %q", copied, "hello")
@@ -534,13 +600,57 @@ func TestHandleMouseEventCopyModeDoubleClickSelectsWordAndArmsCopy(t *testing.T)
 			Button: mouse.ButtonLeft,
 			X:      1,
 			Y:      y,
-		}, cr, sender, &drag)
+		}, cr, sender, &drag, nil)
 		handleMouseEvent(mouse.Event{
 			Action: mouse.Release,
 			Button: mouse.ButtonLeft,
 			X:      1,
 			Y:      y,
-		}, cr, sender, &drag)
+		}, cr, sender, &drag, nil)
+	}
+
+	cm := cr.CopyModeForPane(1)
+	if cm == nil {
+		t.Fatal("pane-1 should remain in copy mode until delayed word copy fires")
+	}
+	if got := cm.SelectedText(); got != "hello" {
+		t.Fatalf("double click selected %q, want %q", got, "hello")
+	}
+	if drag.PendingWordCopyPaneID != 1 {
+		t.Fatalf("pending word copy pane = %d, want 1", drag.PendingWordCopyPaneID)
+	}
+}
+
+func TestHandleMouseEventQueuedCopyModeDoubleClickSelectsWordAndArmsCopy(t *testing.T) {
+	t.Parallel()
+
+	cr := buildTestRenderer(t)
+	cr.EnterCopyMode(1)
+	msgCh := startTestRenderLoop(t, cr)
+
+	clientConn, serverConn := net.Pipe()
+	t.Cleanup(func() {
+		clientConn.Close()
+		serverConn.Close()
+	})
+
+	sender := newMessageSender(clientConn)
+	var drag dragState
+
+	y := mux.StatusLineRows
+	for i := 0; i < 2; i++ {
+		handleMouseEvent(mouse.Event{
+			Action: mouse.Press,
+			Button: mouse.ButtonLeft,
+			X:      1,
+			Y:      y,
+		}, cr, sender, &drag, msgCh)
+		handleMouseEvent(mouse.Event{
+			Action: mouse.Release,
+			Button: mouse.ButtonLeft,
+			X:      1,
+			Y:      y,
+		}, cr, sender, &drag, msgCh)
 	}
 
 	cm := cr.CopyModeForPane(1)
@@ -580,13 +690,13 @@ func TestHandleMouseEventCopyModeTripleClickCopiesLine(t *testing.T) {
 			Button: mouse.ButtonLeft,
 			X:      1,
 			Y:      y,
-		}, cr, sender, &drag)
+		}, cr, sender, &drag, nil)
 		handleMouseEvent(mouse.Event{
 			Action: mouse.Release,
 			Button: mouse.ButtonLeft,
 			X:      1,
 			Y:      y,
-		}, cr, sender, &drag)
+		}, cr, sender, &drag, nil)
 	}
 
 	if copied != "hello from pane 1\n" {
@@ -594,6 +704,41 @@ func TestHandleMouseEventCopyModeTripleClickCopiesLine(t *testing.T) {
 	}
 	if cr.InCopyMode(1) {
 		t.Fatal("pane-1 should exit copy mode after triple-click line copy")
+	}
+}
+
+func TestHandleMouseEventQueuedScrollUpAndDownUsesCopyMode(t *testing.T) {
+	t.Parallel()
+
+	cr := buildTestRenderer(t)
+	msgCh := startTestRenderLoop(t, cr)
+
+	y := mux.StatusLineRows
+	handleMouseEvent(mouse.Event{
+		Button: mouse.ScrollUp,
+		X:      0,
+		Y:      y,
+	}, cr, nil, nil, msgCh)
+
+	if !cr.InCopyMode(1) {
+		t.Fatal("scroll up should enter copy mode on a regular pane")
+	}
+	cm := cr.CopyModeForPane(1)
+	if cm == nil {
+		t.Fatal("pane-1 copy mode missing after scroll up")
+	}
+	if !cm.ScrollExit() {
+		t.Fatal("scroll up should arm scroll-exit")
+	}
+
+	handleMouseEvent(mouse.Event{
+		Button: mouse.ScrollDown,
+		X:      0,
+		Y:      y,
+	}, cr, nil, nil, msgCh)
+
+	if cr.InCopyMode(1) {
+		t.Fatal("scroll down back to live view should exit copy mode when scroll-exit is armed")
 	}
 }
 

--- a/internal/client/local_render.go
+++ b/internal/client/local_render.go
@@ -1,0 +1,48 @@
+package client
+
+import "os"
+
+func applyLocalRenderResultDirect(cr *ClientRenderer, result localRenderResult) {
+	state := &clientRenderLoopState{
+		useFull:             os.Getenv("AMUX_RENDER") == "full",
+		renderFrameInterval: defaultRenderFrameInterval,
+	}
+	_ = cr.executeRenderEffects(state, result.effects, func(string) {})
+}
+
+func runLocalRenderAction(cr *ClientRenderer, msgCh chan<- *RenderMsg, fn localRenderFunc) {
+	if msgCh == nil {
+		applyLocalRenderResultDirect(cr, fn(cr))
+		return
+	}
+	msgCh <- &RenderMsg{Typ: RenderMsgLocalAction, Local: fn}
+}
+
+func callLocalRenderAction[T any](cr *ClientRenderer, msgCh chan<- *RenderMsg, fn localRenderFunc) T {
+	var zero T
+	if msgCh == nil {
+		result := fn(cr)
+		applyLocalRenderResultDirect(cr, result)
+		if result.value == nil {
+			return zero
+		}
+		return result.value.(T)
+	}
+	reply := make(chan any, 1)
+	msgCh <- &RenderMsg{Typ: RenderMsgLocalAction, Local: fn, Reply: reply}
+	value := <-reply
+	if value == nil {
+		return zero
+	}
+	return value.(T)
+}
+
+func renderNowResult() localRenderResult {
+	return localRenderResult{effects: appendStopAndRenderNow(nil)}
+}
+
+func overlayRenderNowResult() localRenderResult {
+	effects := []clientEffect{{kind: clientEffectClearPrevGrid}}
+	effects = append(effects, appendStopAndRenderNow(nil)...)
+	return localRenderResult{effects: effects}
+}

--- a/internal/client/mouse.go
+++ b/internal/client/mouse.go
@@ -150,7 +150,7 @@ func handleGlobalBarClick(ev mouse.Event, layout *mux.LayoutCell, cr *ClientRend
 
 // handleMouseEvent dispatches a parsed mouse event to the appropriate action:
 // click-to-focus, border drag, or scroll wheel.
-func handleMouseEvent(ev mouse.Event, cr *ClientRenderer, sender *messageSender, drag *dragState) {
+func handleMouseEvent(ev mouse.Event, cr *ClientRenderer, sender *messageSender, drag *dragState, msgCh chan<- *RenderMsg) {
 	layout := cr.VisibleLayout()
 
 	if layout == nil {
@@ -181,7 +181,10 @@ func handleMouseEvent(ev mouse.Event, cr *ClientRenderer, sender *messageSender,
 				drag.CopyStartX = target.localX
 				drag.CopyStartY = target.localY
 				drag.CopyMoved = false
-				cr.CopyModeSetCursor(target.paneID, target.localX, target.localY)
+				_ = callLocalRenderAction[struct{}](cr, msgCh, func(cr *ClientRenderer) localRenderResult {
+					cr.CopyModeSetCursor(target.paneID, target.localX, target.localY)
+					return renderNowResult()
+				})
 			} else if target.inContent && paneAllowsMouseCopySelection(cr, target.paneID) {
 				drag.CopyModePaneID = target.paneID
 				drag.CopyStartX = target.localX
@@ -215,18 +218,30 @@ func handleMouseEvent(ev mouse.Event, cr *ClientRenderer, sender *messageSender,
 			return
 		}
 		if !drag.CopyModeActive {
-			cr.EnterCopyMode(drag.CopyModePaneID)
-			if !cr.InCopyMode(drag.CopyModePaneID) {
+			entered := callLocalRenderAction[bool](cr, msgCh, func(cr *ClientRenderer) localRenderResult {
+				cr.EnterCopyMode(drag.CopyModePaneID)
+				return localRenderResult{
+					effects: renderNowResult().effects,
+					value:   cr.InCopyMode(drag.CopyModePaneID),
+				}
+			})
+			if !entered {
 				return
 			}
 			drag.CopyModeActive = true
 		}
-		if !drag.CopyMoved {
-			cr.CopyModeSetCursor(drag.CopyModePaneID, drag.CopyStartX, drag.CopyStartY)
-			cr.CopyModeStartSelection(drag.CopyModePaneID)
+		startSelection := !drag.CopyMoved
+		_ = callLocalRenderAction[struct{}](cr, msgCh, func(cr *ClientRenderer) localRenderResult {
+			if startSelection {
+				cr.CopyModeSetCursor(drag.CopyModePaneID, drag.CopyStartX, drag.CopyStartY)
+				cr.CopyModeStartSelection(drag.CopyModePaneID)
+			}
+			cr.CopyModeSetCursor(drag.CopyModePaneID, target.localX, target.localY)
+			return renderNowResult()
+		})
+		if startSelection {
 			drag.CopyMoved = true
 		}
-		cr.CopyModeSetCursor(drag.CopyModePaneID, target.localX, target.localY)
 
 	case ev.Action == mouse.Release:
 		drag.Active = false
@@ -236,7 +251,10 @@ func handleMouseEvent(ev mouse.Event, cr *ClientRenderer, sender *messageSender,
 					drag.PendingWordCopyPaneID = 0
 					drag.PendingWordCopyAt = time.Time{}
 					drag.ClickCount = 0
-					cr.CopyModeCopySelection(drag.CopyModePaneID)
+					_ = callLocalRenderAction[struct{}](cr, msgCh, func(cr *ClientRenderer) localRenderResult {
+						cr.CopyModeCopySelection(drag.CopyModePaneID)
+						return renderNowResult()
+					})
 				} else if target := mouseTargetAt(layout, ev.X, ev.Y); target != nil && target.inContent && target.paneID == drag.CopyModePaneID {
 					now := time.Now()
 					if target.localX == drag.LastClickX &&
@@ -252,24 +270,30 @@ func handleMouseEvent(ev mouse.Event, cr *ClientRenderer, sender *messageSender,
 
 					switch drag.ClickCount {
 					case 2:
-						if cm := cr.CopyModeForPane(target.paneID); cm != nil {
-							cr.CopyModeSetCursor(target.paneID, target.localX, target.localY)
-							if cm.SelectWord() == copymode.ActionRedraw {
-								cr.markDirty()
+						_ = callLocalRenderAction[struct{}](cr, msgCh, func(cr *ClientRenderer) localRenderResult {
+							if cm := cr.CopyModeForPane(target.paneID); cm != nil {
+								cr.CopyModeSetCursor(target.paneID, target.localX, target.localY)
+								if cm.SelectWord() == copymode.ActionRedraw {
+									cr.markDirty()
+								}
 							}
-						}
+							return renderNowResult()
+						})
 						drag.PendingWordCopyPaneID = target.paneID
 						drag.PendingWordCopyAt = now.Add(mouseWordCopyDelay)
 					case 3:
 						drag.PendingWordCopyPaneID = 0
 						drag.PendingWordCopyAt = time.Time{}
-						if cm := cr.CopyModeForPane(target.paneID); cm != nil {
-							cr.CopyModeSetCursor(target.paneID, target.localX, target.localY)
-							if cm.SelectLine() == copymode.ActionRedraw {
-								cr.markDirty()
+						_ = callLocalRenderAction[struct{}](cr, msgCh, func(cr *ClientRenderer) localRenderResult {
+							if cm := cr.CopyModeForPane(target.paneID); cm != nil {
+								cr.CopyModeSetCursor(target.paneID, target.localX, target.localY)
+								if cm.SelectLine() == copymode.ActionRedraw {
+									cr.markDirty()
+								}
 							}
-						}
-						cr.CopyModeCopySelection(target.paneID)
+							cr.CopyModeCopySelection(target.paneID)
+							return renderNowResult()
+						})
 						drag.ClickCount = 0
 					}
 				}
@@ -286,7 +310,13 @@ func handleMouseEvent(ev mouse.Event, cr *ClientRenderer, sender *messageSender,
 		}
 		if cr.InCopyMode(target.paneID) {
 			focusPane(sender, target.paneID, cr.ActivePaneID())
-			cr.WheelScrollCopyMode(target.paneID, wheelScrollLines, true)
+			_ = callLocalRenderAction[struct{}](cr, msgCh, func(cr *ClientRenderer) localRenderResult {
+				action := cr.WheelScrollCopyMode(target.paneID, wheelScrollLines, true)
+				if action == copymode.ActionNone {
+					return localRenderResult{}
+				}
+				return renderNowResult()
+			})
 			return
 		}
 
@@ -299,11 +329,14 @@ func handleMouseEvent(ev mouse.Event, cr *ClientRenderer, sender *messageSender,
 			}
 		}
 
-		cr.EnterCopyMode(target.paneID)
-		if cm := cr.CopyModeForPane(target.paneID); cm != nil {
-			cm.SetScrollExit(true)
-		}
-		cr.WheelScrollCopyMode(target.paneID, wheelScrollLines, true)
+		_ = callLocalRenderAction[struct{}](cr, msgCh, func(cr *ClientRenderer) localRenderResult {
+			cr.EnterCopyMode(target.paneID)
+			if cm := cr.CopyModeForPane(target.paneID); cm != nil {
+				cm.SetScrollExit(true)
+			}
+			cr.WheelScrollCopyMode(target.paneID, wheelScrollLines, true)
+			return renderNowResult()
+		})
 
 	case ev.Button == mouse.ScrollDown:
 		target := mouseTargetAt(layout, ev.X, ev.Y)
@@ -312,7 +345,13 @@ func handleMouseEvent(ev mouse.Event, cr *ClientRenderer, sender *messageSender,
 		}
 		if cr.InCopyMode(target.paneID) {
 			focusPane(sender, target.paneID, cr.ActivePaneID())
-			cr.WheelScrollCopyMode(target.paneID, wheelScrollLines, false)
+			_ = callLocalRenderAction[struct{}](cr, msgCh, func(cr *ClientRenderer) localRenderResult {
+				action := cr.WheelScrollCopyMode(target.paneID, wheelScrollLines, false)
+				if action == copymode.ActionNone {
+					return localRenderResult{}
+				}
+				return renderNowResult()
+			})
 			return
 		}
 		forwardMouseToPane(cr, sender, target, ev)

--- a/internal/copymode/copymode.go
+++ b/internal/copymode/copymode.go
@@ -6,6 +6,7 @@ import (
 
 	uv "github.com/charmbracelet/ultraviolet"
 	"github.com/charmbracelet/x/ansi"
+	"github.com/weill-labs/amux/internal/debugowner"
 	"github.com/weill-labs/amux/internal/render"
 )
 
@@ -47,7 +48,14 @@ const (
 
 // CopyMode manages the state machine for scrollback browsing, search, and
 // text selection within a single pane.
+//
+// Concurrency:
+// CopyMode is not safe for concurrent use. Mutating methods and copy-mode-backed
+// reads must be serialized by the caller onto one goroutine. In the attached
+// client, the live owner is the client render loop after attach startup.
 type CopyMode struct {
+	owner debugowner.Checker
+
 	emu    TerminalEmulator
 	width  int // pane content width
 	height int // pane content height (viewport rows)
@@ -105,6 +113,10 @@ func New(emu TerminalEmulator, width, height, cursorRow int) *CopyMode {
 	}
 }
 
+func (cm *CopyMode) assertOwner(method string) {
+	cm.owner.Assert("copymode.CopyMode", method)
+}
+
 // HandleInput processes raw input bytes and returns the action the client
 // should take. When searching, printable keys build the query; otherwise
 // vi-style keys control scrolling, search, and selection.
@@ -113,6 +125,7 @@ func New(emu TerminalEmulator, width, height, cursorRow int) *CopyMode {
 // immediately (remaining bytes are dropped). ActionRedraw is accumulated
 // so that batched keystrokes (e.g. rapid "Vy") are fully handled.
 func (cm *CopyMode) HandleInput(data []byte) Action {
+	cm.assertOwner("HandleInput")
 	if len(data) == 0 {
 		return ActionNone
 	}
@@ -574,6 +587,7 @@ func (cm *CopyMode) SearchQuery() string {
 
 // SetScrollExit enables or disables auto-exit when scrolling back to live view.
 func (cm *CopyMode) SetScrollExit(enabled bool) {
+	cm.assertOwner("SetScrollExit")
 	cm.scrollExit = enabled
 }
 
@@ -589,6 +603,7 @@ func (cm *CopyMode) ScrollOffset() int {
 
 // WheelScrollUp scrolls the viewport upward without moving the copy-mode cursor.
 func (cm *CopyMode) WheelScrollUp(lines int) Action {
+	cm.assertOwner("WheelScrollUp")
 	if lines <= 0 {
 		return ActionNone
 	}
@@ -604,6 +619,7 @@ func (cm *CopyMode) WheelScrollUp(lines int) Action {
 // WheelScrollDown scrolls the viewport downward without moving the cursor.
 // When scroll-exit is armed, reaching live view exits copy mode.
 func (cm *CopyMode) WheelScrollDown(lines int) Action {
+	cm.assertOwner("WheelScrollDown")
 	if lines <= 0 {
 		return ActionNone
 	}
@@ -634,6 +650,7 @@ func (cm *CopyMode) TotalLines() int {
 
 // Resize updates the viewport dimensions.
 func (cm *CopyMode) Resize(width, height int) {
+	cm.assertOwner("Resize")
 	cm.width = width
 	cm.height = height
 	cm.oy = clamp(cm.oy, 0, cm.maxOY())
@@ -956,6 +973,7 @@ func (cm *CopyMode) CellAt(col, viewportRow int) render.ScreenCell {
 
 // SetCursor moves the copy-mode cursor to a viewport-relative position.
 func (cm *CopyMode) SetCursor(col, viewportRow int) Action {
+	cm.assertOwner("SetCursor")
 	row := clamp(viewportRow, 0, cm.height-1)
 	line := []rune(cm.lineText(cm.FirstVisibleLine() + row))
 	maxCol := 0
@@ -974,6 +992,7 @@ func (cm *CopyMode) SetCursor(col, viewportRow int) Action {
 
 // StartSelection begins a character selection at the current cursor position.
 func (cm *CopyMode) StartSelection() Action {
+	cm.assertOwner("StartSelection")
 	absY := cm.cursorAbsLine()
 	cm.lineSelect = false
 	cm.rectSelect = false
@@ -987,6 +1006,7 @@ func (cm *CopyMode) StartSelection() Action {
 
 // ClearSelection removes the current selection without exiting copy mode.
 func (cm *CopyMode) ClearSelection() Action {
+	cm.assertOwner("ClearSelection")
 	if !cm.selecting && !cm.lineSelect && !cm.rectSelect {
 		return ActionNone
 	}
@@ -998,6 +1018,7 @@ func (cm *CopyMode) ClearSelection() Action {
 
 // SelectLine begins a tmux-style line selection at the current cursor line.
 func (cm *CopyMode) SelectLine() Action {
+	cm.assertOwner("SelectLine")
 	absY := cm.cursorAbsLine()
 	cm.selecting = true
 	cm.lineSelect = true
@@ -1011,6 +1032,7 @@ func (cm *CopyMode) SelectLine() Action {
 
 // SelectWord begins a tmux-style word selection around the cursor.
 func (cm *CopyMode) SelectWord() Action {
+	cm.assertOwner("SelectWord")
 	line := cm.cursorLineRunes()
 	if len(line) == 0 {
 		return ActionNone
@@ -1047,6 +1069,7 @@ func (cm *CopyMode) SelectWord() Action {
 
 // ToggleRectangleSelection toggles tmux rectangle mode.
 func (cm *CopyMode) ToggleRectangleSelection() Action {
+	cm.assertOwner("ToggleRectangleSelection")
 	absY := cm.cursorAbsLine()
 	if !cm.selecting {
 		cm.selecting = true
@@ -1063,6 +1086,7 @@ func (cm *CopyMode) ToggleRectangleSelection() Action {
 
 // OtherEnd swaps the active and anchor selection endpoints.
 func (cm *CopyMode) OtherEnd() Action {
+	cm.assertOwner("OtherEnd")
 	if !cm.selecting {
 		return ActionNone
 	}
@@ -1081,6 +1105,7 @@ func (cm *CopyMode) queueCopyText(text string, append bool) {
 
 // ConsumeCopyText returns and clears any queued copy payload.
 func (cm *CopyMode) ConsumeCopyText() (string, bool) {
+	cm.assertOwner("ConsumeCopyText")
 	text, appendCopy := cm.copyText, cm.appendCopy
 	cm.copyText = ""
 	cm.appendCopy = false

--- a/internal/copymode/owner_debug_test.go
+++ b/internal/copymode/owner_debug_test.go
@@ -1,0 +1,31 @@
+//go:build debug
+
+package copymode
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCopyModePanicsOnCrossGoroutineMutation(t *testing.T) {
+	emu := newFakeEmulator(80, 24)
+	cm := New(emu, 80, 24, 0)
+
+	cm.SetScrollExit(true)
+
+	panicCh := make(chan any, 1)
+	go func() {
+		defer func() {
+			panicCh <- recover()
+		}()
+		cm.SetScrollExit(false)
+	}()
+
+	panicValue := <-panicCh
+	if panicValue == nil {
+		t.Fatal("expected panic from cross-goroutine mutation")
+	}
+	if got := panicValue.(string); !strings.Contains(got, "copymode.CopyMode.SetScrollExit") {
+		t.Fatalf("panic = %q, want method name", got)
+	}
+}

--- a/internal/debugowner/owner_debug.go
+++ b/internal/debugowner/owner_debug.go
@@ -1,0 +1,46 @@
+//go:build debug
+
+package debugowner
+
+import (
+	"fmt"
+	"runtime"
+	"strconv"
+	"strings"
+	"sync/atomic"
+)
+
+// Checker records the first mutating goroutine and panics on later mutations
+// from a different goroutine in debug builds.
+type Checker struct {
+	owner atomic.Uint64
+}
+
+func (c *Checker) Assert(typeName, method string) {
+	gid := currentGoroutineID()
+	if gid == 0 {
+		return
+	}
+	if owner := c.owner.Load(); owner == gid {
+		return
+	}
+	if c.owner.CompareAndSwap(0, gid) {
+		return
+	}
+	owner := c.owner.Load()
+	if owner != gid {
+		panic(fmt.Sprintf("%s.%s called from goroutine %d; owner is goroutine %d", typeName, method, gid, owner))
+	}
+}
+
+func currentGoroutineID() uint64 {
+	var buf [64]byte
+	n := runtime.Stack(buf[:], false)
+	line := strings.TrimPrefix(string(buf[:n]), "goroutine ")
+	field := line
+	if i := strings.IndexByte(line, ' '); i >= 0 {
+		field = line[:i]
+	}
+	gid, _ := strconv.ParseUint(field, 10, 64)
+	return gid
+}

--- a/internal/debugowner/owner_nodebug.go
+++ b/internal/debugowner/owner_nodebug.go
@@ -1,0 +1,8 @@
+//go:build !debug
+
+package debugowner
+
+// Checker is a no-op in non-debug builds.
+type Checker struct{}
+
+func (c *Checker) Assert(typeName, method string) {}

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -54,6 +54,14 @@ const (
 )
 
 // Registry stores hooks and executes them on events.
+//
+// Concurrency:
+// Add, Remove, RemoveAll, List, Fire, and FireWithCallback are safe for
+// concurrent use. Fire and FireWithCallback launch hook commands in separate
+// goroutines, so hook execution and onResult callbacks happen asynchronously.
+// Callers must not mutate ErrorWriter or HookTimeout concurrently with firing
+// hooks, and any shared state touched by onResult must be synchronized by the
+// callback owner.
 type Registry struct {
 	mu          sync.RWMutex
 	hooks       map[Event][]Entry

--- a/internal/mux/window.go
+++ b/internal/mux/window.go
@@ -3,6 +3,8 @@ package mux
 import (
 	"fmt"
 	"sync/atomic"
+
+	"github.com/weill-labs/amux/internal/debugowner"
 )
 
 // StatusLineRows is the number of rows reserved for the per-pane status line.
@@ -13,7 +15,13 @@ const StatusLineRows = 1
 const DefaultRestoreHeight = 12
 
 // Window holds the layout tree and active pane for one window.
+//
+// Concurrency:
+// Window is owned by the server session event loop. No Window methods are safe
+// for concurrent use; callers must serialize all reads and writes through the
+// session queue/query helpers or otherwise guarantee exclusive access.
 type Window struct {
+	owner        debugowner.Checker
 	ID           uint32
 	Name         string
 	Root         *LayoutCell
@@ -41,17 +49,23 @@ func NewWindow(pane *Pane, width, height int) *Window {
 	}
 }
 
+func (w *Window) assertOwner(method string) {
+	w.owner.Assert("mux.Window", method)
+}
+
 // SplitRoot splits the entire window at the root level.
 // If the root already has the same split direction, the new pane is added
 // as a sibling (equal distribution). Otherwise, wraps the root in a new parent.
 // Auto-unzooms if a pane is zoomed.
 func (w *Window) SplitRoot(dir SplitDir, newPane *Pane) (*Pane, error) {
+	w.assertOwner("SplitRoot")
 	return w.SplitRootWithOptions(dir, newPane, SplitOptions{})
 }
 
 // SplitRootWithOptions splits the entire window at the root level with
 // explicit focus/zoom behavior control.
 func (w *Window) SplitRootWithOptions(dir SplitDir, newPane *Pane, opts SplitOptions) (*Pane, error) {
+	w.assertOwner("SplitRootWithOptions")
 	if w.ZoomedPaneID != 0 && !opts.Background {
 		w.Unzoom()
 	}
@@ -122,11 +136,13 @@ func (w *Window) SplitRootWithOptions(dir SplitDir, newPane *Pane, opts SplitOpt
 // via the provided factory function. Returns the new pane.
 // Auto-unzooms if a pane is zoomed.
 func (w *Window) Split(dir SplitDir, newPane *Pane) (*Pane, error) {
+	w.assertOwner("Split")
 	return w.SplitWithOptions(dir, newPane, SplitOptions{})
 }
 
 // SplitWithOptions splits the active pane with explicit focus/zoom behavior control.
 func (w *Window) SplitWithOptions(dir SplitDir, newPane *Pane, opts SplitOptions) (*Pane, error) {
+	w.assertOwner("SplitWithOptions")
 	if w.ZoomedPaneID != 0 && !opts.Background {
 		w.Unzoom()
 	}
@@ -170,6 +186,7 @@ func (w *Window) SplitWithOptions(dir SplitDir, newPane *Pane, opts SplitOptions
 // ClosePane removes a pane from the layout and reclaims its space.
 // If the closed pane was zoomed, zoom is automatically cleared.
 func (w *Window) ClosePane(paneID uint32) error {
+	w.assertOwner("ClosePane")
 	cell := w.Root.FindPane(paneID)
 	if cell == nil {
 		return fmt.Errorf("pane %d not found", paneID)
@@ -257,6 +274,7 @@ func (w *Window) autoRestoreOne(root *LayoutCell) {
 
 // Resize adjusts the layout to fit new terminal dimensions.
 func (w *Window) Resize(width, height int) {
+	w.assertOwner("Resize")
 	w.Width = width
 	w.Height = height
 	w.Root.ResizeAll(width, height)
@@ -279,6 +297,7 @@ func (w *Window) setActive(p *Pane) {
 // Used by the server when focusing by name or ID.
 // Auto-unzooms if a pane is zoomed and the target is a different pane.
 func (w *Window) FocusPane(p *Pane) {
+	w.assertOwner("FocusPane")
 	if w.ZoomedPaneID != 0 && p.ID != w.ZoomedPaneID {
 		w.Unzoom()
 	}
@@ -289,6 +308,7 @@ func (w *Window) FocusPane(p *Pane) {
 // Uses tmux-style adjacency + perpendicular overlap + wrapping + recency tiebreaker.
 // Auto-unzooms if a pane is zoomed.
 func (w *Window) Focus(direction string) {
+	w.assertOwner("Focus")
 	if w.ZoomedPaneID != 0 {
 		w.Unzoom()
 	}
@@ -432,6 +452,7 @@ func PaneContentHeight(cellH int) int {
 // For horizontal borders (horizontal split), delta is applied vertically.
 // Returns true if a resize was performed.
 func (w *Window) ResizeBorder(x, y, delta int) bool {
+	w.assertOwner("ResizeBorder")
 	hit := w.Root.FindBorderNear(x, y)
 	if hit == nil || delta == 0 {
 		return false
@@ -480,6 +501,7 @@ func (w *Window) ResizeBorder(x, y, delta int) bool {
 // direction is "left", "right", "up", or "down".
 // Returns true if a resize was performed.
 func (w *Window) ResizeActive(direction string, delta int) bool {
+	w.assertOwner("ResizeActive")
 	if w.ActivePane == nil {
 		return false
 	}
@@ -490,6 +512,7 @@ func (w *Window) ResizeActive(direction string, delta int) bool {
 // direction is "left", "right", "up", or "down". delta is the number of cells to move.
 // Returns true if a resize was performed.
 func (w *Window) ResizePane(paneID uint32, direction string, delta int) bool {
+	w.assertOwner("ResizePane")
 	if delta <= 0 {
 		return false
 	}
@@ -679,6 +702,7 @@ func (w *Window) finishTreeMutation() {
 // to match their new cell dimensions.
 // Both the Pane struct and its Meta travel together (swap-with-meta semantics).
 func (w *Window) SwapPanes(id1, id2 uint32) error {
+	w.assertOwner("SwapPanes")
 	if id1 == id2 {
 		return nil
 	}
@@ -697,6 +721,7 @@ func (w *Window) SwapPanes(id1, id2 uint32) error {
 
 // SwapTree swaps the root-level groups containing the given panes.
 func (w *Window) SwapTree(id1, id2 uint32) error {
+	w.assertOwner("SwapTree")
 	_, idx1, err := w.rootChildForPaneID(id1)
 	if err != nil {
 		return err
@@ -721,6 +746,7 @@ func (w *Window) SwapTree(id1, id2 uint32) error {
 // MovePane moves the root-level group containing paneID before or after the
 // root-level group containing targetPaneID.
 func (w *Window) MovePane(paneID, targetPaneID uint32, before bool) error {
+	w.assertOwner("MovePane")
 	_, fromIdx, err := w.rootChildForPaneID(paneID)
 	if err != nil {
 		return err
@@ -760,6 +786,7 @@ func (w *Window) MovePane(paneID, targetPaneID uint32, before bool) error {
 
 // SwapPaneForward swaps the active pane with the next pane in walk order.
 func (w *Window) SwapPaneForward() error {
+	w.assertOwner("SwapPaneForward")
 	cells := w.paneLeaves()
 	if len(cells) <= 1 {
 		return nil
@@ -774,6 +801,7 @@ func (w *Window) SwapPaneForward() error {
 
 // SwapPaneBackward swaps the active pane with the previous pane in walk order.
 func (w *Window) SwapPaneBackward() error {
+	w.assertOwner("SwapPaneBackward")
 	cells := w.paneLeaves()
 	if len(cells) <= 1 {
 		return nil
@@ -791,6 +819,7 @@ func (w *Window) SwapPaneBackward() error {
 // gets the pane from the previous cell, with the last pane wrapping to the
 // first cell.
 func (w *Window) RotatePanes(forward bool) {
+	w.assertOwner("RotatePanes")
 	cells := w.paneLeaves()
 	if len(cells) <= 1 {
 		return
@@ -840,6 +869,7 @@ func (w *Window) activeCellIndex(cells []*LayoutCell) int {
 // If the pane is the last visible in a non-rightmost column, the column is
 // dissolved into the next column to the right. Auto-unzooms if zoomed.
 func (w *Window) Minimize(paneID uint32) error {
+	w.assertOwner("Minimize")
 	if w.ZoomedPaneID != 0 {
 		w.Unzoom()
 	}
@@ -897,6 +927,7 @@ func (w *Window) Minimize(paneID uint32) error {
 // intact; the ZoomedPaneID field tells the client to render only this pane.
 // The zoomed pane's PTY is resized to the full window dimensions.
 func (w *Window) Zoom(paneID uint32) error {
+	w.assertOwner("Zoom")
 	if w.ZoomedPaneID == paneID {
 		return w.Unzoom()
 	}
@@ -928,6 +959,7 @@ func (w *Window) Zoom(paneID uint32) error {
 // Unzoom restores the normal multi-pane view. The zoomed pane's PTY is
 // resized back to match its layout cell.
 func (w *Window) Unzoom() error {
+	w.assertOwner("Unzoom")
 	if w.ZoomedPaneID == 0 {
 		return fmt.Errorf("no pane is zoomed")
 	}
@@ -946,6 +978,7 @@ func (w *Window) Unzoom() error {
 
 // Restore expands a minimized pane back to its saved height.
 func (w *Window) Restore(paneID uint32) error {
+	w.assertOwner("Restore")
 	cell := w.Root.FindPane(paneID)
 	if cell == nil {
 		return fmt.Errorf("pane %d not found", paneID)
@@ -998,6 +1031,7 @@ func (w *Window) Restore(paneID uint32) error {
 // ToggleMinimize toggles the active pane's minimized state.
 // Returns the affected pane's name and whether it was minimized (true) or restored (false).
 func (w *Window) ToggleMinimize() (name string, minimized bool, err error) {
+	w.assertOwner("ToggleMinimize")
 	if w.ActivePane == nil {
 		return "", false, fmt.Errorf("no active pane")
 	}
@@ -1029,6 +1063,7 @@ func (w *Window) recoverMinimizeSeq() {
 // new panes. The original cell's dimensions are preserved.
 // Returns the list of newly created layout cells.
 func (w *Window) SplicePane(oldPaneID uint32, newPanes []*Pane) ([]*LayoutCell, error) {
+	w.assertOwner("SplicePane")
 	if len(newPanes) == 0 {
 		return nil, fmt.Errorf("no panes to splice")
 	}
@@ -1098,6 +1133,7 @@ func (w *Window) SplicePane(oldPaneID uint32, newPanes []*Pane) ([]*LayoutCell, 
 // proxy panes for a specific host) with a single pane. Used to revert
 // a takeover and restore the original SSH pane.
 func (w *Window) UnsplicePane(hostName string, replacement *Pane) error {
+	w.assertOwner("UnsplicePane")
 	allProxyLeavesForHost := func(cell *LayoutCell) bool {
 		if cell == nil {
 			return false

--- a/internal/mux/window_owner_debug_test.go
+++ b/internal/mux/window_owner_debug_test.go
@@ -1,0 +1,30 @@
+//go:build debug
+
+package mux
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestWindowPanicsOnCrossGoroutineMutation(t *testing.T) {
+	w := NewWindow(fakePaneID(1), 80, 24)
+
+	w.Resize(81, 24)
+
+	panicCh := make(chan any, 1)
+	go func() {
+		defer func() {
+			panicCh <- recover()
+		}()
+		w.Resize(82, 24)
+	}()
+
+	panicValue := <-panicCh
+	if panicValue == nil {
+		t.Fatal("expected panic from cross-goroutine mutation")
+	}
+	if got := panicValue.(string); !strings.Contains(got, "mux.Window.Resize") {
+		t.Fatalf("panic = %q, want method name", got)
+	}
+}

--- a/internal/remote/manager.go
+++ b/internal/remote/manager.go
@@ -39,6 +39,12 @@ type StateChangeCallback func(hostName string, state ConnState)
 
 // Manager coordinates all remote host connections. It maps local pane IDs
 // to their remote counterparts and routes I/O through the appropriate HostConn.
+//
+// Concurrency:
+// After initialization, Manager's public methods are safe for concurrent use.
+// Internal host/pane maps are protected by mu, and each HostConn owns its own
+// actor state. SetCallbacks must be called before concurrent pane creation, and
+// callers must treat the Config pointer returned by Config as read-only.
 type Manager struct {
 	mu        sync.Mutex
 	hosts     map[string]*HostConn // keyed by config host name


### PR DESCRIPTION
## Motivation

LAB-424 asks us to make the concurrency contracts in the hot paths explicit. LAB-425 follows from that by making attached-client copy mode honor a single runtime owner and by adding debug-only assertions that catch cross-goroutine mutations early.

## Summary

- document the concurrency contracts for `remote.Manager`, `hooks.Registry`, `copymode.CopyMode`, and `mux.Window`
- route attached-client local copy mode and local overlay updates through the render loop so copy-mode-backed state stays on one goroutine after attach startup
- add debug-only owner assertions for `CopyMode` and `Window`, plus queued-path and cross-goroutine panic tests

## Testing

- `go test ./internal/client -count=1`
- `go test ./internal/copymode ./internal/mux ./internal/hooks ./internal/remote -count=1`
- `go test -tags debug ./internal/copymode ./internal/mux -count=1`
- `go test ./internal/client -run 'Test(SyncTerminalSize|HandleDisplayPaneSelection|HandleMouseEvent|RunSessionHandlesServerMessagesAndInteractiveInput)' -count=100`
- `go test -tags debug ./internal/copymode ./internal/mux -run 'Test(CopyModePanicsOnCrossGoroutineMutation|WindowPanicsOnCrossGoroutineMutation)' -count=100`
- `go test ./... -timeout 120s` currently fails in unrelated existing `test.TestCapturePaneHistoryRewrapsNarrowLiveHistoryAndContent`
- `env -u AMUX_SESSION -u TMUX scripts/coverage.sh --ci` currently fails for the same unrelated existing `./test` package blocker

## Review focus

- the new render-loop local-action path for attached-client copy mode and local overlays
- the scope of the debug-only owner assertions on `CopyMode` and `Window`
- whether the known unrelated `capture --history --rewrap` integration failure should be handled in a follow-up

Closes LAB-424
Closes LAB-425
