### PR TITLE
Add stuck worker recovery helper

### DIFF
--- a/recover_worker_test.go
+++ b/recover_worker_test.go
@@ -78,12 +78,39 @@ func TestRecoverWorkerScriptRejectsPaneWithoutKnownDialog(t *testing.T) {
 	}
 }
 
+func TestRecoverWorkerScriptRejectsPaneWithoutChildProcesses(t *testing.T) {
+	t.Parallel()
+
+	fixture := newRecoverWorkerFixture(t)
+
+	out, exitCode := runRecoverWorkerScript(t, fixture.tempDir,
+		"FAKE_AMUX_LOG="+fixture.logPath,
+		"FAKE_STAGE_FILE="+fixture.stagePath,
+		"FAKE_INITIAL_STAGE=no_children",
+	)
+	if exitCode != 1 {
+		t.Fatalf("exit code = %d, want 1\n%s", exitCode, out)
+	}
+	if !strings.Contains(out, "has no child processes") {
+		t.Fatalf("output missing child-process failure:\n%s", out)
+	}
+
+	got, err := os.ReadFile(fixture.logPath)
+	if err != nil {
+		t.Fatalf("read fake amux log: %v", err)
+	}
+	if strings.Contains(string(got), "send-keys") {
+		t.Fatalf("expected no recovery input without child processes, got log:\n%s", got)
+	}
+}
+
 func TestRecoverWorkerScriptFailsWhenOutputDoesNotAdvance(t *testing.T) {
 	t.Parallel()
 
 	fixture := newRecoverWorkerFixture(t)
 
 	out, exitCode := runRecoverWorkerScript(t, fixture.tempDir,
+		"FAKE_AMUX_LOG="+fixture.logPath,
 		"FAKE_STAGE_FILE="+fixture.stagePath,
 		"FAKE_FINAL_STAGE=unchanged",
 	)
@@ -92,6 +119,24 @@ func TestRecoverWorkerScriptFailsWhenOutputDoesNotAdvance(t *testing.T) {
 	}
 	if !strings.Contains(out, "pane content did not change") {
 		t.Fatalf("output missing no-progress failure:\n%s", out)
+	}
+}
+
+func TestRecoverWorkerScriptFailsWhenDialogStillBlocksAfterRecovery(t *testing.T) {
+	t.Parallel()
+
+	fixture := newRecoverWorkerFixture(t)
+
+	out, exitCode := runRecoverWorkerScript(t, fixture.tempDir,
+		"FAKE_AMUX_LOG="+fixture.logPath,
+		"FAKE_STAGE_FILE="+fixture.stagePath,
+		"FAKE_FINAL_STAGE=still_blocked",
+	)
+	if exitCode != 1 {
+		t.Fatalf("exit code = %d, want 1\n%s", exitCode, out)
+	}
+	if !strings.Contains(out, "still matches a blocking dialog") {
+		t.Fatalf("output missing dialog-still-blocked failure:\n%s", out)
 	}
 }
 
@@ -189,6 +234,16 @@ EOF
         not_stuck)
             cat <<'EOF'
 {"child_pids":[42],"content":["build passed","shell prompt ready"]}
+EOF
+            ;;
+        no_children)
+            cat <<'EOF'
+{"child_pids":[],"content":["Do you trust the contents of this directory?","Working with untrusted contents comes with higher risk of prompt injection.","Press enter to continue"]}
+EOF
+            ;;
+        still_blocked)
+            cat <<'EOF'
+{"child_pids":[42],"content":["Resumed rollout successfully from abc123","Press enter to continue"]}
 EOF
             ;;
         *)

--- a/scripts/recover-worker.sh
+++ b/scripts/recover-worker.sh
@@ -36,14 +36,18 @@ require_cmd() {
     fi
 }
 
-pane=${1:-}
-if [[ $# -ne 1 ]] || [[ "$pane" == "-h" ]] || [[ "$pane" == "--help" ]] || [[ -z "$pane" ]]; then
-    if [[ "${1:-}" == "-h" ]] || [[ "${1:-}" == "--help" ]]; then
+case "${1:-}" in
+    -h|--help)
         usage
         exit 0
-    fi
+        ;;
+esac
+
+if [[ $# -ne 1 ]] || [[ -z "${1:-}" ]]; then
     die_usage
 fi
+
+pane=$1
 
 AMUX_BIN=${AMUX:-amux}
 VT_IDLE_TIMEOUT=${AMUX_RECOVER_VT_IDLE_TIMEOUT:-20s}
@@ -71,7 +75,7 @@ has_child_processes() {
 
 content_lines() {
     local capture=$1
-    jq -r '.content[]? // empty' <<<"$capture"
+    jq -r '.content[]?' <<<"$capture"
 }
 
 content_snapshot() {


### PR DESCRIPTION
## Motivation
Stuck worker panes currently need a manual Codex recovery sequence. This adds a scripted recovery path for panes that are visibly blocked in a settled dialog state but still have live child processes.

## Summary
- add `scripts/recover-worker.sh` to detect a stuck worker via `wait vt-idle`, `capture --format json`, child-process presence, and known Codex dialog text
- drive the recovery sequence with amux primitives: `Escape`, `/exit`, `codex --yolo resume`, session selection, and `.` to continue, with `wait vt-idle` between each step
- verify recovery by requiring the pane content to advance and no longer match the blocking dialog patterns
- add direct script tests with a fake `amux` binary that cover the stuck-state gate, the exact command sequence, and the no-progress failure path

## Testing
- `go test ./... -run 'TestRecoverWorkerScript' -count=100`
- `go test ./test -run TestDelegateSendsTextWaitsAndConfirmsBusy -count=10`
- `go test ./... -timeout 120s`

## Review focus
- Are the dialog-pattern heuristics broad enough to catch the stuck Codex states we care about without over-matching normal pane content?
- Does the final content-change check feel like the right recovery confirmation signal, or should it get stricter about the resumed prompt state?

Closes LAB-518
