### PR TITLE
Serialize nested overlay input on the render loop

### DIFF
--- a/internal/client/attach.go
+++ b/internal/client/attach.go
@@ -843,8 +843,15 @@ func RunSession(sessionName string, getTermSize func(int) (int, int, error)) err
 			}
 
 			if cr.ChooserActive() {
+				// ChooserActive() is an atomic snapshot read. Re-check on the
+				// render loop before mutating chooser state so a queued layout can
+				// hide the chooser first without racing the input goroutine.
 				result := handleChooserInputOnRenderLoop(cr, msgCh, normalizeLocalInput(raw))
 				if !result.handled {
+					// If the chooser disappeared between the snapshot read above and
+					// the render-loop action, drop this key instead of forwarding it
+					// into the pane while the user was visually interacting with the
+					// chooser.
 					cr.SetInputIdle(true)
 					continue
 				}

--- a/internal/client/attach_overlay_test.go
+++ b/internal/client/attach_overlay_test.go
@@ -42,6 +42,41 @@ func TestToggleDisplayPanesOnRenderLoopWaitsForQueuedLayout(t *testing.T) {
 	}
 }
 
+func TestToggleDisplayPanesOnRenderLoopHidesActiveOverlay(t *testing.T) {
+	t.Parallel()
+
+	cr := buildTestRenderer(t)
+	msgCh := startTestRenderLoop(t, cr)
+
+	if !toggleDisplayPanesOnRenderLoop(cr, msgCh) {
+		t.Fatal("toggleDisplayPanesOnRenderLoop should show display panes")
+	}
+	if !cr.DisplayPanesActive() {
+		t.Fatal("display-panes overlay should be active after first toggle")
+	}
+
+	if !toggleDisplayPanesOnRenderLoop(cr, msgCh) {
+		t.Fatal("toggleDisplayPanesOnRenderLoop should hide an active overlay")
+	}
+	if cr.DisplayPanesActive() {
+		t.Fatal("display-panes overlay should be inactive after second toggle")
+	}
+}
+
+func TestToggleDisplayPanesOnRenderLoopReturnsFalseWithoutLayout(t *testing.T) {
+	t.Parallel()
+
+	cr := NewClientRenderer(80, 24)
+	msgCh := startTestRenderLoop(t, cr)
+
+	if toggleDisplayPanesOnRenderLoop(cr, msgCh) {
+		t.Fatal("toggleDisplayPanesOnRenderLoop should fail before layout is ready")
+	}
+	if cr.DisplayPanesActive() {
+		t.Fatal("display-panes overlay should stay inactive without layout")
+	}
+}
+
 func TestShowChooserOnRenderLoopWaitsForQueuedLayout(t *testing.T) {
 	t.Parallel()
 
@@ -68,6 +103,20 @@ func TestShowChooserOnRenderLoopWaitsForQueuedLayout(t *testing.T) {
 	}
 }
 
+func TestShowChooserOnRenderLoopReturnsFalseWithoutLayout(t *testing.T) {
+	t.Parallel()
+
+	cr := NewClientRenderer(80, 24)
+	msgCh := startTestRenderLoop(t, cr)
+
+	if showChooserOnRenderLoop(cr, msgCh, chooserModeWindow) {
+		t.Fatal("showChooserOnRenderLoop should fail before layout is ready")
+	}
+	if cr.ChooserActive() {
+		t.Fatal("chooser overlay should stay inactive without layout")
+	}
+}
+
 func TestHandleChooserInputOnRenderLoopSelectsFilteredWindow(t *testing.T) {
 	t.Parallel()
 
@@ -85,10 +134,26 @@ func TestHandleChooserInputOnRenderLoopSelectsFilteredWindow(t *testing.T) {
 	if result.action.command != "select-window" {
 		t.Fatalf("chooser command = %q, want select-window", result.action.command)
 	}
+	// buildMultiWindowRendererAt(t, 1) uses window 2 for the "logs" fixture.
 	if len(result.action.args) != 1 || result.action.args[0] != "2" {
 		t.Fatalf("chooser args = %v, want [2]", result.action.args)
 	}
 	if cr.ChooserActive() {
 		t.Fatal("chooser should hide after selecting a row")
+	}
+}
+
+func TestHandleChooserInputOnRenderLoopReturnsUnhandledWhenChooserInactive(t *testing.T) {
+	t.Parallel()
+
+	cr := buildTestRenderer(t)
+	msgCh := startTestRenderLoop(t, cr)
+
+	result := handleChooserInputOnRenderLoop(cr, msgCh, []byte("logs\r"))
+	if result.handled {
+		t.Fatal("chooser input should not be handled when chooser is inactive")
+	}
+	if result.action.command != "" || result.action.bell || len(result.action.args) != 0 {
+		t.Fatalf("chooser action = %+v, want zero value", result.action)
 	}
 }

--- a/internal/client/local_render.go
+++ b/internal/client/local_render.go
@@ -5,9 +5,10 @@ import "os"
 // Local render actions are reserved for client state that cannot be updated
 // safely through the clientSnapshot CAS helpers. CopyMode instances are shared,
 // deeply mutable structs, so attached-client access is serialized onto the
-// render loop. Simpler UI state such as messages, chooser visibility, and pane
-// overlays lives in clientSnapshot and can continue to use updateState /
-// updateClientStateValue from any goroutine.
+// render loop. Simpler UI state such as messages still lives in clientSnapshot
+// and can use updateState / updateClientStateValue from any goroutine, but
+// chooser and pane-overlay activation must be serialized on the render loop so
+// queued layout messages apply before those overlays inspect renderer state.
 func applyLocalRenderResultDirect(cr *ClientRenderer, result localRenderResult) {
 	state := &clientRenderLoopState{
 		useFull:             os.Getenv("AMUX_RENDER") == "full",


### PR DESCRIPTION
## Motivation

Nested `send-keys` could intermittently miss client-local overlay bindings in nested amux sessions because chooser and display-panes input was racing the client render loop's pending layout work.

## Summary

- serialize display-panes and chooser activation onto the render loop instead of reading renderer state directly from the input goroutine
- serialize chooser keystroke handling onto the render loop so query edits and Enter selection stay ordered with queued layout/UI messages
- add deterministic client regression tests for queued-layout overlay activation and chooser selection

## Testing

```bash
go test ./internal/client -run 'TestToggleDisplayPanesOnRenderLoopWaitsForQueuedLayout|TestShowChooserOnRenderLoopWaitsForQueuedLayout|TestHandleChooserInputOnRenderLoopSelectsFilteredWindow' -count=100
env -u AMUX_SESSION -u TMUX go test ./test -run 'TestDisplayPanes|TestChoose' -count=100
env -u AMUX_SESSION -u TMUX go test ./test -run TestSendKeysPacesEnterAfterText -count=100
env -u AMUX_SESSION -u TMUX go test ./... -timeout 120s
```

## Review focus

- whether routing overlay activation and chooser input through `callLocalRenderAction` is the right boundary for render-loop-sensitive client state
- whether the new regression tests cover the stale-layout ordering bug without overfitting to the current implementation

Closes LAB-497
