### PR TITLE
Add mergeability check rule to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,6 +146,10 @@ If you ran `$postmortem`, provide the log path, summarize the key learnings, lis
 
 After resolving merge conflicts, run `go vet ./...` locally before committing. Git auto-merge can silently produce duplicate declarations (e.g., methods defined in both sides) that compile but fail vet.
 
+### Verify Mergeability Before Declaring PRs Ready
+
+Before telling the user a PR is safe to merge, check for merge conflicts with main: `git fetch origin main && git merge-tree --write-tree origin/main origin/BRANCH`. If there are conflicts, rebase the branch onto `origin/main` and resolve them before declaring ready.
+
 ### Merge Policy
 
 GitHub PRs for this repo are squash-only. `gh pr merge --merge` and `gh pr merge --rebase` will fail.


### PR DESCRIPTION
## Motivation

During this session, I declared two PRs safe to merge without checking for conflicts. PR #407 had a conflict with a new `lint-sync.sh` hook that landed on main. The user had to ask "Did you check if they have merge conflicts?"

## Summary

Add a rule to CLAUDE.md requiring agents to check for merge conflicts before declaring PRs ready to merge, using `git merge-tree --write-tree`.