### PR TITLE
Add move-to pane reparenting across columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,12 +274,14 @@ All commands accept `-s <session>` to target a specific session. Panes are refer
 | `amux swap forward\|backward` | Swap active pane with neighbor |
 | `amux swap-tree <p1> <p2>` | Swap the root-level groups containing two panes |
 | `amux move <pane> --before\|--after <target>` | Move a pane's root-level group before or after another |
+| `amux move-to <pane> <target>` | Move one pane into the target pane's column, appending at the bottom |
 | `amux rotate [--reverse]` | Rotate pane positions |
 | `amux copy-mode [pane] [--wait ui=copy-mode-shown] [--timeout <duration>]` | Enter copy/scroll mode |
 | `amux set-meta <pane> key=value...` | Set single-value pane metadata (`task`, `branch`, `pr`) |
 | `amux add-meta <pane> key=value...` | Add pane metadata values (`pr=NUMBER`, `issue=ID`) |
 | `amux rm-meta <pane> key=value...` | Remove pane metadata values (`pr=NUMBER`, `issue=ID`) |
 `swap-tree` and `move` treat each pane ref as identifying the root-level group that contains that pane, so moving `pane-3` can move an entire column or row rather than only one leaf cell.
+`move-to` instead moves exactly one pane into the target pane's logical column and appends it to the bottom of that stack.
 `split`, `spawn`, and `add-pane` are pure layout mutations: they create the pane but do not change focus. Use `amux focus <pane|direction>` when you want a focus change explicitly. When the active pane is zoomed, these commands preserve the zoom and keep the focused pane unchanged.
 
 `add-pane` builds outward in a clockwise spiral. At 1, 4, 9, 16, ... panes the spiral canvas reaches a uniform `N x N` grid. When a lead pane is active, the lead column stays pinned on the left and `add-pane` spirals only within the right subtree.

--- a/internal/mux/window.go
+++ b/internal/mux/window.go
@@ -686,6 +686,76 @@ func (w *Window) rootChildForPaneID(paneID uint32) (*LayoutCell, int, error) {
 	return cell, cell.IndexInParent(), nil
 }
 
+func (w *Window) columnContainerForPaneID(paneID uint32) (*LayoutCell, error) {
+	if w.Root == nil {
+		return nil, fmt.Errorf("window has no layout")
+	}
+	if w.Root.FindPane(paneID) == nil {
+		return nil, fmt.Errorf("pane %d not found", paneID)
+	}
+	if w.Root.IsLeaf() || w.Root.Dir != SplitVertical {
+		return w.Root, nil
+	}
+	cell, _, err := w.rootChildForPaneID(paneID)
+	if err != nil {
+		return nil, err
+	}
+	return cell, nil
+}
+
+func firstOtherPaneID(cell *LayoutCell, exclude uint32) (uint32, bool) {
+	other := uint32(0)
+	cell.Walk(func(leaf *LayoutCell) {
+		if other != 0 || leaf == nil || leaf.Pane == nil || leaf.Pane.ID == exclude {
+			return
+		}
+		other = leaf.Pane.ID
+	})
+	return other, other != 0
+}
+
+func (w *Window) wrapColumnWithBottomPane(column *LayoutCell, pane *Pane) {
+	oldParent := column.Parent
+	oldIdx := column.IndexInParent()
+	oldX, oldY, oldW, oldH := column.X, column.Y, column.W, column.H
+	size2 := (oldH - 1) / 2
+	size1 := oldH - 1 - size2
+
+	column.ResizeSubtree(oldW, size1)
+	newLeaf := NewLeaf(pane, oldX, oldY+size1+1, oldW, size2)
+	newRoot := &LayoutCell{
+		X:        oldX,
+		Y:        oldY,
+		W:        oldW,
+		H:        oldH,
+		Dir:      SplitHorizontal,
+		Parent:   oldParent,
+		Children: []*LayoutCell{column, newLeaf},
+	}
+	column.Parent = newRoot
+	newLeaf.Parent = newRoot
+
+	if oldParent == nil {
+		w.Root = newRoot
+		return
+	}
+	oldParent.Children[oldIdx] = newRoot
+}
+
+func (w *Window) appendPaneToColumn(column *LayoutCell, pane *Pane) {
+	switch {
+	case column.IsLeaf():
+		w.wrapColumnWithBottomPane(column, pane)
+	case column.Dir == SplitHorizontal:
+		newLeaf := NewLeaf(pane, 0, 0, 0, 0)
+		newLeaf.Parent = column
+		column.Children = append(column.Children, newLeaf)
+		column.distributeEqual()
+	default:
+		w.wrapColumnWithBottomPane(column, pane)
+	}
+}
+
 func (w *Window) finishTreeMutation() {
 	w.Root.FixOffsets()
 	w.resizePTYs()
@@ -795,6 +865,82 @@ func (w *Window) MovePane(paneID, targetPaneID uint32, before bool) error {
 	w.Root.Children = children
 
 	w.finishTreeMutation()
+	return nil
+}
+
+// MovePaneToColumn reparents paneID into the logical column selected by
+// targetPaneID, appending the moved pane to the bottom of that column.
+func (w *Window) MovePaneToColumn(paneID, targetPaneID uint32) error {
+	w.assertOwner("MovePaneToColumn")
+	if col := w.leadColumn(); col != nil {
+		inSource := containsPane(col, paneID)
+		inTarget := containsPane(col, targetPaneID)
+		if inSource != inTarget {
+			return fmt.Errorf("cannot move panes across lead column")
+		}
+	}
+
+	sourceCell := w.Root.FindPane(paneID)
+	if sourceCell == nil {
+		return fmt.Errorf("pane %d not found", paneID)
+	}
+	if w.Root.FindPane(targetPaneID) == nil {
+		return fmt.Errorf("pane %d not found", targetPaneID)
+	}
+
+	sourcePane := sourceCell.Pane
+	sourceColumn, err := w.columnContainerForPaneID(paneID)
+	if err != nil {
+		return err
+	}
+	destColumn, err := w.columnContainerForPaneID(targetPaneID)
+	if err != nil {
+		return err
+	}
+
+	sameColumn := sourceColumn == destColumn
+	destWasRoot := destColumn == w.Root
+	anchorPaneID := targetPaneID
+	if sameColumn && paneID == targetPaneID {
+		ok := false
+		anchorPaneID, ok = firstOtherPaneID(destColumn, paneID)
+		if !ok {
+			return nil
+		}
+	}
+
+	if sameColumn || destColumn.IsLeaf() || destColumn.Dir != SplitHorizontal {
+		if destColumn.H < 2*PaneMinSize+1 {
+			return fmt.Errorf("not enough space to move pane into destination column (%d < %d)", destColumn.H, 2*PaneMinSize+1)
+		}
+	}
+
+	if w.ZoomedPaneID != 0 {
+		w.Unzoom()
+	}
+
+	sourceWasActive := w.ActivePane != nil && w.ActivePane.ID == paneID
+	if err := w.ClosePane(paneID); err != nil {
+		return err
+	}
+
+	postDestColumn := destColumn
+	if sameColumn {
+		if destWasRoot {
+			postDestColumn = w.Root
+		} else {
+			postDestColumn, err = w.columnContainerForPaneID(anchorPaneID)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	w.appendPaneToColumn(postDestColumn, sourcePane)
+	w.finishTreeMutation()
+	if sourceWasActive {
+		w.setActive(sourcePane)
+	}
 	return nil
 }
 

--- a/internal/mux/window_test.go
+++ b/internal/mux/window_test.go
@@ -1044,6 +1044,185 @@ func TestMovePaneAfter(t *testing.T) {
 	}
 }
 
+func TestMovePaneToColumnAcrossRootColumns(t *testing.T) {
+	t.Parallel()
+
+	p1 := fakePaneID(1)
+	w := NewWindow(p1, 120, 24)
+
+	p2 := fakePaneID(2)
+	if _, err := w.SplitRoot(SplitVertical, p2); err != nil {
+		t.Fatalf("split root vertical: %v", err)
+	}
+	p3 := fakePaneID(3)
+	if _, err := w.SplitRoot(SplitVertical, p3); err != nil {
+		t.Fatalf("split root vertical again: %v", err)
+	}
+
+	w.FocusPane(p1)
+	p4 := fakePaneID(4)
+	if _, err := w.Split(SplitHorizontal, p4); err != nil {
+		t.Fatalf("split left column horizontal: %v", err)
+	}
+
+	if err := w.MovePaneToColumn(4, 2); err != nil {
+		t.Fatalf("MovePaneToColumn: %v", err)
+	}
+
+	if got := w.Root.Children[0].FindPane(1); got == nil {
+		t.Fatal("left root child should contain pane-1 after extraction")
+	}
+	if got := w.Root.Children[1].FindPane(2); got == nil {
+		t.Fatal("middle root child should contain pane-2 after insertion")
+	}
+	if got := w.Root.Children[1].FindPane(4); got == nil {
+		t.Fatal("middle root child should contain moved pane-4")
+	}
+	if got := w.Root.Children[2].FindPane(3); got == nil {
+		t.Fatal("right root child should contain pane-3")
+	}
+
+	middle := w.Root.Children[1]
+	if middle.IsLeaf() || middle.Dir != SplitHorizontal {
+		t.Fatalf("target root child = %+v, want horizontal stack", middle)
+	}
+	if middle.Children[0].Pane != p2 || middle.Children[1].Pane != p4 {
+		t.Fatalf("target column child order = [%d %d], want [2 4]", middle.Children[0].Pane.ID, middle.Children[1].Pane.ID)
+	}
+	if w.ActivePane != p4 {
+		t.Fatalf("active pane = %v, want pane-4 pointer", w.ActivePane)
+	}
+}
+
+func TestMovePaneToColumnSameColumnMovesSourceToBottom(t *testing.T) {
+	t.Parallel()
+
+	p1 := fakePaneID(1)
+	w := NewWindow(p1, 80, 24)
+
+	p2 := fakePaneID(2)
+	if _, err := w.SplitRoot(SplitVertical, p2); err != nil {
+		t.Fatalf("split root vertical: %v", err)
+	}
+
+	w.FocusPane(p1)
+	p3 := fakePaneID(3)
+	if _, err := w.Split(SplitHorizontal, p3); err != nil {
+		t.Fatalf("split left column horizontal: %v", err)
+	}
+	p4 := fakePaneID(4)
+	if _, err := w.Split(SplitHorizontal, p4); err != nil {
+		t.Fatalf("split left column horizontal again: %v", err)
+	}
+
+	w.FocusPane(p2)
+	if err := w.MovePaneToColumn(1, 1); err != nil {
+		t.Fatalf("MovePaneToColumn same column: %v", err)
+	}
+
+	left := w.Root.Children[0]
+	if left.IsLeaf() || left.Dir != SplitHorizontal {
+		t.Fatalf("left root child = %+v, want horizontal stack", left)
+	}
+	if got := []uint32{left.Children[0].Pane.ID, left.Children[1].Pane.ID, left.Children[2].Pane.ID}; got[0] != 3 || got[1] != 4 || got[2] != 1 {
+		t.Fatalf("left column order = %v, want [3 4 1]", got)
+	}
+	if w.ActivePane != p2 {
+		t.Fatalf("active pane = %v, want pane-2 pointer", w.ActivePane)
+	}
+}
+
+func TestMovePaneToColumnSingleColumnReordersToBottom(t *testing.T) {
+	t.Parallel()
+
+	p1 := fakePaneID(1)
+	w := NewWindow(p1, 80, 24)
+
+	p2 := fakePaneID(2)
+	if _, err := w.Split(SplitHorizontal, p2); err != nil {
+		t.Fatalf("split horizontal: %v", err)
+	}
+	p3 := fakePaneID(3)
+	if _, err := w.Split(SplitHorizontal, p3); err != nil {
+		t.Fatalf("split horizontal again: %v", err)
+	}
+
+	if err := w.MovePaneToColumn(1, 1); err != nil {
+		t.Fatalf("MovePaneToColumn single column: %v", err)
+	}
+
+	if ids := collectPaneIDs(w); ids[0] != 2 || ids[1] != 3 || ids[2] != 1 {
+		t.Fatalf("single-column move order = %v, want [2 3 1]", ids)
+	}
+}
+
+func TestMovePaneToColumnAutoUnzooms(t *testing.T) {
+	t.Parallel()
+
+	p1 := fakePaneID(1)
+	w := NewWindow(p1, 80, 24)
+
+	p2 := fakePaneID(2)
+	if _, err := w.SplitRoot(SplitVertical, p2); err != nil {
+		t.Fatalf("split root vertical: %v", err)
+	}
+
+	if err := w.Zoom(2); err != nil {
+		t.Fatalf("zoom pane-2: %v", err)
+	}
+	if err := w.MovePaneToColumn(1, 2); err != nil {
+		t.Fatalf("MovePaneToColumn while zoomed: %v", err)
+	}
+	if w.ZoomedPaneID != 0 {
+		t.Fatalf("move-to should auto-unzoom, got ZoomedPaneID=%d", w.ZoomedPaneID)
+	}
+}
+
+func TestMovePaneToColumnErrorPaths(t *testing.T) {
+	t.Parallel()
+
+	t.Run("missing source pane", func(t *testing.T) {
+		t.Parallel()
+
+		w := NewWindow(fakePaneID(1), 80, 24)
+		if _, err := w.SplitRoot(SplitVertical, fakePaneID(2)); err != nil {
+			t.Fatalf("split root vertical: %v", err)
+		}
+		if err := w.MovePaneToColumn(99, 1); err == nil || !strings.Contains(err.Error(), "pane 99 not found") {
+			t.Fatalf("MovePaneToColumn missing source = %v, want pane not found", err)
+		}
+	})
+
+	t.Run("missing target pane", func(t *testing.T) {
+		t.Parallel()
+
+		w := NewWindow(fakePaneID(1), 80, 24)
+		if _, err := w.SplitRoot(SplitVertical, fakePaneID(2)); err != nil {
+			t.Fatalf("split root vertical: %v", err)
+		}
+		if err := w.MovePaneToColumn(1, 99); err == nil || !strings.Contains(err.Error(), "pane 99 not found") {
+			t.Fatalf("MovePaneToColumn missing target = %v, want pane not found", err)
+		}
+	})
+
+	t.Run("lead column boundary", func(t *testing.T) {
+		t.Parallel()
+
+		p1 := fakePaneID(1)
+		p2 := fakePaneID(2)
+		w := NewWindow(p1, 80, 24)
+		if _, err := w.SplitRoot(SplitVertical, p2); err != nil {
+			t.Fatalf("split root vertical: %v", err)
+		}
+		if err := w.SetLead(1); err != nil {
+			t.Fatalf("SetLead: %v", err)
+		}
+		if err := w.MovePaneToColumn(1, 2); err == nil || !strings.Contains(err.Error(), "lead column") {
+			t.Fatalf("MovePaneToColumn across lead boundary = %v, want lead-column error", err)
+		}
+	})
+}
+
 func TestSwapPaneForward(t *testing.T) {
 	t.Parallel()
 	p1 := fakePaneID(1)

--- a/internal/server/commands.go
+++ b/internal/server/commands.go
@@ -86,6 +86,7 @@ var commandRegistry = map[string]CommandHandler{
 	"swap":           cmdSwap,
 	"swap-tree":      cmdSwapTree,
 	"move":           cmdMove,
+	"move-to":        cmdMoveTo,
 	"rotate":         cmdRotate,
 	"copy-mode":      cmdCopyMode,
 	"cursor":         cmdCursor,

--- a/internal/server/commands/layout/tree/move.go
+++ b/internal/server/commands/layout/tree/move.go
@@ -3,6 +3,7 @@ package tree
 import "fmt"
 
 const MoveUsage = "usage: move <pane> --before <target> | move <pane> --after <target>"
+const MoveToUsage = "usage: move-to <pane> <target>"
 
 func ParseMoveArgs(args []string) (paneRef, targetRef string, before bool, err error) {
 	if len(args) != 3 {
@@ -21,4 +22,11 @@ func ParseMoveArgs(args []string) (paneRef, targetRef string, before bool, err e
 	}
 
 	return paneRef, targetRef, before, nil
+}
+
+func ParseMoveToArgs(args []string) (paneRef, targetRef string, err error) {
+	if len(args) != 2 {
+		return "", "", fmt.Errorf(MoveToUsage)
+	}
+	return args[0], args[1], nil
 }

--- a/internal/server/commands_tree.go
+++ b/internal/server/commands_tree.go
@@ -7,9 +7,14 @@ import (
 )
 
 const moveUsage = treecmd.MoveUsage
+const moveToUsage = treecmd.MoveToUsage
 
 func parseMoveArgs(args []string) (paneRef, targetRef string, before bool, err error) {
 	return treecmd.ParseMoveArgs(args)
+}
+
+func parseMoveToArgs(args []string) (paneRef, targetRef string, err error) {
+	return treecmd.ParseMoveToArgs(args)
 }
 
 func cmdSwap(ctx *CommandContext) {
@@ -102,6 +107,37 @@ func cmdMove(ctx *CommandContext) {
 		}
 		return commandMutationResult{
 			output:          fmt.Sprintf("Moved %s %s %s\n", pane.Meta.Name, pos, target.Meta.Name),
+			broadcastLayout: true,
+		}
+	}))
+}
+
+func cmdMoveTo(ctx *CommandContext) {
+	ctx.replyCommandMutation(ctx.Sess.enqueueCommandMutation(func(sess *Session) commandMutationResult {
+		paneRef, targetRef, err := parseMoveToArgs(ctx.Args)
+		if err != nil {
+			return commandMutationResult{err: err}
+		}
+
+		w := sess.windowForActor(ctx.ActorPaneID)
+		if w == nil {
+			return commandMutationResult{err: fmt.Errorf("no session")}
+		}
+
+		pane, err := w.ResolvePane(paneRef)
+		if err != nil {
+			return commandMutationResult{err: err}
+		}
+		target, err := w.ResolvePane(targetRef)
+		if err != nil {
+			return commandMutationResult{err: err}
+		}
+		if err := w.MovePaneToColumn(pane.ID, target.ID); err != nil {
+			return commandMutationResult{err: err}
+		}
+
+		return commandMutationResult{
+			output:          fmt.Sprintf("Moved %s to %s's column\n", pane.Meta.Name, target.Meta.Name),
 			broadcastLayout: true,
 		}
 	}))

--- a/internal/server/tree_commands_test.go
+++ b/internal/server/tree_commands_test.go
@@ -71,6 +71,56 @@ func TestParseMoveArgs(t *testing.T) {
 	}
 }
 
+func TestParseMoveToArgs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		args       []string
+		wantPane   string
+		wantTarget string
+		wantErr    string
+	}{
+		{
+			name:       "valid",
+			args:       []string{"pane-1", "pane-2"},
+			wantPane:   "pane-1",
+			wantTarget: "pane-2",
+		},
+		{
+			name:    "too short",
+			args:    []string{"pane-1"},
+			wantErr: moveToUsage,
+		},
+		{
+			name:    "too many args",
+			args:    []string{"pane-1", "pane-2", "pane-3"},
+			wantErr: moveToUsage,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			paneRef, targetRef, err := parseMoveToArgs(tt.args)
+			if tt.wantErr != "" {
+				if err == nil || err.Error() != tt.wantErr {
+					t.Fatalf("parseMoveToArgs(%v) error = %v, want %q", tt.args, err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseMoveToArgs(%v): %v", tt.args, err)
+			}
+			if paneRef != tt.wantPane || targetRef != tt.wantTarget {
+				t.Fatalf("parseMoveToArgs(%v) = (%q, %q), want (%q, %q)", tt.args, paneRef, targetRef, tt.wantPane, tt.wantTarget)
+			}
+		})
+	}
+}
+
 func TestQueuedCommandSwapTreeErrorPaths(t *testing.T) {
 	t.Parallel()
 
@@ -166,6 +216,45 @@ func TestQueuedCommandMoveErrorPaths(t *testing.T) {
 	sameGroup := runTestCommand(t, srv, sess, "move", "pane-1", "--before", "pane-3")
 	if !strings.Contains(sameGroup.cmdErr, "same root-level group") {
 		t.Fatalf("move same group error = %q", sameGroup.cmdErr)
+	}
+}
+
+func TestQueuedCommandMoveToErrorPaths(t *testing.T) {
+	t.Parallel()
+
+	srv, sess, cleanup := newCommandTestSession(t)
+	defer cleanup()
+
+	usageRes := runTestCommand(t, srv, sess, "move-to", "pane-1")
+	if usageRes.cmdErr != moveToUsage {
+		t.Fatalf("move-to usage error = %q", usageRes.cmdErr)
+	}
+
+	noSessionRes := runTestCommand(t, srv, sess, "move-to", "pane-1", "pane-2")
+	if noSessionRes.cmdErr != "no session" {
+		t.Fatalf("move-to no session error = %q", noSessionRes.cmdErr)
+	}
+
+	p1 := newTestPane(sess, 1, "pane-1")
+	p2 := newTestPane(sess, 2, "pane-2")
+	w := mux.NewWindow(p1, 80, 23)
+	w.ID = 1
+	w.Name = "main"
+	if _, err := w.SplitRoot(mux.SplitVertical, p2); err != nil {
+		t.Fatalf("SplitRoot: %v", err)
+	}
+	if err := setAttachTestLayout(sess, []*mux.Window{w}, w.ID, []*mux.Pane{p1, p2}); err != nil {
+		t.Fatalf("setAttachTestLayout: %v", err)
+	}
+
+	missingPane := runTestCommand(t, srv, sess, "move-to", "missing", "pane-1")
+	if missingPane.cmdErr != `pane "missing" not found` {
+		t.Fatalf("move-to missing pane error = %q", missingPane.cmdErr)
+	}
+
+	missingTarget := runTestCommand(t, srv, sess, "move-to", "pane-1", "missing")
+	if missingTarget.cmdErr != `pane "missing" not found` {
+		t.Fatalf("move-to missing target error = %q", missingTarget.cmdErr)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -167,6 +167,12 @@ func main() {
 			os.Exit(1)
 		}
 		runSessionCommand("move", args[1:])
+	case "move-to":
+		if len(args) != 3 {
+			fmt.Fprintf(os.Stderr, "usage: amux move-to <pane> <target>\n")
+			os.Exit(1)
+		}
+		runSessionCommand("move-to", args[1:])
 	case "rotate":
 		runSessionCommand("rotate", args[1:])
 	case "resize-pane":
@@ -452,6 +458,8 @@ Usage:
   amux [-s session] move <pane> --before <target>
   amux [-s session] move <pane> --after <target>
                                        Move a pane's root-level group before or after another
+  amux [-s session] move-to <pane> <target>
+                                       Move one pane into another pane's column, appending at the bottom
   amux [-s session] rotate             Rotate pane positions forward
   amux [-s session] rotate --reverse   Rotate pane positions backward
   amux [-s session] reset <pane>       Clear pane history and reset terminal state

--- a/test/command_coverage_test.go
+++ b/test/command_coverage_test.go
@@ -187,3 +187,13 @@ func TestMoveRejectsConflictingFlags(t *testing.T) {
 		t.Fatalf("expected move parser usage error, got: %s", out)
 	}
 }
+
+func TestMoveToUsage(t *testing.T) {
+	t.Parallel()
+	h := newServerHarness(t)
+
+	out := h.runCmd("move-to", "pane-1")
+	if !strings.Contains(out, "usage: amux move-to <pane> <target>") {
+		t.Fatalf("expected move-to usage error, got: %s", out)
+	}
+}

--- a/test/swap_test.go
+++ b/test/swap_test.go
@@ -190,6 +190,83 @@ func TestMoveAfterCLI(t *testing.T) {
 	}
 }
 
+func TestMoveToCLI(t *testing.T) {
+	t.Parallel()
+	h := newServerHarness(t)
+
+	h.splitV()
+	h.splitV()
+	h.runCmd("focus", "pane-1")
+	h.splitH()
+
+	out := h.runCmd("move-to", "pane-4", "pane-2")
+	if strings.Contains(out, "unknown command") {
+		t.Fatalf("move-to command not recognized: %s", out)
+	}
+
+	c := h.captureJSON()
+	p1 := h.jsonPane(c, "pane-1")
+	p2 := h.jsonPane(c, "pane-2")
+	p3 := h.jsonPane(c, "pane-3")
+	p4 := h.jsonPane(c, "pane-4")
+
+	if !(p1.Position.X < p2.Position.X && p2.Position.X < p3.Position.X) {
+		t.Fatalf("move-to should keep root column order pane-1 | pane-2 subtree | pane-3: p1=%+v p2=%+v p3=%+v", p1.Position, p2.Position, p3.Position)
+	}
+	if p2.Position.X != p4.Position.X {
+		t.Fatalf("move-to should place pane-4 in pane-2's column: p2=%+v p4=%+v", p2.Position, p4.Position)
+	}
+	if p2.Position.Y >= p4.Position.Y {
+		t.Fatalf("move-to should append pane-4 below pane-2: p2=%+v p4=%+v", p2.Position, p4.Position)
+	}
+}
+
+func TestMoveToSameColumnCLI(t *testing.T) {
+	t.Parallel()
+	h := newServerHarness(t)
+
+	h.splitV()
+	h.runCmd("focus", "pane-1")
+	h.splitH()
+	h.splitH()
+
+	out := h.runCmd("move-to", "pane-1", "pane-1")
+	if strings.Contains(out, "unknown command") {
+		t.Fatalf("move-to command not recognized: %s", out)
+	}
+
+	c := h.captureJSON()
+	p1 := h.jsonPane(c, "pane-1")
+	p3 := h.jsonPane(c, "pane-3")
+	p4 := h.jsonPane(c, "pane-4")
+
+	if !(p3.Position.Y < p4.Position.Y && p4.Position.Y < p1.Position.Y) {
+		t.Fatalf("move-to same-column should reorder left column to pane-3 | pane-4 | pane-1: p1=%+v p3=%+v p4=%+v", p1.Position, p3.Position, p4.Position)
+	}
+}
+
+func TestMoveToSingleColumnCLI(t *testing.T) {
+	t.Parallel()
+	h := newServerHarness(t)
+
+	h.splitH()
+	h.splitH()
+
+	out := h.runCmd("move-to", "pane-1", "pane-1")
+	if strings.Contains(out, "unknown command") {
+		t.Fatalf("move-to command not recognized: %s", out)
+	}
+
+	c := h.captureJSON()
+	p1 := h.jsonPane(c, "pane-1")
+	p2 := h.jsonPane(c, "pane-2")
+	p3 := h.jsonPane(c, "pane-3")
+
+	if !(p2.Position.Y < p3.Position.Y && p3.Position.Y < p1.Position.Y) {
+		t.Fatalf("move-to single-column should reorder panes to pane-2 | pane-3 | pane-1: p1=%+v p2=%+v p3=%+v", p1.Position, p2.Position, p3.Position)
+	}
+}
+
 func TestRotate(t *testing.T) {
 	t.Parallel()
 	h := newServerHarness(t)


### PR DESCRIPTION
## Motivation

There is currently no way to move a single pane from one root-level column into another while preserving its running shell. The existing `move` command only reorders whole root groups, which forces users to kill and recreate panes when they want to reparent one pane into a different column.

## Summary

- add `amux move-to <pane> <target>` at the CLI, server command, and layout layers
- reparent a single pane into the target pane's logical column, appending it at the bottom while preserving the pane's PTY and history
- allow same-column reorder cases like `move-to pane-1 pane-1`, with lead-column boundary checks on rebased `origin/main`
- add unit, server-command, and integration coverage for cross-column moves, same-column reorders, single-column stacks, usage, and lead-column blocking

## Testing

- `go test ./internal/mux -run 'TestMovePaneToColumn' -count=100`
- `go vet ./...`
- `go test ./... -timeout 120s`

## Review focus

- `MovePaneToColumn` in `internal/mux/window.go`, especially the extract-and-reinsert flow for same-column moves where the target pane may disappear during collapse
- lead-column behavior after the rebase onto `origin/main`, to confirm `move-to` follows the same cross-column restrictions as the other layout mutations
- CLI/README wording, to confirm `move-to` is clearly distinguished from the existing root-group `move` command

Closes LAB-458
