### PR TITLE
Cover move-to lead boundary in both directions

### DIFF
--- a/internal/mux/window_test.go
+++ b/internal/mux/window_test.go
@@ -1221,6 +1221,23 @@ func TestMovePaneToColumnErrorPaths(t *testing.T) {
 			t.Fatalf("MovePaneToColumn across lead boundary = %v, want lead-column error", err)
 		}
 	})
+
+	t.Run("lead column boundary into lead pane", func(t *testing.T) {
+		t.Parallel()
+
+		p1 := fakePaneID(1)
+		p2 := fakePaneID(2)
+		w := NewWindow(p1, 80, 24)
+		if _, err := w.SplitRoot(SplitVertical, p2); err != nil {
+			t.Fatalf("split root vertical: %v", err)
+		}
+		if err := w.SetLead(1); err != nil {
+			t.Fatalf("SetLead: %v", err)
+		}
+		if err := w.MovePaneToColumn(2, 1); err == nil || !strings.Contains(err.Error(), "lead column") {
+			t.Fatalf("MovePaneToColumn into lead column = %v, want lead-column error", err)
+		}
+	})
 }
 
 func TestSwapPaneForward(t *testing.T) {


### PR DESCRIPTION
## Motivation
`origin/main` now carries the helper fix for the move-to compile break, but the lead-column guard only had regression coverage for moving the lead pane out of that column. The opposite direction could still regress without a dedicated test.

## Summary
- add the missing `MovePaneToColumn(2, 1)` regression case when pane-1 is anchored as lead
- keep the existing opposite-direction assertion so the lead-column contract is specified both ways
- leave production code untouched on top of the upstream helper restoration

## Testing
- `go test ./internal/mux -run 'TestMovePaneToColumnErrorPaths|TestMovePaneToColumnAcrossRootColumns|TestMovePaneWithLeadUsesLogicalRoot|TestSwapTreeWithLeadUsesLogicalRoot' -count=100`
- `env -u AMUX_SESSION -u TMUX go test ./... -run '^$'`

## Review focus
- verify the new subtest is the missing direction for the existing lead-column contract
- confirm the rebased PR is test-only and does not alter runtime behavior beyond what already landed on `main`
