### PR TITLE
Upload CI timing artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,17 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
 
+      - name: Upload test timing artifacts
+        if: ${{ always() && steps.changes.outputs.code_changed == 'true' && hashFiles('root-results.json', 'unit-results.json', 'integration-results.json') != '' }}
+        uses: actions/upload-artifact@v7.0.0
+        with:
+          name: test-timing-artifacts
+          if-no-files-found: ignore
+          path: |
+            root-results.json
+            unit-results.json
+            integration-results.json
+
       - name: Coverage summary
         if: always() && steps.changes.outputs.code_changed == 'true'
         run: |


### PR DESCRIPTION
## Motivation
`scripts/coverage.sh --ci` writes `root-results.json`, `unit-results.json`, and `integration-results.json`, but the CI workflow only preserves the coverage profiles. That leaves the raw timing inputs unavailable after the run even though the timing summary depends on them.

## Summary
- add a dedicated `test-timing-artifacts` upload step to CI
- preserve the three `go test -json` outputs emitted by `scripts/coverage.sh --ci`
- leave the existing Codecov uploads and `coverage-artifacts` bundle unchanged

## Testing
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml")'`
- `gh api repos/weill-labs/amux/actions/runs/23659589702/artifacts | jq -r '.artifacts[].name'`

## Review focus
- confirm the new artifact step only retains the raw timing JSON and does not change the existing coverage upload path
- confirm the `always()` + `hashFiles(...)` guard is the right failure behavior when tests emit partial JSON before a later step fails

Closes LAB-477
