### PR TITLE
Add a one-table worker status monitor

### DIFF
--- a/scripts/worker-status.sh
+++ b/scripts/worker-status.sh
@@ -59,7 +59,7 @@ if ! pane_list="$(amux list --no-cwd)"; then
     die "failed to list panes"
 fi
 
-printf "$table_format" "PANE" "ISSUE" "STATE" "PR" "LAST OUTPUT"
+printf -- "$table_format" "PANE" "ISSUE" "STATE" "PR" "LAST OUTPUT"
 
 while IFS= read -r pane; do
     [[ -n "$pane" ]] || continue
@@ -114,7 +114,7 @@ while IFS= read -r pane; do
                 ] | last // "-"
             )
         ] | @tsv
-    ' <<<"$capture")"
+    ' <<<"$capture")" || continue
 
     if [[ -z "$pane_name" ]]; then
         pane_name="$pane"
@@ -140,10 +140,23 @@ while IFS= read -r pane; do
     pr_cell="$(truncate_cell "$pr" 8)"
     output_cell="$(truncate_cell "$last_output" 96)"
 
-    printf "$table_format" \
+    printf -- "$table_format" \
         "$pane_cell" \
         "$issue_cell" \
         "$state_cell" \
         "$pr_cell" \
         "$output_cell"
-done < <(printf '%s\n' "$pane_list" | awk 'NR > 1 && $2 != "" { print $2 }')
+done < <(printf '%s\n' "$pane_list" | awk '
+NR == 1 {
+    for (i = 1; i <= NF; i++) {
+        if ($i == "NAME") {
+            name_col = i
+            break
+        }
+    }
+    next
+}
+name_col && $name_col != "" {
+    print $name_col
+}
+')

--- a/worker_status_test.go
+++ b/worker_status_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 )
@@ -21,6 +22,9 @@ PANE   NAME                 HOST            BRANCH                         WINDO
  8     logs-worker          local           feature/logs                   main       build
  9     pane-9               local           feature/pr-500                 main       worker       prs=[500] issues=[LAB-500]
 10     pane-10              local           feature/other                  main       build
+11     pane-11              local           feature/pr-511                 main       worker       prs=[511]
+12     pane-12              local           feature/pr-512                 main       worker       prs=[512]
+13     pane-13              local           feature/pr-513                 main       worker       prs=[513]
 EOF
 exit 0
 fi
@@ -78,12 +82,55 @@ cat <<'EOF'
 EOF
 exit 0
 ;;
+    pane-10)
+cat <<'EOF'
+{
+  "name": "pane-10",
+  "task": "build",
+  "meta": {
+    "tracked_issues": [{"id": "LAB-700", "status": "active"}],
+    "tracked_prs": [{"number": 700, "status": "active"}]
+  },
+  "idle": false,
+  "child_pids": [303],
+  "content": ["not a worker"]
+}
+EOF
+exit 0
+;;
+    pane-12)
+cat <<'EOF'
+{
+  "error": {
+    "code": "capture_unavailable",
+    "message": "capture unavailable"
+  }
+}
+EOF
+exit 0
+;;
+    pane-13)
+cat <<'EOF'
+{
+  "name": "pane-13",
+  "task": "worker",
+  "meta": {
+    "tracked_issues": [{"id": "LAB-513", "status": "active"}],
+    "tracked_prs": [{"number": 513, "status": "active"}]
+  },
+  "idle": false,
+  "child_pids": [],
+  "content": ["waiting quietly"]
+}
+EOF
+exit 0
+;;
 esac
 fi
 
 if [ "$1" = "wait" ] && [ "$2" = "vt-idle" ]; then
 case "$3" in
-    logs-worker|pane-9)
+    logs-worker|pane-9|pane-13)
         printf 'vt-idle\n'
         exit 0
         ;;
@@ -109,18 +156,13 @@ exit 1
 		}
 	}
 
-	if !strings.Contains(out, "pane-7") || !strings.Contains(out, "LAB-517") || !strings.Contains(out, "busy") || !strings.Contains(out, "422") || !strings.Contains(out, "streaming output") {
-		t.Fatalf("output missing metadata-worker row:\n%s", out)
-	}
-	if !strings.Contains(out, "logs-worker") || !strings.Contains(out, "LAB-600") || !strings.Contains(out, "idle") || !strings.Contains(out, "600") || !strings.Contains(out, "worker finished") {
-		t.Fatalf("output missing name-convention worker row:\n%s", out)
-	}
-	if !strings.Contains(out, "pane-9") || !strings.Contains(out, "stuck") || !strings.Contains(out, "500") || !strings.Contains(out, "higher risk of prompt injection.") {
-		t.Fatalf("output missing stuck worker row:\n%s", out)
-	}
-	if strings.Contains(out, "pane-10") {
-		t.Fatalf("output should skip non-worker panes:\n%s", out)
-	}
+	assertWorkerStatusRow(t, out, "pane-7", "LAB-517", "busy", "422", "streaming output")
+	assertWorkerStatusRow(t, out, "logs-worker", "LAB-600", "idle", "600", "worker finished")
+	assertWorkerStatusRow(t, out, "pane-9", "LAB-500", "stuck", "500", "higher risk of prompt injection.")
+	assertWorkerStatusRow(t, out, "pane-13", "LAB-513", "vt-idle", "513", "waiting quietly")
+	assertWorkerStatusRowAbsent(t, out, "pane-10")
+	assertWorkerStatusRowAbsent(t, out, "pane-11")
+	assertWorkerStatusRowAbsent(t, out, "pane-12")
 }
 
 func TestWorkerStatusScriptPrintsHeaderWhenNoWorkersMatch(t *testing.T) {
@@ -170,4 +212,32 @@ func runWorkerStatusScript(t *testing.T, tempDir string, extraEnv ...string) (st
 		t.Fatalf("unexpected error: %v\n%s", err, out)
 	}
 	return string(out), exitErr.ExitCode()
+}
+
+func assertWorkerStatusRow(t *testing.T, out, pane, issue, state, pr, lastOutput string) {
+	t.Helper()
+
+	pattern := "(?m)^" +
+		regexp.QuoteMeta(pane) +
+		` +` +
+		regexp.QuoteMeta(issue) +
+		` +` +
+		regexp.QuoteMeta(state) +
+		` +` +
+		regexp.QuoteMeta(pr) +
+		` +` +
+		regexp.QuoteMeta(lastOutput) +
+		`$`
+	if !regexp.MustCompile(pattern).MatchString(out) {
+		t.Fatalf("output missing row %q/%q/%q/%q/%q:\n%s", pane, issue, state, pr, lastOutput, out)
+	}
+}
+
+func assertWorkerStatusRowAbsent(t *testing.T, out, pane string) {
+	t.Helper()
+
+	pattern := "(?m)^" + regexp.QuoteMeta(pane) + ` +`
+	if regexp.MustCompile(pattern).MatchString(out) {
+		t.Fatalf("output should not include row for %q:\n%s", pane, out)
+	}
 }


### PR DESCRIPTION
Motivation

Worker panes already expose enough state through amux capture and wait primitives, but there is no single command that turns that into a compact operator view. LAB-517 asks for a one-table worker monitor that shows issue/PR ownership, current state, and the most recent visible output, including a stuck-worker signal for trust dialogs.

Summary

- add `scripts/worker-status.sh` to enumerate panes via `amux list --no-cwd`, then inspect each pane with `amux capture --format json`
- classify worker panes by either `task=worker` metadata or a worker-style pane name
- print a single `PANE / ISSUE / STATE / PR / LAST OUTPUT` table, with `stuck` when a pane is `vt-idle`, still has child processes, and shows the Codex trust dialog text
- add shell-script tests for metadata-based workers, name-based workers, stuck-worker detection, and the no-worker header case

Testing

- `go test ./... -run 'TestWorkerStatusScript' -count=100`
- `go test ./... -timeout 120s`
- `env -u AMUX_SESSION -u TMUX go test ./test -run TestDelegateSendsTextWaitsAndConfirmsBusy -count=5 -timeout 120s`

Review focus

- worker discovery intentionally treats JSON capture as the source of truth and only uses `amux list --no-cwd` to enumerate pane refs, so the script does not depend on the list table's `TASK` column layout
- the stuck heuristic is intentionally narrow: it only upgrades `vt-idle` workers to `stuck` when child processes are still present and the current screen matches the existing Codex trust dialog strings
- the pre-push hook hit one transient failure in `TestDelegateSendsTextWaitsAndConfirmsBusy`, but the clean-env rerun above passed 5/5 and the branch push completed

Closes LAB-517
