### PR TITLE
Add guidance: fix flaky tests by finding root cause, never serialize

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,6 +97,8 @@ Tests should read like specs. Minimize logic in assertions so a human can read t
 
 When a change adds a new test or modifies an existing test, run that targeted test slice with `-count=100` before calling the work done. Treat any failure in those repeated runs as a flake to investigate, not as an acceptable one-off.
 
+**Fix flaky tests by finding the root cause.** Never make tests serial to avoid a flake — that hides the bug (shared state, resource contention, missing synchronization) instead of fixing it. If tests deadlock under `-count=3 -parallel=2`, the fix is in the code, not the test runner flags.
+
 **Root CLI subprocess tests must use the shared hermetic helper.** Do not open-code `exec.Command(os.Args[0], ...)` or inherit ambient `AMUX_SESSION` / `TMUX` state in root package tests; route those tests through the shared helper so they always run with an isolated session and scrubbed env.
 
 **Changes to `main.go` CLI dispatch need direct unit coverage on the touched lines.** Keep the hermetic subprocess tests for end-to-end CLI behavior, but when a change touches the dispatch branches in `main.go`, add direct unit coverage (for example in `main_test.go`) for those specific lines too. Codecov patch coverage measures the changed `main.go` lines directly and may miss coverage that only arrives through subprocess tests.


### PR DESCRIPTION
## Motivation

PR #532 serialized zoom tests to avoid a deadlock under -count=3. That hides the bug instead of fixing it. Codify this as a project rule.

## Summary

- Add to CLAUDE.md Test Philosophy: never make tests serial to fix flakes, find the root cause instead

## Testing

CLAUDE.md only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)