### PR TITLE
Add LGTM signal to Claude code review

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -38,7 +38,11 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          prompt: |
+            /code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}
+
+            After your review, if you found no blocking issues, end your comment with "LGTM" on its own line.
+            If you found blocking issues, do not write LGTM.
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 


### PR DESCRIPTION
## Motivation

The Claude code reviewer posts detailed feedback but never signals when a PR is clean. The human lead has to read every review to determine merge-readiness. Adding an explicit LGTM signal enables at-a-glance triage across many PRs (LAB-504).

## Summary

- Add prompt instruction to `claude-code-review.yml`: end comment with "LGTM" when no blocking issues found

## Testing

Will self-test on this PR when the workflow runs.