### PR TITLE
Stabilize agent status busy/idle test

### DIFF
--- a/internal/mux/pane_window_process_test.go
+++ b/internal/mux/pane_window_process_test.go
@@ -48,7 +48,7 @@ func newAgentStatusTestPane(t *testing.T) *Pane {
 
 	p := &Pane{
 		ID:              123,
-		Meta:            PaneMeta{Name: "pane-123", Host: DefaultHost, Color: "f5e0dc"},
+		Meta:            PaneMeta{Name: "pane-123", Host: DefaultHost},
 		ptmx:            ptmx,
 		cmd:             cmd,
 		emulator:        NewVTEmulatorWithScrollback(40, 10, DefaultScrollbackLines),


### PR DESCRIPTION
## Motivation

`TestAgentStatusTracksBusyAndIdle` was using the `go test` process as the pane shell and then asserting on that process tree. Under repeated runs and coverage-heavy package execution, unrelated child processes could leak into the observed tree and make the test fail for reasons unrelated to `Pane.AgentStatus()`.

## Summary

- replace the shared test-process shell with a dedicated PTY-backed shell owned by the test
- drive the busy/idle transition through that shell so the observed child PID belongs only to the test pane
- keep the same behavioral assertions while removing package-level process-tree interference

## Testing

- `go test ./internal/mux -run '^TestAgentStatusTracksBusyAndIdle$' -count=100`
- `go test ./... -timeout 120s`
- `env -u AMUX_SESSION -u TMUX scripts/coverage.sh --ci`

## Review focus

Please focus on whether the new `newAgentStatusTestPane` helper in `internal/mux/pane_window_process_test.go` is the right minimal seam for isolating `AgentStatus()` from unrelated package subprocesses.
