### PR TITLE
Wait for input-idle in repeat timeout test

### DIFF
--- a/test/repeat_test.go
+++ b/test/repeat_test.go
@@ -119,9 +119,9 @@ func TestRepeatExpiresAfterTimeout(t *testing.T) {
 	gen = h.generation()
 	h.sendKeys("C-a", "L")
 	h.waitLayout(gen)
+	uiGen := h.uiGen()
 	h.waitDuration(700 * time.Millisecond)
 	// This L should be typed into the shell (repeat expired), not trigger resize
-	uiGen := h.uiGen()
 	h.sendKeys("L")
 	h.waitUIAfter(proto.UIEventInputIdle, uiGen, 3*time.Second)
 


### PR DESCRIPTION
## Motivation
TestRepeatExpiresAfterTimeout still used a fixed 300ms settle after the intentional 700ms repeat-timeout wait. After opening the PR, CI also exposed a separate flake in the zoomed display-panes integration test, so this branch now carries both the LAB-200 fix and the related test-hardening needed to get the PR green.

## Summary
- replace the post-expiry fixed settle in `TestRepeatExpiresAfterTimeout` with `waitUIAfter(input-idle, ...)`, capturing `uiGen` before the real timeout wait
- keep the intentional 700ms wall-clock wait for repeat timeout expiry unchanged
- harden `TestDisplayPanesZoomedOnlyShowsVisiblePane` by waiting for fresh `display-panes-shown` and `display-panes-hidden` UI events before asserting on outer capture content

## Testing
- `env -u AMUX_SESSION -u TMUX go test ./test -run ^'^TestRepeatExpiresAfterTimeout$' -count=25`
- `env -u AMUX_SESSION -u TMUX go test ./test -run 'TestRepeatResize|TestRepeatFocus|TestRepeatCrossKey|TestRepeatExpiresAfterTimeout' -count=20`
- `env -u AMUX_SESSION -u TMUX go test ./test -run ^'^TestDisplayPanesZoomedOnlyShowsVisiblePane$' -count=100`
- `env -u AMUX_SESSION -u TMUX go test -count=3 -parallel 2 -timeout 300s ./test/`

## Review focus
- confirm the repeat-timeout test now waits on a fresh input cycle without changing the real timeout behavior it is asserting
- confirm the zoomed display-panes test is now synchronized on client UI state, not just outer PTY timing

Closes LAB-200
