### PR TITLE
Stabilize zoom stale-cursor resync test

### DIFF
--- a/test/zoom_test.go
+++ b/test/zoom_test.go
@@ -125,6 +125,10 @@ func TestZoomResyncsStaleCursorState(t *testing.T) {
 	t.Parallel()
 	h := newServerHarnessWithSize(t, 255, 62)
 
+	// The headless control client can become command-ready slightly before
+	// short-lived CLI subprocesses are able to connect. Establish CLI command
+	// readiness before the first split helper issues `_layout-json`.
+	_ = h.generation()
 	h.splitH()
 	h.waitFor("pane-2", "$")
 
@@ -138,14 +142,20 @@ func TestZoomResyncsStaleCursorState(t *testing.T) {
 		{
 			name: "zoom",
 			zoom: func() {
+				gen := h.generation()
 				h.runCmd("zoom", "pane-2")
+				h.waitLayout(gen)
 			},
 		},
 		{
 			name: "unzoom",
 			zoom: func() {
+				gen := h.generation()
 				h.runCmd("zoom", "pane-2")
+				h.waitLayout(gen)
+				gen = h.generation()
 				h.runCmd("zoom", "pane-2")
+				h.waitLayout(gen)
 			},
 		},
 	}
@@ -167,7 +177,7 @@ func TestZoomResyncsStaleCursorState(t *testing.T) {
 
 			afterCapture := h.captureJSON()
 			after := h.jsonPane(afterCapture, "pane-2")
-			if got, want := after.Content[0], healthy.Content[0]; got != want {
+			if got, want := strings.TrimLeft(after.Content[0], " "), strings.TrimLeft(healthy.Content[0], " "); got != want {
 				t.Fatalf("pane-2 content after %s = %q, want %q", tt.name, got, want)
 			}
 			if got, want := after.Cursor.Col, healthy.Cursor.Col; got != want {


### PR DESCRIPTION
## Motivation
`TestZoomResyncsStaleCursorState` was flaky in CI under `-count=3 -parallel 2`. On current `main`, the failure came from two timing gaps in the test itself: it could start issuing CLI-only split helpers before subprocess commands were connect-ready, and it captured immediately after `zoom`/`unzoom` before the next layout broadcast had reached the client renderer.

## Summary
- establish CLI command readiness before the test's first `splitH()` helper call
- wait for the next layout generation after each `zoom`/`unzoom` before capturing pane state
- compare the first content line with leading prompt padding normalized, matching the existing attach stale-cursor test

## Testing
```bash
env -u AMUX_SESSION -u TMUX go test ./test -run TestZoomResyncsStaleCursorState -count=100 -parallel 2 -timeout 600s
```

## Review focus
- whether `generation()` plus `waitLayout()` is the right synchronization boundary for the zoom and unzoom transitions
- whether the initial CLI-readiness gate is the right place to absorb the startup race without widening this PR into shared harness changes

Closes LAB-469
