### PR TITLE
Fix stale CLAUDE.md README references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Design Philosophy
 
-See [README.md -- Philosophy](README.md#philosophy) for the project thesis and three tenets.
+See [README.md -- How it works](README.md#how-it-works) for the project overview and system model.
 
 **Client-server architecture.** The server is a background daemon that owns PTYs and layout state. Clients connect over a Unix socket, receive layout snapshots and raw pane output, and render locally. This enables hot-reload: rebuilding the binary auto-restarts the client with new rendering code while preserving running shells.
 


### PR DESCRIPTION
## Motivation

`CLAUDE.md` still linked to a removed `README.md#philosophy` anchor and referred to a nonexistent "Philosophy" section. The agent guidance should follow the README as the source of truth and avoid pointing contributors at stale anchors or deprecated command references.

## Summary

- update the `CLAUDE.md` design-philosophy link to point at `README.md#how-it-works`
- align the sentence text with the current README section name and content
- audit the remaining README links in `CLAUDE.md` and confirm the file does not mention the `delegate` or `--continue-known-dialogs` paths tracked in `LAB-519` and `LAB-511`

## Testing

```bash
rg -n 'README\.md#|README\.md --' CLAUDE.md
rg -n '^## ' README.md
rg -n 'continue-known-dialogs|delegate' CLAUDE.md
git diff --check
```

## Review focus

Confirm the README link now targets the current project-overview section and that no other stale README anchors or soon-to-be-deprecated command references remain in `CLAUDE.md`.

Closes LAB-523
