### PR TITLE
Add regression test for known_hosts rewrites

### DIFF
--- a/internal/remote/hostkey_test.go
+++ b/internal/remote/hostkey_test.go
@@ -269,6 +269,56 @@ func TestBuildSSHConfigWiresHostKeyCallback(t *testing.T) {
 	}
 }
 
+func TestBuildSSHConfigHostKeyCallbackReloadsKnownHostsFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+	t.Setenv("SSH_AUTH_SOCK", "")
+
+	sshDir := filepath.Join(tmpDir, ".ssh")
+	if err := os.MkdirAll(sshDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	writeTestKey(t, filepath.Join(sshDir, "id_ed25519"))
+
+	hc := NewHostConn("test", configStubHost(), "hash", nil, nil, nil)
+	defer hc.Close()
+
+	cfg, err := hc.buildSSHConfig()
+	if err != nil {
+		t.Fatalf("buildSSHConfig: %v", err)
+	}
+
+	oldKey := testHostKey(t)
+	newKey := testHostKey(t)
+	khPath := filepath.Join(sshDir, "known_hosts")
+
+	// Write an initial host key, then keep using the same callback after the
+	// file is rewritten to prove it does not cache stale known_hosts contents.
+	oldLine := knownhosts.Line([]string{"example.com:22"}, oldKey)
+	if err := os.WriteFile(khPath, []byte(oldLine+"\n"), 0600); err != nil {
+		t.Fatalf("writing initial known_hosts: %v", err)
+	}
+	if err := cfg.HostKeyCallback("example.com:22", fakeAddr{"1.2.3.4:22"}, oldKey); err != nil {
+		t.Fatalf("initial host key should match, got: %v", err)
+	}
+
+	newLine := knownhosts.Line([]string{"example.com:22"}, newKey)
+	if err := os.WriteFile(khPath, []byte(newLine+"\n"), 0600); err != nil {
+		t.Fatalf("rewriting known_hosts: %v", err)
+	}
+	if err := cfg.HostKeyCallback("example.com:22", fakeAddr{"1.2.3.4:22"}, newKey); err != nil {
+		t.Fatalf("rewritten known_hosts should be re-read by the same callback, got: %v", err)
+	}
+
+	err = cfg.HostKeyCallback("example.com:22", fakeAddr{"1.2.3.4:22"}, oldKey)
+	if err == nil {
+		t.Fatal("stale host key should be rejected after known_hosts rewrite")
+	}
+	if !strings.Contains(err.Error(), "CHANGED") {
+		t.Fatalf("stale host key error = %q, want changed-host warning", err)
+	}
+}
+
 func TestBuildSSHConfigInsecureEnvVar(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)


### PR DESCRIPTION
## Motivation
LAB-554 reports that amux can keep using stale `known_hosts` data after an SSH host key rotates. The runtime fix is already on `main`, but there was no regression test proving that a long-lived host key callback re-reads a rewritten `known_hosts` file instead of caching stale entries.

## Summary
- add a remote-unit regression that builds one SSH config and reuses the same host key callback across a `known_hosts` rewrite
- verify the callback accepts the replacement key after the rewrite and rejects the stale key afterward
- document the intended behavior directly in the test so future refactors do not regress back to cached host key state

## Testing
- `go test ./internal/remote -run 'TestBuildSSHConfigHostKeyCallbackReloadsKnownHostsFile' -count=100`
- `go test ./internal/remote -run 'TestHostKey|TestBuildSSHConfig' -count=1`
- `go test ./test -run 'TestTakeoverAttachHostKeyMismatchShowsNotice|TestTakeoverReconnectAfterRemoteReload' -count=1`

## Review focus
- `internal/remote/hostkey_test.go`: the new test reuses a single `cfg.HostKeyCallback` across a rewritten `known_hosts` file, which is the behavior LAB-554 was concerned about
- this PR intentionally adds regression coverage only; `main` already has the runtime re-read behavior in `internal/remote/hostkey.go`

Closes LAB-554
