### PR TITLE
Replace scheduling sleeps with deterministic AwaitTimers

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -46,7 +46,7 @@ if [ "$NEEDS_FMT" = true ]; then
 fi
 
 # Reject new time.Sleep additions in test files — use wait primitives instead
-SLEEP_ADDITIONS=$(git diff --cached --diff-filter=ACM -U0 -- '*_test.go' | grep '^\+' | grep -vF '+++' | grep -F 'time.Sleep' | grep -v 'nolint:gosleep')
+SLEEP_ADDITIONS=$(git diff --cached --diff-filter=ACM -U0 -- '*_test.go' | grep '^\+' | grep -vF '+++' | grep -F 'time.Sleep')
 if [ -n "$SLEEP_ADDITIONS" ]; then
     echo "ERROR: new time.Sleep added to test files"
     echo "  Use deterministic wait primitives instead:"

--- a/internal/server/clock_test.go
+++ b/internal/server/clock_test.go
@@ -7,14 +7,21 @@ import (
 
 // FakeClock is a test clock where time only advances via Advance().
 // Timers fire during Advance() when their deadline is reached.
+// AwaitTimers blocks until a given number of timer operations (NewTimer,
+// AfterFunc, Reset) have occurred, providing deterministic synchronization
+// without wall-clock sleeps.
 type FakeClock struct {
-	mu     sync.Mutex
-	now    time.Time
-	timers []*fakeTimer
+	mu       sync.Mutex
+	cond     *sync.Cond
+	now      time.Time
+	timers   []*fakeTimer
+	timerOps int // total NewTimer + AfterFunc + Reset calls
 }
 
 func NewFakeClock(start time.Time) *FakeClock {
-	return &FakeClock{now: start}
+	c := &FakeClock{now: start}
+	c.cond = sync.NewCond(&c.mu)
+	return c
 }
 
 func (c *FakeClock) Now() time.Time {
@@ -32,6 +39,8 @@ func (c *FakeClock) newFakeTimer(d time.Duration, fn func()) *fakeTimer {
 		fn:       fn,
 	}
 	c.timers = append(c.timers, ft)
+	c.timerOps++
+	c.cond.Broadcast()
 	return ft
 }
 
@@ -47,13 +56,28 @@ func (c *FakeClock) AfterFunc(d time.Duration, f func()) Timer {
 	return c.newFakeTimer(d, f)
 }
 
+// AwaitTimers blocks until at least n timer operations (NewTimer, AfterFunc,
+// or Reset) have been performed. This provides a deterministic rendezvous
+// point: the test waits for the production goroutine to create or reset its
+// timers before advancing the clock.
+func (c *FakeClock) AwaitTimers(n int) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for c.timerOps < n {
+		c.cond.Wait()
+	}
+}
+
 // Advance moves the clock forward by d and fires all expired timers.
 // AfterFunc callbacks run synchronously; NewTimer channels receive a value.
 //
+// Because fakeTimer.ch is buffered (size 1), Advance can fire a timer even
+// if the consuming goroutine hasn't entered its select yet — the value is
+// buffered and consumed on the next iteration.
+//
 // Lock order: c.mu is held only to snapshot and update the timer list.
 // Individual ft.mu locks are acquired after c.mu is released to avoid
-// lock-order inversion with fakeTimer.Reset (which acquires c.mu while
-// potentially holding ft.mu from the caller's resetTimer path).
+// lock-order inversion with fakeTimer.Reset.
 func (c *FakeClock) Advance(d time.Duration) {
 	c.mu.Lock()
 	c.now = c.now.Add(d)
@@ -130,5 +154,7 @@ func (t *fakeTimer) Reset(d time.Duration) bool {
 	t.mu.Unlock()
 
 	t.clock.timers = append(t.clock.timers, t)
+	t.clock.timerOps++
+	t.clock.cond.Broadcast()
 	return was
 }

--- a/internal/server/wait_vt_idle_test.go
+++ b/internal/server/wait_vt_idle_test.go
@@ -11,15 +11,6 @@ import (
 	"github.com/weill-labs/amux/internal/mux"
 )
 
-// yieldToCommandHandler gives the command handler goroutine a chance to
-// consume from its channels and enter/re-enter its select loop. This is a
-// scheduling yield, not a timing assertion — the fake clock controls all
-// timer-based logic. The sleep duration is generous to avoid flakes under
-// heavy CPU contention with -race -count=100.
-func yieldToCommandHandler() {
-	time.Sleep(5 * time.Millisecond) //nolint:gosleep
-}
-
 func startAsyncCommand(t *testing.T, srv *Server, sess *Session, name string, args ...string) (net.Conn, *clientConn, <-chan struct{}) {
 	t.Helper()
 
@@ -177,13 +168,12 @@ func TestCmdWaitVTIdleTimeout(t *testing.T) {
 
 	clientConn, _, done := startAsyncCommand(t, srv, sess, "wait-vt-idle", "pane-1", "--settle", "200ms", "--timeout", "40ms")
 
-	// Wait for the command goroutine to enter its select loop. The event-loop
-	// barrier ensures the subscribe has been processed; a short yield lets the
-	// goroutine reach the select statement.
-	sess.queryVTIdleWaitState(1)
-	yieldToCommandHandler()
+	// Wait for cmdWaitVTIdle to create its two timers (settle + timeout).
+	// Because fakeTimer.ch is buffered, Advance can fire a timer even if the
+	// goroutine hasn't entered its select yet.
+	clk.AwaitTimers(2)
 
-	// Advance past the timeout deadline — the command should reply immediately.
+	// Advance past the timeout deadline — fires into the buffered channel.
 	clk.Advance(50 * time.Millisecond)
 
 	msg := readMsgWithTimeout(t, clientConn)
@@ -209,20 +199,18 @@ func TestCmdWaitVTIdleResetsSettleTimerOnOutput(t *testing.T) {
 
 	clientConn, _, done := startAsyncCommand(t, srv, sess, "wait-vt-idle", "pane-1", "--settle", "100ms", "--timeout", "5s")
 
-	// Let the command goroutine enter its select loop.
-	sess.queryVTIdleWaitState(1)
-	yieldToCommandHandler()
+	// Wait for the two initial timers (settle + timeout).
+	clk.AwaitTimers(2)
 
-	// Send output — resets the settle timer.
+	// Send output — the event loop calls TrackOutput (AfterFunc, +1) and
+	// notifies the command handler which calls resetTimer (Reset, +1).
 	pane.FeedOutput([]byte("first"))
-	sess.queryVTIdleWaitState(1) // barrier: event loop processed the output
-	yieldToCommandHandler()      // yield: let command handler consume from outputCh
+	clk.AwaitTimers(4) // 2 initial + 1 AfterFunc + 1 Reset
 	clk.Advance(50 * time.Millisecond)
 
-	// More output — resets settle timer again.
+	// More output — same pattern: AfterFunc (+1) + Reset (+1).
 	pane.FeedOutput([]byte("second"))
-	sess.queryVTIdleWaitState(1)
-	yieldToCommandHandler()
+	clk.AwaitTimers(6) // 4 prev + 1 AfterFunc + 1 Reset
 	clk.Advance(50 * time.Millisecond)
 
 	// Advance past the settle window from the last output.


### PR DESCRIPTION
## Motivation

PR #397 introduced FakeClock but used 5ms `time.Sleep` scheduling yields to wait for the command goroutine to enter its `select`. These sleeps were a scheduling workaround, not a timing assertion, but they violated the project's no-sleep-in-tests principle.

## Summary

Key insight: `fakeTimer.ch` is buffered (size 1), so `Advance()` can fire a timer even if the consuming goroutine hasn't entered its `select` yet — the value buffers. We only need to know timers have been *created*, not that the goroutine is *blocked*.

- Add `AwaitTimers(n)` to `FakeClock`: blocks via `sync.Cond` until `n` timer operations (NewTimer, AfterFunc, Reset) have occurred
- `timerOps` counter incremented in `newFakeTimer` and `fakeTimer.Reset`, with `Broadcast()` on each
- Timeout test: `AwaitTimers(2)` — waits for settle + timeout timer creation
- Settle-reset test: `AwaitTimers(4)` and `AwaitTimers(6)` — accounts for `TrackOutput`'s `AfterFunc` + command handler's `resetTimer → Reset` per output event
- Removed: `yieldToCommandHandler`, `nolint:gosleep` annotation, pre-commit hook `nolint:gosleep` exemption

## Testing

```
go test -race -count=100 -run 'TestCmdWaitVTIdleTimeout$|TestCmdWaitVTIdleResetsSettleTimerOnOutput$' ./internal/server/
```

100/100 pass. Zero wall-clock sleeps in timing logic.

## Review focus

- The timer op counting (2 → 4 → 6) depends on knowing that `TrackOutput` calls `AfterFunc` and `resetTimer` calls `Reset`. If the production code adds another timer operation in the path, the count needs updating. The comments document the accounting.