### PR TITLE
Run zoom nested-harness tests serially

### DIFF
--- a/test/zoom_test.go
+++ b/test/zoom_test.go
@@ -448,7 +448,9 @@ func TestZoomKeybinding(t *testing.T) {
 }
 
 func TestZoomSplitKeepsZoomAndFocus(t *testing.T) {
-	t.Parallel()
+	// Keep this serial: nested AmuxHarness startup is globally serialized, and
+	// running this zoom split path in the flake-detection x3 job can leave it
+	// stuck behind package-wide waitParallel contention before the test body runs.
 	h := newAmuxHarness(t)
 
 	h.splitH()
@@ -486,7 +488,10 @@ func TestZoomSplitKeepsZoomAndFocus(t *testing.T) {
 }
 
 func TestZoomAutoUnzoomOnFocus(t *testing.T) {
-	t.Parallel()
+	// Keep this serial for the same reason as TestZoomSplitKeepsZoomAndFocus:
+	// the nested harness startup gate already removes the startup benefit of
+	// top-level parallelism, while Go's flake-detection run has timed out with
+	// this test queued in waitParallel under -count=3 -parallel=2.
 	h := newAmuxHarness(t)
 
 	h.splitH()


### PR DESCRIPTION
## Motivation
The flake-detection integration job (`go test -count=3 -parallel 2 -timeout 300s ./test/`) has timed out with `TestZoomSplitKeepsZoomAndFocus` and `TestZoomAutoUnzoomOnFocus` stuck in `testing.(*testState).waitParallel` before their bodies ran. Both cases use `newAmuxHarness`, whose nested startup is already globally serialized, so top-level parallel scheduling adds contention without meaningful runtime benefit for these tests.

## Summary
- remove `t.Parallel()` from the two nested-harness zoom keybinding tests
- document why those cases intentionally stay serial in the flake-detection x3 job
- keep the zoom behavior assertions unchanged while avoiding extra `waitParallel` pressure

## Testing
- `env -u AMUX_SESSION -u TMUX go test ./test/ -run 'TestZoomSplitKeepsZoomAndFocus|TestZoomAutoUnzoomOnFocus' -count=3 -parallel=2 -timeout 120s`
- `env -u AMUX_SESSION -u TMUX go test ./test/ -run 'TestZoomSplitKeepsZoomAndFocus|TestZoomAutoUnzoomOnFocus' -count=50 -parallel=2 -timeout 300s`
- `env -u AMUX_SESSION -u TMUX go test ./test/ -run 'TestZoomSplitKeepsZoomAndFocus|TestZoomAutoUnzoomOnFocus' -count=100 -parallel=2 -timeout 600s`

## Review focus
- Is serializing only these two nested-harness zoom tests the right containment scope for LAB-558?
- Are the comments clear enough about why these tests intentionally avoid `t.Parallel()`?

Closes LAB-558
