### PR TITLE
Skip issue metadata check for lead pane

### DIFF
--- a/issue_meta_check_test.go
+++ b/issue_meta_check_test.go
@@ -41,6 +41,31 @@ EOF
 	}
 }
 
+func TestCheckPaneIssueMetaSkipsLeadPane(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	amuxPath := filepath.Join(tempDir, "amux")
+	if err := os.WriteFile(amuxPath, []byte(`#!/bin/sh
+cat <<'EOF'
+{"lead":true,"meta":{"tracked_issues":[]}}
+EOF
+`), 0755); err != nil {
+		t.Fatalf("write fake amux: %v", err)
+	}
+
+	cmd := exec.Command("bash", "scripts/check-pane-issue-meta.sh")
+	cmd.Dir = "."
+	cmd.Env = issueMetaScriptEnv(tempDir)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("expected success for lead pane (no issue metadata required): %v\n%s", err, out)
+	}
+	if strings.TrimSpace(string(out)) != "" {
+		t.Fatalf("expected no output, got:\n%s", out)
+	}
+}
+
 func TestCheckPaneIssueMetaPassesWhenIssueMetadataExists(t *testing.T) {
 	t.Parallel()
 

--- a/scripts/check-pane-issue-meta.sh
+++ b/scripts/check-pane-issue-meta.sh
@@ -18,6 +18,10 @@ if ! capture=$(amux capture --format json "$AMUX_PANE" 2>/dev/null); then
     exit 0
 fi
 
+if printf '%s\n' "$capture" | jq -e '.lead == true' >/dev/null 2>&1; then
+    exit 0
+fi
+
 if ! issue_count=$(printf '%s\n' "$capture" | jq -r '(.meta.tracked_issues // []) | length' 2>/dev/null); then
     exit 0
 fi


### PR DESCRIPTION
## Motivation

The stop hook fires on the lead pane and warns about missing issue metadata, but the lead pane is a persistent overview pane not tied to any specific issue.

## Summary

- Check `.lead == true` in the capture JSON before requiring issue metadata in `scripts/check-pane-issue-meta.sh`
- Add `TestCheckPaneIssueMetaSkipsLeadPane` regression test

## Testing

```bash
env -u AMUX_SESSION -u TMUX go test -run 'TestCheckPaneIssueMeta' -count=100
```

## Review focus

The `.lead` field on single-pane capture JSON — confirming it's the right field to check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)