### PR TITLE
Skip stale test cleanup during concurrent runs

### DIFF
--- a/test/harness_cleanup_test.go
+++ b/test/harness_cleanup_test.go
@@ -1,0 +1,71 @@
+package test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func TestHasOtherActiveTestRunIgnoresCurrentProcessLock(t *testing.T) {
+	t.Parallel()
+
+	socketDir := t.TempDir()
+	if _, err := writeTestRunLock(socketDir, os.Getpid()); err != nil {
+		t.Fatalf("writeTestRunLock(current): %v", err)
+	}
+
+	if hasOtherActiveTestRun(socketDir, os.Getpid()) {
+		t.Fatal("hasOtherActiveTestRun reported current process as another active test run")
+	}
+}
+
+func TestHasOtherActiveTestRunDetectsLiveOtherProcess(t *testing.T) {
+	t.Parallel()
+
+	socketDir := t.TempDir()
+	cmd := exec.Command("sleep", "30")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start sleep: %v", err)
+	}
+	t.Cleanup(func() {
+		if cmd.Process != nil {
+			_ = cmd.Process.Kill()
+			_, _ = cmd.Process.Wait()
+		}
+	})
+
+	if _, err := writeTestRunLock(socketDir, cmd.Process.Pid); err != nil {
+		t.Fatalf("writeTestRunLock(other): %v", err)
+	}
+
+	if !hasOtherActiveTestRun(socketDir, os.Getpid()) {
+		t.Fatal("hasOtherActiveTestRun did not detect the live other test process")
+	}
+}
+
+func TestHasOtherActiveTestRunRemovesStaleLocks(t *testing.T) {
+	t.Parallel()
+
+	socketDir := t.TempDir()
+	cmd := exec.Command("sh", "-c", "exit 0")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start short-lived process: %v", err)
+	}
+	stalePID := cmd.Process.Pid
+	if err := cmd.Wait(); err != nil {
+		t.Fatalf("wait short-lived process: %v", err)
+	}
+
+	lockPath, err := writeTestRunLock(socketDir, stalePID)
+	if err != nil {
+		t.Fatalf("writeTestRunLock(stale): %v", err)
+	}
+
+	if hasOtherActiveTestRun(socketDir, os.Getpid()) {
+		t.Fatal("hasOtherActiveTestRun reported a stale lock as live")
+	}
+	if _, err := os.Stat(lockPath); !os.IsNotExist(err) {
+		t.Fatalf("stale lock %s should be removed, stat err=%v", filepath.Base(lockPath), err)
+	}
+}

--- a/test/harness_test.go
+++ b/test/harness_test.go
@@ -8,7 +8,9 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 )
@@ -21,6 +23,8 @@ var gocoverDir string
 
 // gocoverOwned is true when TestMain created gocoverDir (vs. inheriting it).
 var gocoverOwned bool
+
+const testRunLockPrefix = "test-run-"
 
 // buildAmux builds the amux binary at binPath. When GOCOVERDIR is set,
 // the binary is built with -cover so it writes coverage data on exit.
@@ -79,6 +83,14 @@ func privateAmuxBin(tb testing.TB) string {
 }
 
 func TestMain(m *testing.M) {
+	socketDir := fmt.Sprintf("/tmp/amux-%d", os.Getuid())
+	lockPath, err := writeTestRunLock(socketDir, os.Getpid())
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "creating test-run lock: %v\n", err)
+		os.Exit(1)
+	}
+	defer os.Remove(lockPath)
+
 	// Clean up orphaned test sessions from previous runs that may have
 	// been killed by a timeout panic (t.Cleanup doesn't run on panic).
 	cleanupStaleTestSessions()
@@ -154,6 +166,9 @@ func newTestHome(tb testing.TB) string {
 // `go test` invocation is running concurrently.
 func cleanupStaleTestSessions() {
 	socketDir := fmt.Sprintf("/tmp/amux-%d", os.Getuid())
+	if hasOtherActiveTestRun(socketDir, os.Getpid()) {
+		return
+	}
 
 	// Kill orphaned amux server processes, but only if their socket is stale
 	out, _ := exec.Command("pgrep", "-fl", "amux _server t-").Output()
@@ -219,6 +234,59 @@ func cleanupStaleTestSessions() {
 			}
 		}
 	}
+}
+
+func writeTestRunLock(socketDir string, pid int) (string, error) {
+	if err := os.MkdirAll(socketDir, 0o700); err != nil {
+		return "", err
+	}
+	path := filepath.Join(socketDir, fmt.Sprintf("%s%d.lock", testRunLockPrefix, pid))
+	if err := os.WriteFile(path, nil, 0o600); err != nil {
+		return "", err
+	}
+	return path, nil
+}
+
+func hasOtherActiveTestRun(socketDir string, selfPID int) bool {
+	entries, err := os.ReadDir(socketDir)
+	if err != nil {
+		return false
+	}
+	for _, e := range entries {
+		pid, ok := parseTestRunLockPID(e.Name())
+		if !ok {
+			continue
+		}
+		path := filepath.Join(socketDir, e.Name())
+		if !processExists(pid) {
+			_ = os.Remove(path)
+			continue
+		}
+		if pid != selfPID {
+			return true
+		}
+	}
+	return false
+}
+
+func parseTestRunLockPID(name string) (int, bool) {
+	if !strings.HasPrefix(name, testRunLockPrefix) || !strings.HasSuffix(name, ".lock") {
+		return 0, false
+	}
+	pidStr := strings.TrimSuffix(strings.TrimPrefix(name, testRunLockPrefix), ".lock")
+	pid, err := strconv.Atoi(pidStr)
+	if err != nil {
+		return 0, false
+	}
+	return pid, true
+}
+
+func processExists(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	err := syscall.Kill(pid, 0)
+	return err == nil || err == syscall.EPERM
 }
 
 // killOrphanedTestClients kills amux client processes connected to dead test


### PR DESCRIPTION
## Motivation
Concurrent `go test ./test` invocations share `/tmp/amux-$UID`, and `TestMain` currently does a global stale-session sweep on startup and shutdown. During the LAB-420 investigation, that sweep was sending `SIGTERM` to live `t-*` servers from other test runs, which made unrelated tests fail with `server not running`, `EOF`, or missing sockets.

## Summary
- add a per-test-process lock file in the shared test socket directory
- skip the stale-session sweep when another live test process is active
- remove stale lock files opportunistically by checking whether their PID still exists
- add focused tests for current-process, live-other-process, and stale-lock cases

## Testing
```bash
env -u AMUX_SESSION -u TMUX go test ./test -run 'TestHasOtherActiveTestRun(IgnoresCurrentProcessLock|DetectsLiveOtherProcess|RemovesStaleLocks)' -count=100 -timeout 120s
go vet ./...
```

## Review focus
- Is skipping destructive stale-session cleanup while another test process is active the right tradeoff for the shared `/tmp/amux-$UID` namespace?
- Are the lock-file naming and stale-lock cleanup rules in `TestMain` conservative enough to avoid cross-run interference without leaving permanent garbage behind?
- I did not claim a fresh `go test ./...` pass here because older background `test.test` processes were still active on this machine with the pre-fix cleanup behavior; those runs would not have been a trustworthy read on this branch.

Closes LAB-420
