### PR TITLE
Add delegate-task helper for verified pane handoff

### DIFF
--- a/delegate_task_script_test.go
+++ b/delegate_task_script_test.go
@@ -61,6 +61,9 @@ func TestDelegateTaskScriptCapturesPaneWhenWorkerNeverAccepts(t *testing.T) {
 	if !strings.Contains(out, "pane-47 appears stuck") {
 		t.Fatalf("output = %q, want stuck-state message", out)
 	}
+	if !strings.Contains(out, "expected output within 100ms") {
+		t.Fatalf("output = %q, want output-timeout message", out)
+	}
 	if !strings.Contains(out, "worker prompt is still idle") {
 		t.Fatalf("output = %q, want captured pane contents", out)
 	}
@@ -132,6 +135,43 @@ func TestDelegateTaskScriptRejectsInvalidTimeout(t *testing.T) {
 	if strings.Contains(out, "appears stuck") {
 		t.Fatalf("output = %q, did not expect stuck-state fallback", out)
 	}
+
+	got, err := os.ReadFile(logPath)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			t.Fatalf("read fake amux log: %v", err)
+		}
+		return
+	}
+	if strings.Contains(string(got), "send-keys") {
+		t.Fatalf("amux log = %q, did not expect send-keys for invalid timeout", got)
+	}
+}
+
+func TestDelegateTaskScriptRequiresPaneArgument(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	out, exitCode := runDelegateTaskScript(t, tempDir, nil)
+	if exitCode != 2 {
+		t.Fatalf("exit code = %d, want 2\n%s", exitCode, out)
+	}
+	if !strings.Contains(out, "usage: scripts/delegate-task.sh") {
+		t.Fatalf("output = %q, want usage text", out)
+	}
+}
+
+func TestDelegateTaskScriptRequiresTaskArgument(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	out, exitCode := runDelegateTaskScript(t, tempDir, nil, "pane-47")
+	if exitCode != 2 {
+		t.Fatalf("exit code = %d, want 2\n%s", exitCode, out)
+	}
+	if !strings.Contains(out, "usage: scripts/delegate-task.sh") {
+		t.Fatalf("output = %q, want usage text", out)
+	}
 }
 
 func runDelegateTaskScript(t *testing.T, tempDir string, extraEnv []string, args ...string) (string, int) {
@@ -170,20 +210,20 @@ log_call() {
 cmd="${1:-}"
 shift || true
 
-	case "$cmd" in
-	    events)
-	        printf '{"type":"layout","pane_name":"pane-47"}\n'
-	        if [[ "${FAKE_AMUX_EVENT_MODE:-success}" == "success" ]]; then
-	            deadline=$((SECONDS + 5))
-	            while [[ ! -f "$FAKE_AMUX_SEND_MARKER" && $SECONDS -lt $deadline ]]; do
-	                sleep 0.01
-	            done
-	            printf '{"type":"output","pane_name":"pane-47"}\n'
-	            exit 0
-	        fi
-	        sleep 0.5
-	        exit 0
-	        ;;
+case "$cmd" in
+    events)
+        printf '{"type":"layout","pane_name":"pane-47"}\n'
+        if [[ "${FAKE_AMUX_EVENT_MODE:-success}" == "success" ]]; then
+            deadline=$((SECONDS + 5))
+            while [[ ! -f "$FAKE_AMUX_SEND_MARKER" && $SECONDS -lt $deadline ]]; do
+                sleep 0.01
+            done
+            printf '{"type":"output","pane_name":"pane-47"}\n'
+            exit 0
+        fi
+        sleep 0.5
+        exit 0
+        ;;
     send-keys)
         : >"$FAKE_AMUX_SEND_MARKER"
         log_call "$cmd" "$@"

--- a/scripts/delegate-task.sh
+++ b/scripts/delegate-task.sh
@@ -24,6 +24,44 @@ require_cmd() {
     fi
 }
 
+validate_duration() {
+    local duration="$1"
+
+    python3 -c '
+import re
+import sys
+
+
+def parse_duration(raw: str) -> None:
+    units = {
+        "ns": 1e-9,
+        "us": 1e-6,
+        "µs": 1e-6,
+        "μs": 1e-6,
+        "ms": 1e-3,
+        "s": 1.0,
+        "m": 60.0,
+        "h": 3600.0,
+    }
+    pattern = re.compile(r"([0-9]+(?:\.[0-9]+)?)(ns|us|µs|μs|ms|s|m|h)")
+    pos = 0
+    for match in pattern.finditer(raw):
+        if match.start() != pos:
+            raise ValueError(raw)
+        _ = float(match.group(1)) * units[match.group(2)]
+        pos = match.end()
+    if pos != len(raw):
+        raise ValueError(raw)
+
+
+try:
+    parse_duration(sys.argv[1])
+except ValueError:
+    print(f"invalid duration: {sys.argv[1]}", file=sys.stderr)
+    sys.exit(1)
+' "$duration" >/dev/null
+}
+
 wait_for_event() {
     local want_event="$1"
     local timeout="$2"
@@ -144,6 +182,9 @@ task="$*"
 
 require_cmd amux
 require_cmd python3
+if ! validate_duration "$timeout"; then
+    exit 2
+fi
 
 events_pid=""
 events_fd=""
@@ -158,7 +199,7 @@ cleanup() {
 }
 trap cleanup EXIT
 
-coproc EVENT_STREAM { amux events --pane "$pane" --filter layout,output,vt-idle --throttle 0s --no-reconnect; }
+coproc EVENT_STREAM { amux events --pane "$pane" --filter layout,output --throttle 0s --no-reconnect; }
 events_pid="$EVENT_STREAM_PID"
 exec {events_fd}<&"${EVENT_STREAM[0]}"
 
@@ -177,7 +218,7 @@ else
     fi
     capture="$(amux capture "$pane" 2>&1 || true)"
     {
-        echo "scripts/delegate-task.sh: $pane appears stuck: expected vt-idle to break within $timeout."
+        echo "scripts/delegate-task.sh: $pane appears stuck: expected output within $timeout after sending the task."
         echo "Captured $pane:"
         printf '%s\n' "$capture"
     } >&2


### PR DESCRIPTION
## Motivation
LAB-515 needs a small shell helper for delegating a task to a worker pane and confirming the pane actually reacted. Without that acceptance check, a handoff can silently disappear and the only signal is a later idle pane.

## Summary
- add `scripts/delegate-task.sh` to send task text with `amux send-keys`, subscribe to `amux events`, and wait for fresh `output` after the initial layout snapshot
- capture the pane and return non-zero when no output arrives before the timeout, and reject invalid timeout values as usage errors
- optionally add `issue=...` metadata only after the pane accepts the task
- add root-level subprocess tests covering acceptance, stuck capture, metadata ordering, and invalid timeout handling

## Testing
- `go test . -run 'TestDelegateTaskScript' -count=100`
- `env -u AMUX_SESSION -u TMUX go test ./internal/server -run 'TestCmdSendKeysWaitsForInputIdle|TestCmdTypeKeysWaitsForInputIdle' -count=10`
- `env -u AMUX_SESSION -u TMUX go test ./... -timeout 120s`

## Review Focus
- the script relies on the initial `layout` snapshot from `amux events` so it can start listening before `send-keys` without racing the first post-send `output` event
- timeout failures intentionally fall back to `amux capture` even when the event stream closes early, while invalid `--timeout` values exit as usage errors instead of being treated as stuck panes
- issue metadata is added only after acceptance is confirmed

Closes LAB-515
