### PR TITLE
Add spawn-worker script for automated codex delegation

### DIFF
--- a/.agents/skills/amux/SKILL.md
+++ b/.agents/skills/amux/SKILL.md
@@ -119,7 +119,16 @@ amux prev-window             # Previous window
 
 ## Delegating Tasks to Agents
 
-When delegating work to an agent (codex, claude, grok) running in a pane, follow this sequence to avoid garbled input:
+**Before every delegation:** (1) capture the pane to see what's running, (2) verify it's on the right branch and in a clean worktree, (3) verify NO other pane shares the same CWD — if it does, move the worker to a free worktree first, (4) use `amux wait` primitives — never `sleep`. These checks prevent the most common delegation mistakes.
+
+```bash
+# Check for CWD collisions before delegating
+amux list | awk 'NR>1 {print $5, $1}' | sort | awk '{d[$1]=d[$1]" "$2} END {for(k in d){n=split(d[k],a," ");if(n>1) print k" →"d[k]}}'
+```
+
+If any workers share a directory, move one to a free worktree before sending work.
+
+When delegating work to an agent (codex, claude, grok) running in a pane, follow this sequence:
 
 ### 1. Confirm the agent is ready
 
@@ -317,6 +326,19 @@ amux send-keys 32 "Nice work. One thing to optimize: the scan is slow because it
 ```
 
 This is useful for iterative delegation — give feedback, let the agent refine.
+
+## Spawning a New Worker for a Task
+
+Use the `spawn-worker.sh` script — it handles worktree selection, trust dialogs, and confirmation automatically:
+
+```bash
+scripts/spawn-worker.sh <parent-pane> <issue> "<prompt>"
+
+# Example:
+scripts/spawn-worker.sh pane-105 LAB-505 "Make Pane.Close() non-blocking by design"
+```
+
+The script finds a free worktree, splits a pane, tags it, starts codex, and sends the task.
 
 ## Pane References
 

--- a/scripts/spawn-worker.sh
+++ b/scripts/spawn-worker.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Spawn a new codex worker pane for a task.
+#
+# Usage:
+#   scripts/spawn-worker.sh <parent-pane> <issue> <prompt>
+#
+# Example:
+#   scripts/spawn-worker.sh pane-105 LAB-505 "Make Pane.Close() non-blocking by design"
+#
+# What it does:
+#   1. Finds a free worktree (clean, on main, not used by any pane)
+#   2. Pulls latest origin/main in that worktree
+#   3. Splits a new pane under the parent
+#   4. Tags the pane with issue metadata
+#   5. cd's to the worktree and starts codex --yolo
+#   6. Handles the codex trust dialog
+#   7. Sends the prompt
+#   8. Confirms codex accepted
+set -euo pipefail
+
+PARENT="${1:?Usage: spawn-worker.sh <parent-pane> <issue> <prompt>}"
+ISSUE="${2:?Usage: spawn-worker.sh <parent-pane> <issue> <prompt>}"
+PROMPT="${3:?Usage: spawn-worker.sh <parent-pane> <issue> <prompt>}"
+
+# 1. Find a free worktree
+WORKTREE=""
+USED_DIRS=$(amux list 2>/dev/null | awk 'NR>1 {print $5}' | sed 's|~|'"$HOME"'|')
+for dir in "$HOME"/sync/github/amux/amux*/; do
+  [ -d "$dir/.git" ] || [ -f "$dir/.git" ] || continue
+  branch=$(git -C "$dir" branch --show-current 2>/dev/null) || continue
+  dirty=$(git -C "$dir" status --porcelain 2>/dev/null | wc -l | tr -d ' ')
+  if [ "$branch" = "main" ] && [ "$dirty" -eq 0 ]; then
+    resolved=$(cd "$dir" && pwd -P)
+    if ! echo "$USED_DIRS" | grep -qF "$resolved" 2>/dev/null; then
+      WORKTREE="$dir"
+      break
+    fi
+  fi
+done
+
+if [ -z "$WORKTREE" ]; then
+  echo "ERROR: No free worktree found (clean, on main, not used by any pane)" >&2
+  exit 1
+fi
+echo "Using worktree: $WORKTREE"
+
+# 2. Pull latest
+git -C "$WORKTREE" pull --ff-only >/dev/null 2>&1 || true
+
+# 3. Split new pane
+SPLIT_OUTPUT=$(amux split "$PARENT" --horizontal)
+NEW_PANE=$(echo "$SPLIT_OUTPUT" | grep -oE 'pane-[0-9]+' | tail -1)
+NEW_ID=$(echo "$NEW_PANE" | grep -oE '[0-9]+')
+echo "Created $NEW_PANE"
+
+# 4. Tag with issue metadata
+amux add-meta "$NEW_PANE" issue="$ISSUE"
+
+# 5. cd and start codex in one shell command
+amux send-keys "$NEW_PANE" "cd $WORKTREE && codex --yolo" Enter
+
+# 6. Handle trust dialog — poll full-session capture for the pane content
+echo "Waiting for codex to start..."
+for i in $(seq 1 30); do
+  sleep 1
+  CONTENT=$(amux capture --format json 2>/dev/null | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+for p in d.get('panes', []):
+    if p['id'] == $NEW_ID:
+        lines = [l.strip() for l in p.get('content', []) if l.strip()]
+        print('\n'.join(lines[-5:]))
+" 2>/dev/null || true)
+
+  if echo "$CONTENT" | grep -qi "trust\|Press enter to continue"; then
+    amux send-keys "$NEW_PANE" Enter
+    echo "Accepted trust dialog"
+    continue
+  fi
+
+  if echo "$CONTENT" | grep -qi "gpt"; then
+    echo "Codex ready"
+    break
+  fi
+done
+
+# 7. Send the prompt
+FULL_PROMPT="Fix $ISSUE: $PROMPT. Branch from main, open a PR with Closes $ISSUE."
+amux send-keys "$NEW_PANE" "$FULL_PROMPT" Enter
+echo "Sent task to $NEW_PANE"
+
+# 8. Confirm accepted
+if amux wait content "$NEW_PANE" "Working" --timeout 15s 2>/dev/null; then
+  echo "ACCEPTED: $NEW_PANE is working on $ISSUE in $(basename "$WORKTREE")"
+else
+  echo "WARNING: $NEW_PANE did not confirm acceptance — check manually"
+fi


### PR DESCRIPTION
## Motivation

Spawning a new codex worker for a task requires 8 steps with multiple gotchas: finding a free worktree, avoiding CWD collisions, handling the codex trust dialog, using full-session capture as a workaround for LAB-506. These steps were documented in the amux skill but too complex for a skill — they belong in a script.

## Summary

- Add `scripts/spawn-worker.sh` — one command to spawn a fully configured codex worker
- Simplify the amux skill's "Spawning a New Worker" section to reference the script

## Usage

```bash
scripts/spawn-worker.sh pane-105 LAB-505 "Make Pane.Close() non-blocking by design"
```

## Testing

Manual testing — the script orchestrates amux and codex interactively.

## Review focus

- Worktree selection logic (must not collide with existing panes)
- Trust dialog handling (poll full-session capture since single-pane capture may be empty per LAB-506)
- Whether the sleep-based polling in step 6 should use amux wait primitives instead