### PR TITLE
Stabilize restart-window pane-meta and takeover tests

### DIFF
--- a/test/amux_harness_test.go
+++ b/test/amux_harness_test.go
@@ -3,6 +3,7 @@ package test
 import (
 	"context"
 	"crypto/rand"
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
@@ -432,6 +433,37 @@ func (h *AmuxHarness) assertScreen(msg string, fn func(string) bool) {
 func (h *AmuxHarness) captureJSON() proto.CaptureJSON {
 	h.tb.Helper()
 	return captureJSONFor(h.tb, h.runCmd)
+}
+
+// waitForCaptureJSONReady blocks until the inner session can serve a
+// client-backed JSON capture without returning an error object. Outer pane
+// text like "[pane-" can be stale across reloads, so it is not a reliable
+// signal that the re-execed inner client has finished reattaching.
+func (h *AmuxHarness) waitForCaptureJSONReady(timeout time.Duration) proto.CaptureJSON {
+	h.tb.Helper()
+
+	deadline := time.Now().Add(timeout)
+	ticker := time.NewTicker(25 * time.Millisecond)
+	defer ticker.Stop()
+
+	var last string
+	for time.Now().Before(deadline) {
+		last = h.runCmd("capture", "--format", "json")
+		if isCaptureUnavailable(last) {
+			<-ticker.C
+			continue
+		}
+
+		var capture proto.CaptureJSON
+		if err := json.Unmarshal([]byte(last), &capture); err == nil && capture.Error == nil && len(capture.Panes) > 0 {
+			return capture
+		}
+
+		<-ticker.C
+	}
+
+	h.tb.Fatalf("inner JSON capture did not become ready within %v\nlast output:\n%s\nouter:\n%s", timeout, last, h.captureOuter())
+	return proto.CaptureJSON{}
 }
 
 // jsonPane finds a pane by name in a CaptureJSON, or fails the test.

--- a/test/pane_meta_test.go
+++ b/test/pane_meta_test.go
@@ -516,9 +516,7 @@ func TestPaneMetaSurvivesReloadServer(t *testing.T) {
 	h.runCmd("add-meta", "pane-1", "pr=42", "issue=LAB-338")
 
 	h.runCmd("reload-server")
-	if !h.waitFor("[pane-", 5*time.Second) {
-		t.Fatalf("session did not recover after reload-server\nScreen:\n%s", h.captureOuter())
-	}
+	h.waitForCaptureJSONReady(15 * time.Second)
 
 	waitForPostIdleRefresh(t, "pane-1", h.runCmd, h.waitLayoutOrTimeout)
 

--- a/test/takeover_test.go
+++ b/test/takeover_test.go
@@ -355,6 +355,9 @@ func takeoverCaptureJSON(h *ServerHarness) (proto.CaptureJSON, bool) {
 	if err := json.Unmarshal([]byte(out), &capture); err != nil {
 		h.tb.Fatalf("captureJSON: %v\nraw: %s", err, out)
 	}
+	if capture.Error != nil {
+		return proto.CaptureJSON{}, false
+	}
 	return capture, true
 }
 


### PR DESCRIPTION
## Motivation
LAB-474 tracks a repeated local flake where the nested reload pane-meta test and the adjacent takeover failure-notice test would fail together. The common failure mode was a weak restart-window readiness boundary: the pane-meta test treated stale outer-pane UI as proof that the re-execed inner client had reattached, and the takeover helper treated JSON error captures as usable state.

## Summary
- add `AmuxHarness.waitForCaptureJSONReady` so nested reload tests wait for a client-backed inner JSON capture instead of a stale `[pane-` frame in the outer pane
- update `TestPaneMetaSurvivesReloadServer` to use that stronger post-reload readiness boundary before asserting recovered metadata
- treat JSON error captures as unavailable in `takeoverCaptureJSON` so takeover notice polling does not treat `capture` error objects as real session state

## Testing
- `env -u AMUX_SESSION -u TMUX go test ./test -run '^(TestPaneMetaSurvivesReloadServer|TestTakeoverAttachFailureLeavesSSHPaneVisible)$' -count=100 -timeout 600s`
- `env -u AMUX_SESSION -u TMUX go test ./test -run '^(TestTakeoverAttachFailureLeavesSSHPaneVisible|TestTakeoverFailureNoticeExpires|TestPaneMetaSurvivesReloadServer)$' -count=5 -timeout 180s`

## Review focus
- whether `waitForCaptureJSONReady` is the right proof that a nested reload finished reattaching the inner client, versus the old outer-pane text check
- whether treating `CaptureJSON.Error` as unavailable state is the right behavior for takeover notice polling helpers
- whether there are any other nested reload tests that should migrate off outer-pane text as a readiness signal in follow-up work

Closes LAB-474
