### PR TITLE
Add wide-rune clipLine regression coverage

### DIFF
--- a/internal/render/compositor.go
+++ b/internal/render/compositor.go
@@ -315,10 +315,10 @@ func (c *Compositor) visibleContentHeight(cell *mux.LayoutCell) int {
 	return contentH
 }
 
-// clipLine truncates an ANSI-escaped line to at most maxWidth visible
-// characters, preserving escape sequences that precede the cutoff.
+// clipLine truncates an ANSI-escaped line to at most maxWidth display
+// columns, preserving escape sequences that precede the cutoff.
 func clipLine(line string, maxWidth int) string {
-	visible := 0
+	displayCols := 0
 	i := 0
 	for i < len(line) {
 		b := line[i]
@@ -340,10 +340,10 @@ func clipLine(line string, maxWidth int) string {
 		if width < 0 {
 			width = 0
 		}
-		if width > 0 && visible+width > maxWidth {
+		if width > 0 && displayCols+width > maxWidth {
 			return line[:i]
 		}
-		visible += width
+		displayCols += width
 		i += size
 	}
 	return line

--- a/internal/render/compositor_test.go
+++ b/internal/render/compositor_test.go
@@ -350,3 +350,42 @@ func TestBlitPaneClipsToWidth(t *testing.T) {
 		}
 	}
 }
+
+func TestBlitPaneClipsWideRunesToWidth(t *testing.T) {
+	t.Parallel()
+
+	width, height := 11, 3
+	left := mux.NewLeaf(&mux.Pane{ID: 1}, 0, 0, 5, height)
+	right := mux.NewLeaf(&mux.Pane{ID: 2}, 6, 0, 5, height)
+	root := &mux.LayoutCell{
+		X: 0, Y: 0, W: width, H: height,
+		Dir:      mux.SplitVertical,
+		Children: []*mux.LayoutCell{left, right},
+	}
+	left.Parent = root
+	right.Parent = root
+
+	comp := NewCompositor(width, height+GlobalBarHeight, "test")
+	lookup := func(id uint32) PaneData {
+		switch id {
+		case 1:
+			return &fakePaneData{id: 1, name: "pane-1", screen: "中中中", cursorHidden: true}
+		case 2:
+			return &fakePaneData{id: 2, name: "pane-2", screen: "abcde", cursorHidden: true}
+		}
+		return nil
+	}
+
+	output := comp.RenderFull(root, 1, lookup)
+	grid := MaterializeGrid(output, width, height+GlobalBarHeight)
+	lines := strings.Split(grid, "\n")
+	contentRow := []rune(lines[1])
+
+	wantLeft := string([]rune{'中', ' ', '中', ' ', ' '})
+	if got := string(contentRow[:5]); got != wantLeft {
+		t.Fatalf("left pane content = %q, want %q", got, wantLeft)
+	}
+	if got := string(contentRow[6:11]); got != "abcde" {
+		t.Fatalf("right pane content = %q, want %q", got, "abcde")
+	}
+}

--- a/internal/render/overlay_extra_test.go
+++ b/internal/render/overlay_extra_test.go
@@ -239,6 +239,7 @@ func TestCompositorHelpersAndClipLine(t *testing.T) {
 		{name: "plain text", line: "hello", maxWidth: 3, want: "hel"},
 		{name: "preserves ansi prefix", line: "\x1b[31mhello", maxWidth: 3, want: "\x1b[31mhel"},
 		{name: "skips control chars", line: "a\tbcd", maxWidth: 2, want: "a\tb"},
+		{name: "wide runes use display columns", line: "中中中", maxWidth: 5, want: "中中"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Motivation
LAB-144s wide-rune runtime fix is already present on `main`, but the issues exact `中中中` overflow scenario was only covered indirectly. This PR adds direct regression coverage so future changes to `clipLine()` or the compositor cant reintroduce pane bleed for wide characters.

## Summary
- add a `clipLine()` unit regression for `中中中` in a 5-column cell so wide runes are counted by display width, not rune count
- add a split-pane compositor regression that proves the right-hand pane still starts cleanly after a wide-rune line on the left
- rename the local width counter and comment in `clipLine()` from visible characters to display columns to match the actual semantics

## Testing
- `env -u AMUX_SESSION -u TMUX go test ./internal/render -run "''TestBlitPaneClipsWideRunesToWidth|TestCompositorUtilitySettersAndClearPrevGrid''"`
- `env -u AMUX_SESSION -u TMUX go test ./internal/render -run "''TestBlitPaneClipsWideRunesToWidth''" -count=100`
- `env -u AMUX_SESSION -u TMUX go test ./internal/render -run "''TestCompositorUtilitySettersAndClearPrevGrid''" -count=100`
- `env -u AMUX_SESSION -u TMUX go test ./internal/render -count=1`
- `env -u AMUX_SESSION -u TMUX go test ./... -count=1`

## Review focus
- the new compositor regression in `internal/render/compositor_test.go`, especially the expected cell layout for a clipped wide-rune row beside live content in the adjacent pane
- the `clipLine()` table case in `internal/render/overlay_extra_test.go` and the semantics wording in `internal/render/compositor.go`

Closes LAB-144
