### PR TITLE
Use prompt input in Claude workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -40,8 +40,8 @@ jobs:
           additional_permissions: |
             actions: read
 
-          # LGTM signal: when reviewing a PR and finding no blocking issues, end the comment with "LGTM"
-          additional_instructions: |
+          # LGTM signal: append custom instructions for PR reviews and replies
+          prompt: |
             When reviewing a PR, if you found no blocking issues, end your comment with "LGTM" on its own line.
             If you found blocking issues, do not write LGTM.
 
@@ -49,4 +49,3 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
           # claude_args: '--allowed-tools Bash(gh pr:*)'
-


### PR DESCRIPTION
## Motivation
`anthropics/claude-code-action@v1` warns that `additional_instructions` is not a valid input in `.github/workflows/claude.yml`, so the LGTM guidance in that workflow is ignored. The workflow log for run `23698985602` shows the warning and lists `prompt` and `settings` as the supported replacements.

## Summary
- replace the unsupported `additional_instructions` field in `.github/workflows/claude.yml` with the supported `prompt` input
- keep the existing LGTM review guidance text unchanged so tag-triggered Claude runs still receive the same custom instructions
- align the workflow with `.github/workflows/claude-code-review.yml` and the published `anthropics/claude-code-action@v1` input contract

## Testing
- `actionlint .github/workflows/claude.yml`
- `git diff --check origin/main...HEAD`

## Review focus
- confirm `prompt` is the right v1 replacement for tag-triggered `@claude` workflows and that the existing instructions should remain prompt text rather than moving into `settings`
- confirm the change is intentionally limited to removing the unsupported input warning without altering any other workflow behavior

Closes LAB-510
