### PR TITLE
Centralize default timing constants in config

### DIFF
--- a/internal/client/attach.go
+++ b/internal/client/attach.go
@@ -76,13 +76,6 @@ func applyAttachBootstrapMessage(cr *ClientRenderer, msg attachBootstrapMessage)
 	}
 }
 
-const (
-	// Wait only briefly for the rest of attach replay so a stuck pane does not
-	// hold the terminal on a blank attach indefinitely.
-	defaultBootstrapPaneReplayWait   = 50 * time.Millisecond
-	defaultBootstrapCorrectionWindow = 50 * time.Millisecond
-)
-
 func readImmediateAttachCorrection(conn net.Conn, cr *ClientRenderer, timeout time.Duration) error {
 	if err := conn.SetReadDeadline(time.Now().Add(timeout)); err != nil {
 		return err
@@ -170,7 +163,7 @@ func readAttachBootstrap(conn net.Conn, cr *ClientRenderer) error {
 		remainingOutputs -= applyAttachBootstrapMessage(cr, msg)
 	}
 
-	remainingOutputs, err := readAttachBootstrapPaneReplays(conn, cr, remainingOutputs, defaultBootstrapPaneReplayWait)
+	remainingOutputs, err := readAttachBootstrapPaneReplays(conn, cr, remainingOutputs, config.BootstrapPaneReplayWait)
 	if err != nil {
 		return err
 	}
@@ -181,7 +174,7 @@ func readAttachBootstrap(conn net.Conn, cr *ClientRenderer) error {
 		return nil
 	}
 
-	return readImmediateAttachCorrection(conn, cr, defaultBootstrapCorrectionWindow)
+	return readImmediateAttachCorrection(conn, cr, config.BootstrapCorrectionWindow)
 }
 
 type displayPaneSelectionResult struct {

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	caputil "github.com/weill-labs/amux/internal/capture"
+	"github.com/weill-labs/amux/internal/config"
 	"github.com/weill-labs/amux/internal/copymode"
 	"github.com/weill-labs/amux/internal/mux"
 	"github.com/weill-labs/amux/internal/proto"
@@ -310,11 +311,6 @@ type clientEffect struct {
 	uiEvents []string
 }
 
-const (
-	defaultRenderFrameInterval  = 16 * time.Millisecond
-	defaultRenderPriorityWindow = 40 * time.Millisecond
-)
-
 type clientRenderLoopState struct {
 	renderTimer         *time.Timer
 	renderC             <-chan time.Time
@@ -505,11 +501,11 @@ func (cr *ClientRenderer) shouldPrioritizePaneOutput(paneID uint32) bool {
 // full repaint through the diff engine.
 func (cr *ClientRenderer) RenderCoalesced(msgCh <-chan *RenderMsg, write func(string)) {
 	if cr.renderPriorityWindow == 0 {
-		cr.renderPriorityWindow = defaultRenderPriorityWindow
+		cr.renderPriorityWindow = config.RenderPriorityWindow
 	}
 	frameInterval := cr.renderFrameInterval
 	if frameInterval == 0 {
-		frameInterval = defaultRenderFrameInterval
+		frameInterval = config.RenderFrameInterval
 	}
 	state := &clientRenderLoopState{
 		useFull:             os.Getenv("AMUX_RENDER") == "full",

--- a/internal/client/local_render.go
+++ b/internal/client/local_render.go
@@ -1,6 +1,10 @@
 package client
 
-import "os"
+import (
+	"os"
+
+	"github.com/weill-labs/amux/internal/config"
+)
 
 // Local render actions are reserved for client state that cannot be updated
 // safely through the clientSnapshot CAS helpers. CopyMode instances are shared,
@@ -12,7 +16,7 @@ import "os"
 func applyLocalRenderResultDirect(cr *ClientRenderer, result localRenderResult) {
 	state := &clientRenderLoopState{
 		useFull:             os.Getenv("AMUX_RENDER") == "full",
-		renderFrameInterval: defaultRenderFrameInterval,
+		renderFrameInterval: config.RenderFrameInterval,
 	}
 	_ = cr.executeRenderEffects(state, result.effects, func(string) {})
 }

--- a/internal/config/timing.go
+++ b/internal/config/timing.go
@@ -1,0 +1,15 @@
+package config
+
+import "time"
+
+// Shared default timing values. Tests can still override per-struct fields in
+// the consuming packages; these constants are only the built-in defaults.
+const (
+	VTIdleSettle              = 2 * time.Second
+	VTIdleTimeout             = 60 * time.Second
+	UndoGracePeriod           = 30 * time.Second
+	BootstrapPaneReplayWait   = 50 * time.Millisecond
+	BootstrapCorrectionWindow = 50 * time.Millisecond
+	RenderFrameInterval       = 16 * time.Millisecond
+	RenderPriorityWindow      = 40 * time.Millisecond
+)

--- a/internal/server/idle.go
+++ b/internal/server/idle.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"sync/atomic"
 	"time"
+
+	"github.com/weill-labs/amux/internal/config"
 )
 
 // idleTracker manages per-pane idle timers and state transitions.
@@ -121,12 +123,6 @@ func (t *idleTracker) publish() {
 	}
 	t.snap.Store(&idleSnapshot{state: state, since: since})
 }
-
-// DefaultVTIdleSettle is the default settle window for screen-quiet tracking.
-const DefaultVTIdleSettle = 2 * time.Second
-
-// DefaultVTIdleTimeout is the default timeout for wait idle.
-const DefaultVTIdleTimeout = 60 * time.Second
 
 // VTIdleTracker tracks per-pane output quiescence.
 // Event-loop only.
@@ -335,8 +331,8 @@ func parseWaitIdleArgs(args []string) (string, waitIdleOptions, error) {
 	}
 
 	opts := waitIdleOptions{
-		settle:  DefaultVTIdleSettle,
-		timeout: DefaultVTIdleTimeout,
+		settle:  config.VTIdleSettle,
+		timeout: config.VTIdleTimeout,
 	}
 	for i := 1; i < len(args); i++ {
 		switch args[i] {

--- a/internal/server/idle_test.go
+++ b/internal/server/idle_test.go
@@ -83,7 +83,7 @@ func TestParseWaitIdleArgs(t *testing.T) {
 			name:     "defaults",
 			args:     []string{"pane-1"},
 			wantPane: "pane-1",
-			wantOpts: waitIdleOptions{settle: DefaultVTIdleSettle, timeout: DefaultVTIdleTimeout},
+			wantOpts: waitIdleOptions{settle: config.VTIdleSettle, timeout: config.VTIdleTimeout},
 		},
 		{
 			name:     "custom settle and timeout",

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -23,9 +23,6 @@ const (
 	DefaultTermRows = 24
 )
 
-// DefaultIdleTimeout is how long a pane must be quiet before firing on-idle.
-const DefaultIdleTimeout = 2 * time.Second
-
 // DefaultOutputLines is how many lines `amux output` shows by default.
 const DefaultOutputLines = 50
 
@@ -140,7 +137,7 @@ func (s *Session) vtIdleSettle() time.Duration {
 	if s.VTIdleSettle != 0 {
 		return s.VTIdleSettle
 	}
-	return DefaultVTIdleSettle
+	return config.VTIdleSettle
 }
 
 func (s *Session) detectPaneCwdBranch(pane *mux.Pane) (cwd, branch string) {
@@ -153,14 +150,11 @@ func (s *Session) detectPaneCwdBranch(pane *mux.Pane) (cwd, branch string) {
 	return pane.DetectCwdBranch()
 }
 
-// DefaultUndoGracePeriod is how long a soft-closed pane stays undoable.
-const DefaultUndoGracePeriod = 30 * time.Second
-
 func (s *Session) undoGracePeriod() time.Duration {
 	if s.UndoGracePeriod != 0 {
 		return s.UndoGracePeriod
 	}
-	return DefaultUndoGracePeriod
+	return config.UndoGracePeriod
 }
 
 type captureTimingConfig struct {

--- a/test/events_test.go
+++ b/test/events_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/weill-labs/amux/internal/config"
 	"github.com/weill-labs/amux/internal/proto"
 	"github.com/weill-labs/amux/internal/server"
 )
@@ -32,7 +33,7 @@ func TestEventsInitialSnapshot(t *testing.T) {
 
 	// Wait for the pane to be idle before subscribing to the event stream.
 	// This ensures the idle state is established so the initial snapshot
-	// includes it — avoids waiting for DefaultIdleTimeout on slow CI.
+	// includes it — avoids waiting for config.VTIdleSettle on slow CI.
 	h.waitIdle("pane-1")
 
 	scanner, closer := eventStream(t, h.session)
@@ -135,7 +136,7 @@ func TestEventsIdleBusyTransition(t *testing.T) {
 	}
 
 	// Wait for idle timeout — should trigger idle transition
-	ev = mustReadEvent(t, scanner, server.DefaultIdleTimeout+3*time.Second)
+	ev = mustReadEvent(t, scanner, config.VTIdleSettle+3*time.Second)
 	if ev.Type != "idle" {
 		t.Errorf("after quiet: got %q, want idle", ev.Type)
 	}

--- a/test/idle_status_test.go
+++ b/test/idle_status_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/weill-labs/amux/internal/config"
 	"github.com/weill-labs/amux/internal/proto"
-	"github.com/weill-labs/amux/internal/server"
 )
 
 func TestIdleStatus_ShellAtPrompt(t *testing.T) {
@@ -184,7 +184,7 @@ func TestWaitIdle_TreatsQuietBusyPaneAsIdle(t *testing.T) {
 
 	h.startLongSleep("pane-1")
 
-	time.Sleep(server.DefaultIdleTimeout + time.Second)
+	time.Sleep(config.VTIdleSettle + time.Second)
 
 	out := h.runCmd("wait", "idle", "pane-1", "--timeout", "1s")
 	if strings.Contains(out, "timeout") || strings.Contains(out, "not found") {
@@ -200,7 +200,7 @@ func TestWaitExited_DoesNotTreatQuietBusyPaneAsExited(t *testing.T) {
 
 	h.startLongSleep("pane-1")
 
-	time.Sleep(server.DefaultIdleTimeout + time.Second)
+	time.Sleep(config.VTIdleSettle + time.Second)
 
 	out := h.runCmd("wait", "exited", "pane-1", "--timeout", "1s")
 	if !strings.Contains(out, "timeout") {


### PR DESCRIPTION
## Motivation

LAB-423 centralizes the default timing values that were still split across client and server packages. The current issue text was slightly stale: the old hook timeout no longer exists, and the old server idle timeout had already collapsed onto the VT-idle settle window, so this change consolidates the real current defaults without changing behavior.

## Summary

- add `internal/config/timing.go` as the single source of truth for shared default timing values
- update attach bootstrap, render-loop, wait-idle, and undo-grace call sites to read those defaults from `internal/config`
- update the affected tests to assert against the shared timing constants instead of package-local aliases

## Testing

```bash
env -u AMUX_SESSION -u TMUX go test ./internal/server -run '^TestParseWaitIdleArgs$' -count=100
```

```bash
env -u AMUX_SESSION -u TMUX go test ./test -run '^TestEventsIdleBusyTransition$' -count=100 -timeout 600s
```

```bash
env -u AMUX_SESSION -u TMUX go test ./test -run '^(TestWaitIdle_TreatsQuietBusyPaneAsIdle|TestWaitExited_DoesNotTreatQuietBusyPaneAsExited)$' -count=100 -timeout 900s
```

```bash
env -u AMUX_SESSION -u TMUX go test ./internal/config ./test -run '^(TestWaitIdle_TreatsQuietBusyPaneAsIdle|TestWaitExited_DoesNotTreatQuietBusyPaneAsExited|TestEventsIdleBusyTransition)$' -count=1 -timeout 300s
```

```bash
env -u AMUX_SESSION -u TMUX go test ./internal/client ./internal/server -timeout 300s
```

```bash
env -u AMUX_SESSION -u TMUX go test ./... -timeout 300s
```

## Review focus

- whether `internal/config/timing.go` now captures the right current default timing surface without reintroducing stale aliases
- whether using `config.VTIdleSettle` in the idle-status integration tests matches the real runtime behavior after the old server-local idle timeout alias disappeared
- whether any other shared timing defaults should move into this file now, or whether the remaining durations are intentionally package-local

Closes LAB-423
