### PR TITLE
Avoid cloning decoded bytes during pane forwarding

### DIFF
--- a/internal/client/input_keys.go
+++ b/internal/client/input_keys.go
@@ -45,10 +45,10 @@ func normalizeLocalInput(raw []byte) []byte {
 }
 
 func forwardedBytesForDecodedInput(decoded decodedInputEvent) []byte {
-	// Preserve the original bytes for pane forwarding. Local bindings and copy
-	// mode normalize decoded keypresses separately, but applications inside the
-	// pane should see the richer keyboard protocol bytes the outer terminal sent.
-	return append([]byte(nil), decoded.raw...)
+	// Preserve the original bytes for pane forwarding. decodeInputEvents
+	// already gives each decoded event its own copy, so callers can forward
+	// the slice directly without re-encoding or cloning it again.
+	return decoded.raw
 }
 
 func keyPressMatchesByte(key uv.KeyPressEvent, want byte) bool {


### PR DESCRIPTION
## Motivation
PR #492 merged with one follow-up reviewer observation on `internal/client/input_keys.go`: `decodeInputEvents` already gives each decoded event its own byte slice, so the extra clone in `forwardedBytesForDecodedInput` was unnecessary. This PR removes that redundant allocation without changing keyboard forwarding behavior.

## Summary
- return `decoded.raw` directly from `forwardedBytesForDecodedInput`
- update the comment to document the ownership guarantee from `decodeInputEvents`
- keep the LAB-282 CSI-u forwarding behavior from #492 unchanged

## Testing
- `env -u AMUX_SESSION -u TMUX go test ./internal/client -run 'ForwardedBytesForDecodedInput|RunSessionHandlesServerMessagesAndInteractiveInput'`
- `env -u AMUX_SESSION -u TMUX go test ./test -run 'TestPTYClientKittyKeyboardChangesPaneBytes|TestPTYClientKittyKeyboardPrintableCtrlSequences'`

## Review focus
- confirm `decoded.raw` is always event-owned when it reaches `forwardedBytesForDecodedInput`
- confirm this PR is allocation cleanup only, with no behavior change to local key handling or PTY forwarding

Follow-up to #492. Related: LAB-282.
