### PR TITLE
Eliminate vtEmulator.scrollbackMu by moving scrollbackWidths to Pane

### DIFF
--- a/internal/mux/emulator.go
+++ b/internal/mux/emulator.go
@@ -3,7 +3,6 @@ package mux
 import (
 	"fmt"
 	"strings"
-	"sync"
 	"sync/atomic"
 
 	uv "github.com/charmbracelet/ultraviolet"
@@ -55,10 +54,6 @@ type TerminalEmulator interface {
 	// ScrollbackCellAt returns the raw cell at (col, row) in retained
 	// scrollback (0=oldest row). Returns nil for out-of-bounds.
 	ScrollbackCellAt(col, row int) *uv.Cell
-
-	// ScrollbackSourceWidth returns the pane width at which the scrollback row
-	// was originally wrapped. Returns zero when unknown.
-	ScrollbackSourceWidth(row int) int
 
 	// RenderWithoutCursorBlock renders the screen with the cursor cell's
 	// reverse-video attribute cleared. Used for inactive pane rendering so
@@ -129,15 +124,15 @@ func (p MouseProtocol) Enabled() bool {
 
 // vtEmulator wraps charmbracelet/x/vt.SafeEmulator.
 type vtEmulator struct {
-	emu              *vt.SafeEmulator
-	w                atomic.Int32
-	h                atomic.Int32
-	cursorHidden     atomic.Bool
-	altScreen        atomic.Bool
-	mouseFlags       atomic.Uint32
-	scrollbackMu     sync.Mutex
-	scrollbackWidths []int
-	scrollbackLimit  int
+	emu               *vt.SafeEmulator
+	w                 atomic.Int32
+	h                 atomic.Int32
+	cursorHidden      atomic.Bool
+	altScreen         atomic.Bool
+	mouseFlags        atomic.Uint32
+	scrollbackPushFn  func(count, width int)
+	scrollbackClearFn func()
+	scrollbackLimit   int
 }
 
 const (
@@ -174,34 +169,17 @@ func NewVTEmulatorWithScrollback(width, height, scrollbackLines int) TerminalEmu
 			v.setMouseMode(mode, false)
 		},
 		ScrollbackPush: func(count, width int) {
-			v.recordScrollbackPush(count, width)
+			if v.scrollbackPushFn != nil {
+				v.scrollbackPushFn(count, width)
+			}
 		},
 		ScrollbackClear: func() {
-			v.clearScrollbackWidths()
+			if v.scrollbackClearFn != nil {
+				v.scrollbackClearFn()
+			}
 		},
 	})
 	return v
-}
-
-func (v *vtEmulator) recordScrollbackPush(count, width int) {
-	if count <= 0 || width <= 0 {
-		return
-	}
-	v.scrollbackMu.Lock()
-	defer v.scrollbackMu.Unlock()
-	for range count {
-		v.scrollbackWidths = append(v.scrollbackWidths, width)
-	}
-	if overflow := len(v.scrollbackWidths) - v.scrollbackLimit; overflow > 0 {
-		copy(v.scrollbackWidths, v.scrollbackWidths[overflow:])
-		v.scrollbackWidths = v.scrollbackWidths[:len(v.scrollbackWidths)-overflow]
-	}
-}
-
-func (v *vtEmulator) clearScrollbackWidths() {
-	v.scrollbackMu.Lock()
-	defer v.scrollbackMu.Unlock()
-	v.scrollbackWidths = v.scrollbackWidths[:0]
 }
 
 func (v *vtEmulator) setMouseMode(mode ansi.Mode, enabled bool) {
@@ -308,15 +286,6 @@ func (v *vtEmulator) ScrollbackCellAt(col, row int) *uv.Cell {
 	}
 	cell := line[col]
 	return &cell
-}
-
-func (v *vtEmulator) ScrollbackSourceWidth(row int) int {
-	v.scrollbackMu.Lock()
-	defer v.scrollbackMu.Unlock()
-	if row < 0 || row >= len(v.scrollbackWidths) {
-		return 0
-	}
-	return v.scrollbackWidths[row]
 }
 
 // screenLineTextInner extracts plain text from screen row y across w columns.
@@ -579,11 +548,15 @@ func EmulatorScrollbackLines(emu TerminalEmulator) []string {
 }
 
 // EmulatorScrollbackHistoryLines returns retained scrollback rows with their
-// tracked source widths.
-func EmulatorScrollbackHistoryLines(emu TerminalEmulator) []CaptureHistoryLine {
+// tracked source widths. The widths slice is indexed by scrollback row; entries
+// beyond its length report zero width (unknown).
+func EmulatorScrollbackHistoryLines(emu TerminalEmulator, widths []int) []CaptureHistoryLine {
 	lines := make([]CaptureHistoryLine, emu.ScrollbackLen())
 	for y := range len(lines) {
-		sourceWidth := emu.ScrollbackSourceWidth(y)
+		sourceWidth := 0
+		if y < len(widths) {
+			sourceWidth = widths[y]
+		}
 		lines[y] = CaptureHistoryLine{
 			Text:        emu.ScrollbackLineText(y),
 			SourceWidth: sourceWidth,

--- a/internal/mux/emulator_test.go
+++ b/internal/mux/emulator_test.go
@@ -211,23 +211,6 @@ func TestRenderWithoutCursorBlock(t *testing.T) {
 	})
 }
 
-func TestScrollbackSourceWidthClearsWithScrollback(t *testing.T) {
-	t.Parallel()
-
-	emu := NewVTEmulatorWithDrainAndScrollback(5, 1, 2).(*vtEmulator)
-	emu.Write([]byte("11111\r\n"))
-
-	if got := emu.ScrollbackSourceWidth(0); got != 5 {
-		t.Fatalf("ScrollbackSourceWidth(0) = %d, want 5", got)
-	}
-
-	emu.emu.ClearScrollback()
-
-	if got := emu.ScrollbackSourceWidth(0); got != 0 {
-		t.Fatalf("ScrollbackSourceWidth(0) after clear = %d, want 0", got)
-	}
-}
-
 func TestVTEmulatorResetClearsScreenScrollbackAndModes(t *testing.T) {
 	t.Parallel()
 
@@ -261,9 +244,6 @@ func TestVTEmulatorResetClearsScreenScrollbackAndModes(t *testing.T) {
 	}
 	if got := emu.ScrollbackLen(); got != 0 {
 		t.Fatalf("ScrollbackLen() after reset = %d, want 0", got)
-	}
-	if got := emu.ScrollbackSourceWidth(0); got != 0 {
-		t.Fatalf("ScrollbackSourceWidth(0) after reset = %d, want 0", got)
 	}
 	if col, row := emu.CursorPosition(); col != 0 || row != 0 {
 		t.Fatalf("CursorPosition() after reset = (%d, %d), want (0, 0)", col, row)

--- a/internal/mux/pane.go
+++ b/internal/mux/pane.go
@@ -53,10 +53,12 @@ type Pane struct {
 	process  *os.Process // set for restored panes (where cmd is nil)
 	emulator TerminalEmulator
 
-	outputSeq       atomic.Uint64
-	snapshotSeq     atomic.Uint64
-	baseHistory     atomic.Pointer[paneBaseHistory]
-	scrollbackLines int
+	outputSeq        atomic.Uint64
+	snapshotSeq      atomic.Uint64
+	baseHistory      atomic.Pointer[paneBaseHistory]
+	scrollbackWidths atomic.Pointer[[]int]
+	scrollbackLines  int
+	scrollbackLimit  int
 
 	// writeOverride, when non-nil, receives Write() calls instead of the PTY.
 	// Used by proxy panes to route input over SSH to a remote amux server.
@@ -149,9 +151,20 @@ func NewPaneWithScrollback(id uint32, meta PaneMeta, cols, rows int, sessionName
 		onExit:          onExit,
 		createdAt:       time.Now(),
 		scrollbackLines: effectiveScrollbackLines(scrollbackLines),
+		scrollbackLimit: effectiveScrollbackLines(scrollbackLines),
 	}
 	p.baseHistory.Store(&paneBaseHistory{})
+	wireScrollbackCallbacks(p)
 	return p, nil
+}
+
+// wireScrollbackCallbacks connects the emulator's scrollback push/clear
+// callbacks to the pane's atomic width tracking.
+func wireScrollbackCallbacks(p *Pane) {
+	if vte, ok := p.emulator.(*vtEmulator); ok {
+		vte.scrollbackPushFn = p.recordScrollbackPush
+		vte.scrollbackClearFn = p.clearScrollbackWidths
+	}
 }
 
 func paneCommandEnv(base []string, paneID uint32, sessionName string) []string {
@@ -211,8 +224,10 @@ func RestorePaneWithScrollback(id uint32, meta PaneMeta, ptmxFd, pid, cols, rows
 		onExit:          onExit,
 		createdAt:       time.Now(),
 		scrollbackLines: effectiveScrollbackLines(scrollbackLines),
+		scrollbackLimit: effectiveScrollbackLines(scrollbackLines),
 	}
 	p.baseHistory.Store(&paneBaseHistory{})
+	wireScrollbackCallbacks(p)
 
 	// Start drain immediately so screen replay doesn't deadlock
 	// on the emulator's unbuffered response pipe.
@@ -255,6 +270,44 @@ func (p *Pane) loadBaseHistory() []string {
 		return nil
 	}
 	return base.lines
+}
+
+func (p *Pane) loadScrollbackWidths() []int {
+	if ptr := p.scrollbackWidths.Load(); ptr != nil {
+		return *ptr
+	}
+	return nil
+}
+
+func (p *Pane) recordScrollbackPush(count, width int) {
+	if count <= 0 || width <= 0 {
+		return
+	}
+	old := p.loadScrollbackWidths()
+	newWidths := make([]int, len(old), len(old)+count)
+	copy(newWidths, old)
+	for range count {
+		newWidths = append(newWidths, width)
+	}
+	if overflow := len(newWidths) - p.scrollbackLimit; overflow > 0 {
+		newWidths = newWidths[overflow:]
+	}
+	p.scrollbackWidths.Store(&newWidths)
+}
+
+func (p *Pane) clearScrollbackWidths() {
+	empty := make([]int, 0)
+	p.scrollbackWidths.Store(&empty)
+}
+
+// ScrollbackSourceWidth returns the pane width at which the scrollback row
+// was originally wrapped. Returns zero when unknown.
+func (p *Pane) ScrollbackSourceWidth(row int) int {
+	widths := p.loadScrollbackWidths()
+	if row < 0 || row >= len(widths) {
+		return 0
+	}
+	return widths[row]
 }
 
 // PtmxFd returns the file descriptor number for the PTY master.
@@ -546,7 +599,7 @@ func (p *Pane) CaptureSnapshot() CaptureSnapshot {
 	for {
 		before := p.waitForStableSnapshot()
 		baseHistory := p.loadBaseHistory()
-		liveHistory := EmulatorScrollbackHistoryLines(p.emulator)
+		liveHistory := EmulatorScrollbackHistoryLines(p.emulator, p.loadScrollbackWidths())
 		baseHistory, liveHistory, history := p.captureScrollback(baseHistory, liveHistory)
 		contentRows := EmulatorContentHistoryLines(p.emulator)
 		width, _ := p.emulator.Size()
@@ -695,6 +748,7 @@ func (p *Pane) ResetState() {
 	p.beginSnapshotMutation()
 	defer p.endSnapshotMutation()
 	p.baseHistory.Store(&paneBaseHistory{})
+	p.clearScrollbackWidths()
 	if p.emulator != nil {
 		p.emulator.Reset()
 	}
@@ -768,8 +822,10 @@ func NewProxyPaneWithScrollback(id uint32, meta PaneMeta, cols, rows int,
 		createdAt:       time.Now(),
 		drainStarted:    true, // no PTY responses to drain
 		scrollbackLines: effectiveScrollbackLines(scrollbackLines),
+		scrollbackLimit: effectiveScrollbackLines(scrollbackLines),
 	}
 	p.baseHistory.Store(&paneBaseHistory{})
+	wireScrollbackCallbacks(p)
 	// Start drain goroutine for emulator responses (DA replies etc.)
 	// that would otherwise block the emulator's pipe.
 	go p.drainResponsesDiscard()

--- a/internal/mux/pane_test.go
+++ b/internal/mux/pane_test.go
@@ -226,7 +226,9 @@ func TestCaptureSnapshotTracksLiveScrollbackSourceWidthsAcrossResize(t *testing.
 		ID:              1,
 		emulator:        emu,
 		scrollbackLines: 4,
+		scrollbackLimit: 4,
 	}
+	wireScrollbackCallbacks(p)
 
 	emu.Write([]byte("01234567890123456789\r\n"))
 	emu.Resize(10, 1)
@@ -296,7 +298,9 @@ func TestCaptureSnapshotTrimsLiveScrollbackWidthMetadataWithCap(t *testing.T) {
 		ID:              1,
 		emulator:        emu,
 		scrollbackLines: 2,
+		scrollbackLimit: 2,
 	}
+	wireScrollbackCallbacks(p)
 
 	emu.Write([]byte("11111\r\n"))
 	emu.Resize(6, 1)
@@ -313,5 +317,30 @@ func TestCaptureSnapshotTrimsLiveScrollbackWidthMetadataWithCap(t *testing.T) {
 	}
 	if got := snap.LiveHistory[1]; got.Text != "3333333" || got.SourceWidth != 7 {
 		t.Fatalf("LiveHistory[1] = %#v, want text=%q width=7", got, "3333333")
+	}
+}
+
+func TestPaneScrollbackWidthClearsWithScrollback(t *testing.T) {
+	t.Parallel()
+
+	emu := NewVTEmulatorWithDrainAndScrollback(5, 1, 2)
+	p := &Pane{
+		ID:              1,
+		emulator:        emu,
+		scrollbackLines: 2,
+		scrollbackLimit: 2,
+	}
+	wireScrollbackCallbacks(p)
+
+	emu.Write([]byte("11111\r\n"))
+
+	if got := p.ScrollbackSourceWidth(0); got != 5 {
+		t.Fatalf("ScrollbackSourceWidth(0) = %d, want 5", got)
+	}
+
+	emu.(*vtEmulator).emu.ClearScrollback()
+
+	if got := p.ScrollbackSourceWidth(0); got != 0 {
+		t.Fatalf("ScrollbackSourceWidth(0) after clear = %d, want 0", got)
 	}
 }


### PR DESCRIPTION
## Motivation

`vtEmulator` uses a `sync.Mutex` (`scrollbackMu`) to protect `scrollbackWidths []int` — the only mutex in amux-owned production code outside `hooks.Registry`. This PR eliminates it by moving scrollback width tracking from the emulator to the `Pane`, using `atomic.Pointer[[]int]` for lock-free immutable-snapshot access.

## Summary

- Remove `scrollbackMu`, `scrollbackWidths`, `recordScrollbackPush`, `clearScrollbackWidths`, and `ScrollbackSourceWidth` from `vtEmulator`
- Add `scrollbackPushFn`/`scrollbackClearFn` callback fields to `vtEmulator`; the `ScrollbackPush`/`ScrollbackClear` callbacks delegate to these
- Add `scrollbackWidths atomic.Pointer[[]int]` and `scrollbackLimit` to `Pane`
- `Pane.recordScrollbackPush` creates a new immutable slice and atomically stores it — same copy-on-write pattern as `baseHistory`
- Wire callbacks in all three pane constructors (`NewPaneWithScrollback`, `RestorePaneWithScrollback`, `NewProxyPaneWithScrollback`) via `wireScrollbackCallbacks`
- Update `EmulatorScrollbackHistoryLines` to accept widths as a parameter; `CaptureSnapshot` passes `p.loadScrollbackWidths()`
- Remove `ScrollbackSourceWidth` from the `TerminalEmulator` interface (no external implementors)
- Convert emulator-level scrollback width test to pane-level; add `TestPaneScrollbackWidthClearsWithScrollback`

## Testing

```bash
go test ./... -timeout 120s
go test ./internal/mux/ -run "TestCaptureSnapshotTracks|TestCaptureSnapshotTrims|TestPaneResetState|TestPaneScrollbackWidth" -count=100
go test -race ./internal/mux/
```

## Review focus

- `Pane.recordScrollbackPush` allocates a new slice on each push event. This is O(scrollbackLimit) per push. In practice, pushes happen far less frequently than emulator writes, and the limit is 10k entries (~80KB). Verify this tradeoff is acceptable.
- The `wireScrollbackCallbacks` pattern uses a type assertion to `*vtEmulator` inside the `mux` package. This is fine since there's only one implementation, but flagging it.

Closes LAB-432