### PR TITLE
Document main.go dispatch coverage expectations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,6 +96,8 @@ When a change adds a new test or modifies an existing test, run that targeted te
 
 **Root CLI subprocess tests must use the shared hermetic helper.** Do not open-code `exec.Command(os.Args[0], ...)` or inherit ambient `AMUX_SESSION` / `TMUX` state in root package tests; route those tests through the shared helper so they always run with an isolated session and scrubbed env.
 
+**Changes to `main.go` CLI dispatch need direct unit coverage on the touched lines.** Keep the hermetic subprocess tests for end-to-end CLI behavior, but when a change touches the dispatch branches in `main.go`, add direct unit coverage (for example in `main_test.go`) for those specific lines too. Codecov patch coverage measures the changed `main.go` lines directly and may miss coverage that only arrives through subprocess tests.
+
 **Golden files** live in `test/testdata/`. Two types:
 
 - `.golden` -- structural layout frame (status lines, borders, global bar). Open one and you see the expected screen layout.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,6 +54,8 @@ Use table-driven tests with `t.Run(tt.name, ...)` and `t.Parallel()`. See `layou
 
 Root CLI subprocess tests must use the shared hermetic helper in the root package tests. Do not open-code `exec.Command(os.Args[0], ...)` or inherit ambient `AMUX_SESSION` / `TMUX` state in those tests.
 
+If a change touches CLI dispatch branches in `main.go`, add direct unit coverage for those touched lines as well (for example in `main_test.go`). Hermetic subprocess tests still cover end-to-end behavior, but Codecov patch coverage measures the changed `main.go` lines directly and may not credit coverage that only flows through the subprocess path.
+
 ### Golden files
 
 Golden files live in `test/testdata/`:


### PR DESCRIPTION
## Motivation

PR #456 hit a blocking `codecov/patch` failure even though the behavior change already had hermetic root CLI subprocess coverage. The missing piece was direct unit coverage on the touched `main.go` dispatch lines, so this follow-up documents that expectation where contributors look for root CLI testing rules.

## Summary

- add shared repo guidance that `main.go` CLI dispatch changes need direct unit coverage on the touched lines
- keep the existing hermetic subprocess testing rule and explain that both layers are required for this case
- mirror the same note in `CONTRIBUTING.md` so contributor-facing workflow docs match the shared agent instructions

## Testing

- `env -u AMUX_SESSION -u TMUX go test ./... -timeout 120s`

## Review focus

- check that the new wording is explicit about the trigger condition: touched dispatch branches in `main.go`
- check that the reason is stated accurately: Codecov patch coverage measures the changed `main.go` lines directly

Closes LAB-492
