### PR TITLE
Warn about !race-only coverage helpers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,7 +99,7 @@ When a change adds a new test or modifies an existing test, run that targeted te
 
 **Changes to `main.go` CLI dispatch need direct unit coverage on the touched lines.** Keep the hermetic subprocess tests for end-to-end CLI behavior, but when a change touches the dispatch branches in `main.go`, add direct unit coverage (for example in `main_test.go`) for those specific lines too. Codecov patch coverage measures the changed `main.go` lines directly and may miss coverage that only arrives through subprocess tests.
 
-**Coverage-oriented follow-up tests must compile under `-race`.** helpers defined only in `//go:build !race` test files are unavailable to race-enabled CI test builds, even when the eventual coverage command for that package runs without `-race`. When you add coverage-oriented tests or reuse helpers across files, run `go test -race` on the touched package before opening or updating the PR.
+**Coverage-oriented follow-up tests must compile under `-race`.** Helpers defined only in `//go:build !race` test files are unavailable to race-enabled CI test builds, even when the eventual coverage command for that package runs without `-race`. When you add coverage-oriented tests or reuse helpers across files, run `go test -race` on the touched package before opening or updating the PR.
 
 **Golden files** live in `test/testdata/`. Two types:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,7 +60,7 @@ Root CLI subprocess tests must use the shared hermetic helper in the root packag
 
 If a change touches CLI dispatch branches in `main.go`, add direct unit coverage for those touched lines as well (for example in `main_test.go`). Hermetic subprocess tests still cover end-to-end behavior, but Codecov patch coverage measures the changed `main.go` lines directly and may not credit coverage that only flows through the subprocess path.
 
-Coverage-oriented follow-up tests must compile under `-race`. helpers defined only in `//go:build !race` test files are unavailable to race-enabled CI test builds, even when the eventual coverage command for that package runs without `-race`. When you add coverage-oriented tests or reuse helpers across files, run `go test -race` on the touched package before opening or updating the PR.
+Coverage-oriented follow-up tests must compile under `-race`. Helpers defined only in `//go:build !race` test files are unavailable to race-enabled CI test builds, even when the eventual coverage command for that package runs without `-race`. When you add coverage-oriented tests or reuse helpers across files, run `go test -race` on the touched package before opening or updating the PR.
 
 ### Golden files
 

--- a/docs_guidance_test.go
+++ b/docs_guidance_test.go
@@ -18,7 +18,7 @@ func TestDocsWarnAboutRaceOnlyCoverageHelpers(t *testing.T) {
 	}
 
 	wants := []string{
-		"helpers defined only in `//go:build !race` test files are unavailable to race-enabled CI test builds",
+		"helpers defined only in `//go:build !race` test files are unavailable to race-enabled ci test builds",
 		"run `go test -race` on the touched package",
 	}
 
@@ -32,7 +32,7 @@ func TestDocsWarnAboutRaceOnlyCoverageHelpers(t *testing.T) {
 				t.Fatalf("read %s: %v", tt.path, err)
 			}
 
-			text := string(data)
+			text := strings.ToLower(string(data))
 			for _, want := range wants {
 				if !strings.Contains(text, want) {
 					t.Fatalf("%s is missing guidance %q", tt.path, want)


### PR DESCRIPTION
## Motivation

PR #426 needed follow-up coverage tests after a Codecov note, and the subsequent CI failure showed the repo was relying on tribal knowledge: coverage-oriented tests can still compile in race-enabled unit builds even when the coverage command later runs without `-race`.

## Summary

- add a root-package regression test that requires the shared agent docs and contributor guide to mention the `//go:build !race` helper trap
- document that helpers defined only in `!race` test files are unavailable to race-enabled CI builds
- document that coverage-oriented tests and shared test helpers should get a package-level `go test -race` verification pass before PR updates

## Testing

- `go test . -run TestDocsWarnAboutRaceOnlyCoverageHelpers -count=100`
- `go test -race . -run TestDocsWarnAboutRaceOnlyCoverageHelpers -count=1`
- `go test ./... -timeout 120s`
- `env -u AMUX_SESSION -u TMUX scripts/coverage.sh`  
  This run reached merged coverage output but exited non-zero because `./internal/server` hit an existing `-race` unit-test flake. Immediate follow-up repro check: `go test -race ./internal/server -count=1` passed.

## Review focus

- whether the new wording in `CLAUDE.md` and `CONTRIBUTING.md` is the right level of prescriptive guidance for future coverage follow-up tests
- whether the doc test is specific enough to catch this regression without being needlessly brittle

Closes LAB-460
