### PR TITLE
Stabilize detached capture history test

### DIFF
--- a/test/capture_test.go
+++ b/test/capture_test.go
@@ -111,20 +111,17 @@ func TestCapturePaneHistoryWithoutAttachedClient(t *testing.T) {
 
 	h.sendKeys("pane-1", scriptPath, "Enter")
 	h.waitFor("pane-1", "NOCLIENT-35")
+	h.waitIdle("pane-1")
 
 	h.client.close()
 	h.client = nil
 
-	if out := h.runCmd("capture"); !strings.Contains(out, "no client attached") {
-		t.Fatalf("full-screen capture without client should still fail, got: %s", out)
-	}
-
 	out := h.runCmd("capture", "pane-1")
 	if strings.Contains(out, "no client attached") {
-		t.Fatalf("pane capture without client should fall back to the server, got: %s", out)
+		t.Fatalf("pane capture without client should fall back to the server, got: %s\n%s", out, h.diagnosticSnapshot("pane capture reported no client after detach"))
 	}
 	if !strings.Contains(out, "NOCLIENT-35") {
-		t.Fatalf("pane capture should include visible content, got:\n%s", out)
+		t.Fatalf("pane capture should include visible content, got:\n%s\n%s", out, h.diagnosticSnapshot("pane capture missing visible content after detach"))
 	}
 
 	jsonOut := h.runCmd("capture", "--format", "json", "pane-1")
@@ -136,12 +133,16 @@ func TestCapturePaneHistoryWithoutAttachedClient(t *testing.T) {
 		t.Fatalf("json pane name = %q, want pane-1", pane.Name)
 	}
 	if joined := strings.Join(pane.Content, "\n"); !strings.Contains(joined, "NOCLIENT-35") {
-		t.Fatalf("pane JSON should include visible content, got:\n%s", joined)
+		t.Fatalf("pane JSON should include visible content, got:\n%s\n%s", joined, h.diagnosticSnapshot("pane json missing visible content after detach"))
 	}
 
 	out = h.runCmd("capture", "--history", "pane-1")
 	if !strings.Contains(out, "NOCLIENT-01") || !strings.Contains(out, "NOCLIENT-35") {
-		t.Fatalf("history capture should work without attached client, got:\n%s", out)
+		t.Fatalf("history capture should work without attached client, got:\n%s\n%s", out, h.diagnosticSnapshot("history capture missing content after detach"))
+	}
+
+	if out := h.runCmd("capture"); !isCaptureUnavailable(out) {
+		t.Fatalf("full-screen capture without client should remain unavailable, got: %s\n%s", out, h.diagnosticSnapshot("unexpected full-screen capture state after pane fallback"))
 	}
 }
 


### PR DESCRIPTION
## Motivation
`TestCapturePaneHistoryWithoutAttachedClient` was flaky because it detached the headless client as soon as the last history line appeared, before the pane had fully settled back to an idle shell state. In the flaky window, the follow-up full-screen capture could perturb the detached session before the test verified the server-side pane fallback behavior.

## Summary
- wait for `pane-1` to become idle before detaching the headless client in `TestCapturePaneHistoryWithoutAttachedClient`
- verify pane capture, JSON pane capture, and history capture before checking the brittle full-screen negative case
- treat full-screen detached capture as "unavailable" instead of requiring one exact transport error string
- add richer diagnostics to the detached capture assertions so any future failure shows the server-side snapshot context

## Testing
`go test ./test -run '^TestCapturePaneHistoryWithoutAttachedClient$' -count=100`
`go test ./test -run 'Test(ServerHarnessRunCmdFallsBackWhenHeadlessClientDetached|CapturePaneAfterKillAndRespawnWithoutAttachedClient)$'`

## Review focus
The key question is whether waiting for pane idle before detach is the right synchronization boundary for this test, and whether moving the full-screen negative assertion to the end still exercises the intended detached-session contract without over-constraining the exact error string.

Closes LAB-475
