### PR TITLE
Coalesce queued mouse drag motion events

### DIFF
--- a/internal/client/attach.go
+++ b/internal/client/attach.go
@@ -96,6 +96,13 @@ func dragMotionCoalescingActive(drag *dragState) bool {
 	return drag.Active || drag.PaneDragActive || drag.CopyModePaneID != 0
 }
 
+func shouldBatchQueuedMouseInput(raw []byte, parser *mouse.Parser, drag *dragState) bool {
+	if dragMotionCoalescingActive(drag) {
+		return true
+	}
+	return parser != nil && parser.InputLooksLikeMouse(raw)
+}
+
 func drainQueuedStdinChunks(first []byte, stdinCh <-chan []byte) (chunks [][]byte, closed bool) {
 	chunks = [][]byte{first}
 	for {
@@ -1098,7 +1105,7 @@ func RunSession(sessionName string, getTermSize func(int) (int, int, error)) err
 				cr.SetInputIdle(true)
 				continue
 			}
-			if localInput && dragMotionCoalescingActive(&drag) {
+			if localInput && shouldBatchQueuedMouseInput(raw, mouseParser, &drag) {
 				var chunks [][]byte
 				chunks, stdinClosed = drainQueuedStdinChunks(raw, stdinCh)
 				shouldExit = dispatchQueuedMouseInputChunks(

--- a/internal/client/attach_test.go
+++ b/internal/client/attach_test.go
@@ -319,3 +319,45 @@ func TestDispatchQueuedMouseInputChunksKeepsAllMotionsOutsideDrag(t *testing.T) 
 		t.Fatalf("mouse events = %d, want 4 when drag coalescing is disabled", len(got))
 	}
 }
+
+func TestShouldBatchQueuedMouseInput(t *testing.T) {
+	t.Parallel()
+
+	parser := &mouse.Parser{}
+	mousePress := []byte(ansi.MouseSgr(0, 10, 0, false))
+
+	tests := []struct {
+		name string
+		raw  []byte
+		drag dragState
+		want bool
+	}{
+		{
+			name: "drag already active keeps batching non-mouse reads",
+			raw:  []byte("k"),
+			drag: dragState{Active: true},
+			want: true,
+		},
+		{
+			name: "mouse-looking read batches before drag state flips",
+			raw:  mousePress,
+			want: true,
+		},
+		{
+			name: "plain key input does not batch when idle",
+			raw:  []byte("k"),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := shouldBatchQueuedMouseInput(tt.raw, parser, &tt.drag); got != tt.want {
+				t.Fatalf("shouldBatchQueuedMouseInput(%q) = %v, want %v", tt.raw, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Motivation
During pane drags over higher-latency links, the client can queue multiple mouse motion events while one frame is still in flight. Processing every queued motion sequentially makes the overlay lag even though only the final cursor position matters.

## Summary
- coalesce consecutive queued `mouse.Motion` events while a local drag interaction is active
- preserve `Press` and `Release` events so drag start and completion semantics do not change
- keep the coalescing in the client attach loop, where mouse drag state is still structured, instead of the server input path that only sees pane input bytes
- add red tests that verify consecutive drag motions collapse to the final position and that non-drag motion streams still pass through unchanged

## Testing
```bash
go test ./internal/client -run 'TestDispatchQueuedMouseInputChunks(CoalescesConsecutiveDragMotions|KeepsAllMotionsOutsideDrag)'
go test ./internal/client -run 'TestDispatchQueuedMouseInputChunks(CoalescesConsecutiveDragMotions|KeepsAllMotionsOutsideDrag)' -count=100
go test ./internal/client
go test ./test -run 'TestMouse(BorderDrag|HorizontalBorderDrag|StatusLineDragSwapsPanes|StatusLineDragShowsPlaceholderOverlay|StatusLineDragSplitsTargetPaneAtNearestEdge|DragCopiesSelectionInCopyMode|DragAutomaticallyEntersCopyModeAndCopiesSelection)' -timeout 120s
```

## Review focus
- the attach-loop coalescing only activates for active drag interactions and should leave non-drag input semantics unchanged
- the retained motion event rewrites `LastX`/`LastY` to the start of the coalesced run so border resize deltas and drag overlays still see the full movement
- the per-read mouse parser flush behavior is preserved so standalone `Esc` handling does not regress

Closes LAB-685
