### PR TITLE
Fix takeover-only pane transport wiring

### DIFF
--- a/internal/server/pane_transport.go
+++ b/internal/server/pane_transport.go
@@ -65,6 +65,9 @@ func (s *Session) configurePaneTransport(transport proto.PaneTransport, hostColo
 
 func (s *Session) configurePaneTakeover(transport PaneTakeoverTransport) {
 	s.remoteTakeover = transport
+	if paneTransport, ok := transport.(proto.PaneTransport); ok {
+		s.RemoteManager = paneTransport
+	}
 }
 
 func (s *Session) remotePaneColor(hostName string) string {

--- a/internal/server/pane_transport_test.go
+++ b/internal/server/pane_transport_test.go
@@ -63,3 +63,32 @@ func TestServerSetupPaneTransportInstallsTransportOnSessions(t *testing.T) {
 		t.Fatal("SetupPaneTransport should install the transport on the session")
 	}
 }
+
+func TestConfigurePaneTakeoverInstallsPaneTransportForProxyWrites(t *testing.T) {
+	t.Parallel()
+
+	_, sess, cleanup := newCommandTestSession(t)
+	defer cleanup()
+
+	transport := &stubPaneTransport{}
+	sess.configurePaneTakeover(transport)
+
+	if sess.RemoteManager != transport {
+		t.Fatal("configurePaneTakeover should install takeover transports that also satisfy PaneTransport")
+	}
+
+	n, err := sess.remoteWriteOverride(42)([]byte("pwd\n"))
+	if err != nil {
+		t.Fatalf("remoteWriteOverride: %v", err)
+	}
+	if n != len("pwd\n") {
+		t.Fatalf("remoteWriteOverride wrote %d bytes, want %d", n, len("pwd\n"))
+	}
+	if len(transport.sendInputCalls) != 1 {
+		t.Fatalf("SendInput calls = %d, want 1", len(transport.sendInputCalls))
+	}
+	call := transport.sendInputCalls[0]
+	if call.localPaneID != 42 || string(call.data) != "pwd\n" {
+		t.Fatalf("SendInput call = %+v, want pane 42 with pwd input", call)
+	}
+}

--- a/internal/server/pane_transport_test_helpers_test.go
+++ b/internal/server/pane_transport_test_helpers_test.go
@@ -11,6 +11,7 @@ type stubPaneTransport struct {
 	createPaneErr    error
 	createPaneRemote uint32
 	createPaneCalls  []createPaneCall
+	sendInputCalls   []sendInputCall
 	sendInputErr     error
 	sendResizeErr    error
 	killPaneErr      error
@@ -31,6 +32,11 @@ type createPaneCall struct {
 	sessionName string
 }
 
+type sendInputCall struct {
+	localPaneID uint32
+	data        []byte
+}
+
 type attachForTakeoverCall struct {
 	hostName    string
 	sshAddr     string
@@ -46,7 +52,17 @@ type deployCall struct {
 	sshUser  string
 }
 
-func (s *stubPaneTransport) SendInput(uint32, []byte) error {
+type stubTakeoverOnlyTransport struct {
+	attachErr   error
+	attachCalls []attachForTakeoverCall
+	deployCalls []deployCall
+}
+
+func (s *stubPaneTransport) SendInput(localPaneID uint32, data []byte) error {
+	s.sendInputCalls = append(s.sendInputCalls, sendInputCall{
+		localPaneID: localPaneID,
+		data:        append([]byte(nil), data...),
+	})
 	return s.sendInputErr
 }
 
@@ -143,6 +159,30 @@ func (s *stubPaneTransport) AttachForTakeover(hostName, sshAddr, sshUser, remote
 }
 
 func (s *stubPaneTransport) DeployToAddress(hostName, sshAddr, sshUser string) {
+	s.deployCalls = append(s.deployCalls, deployCall{
+		hostName: hostName,
+		sshAddr:  sshAddr,
+		sshUser:  sshUser,
+	})
+}
+
+func (s *stubTakeoverOnlyTransport) AttachForTakeover(hostName, sshAddr, sshUser, remoteUID, sessionName string, paneMappings map[uint32]uint32) error {
+	copied := make(map[uint32]uint32, len(paneMappings))
+	for localPaneID, remotePaneID := range paneMappings {
+		copied[localPaneID] = remotePaneID
+	}
+	s.attachCalls = append(s.attachCalls, attachForTakeoverCall{
+		hostName:    hostName,
+		sshAddr:     sshAddr,
+		sshUser:     sshUser,
+		remoteUID:   remoteUID,
+		sessionName: sessionName,
+		paneMap:     copied,
+	})
+	return s.attachErr
+}
+
+func (s *stubTakeoverOnlyTransport) DeployToAddress(hostName, sshAddr, sshUser string) {
 	s.deployCalls = append(s.deployCalls, deployCall{
 		hostName: hostName,
 		sshAddr:  sshAddr,

--- a/internal/server/session_remote.go
+++ b/internal/server/session_remote.go
@@ -151,7 +151,7 @@ func (s *Session) handleTakeover(sshPaneID uint32, req mux.TakeoverRequest) {
 		failTakeover(err)
 		return
 	}
-	if needsInitialResize && len(proxyPanes) > 0 {
+	if needsInitialResize && len(proxyPanes) > 0 && s.RemoteManager != nil {
 		_ = s.RemoteManager.SendResize(proxyPanes[0].ID, layout.cols, mux.PaneContentHeight(layout.cellH))
 	}
 

--- a/internal/server/session_remote_low_coverage_test.go
+++ b/internal/server/session_remote_low_coverage_test.go
@@ -246,6 +246,84 @@ func TestHandleTakeoverFailureWithoutRemoteManager(t *testing.T) {
 	}
 }
 
+func TestHandleTakeoverSkipsInitialResizeWithoutRemoteManager(t *testing.T) {
+	t.Parallel()
+
+	_, sess, cleanup := newCommandTestSession(t)
+	defer cleanup()
+
+	var writes lockedBuffer
+	sshPane := newRecordingPane(sess, 1, "ssh-pane", &writes)
+	window := newTestWindowWithPanes(t, sess, 1, "main", sshPane)
+	setSessionLayoutForTest(t, sess, window.ID, []*mux.Window{window}, sshPane)
+	sess.counter.Store(sshPane.ID)
+
+	transport := &stubTakeoverOnlyTransport{}
+	sess.configurePaneTakeover(transport)
+
+	req := mux.TakeoverRequest{
+		Host:       "gpu-box",
+		SSHAddress: "127.0.0.1:22",
+		SSHUser:    "carol",
+		UID:        "remote-uid",
+	}
+
+	sess.handleTakeover(sshPane.ID, req)
+
+	wantAck := mux.FormatTakeoverAck(managedSessionName(sess.Name)) + "\n"
+	if got := writes.String(); got != wantAck {
+		t.Fatalf("takeover ack = %q, want %q", got, wantAck)
+	}
+	if len(transport.attachCalls) != 1 {
+		t.Fatalf("AttachForTakeover calls = %d, want 1", len(transport.attachCalls))
+	}
+	attachCall := transport.attachCalls[0]
+	if attachCall.hostName != "gpu-box" || attachCall.sshAddr != "127.0.0.1:22" || attachCall.sshUser != "carol" {
+		t.Fatalf("AttachForTakeover call = %+v, want gpu-box 127.0.0.1:22 carol", attachCall)
+	}
+	if len(attachCall.paneMap) != 1 {
+		t.Fatalf("AttachForTakeover pane map = %#v, want one proxy pane", attachCall.paneMap)
+	}
+
+	state := mustSessionQuery(t, sess, func(sess *Session) struct {
+		notice         string
+		sshDormant     bool
+		proxyPresent   bool
+		proxyConnState string
+	} {
+		ssh := sess.findPaneByID(sshPane.ID)
+		proxy := sess.findPaneByID(sshPane.ID + 1)
+		return struct {
+			notice         string
+			sshDormant     bool
+			proxyPresent   bool
+			proxyConnState string
+		}{
+			notice:       sess.notice,
+			sshDormant:   ssh != nil && ssh.Meta.Dormant,
+			proxyPresent: proxy != nil && sess.activeWindow().Root.FindPane(proxy.ID) != nil,
+			proxyConnState: func() string {
+				if proxy == nil {
+					return ""
+				}
+				return proxy.Meta.Remote
+			}(),
+		}
+	})
+	if state.notice != "" {
+		t.Fatalf("session notice = %q, want empty", state.notice)
+	}
+	if !state.sshDormant {
+		t.Fatal("ssh pane should be marked dormant after successful takeover")
+	}
+	if !state.proxyPresent {
+		t.Fatal("proxy pane should be inserted into the layout")
+	}
+	if state.proxyConnState != string(proto.Connected) {
+		t.Fatalf("proxy remote state = %q, want %q", state.proxyConnState, proto.Connected)
+	}
+}
+
 func TestPrepareRemotePaneAndInsertPreparedPane(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Motivation
PR #550 landed the pane transport boundary, but takeover-only sessions kept two regressions: the initial resize path could dereference a nil `RemoteManager`, and proxy pane input was silently dropped because takeover-only setup never installed a write-capable transport.

## Summary
- add a nil guard before takeover's initial `SendResize` call
- teach `configurePaneTakeover` to install `RemoteManager` when the takeover transport also satisfies `proto.PaneTransport`
- add regression coverage for the takeover-only resize path and proxy-pane write routing

## Testing
- `env -u AMUX_SESSION -u TMUX go test ./internal/server -run 'TestHandleTakeoverFailureWithoutRemoteManager|TestHandleTakeoverSkipsInitialResizeWithoutRemoteManager|TestPrepareRemotePaneUsesConfiguredTransportHostColor|TestServerSetupPaneTransportInstallsTransportOnSessions|TestConfigurePaneTakeoverInstallsPaneTransportForProxyWrites|TestServerHandleConnAndSetupPaneTransport' -count=100`
- `env -u AMUX_SESSION -u TMUX go test ./... -timeout 120s`
- `scripts/push-and-watch-ci.sh -u origin HEAD`

## Review focus
- confirm the takeover-only path now leaves `RemoteManager` nil-safe without changing the normal remote-host path
- verify the new tests cover both the resize regression and the proxy input regression with the smallest possible transport stubs

Follow-up to #550.
