### PR TITLE
Wait for display-panes UI events in zoomed test

### DIFF
--- a/test/display_panes_test.go
+++ b/test/display_panes_test.go
@@ -84,7 +84,9 @@ func TestDisplayPanesZoomedOnlyShowsVisiblePane(t *testing.T) {
 	h.splitV()
 	h.runCmd("zoom", "pane-2")
 
+	uiGen := h.uiGen()
 	h.sendKeys("C-a", "q")
+	h.waitUIAfter(proto.UIEventDisplayPanesShown, uiGen, 3*time.Second)
 	if !h.waitFor("[1]", 3*time.Second) {
 		t.Fatalf("expected overlay label for zoomed pane, got:\n%s", h.captureOuter())
 	}
@@ -94,7 +96,9 @@ func TestDisplayPanesZoomedOnlyShowsVisiblePane(t *testing.T) {
 		t.Fatalf("zoomed overlay should not show hidden pane labels, got:\n%s", outer)
 	}
 
+	uiGen = h.uiGen()
 	h.sendKeys("2")
+	h.waitUIAfter(proto.UIEventDisplayPanesHidden, uiGen, 3*time.Second)
 	if !waitForOuterGone(h, "[1]", 3*time.Second) {
 		t.Fatalf("expected overlay to clear after invalid zoomed label\nScreen:\n%s", h.captureOuter())
 	}


### PR DESCRIPTION
## Motivation
PR #461 merged the LAB-200 repeat-test fix, but its CI run exposed a separate flake in `TestDisplayPanesZoomedOnlyShowsVisiblePane`. The test only waited on outer PTY content, so under load it could assert before the client had emitted the zoomed display-panes state transition.

## Summary
- capture `uiGen` before showing the zoomed display-panes overlay and wait for a fresh `display-panes-shown` event before asserting on `[1]`
- capture `uiGen` again before dismissing the invalid zoomed label and wait for `display-panes-hidden` before checking that the overlay cleared
- keep the existing outer-capture assertions so the test still verifies the rendered result, not just the UI event stream

## Testing
- `env -u AMUX_SESSION -u TMUX go test ./test -run ^'^TestDisplayPanesZoomedOnlyShowsVisiblePane$' -count=100`
- `env -u AMUX_SESSION -u TMUX go test -count=3 -parallel 2 -timeout 300s ./test/`

## Review focus
- confirm the added `waitUIAfter` calls are anchored to fresh UI generations and cannot be satisfied by stale zoom/display-panes state
- confirm the test still exercises the rendered overlay content in addition to the UI events

Follow-up to #461.
