### PR TITLE
Add LGTM instruction to claude.yml workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -40,8 +40,10 @@ jobs:
           additional_permissions: |
             actions: read
 
-          # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
-          # prompt: 'Update the pull request description to include a summary of changes.'
+          # LGTM signal: when reviewing a PR and finding no blocking issues, end the comment with "LGTM"
+          additional_instructions: |
+            When reviewing a PR, if you found no blocking issues, end your comment with "LGTM" on its own line.
+            If you found blocking issues, do not write LGTM.
 
           # Optional: Add claude_args to customize behavior and configuration
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md


### PR DESCRIPTION
## Motivation

PR #484 added LGTM to claude-code-review.yml (auto PR review), but @claude review comments trigger claude.yml which lacked the instruction.

## Summary

- Add `additional_instructions` to claude.yml with the same LGTM rule

## Testing

Trivial config change. Will self-test when triggered.