### PR TITLE
Reply to local render actions before exit

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -416,6 +416,9 @@ func (cr *ClientRenderer) handleLocalRenderMsg(state *clientRenderLoopState, msg
 	}
 	result := msg.Local(cr)
 	if cr.executeRenderEffects(state, result.effects, write) {
+		if msg.Reply != nil {
+			msg.Reply <- result.value
+		}
 		return true
 	}
 	if msg.Reply != nil {

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -1213,6 +1213,43 @@ func TestRenderCoalescedCommandErrorShowsFeedback(t *testing.T) {
 	}
 }
 
+func TestRenderCoalescedLocalActionReplySentBeforeExit(t *testing.T) {
+	t.Parallel()
+
+	cr := buildTestRenderer(t)
+	msgCh := make(chan *RenderMsg, 1)
+	done := make(chan struct{})
+	go func() {
+		cr.RenderCoalesced(msgCh, func(string) {})
+		close(done)
+	}()
+
+	replyCh := make(chan string, 1)
+	go func() {
+		replyCh <- callLocalRenderAction[string](cr, msgCh, func(*ClientRenderer) localRenderResult {
+			return localRenderResult{
+				effects: []clientEffect{{kind: clientEffectExit}},
+				value:   "ok",
+			}
+		})
+	}()
+
+	select {
+	case got := <-replyCh:
+		if got != "ok" {
+			t.Fatalf("reply = %q, want %q", got, "ok")
+		}
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("local action reply blocked on exit")
+	}
+
+	select {
+	case <-done:
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("render loop did not exit after local action exit effect")
+	}
+}
+
 func TestRenderCoalescedPaneOutputRendersImmediatelyAfterIdle(t *testing.T) {
 	t.Parallel()
 

--- a/internal/client/local_render.go
+++ b/internal/client/local_render.go
@@ -2,6 +2,12 @@ package client
 
 import "os"
 
+// Local render actions are reserved for client state that cannot be updated
+// safely through the clientSnapshot CAS helpers. CopyMode instances are shared,
+// deeply mutable structs, so attached-client access is serialized onto the
+// render loop. Simpler UI state such as messages, chooser visibility, and pane
+// overlays lives in clientSnapshot and can continue to use updateState /
+// updateClientStateValue from any goroutine.
 func applyLocalRenderResultDirect(cr *ClientRenderer, result localRenderResult) {
 	state := &clientRenderLoopState{
 		useFull:             os.Getenv("AMUX_RENDER") == "full",


### PR DESCRIPTION
## Motivation

The merged LAB-424/LAB-425 change left one latent deadlock in the render-loop local-action reply path: if a future local action exits the render loop, `callLocalRenderAction` can block forever waiting on `msg.Reply`. The review also asked for a short comment documenting why copy-mode calls use local render actions while simpler client UI state does not.

## Summary

- send `msg.Reply` before returning from `handleLocalRenderMsg` when local action effects exit the render loop
- add a regression test that would block if a local action with exit effects failed to reply
- document the boundary in `local_render.go`: copy-mode-backed mutable structs use render-loop serialization, while snapshot-backed UI state still uses atomic CAS helpers

## Testing

- `go test ./internal/client -run 'TestRenderCoalesced(CommandErrorShowsFeedback|LocalActionReplySentBeforeExit)' -count=100`
- `go test ./internal/client -count=1`

## Review focus

- whether the reply-before-exit ordering in `handleLocalRenderMsg` is the right guard against future local-action exit effects
- the explanatory comment in `local_render.go`
- confirmation that item 2 from PR #398 is still covered: production renderer-owned pane emulator resizes still only happen in `HandleLayout` and `Renderer.Resize`, and `ClientRenderer` already pairs those with `syncCopyModeSizes()`
