### PR TITLE
Inline containsPane into its single call site

### DIFF
--- a/internal/mux/lead.go
+++ b/internal/mux/lead.go
@@ -149,18 +149,3 @@ func (w *Window) leadColumn() *LayoutCell {
 	}
 	return w.Root.Children[0]
 }
-
-func containsPane(cell *LayoutCell, paneID uint32) bool {
-	if cell == nil {
-		return false
-	}
-	if cell.IsLeaf() {
-		return cell.Pane != nil && cell.Pane.ID == paneID
-	}
-	for _, child := range cell.Children {
-		if containsPane(child, paneID) {
-			return true
-		}
-	}
-	return false
-}

--- a/internal/mux/window.go
+++ b/internal/mux/window.go
@@ -857,9 +857,7 @@ func (w *Window) MovePane(paneID, targetPaneID uint32, before bool) error {
 func (w *Window) MovePaneToColumn(paneID, targetPaneID uint32) error {
 	w.assertOwner("MovePaneToColumn")
 	if col := w.leadColumn(); col != nil {
-		inSource := containsPane(col, paneID)
-		inTarget := containsPane(col, targetPaneID)
-		if inSource != inTarget {
+		if (col.FindPane(paneID) != nil) != (col.FindPane(targetPaneID) != nil) {
 			return fmt.Errorf("cannot move panes across lead column")
 		}
 	}


### PR DESCRIPTION
## Motivation

PR #443 added `leadColumn()` and `containsPane()` to `lead.go`, but `containsPane` is a manual recursive tree walk that duplicates `LayoutCell.FindPane()`. Since it has a single call site, inlining `FindPane` is simpler.

## Summary

- Remove 16-line manual `containsPane` function from `lead.go`
- Inline `col.FindPane(paneID) != nil` at the single call site in `MovePaneToColumn`

## Testing

```bash
go build ./...
go vet ./...
go test ./internal/mux/... -run 'MovePaneTo|Lead' -count=100
```

## Review focus

Verify the inlined `FindPane` check at `window.go:860` is equivalent to the removed `containsPane`. `FindPane` uses `Walk` internally, which handles nil cells and recursive traversal identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)