### PR TITLE
Make capture timing overrides session-internal

### DIFF
--- a/internal/server/capture_forward_test.go
+++ b/internal/server/capture_forward_test.go
@@ -258,7 +258,7 @@ func TestForwardCaptureJSONNoClientReturnsErrorObject(t *testing.T) {
 	_, sess, cleanup := newCommandTestSession(t)
 	defer cleanup()
 
-	sess.CaptureAttachMaxRetries = 1
+	sess.captureTiming.attachMaxRetries = 1
 
 	resp := sess.forwardCapture([]string{"--format", "json"})
 	if resp.CmdErr != "" {
@@ -271,8 +271,8 @@ func TestForwardCaptureJSONNoClientRetriesBeforeErrorObject(t *testing.T) {
 	_, sess, cleanup := newCommandTestSession(t)
 	defer cleanup()
 
-	sess.CaptureAttachMaxRetries = 2
-	sess.CaptureAttachRetryDelay = 1 // non-zero to avoid default; effectively instant
+	sess.captureTiming.attachMaxRetries = 2
+	sess.captureTiming.attachRetryDelay = time.Nanosecond
 
 	resp := sess.forwardCapture([]string{"--format", "json"})
 	if resp.CmdErr != "" {
@@ -367,7 +367,7 @@ func TestForwardCaptureJSONTimeoutReturnsErrorObject(t *testing.T) {
 	_, sess, cleanup := newCommandTestSession(t)
 	defer cleanup()
 
-	sess.CaptureResponseTimeout = time.Millisecond
+	sess.captureTiming.responseTimeout = time.Millisecond
 
 	msg, respCh := startForwardCaptureForTest(t, sess, []string{"--format", "json"})
 	if msg.Type != MsgTypeCaptureRequest {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -95,12 +95,13 @@ type Session struct {
 	closedPaneTimers map[uint32]*time.Timer
 
 	// Configurable timing — zero values use defaults. Tests inject short durations.
-	VTIdleSettle            time.Duration // default: 2s
-	UndoGracePeriod         time.Duration // default: 30s
-	CaptureAttachMaxRetries int           // default: 10
-	CaptureAttachRetryDelay time.Duration // default: 300ms
-	CaptureResponseTimeout  time.Duration // default: 3s
-	Clock                   Clock         // nil uses RealClock
+	VTIdleSettle    time.Duration // default: 2s
+	UndoGracePeriod time.Duration // default: 30s
+	Clock           Clock         // nil uses RealClock
+
+	// Internal capture timing overrides. Zero values use defaults.
+	// Tests inject short timings here instead of mutating package globals.
+	captureTiming captureTimingConfig
 
 	// Remote pane management — manages SSH connections to remote hosts.
 	// Nil when no config is loaded or no remote hosts are defined.
@@ -171,23 +172,29 @@ func (s *Session) undoGracePeriod() time.Duration {
 	return DefaultUndoGracePeriod
 }
 
+type captureTimingConfig struct {
+	attachMaxRetries int
+	attachRetryDelay time.Duration
+	responseTimeout  time.Duration
+}
+
 func (s *Session) captureAttachMaxRetries() int {
-	if s.CaptureAttachMaxRetries != 0 {
-		return s.CaptureAttachMaxRetries
+	if s.captureTiming.attachMaxRetries != 0 {
+		return s.captureTiming.attachMaxRetries
 	}
 	return defaultCaptureAttachMaxRetries
 }
 
 func (s *Session) captureAttachRetryDelay() time.Duration {
-	if s.CaptureAttachRetryDelay != 0 {
-		return s.CaptureAttachRetryDelay
+	if s.captureTiming.attachRetryDelay != 0 {
+		return s.captureTiming.attachRetryDelay
 	}
 	return defaultCaptureAttachRetryDelay
 }
 
 func (s *Session) captureResponseTimeout() time.Duration {
-	if s.CaptureResponseTimeout != 0 {
-		return s.CaptureResponseTimeout
+	if s.captureTiming.responseTimeout != 0 {
+		return s.captureTiming.responseTimeout
 	}
 	return defaultCaptureResponseTimeout
 }


### PR DESCRIPTION
## Motivation

`defaultCaptureAttachMaxRetries`, `defaultCaptureAttachRetryDelay`, and `defaultCaptureResponseTimeout` are already constants on `main`, but the current override seam exposes three extra exported `Session` fields just to support tests. That broadens the server API more than this ticket needs.

## Summary

- move capture timing test overrides into an internal `captureTimingConfig` on `Session`
- keep the existing per-session helper methods and default constants unchanged
- update the capture forwarding tests to use the internal override seam instead of exported `Session` fields

## Testing

- `go test ./internal/server -run 'TestForwardCaptureJSON(NoClientReturnsErrorObject|NoClientRetriesBeforeErrorObject|ReturnsSessionShuttingDownBeforeAttach|HandlesNilAndErrResponses|TimeoutReturnsErrorObject)$' -count=100`
- `go test ./internal/server`
- `env -u AMUX_SESSION -u TMUX go test ./test -run 'Test(HotReloadRebuildConvergesFromOutsideRepoWithMismatchedInstallMetadata|MultiClientFocusTransfersSizeOwnership|TypeKeysFocus|TakeoverReconnectAfterRemoteReload|PaneLogSnapshotsExitContext)$' -count=1 -timeout 120s`
- `env -u AMUX_SESSION -u TMUX go test ./... -timeout 120s` still reports existing `test/` package startup flakes in this environment with `server not running` failures outside the touched code path

## Review focus

- whether moving the capture timing seam off exported `Session` fields and into internal config is the right boundary
- whether the test-only overrides remain clear enough now that the capture timing state is grouped instead of flattened

Closes LAB-431
