### PR TITLE
Strip TERM_PROGRAM from pane environment to fix TUI rendering corruption

### DIFF
--- a/internal/mux/pane.go
+++ b/internal/mux/pane.go
@@ -209,6 +209,13 @@ func paneCommandEnvWithProfile(base []string, paneID uint32, sessionName, colorP
 		case "TERM", "AMUX_PANE", "AMUX_SESSION", termprofile.EnvKey:
 			// amux owns these values for pane shells.
 			continue
+		case "TERM_PROGRAM", "TERM_PROGRAM_VERSION":
+			// These identify the outer terminal (e.g. Ghostty, iTerm).
+			// Inside amux the terminal emulator is the vt library, not the
+			// outer app. Propagating these causes TUI apps to enable
+			// features (like DEC 2026 synchronized output) that amux's
+			// emulator does not implement, leading to rendering corruption.
+			continue
 		case "NO_COLOR", "CODEX_CI":
 			// These are launcher-context flags. Passing them through to an
 			// interactive pane makes nested tools like Codex suppress ANSI.

--- a/internal/mux/pane_env_test.go
+++ b/internal/mux/pane_env_test.go
@@ -38,3 +38,24 @@ func TestPaneCommandEnvOverridesInheritedAmuxVars(t *testing.T) {
 		}
 	}
 }
+
+func TestPaneCommandEnvStripsOuterTerminalVars(t *testing.T) {
+	t.Parallel()
+
+	env := paneCommandEnv([]string{
+		"PATH=/usr/bin:/bin",
+		"TERM=xterm-ghostty",
+		"TERM_PROGRAM=ghostty",
+		"TERM_PROGRAM_VERSION=1.5.0",
+	}, 1, "default")
+
+	stripped := []string{"TERM_PROGRAM", "TERM_PROGRAM_VERSION"}
+	for _, key := range stripped {
+		prefix := key + "="
+		for _, entry := range env {
+			if strings.HasPrefix(entry, prefix) {
+				t.Fatalf("%s should be stripped but found: %s", key, entry)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Motivation

When TUI apps (e.g. Claude Code) run inside amux panes, they inherit `TERM_PROGRAM=ghostty` (or whatever the outer terminal is) from the parent environment. This causes false DEC 2026 (synchronized output) detection — the app thinks BSU/ESU wrapping makes frame writes atomic, but amux's vt emulator stores the mode flag without implementing actual synchronized output buffering.

The result is garbled rendering where content from different TUI frames merges onto the same line, because DECSTBM hardware scroll optimization fires without the atomicity guarantee it requires.

## Summary

- Strip `TERM_PROGRAM` and `TERM_PROGRAM_VERSION` from the pane environment in `paneCommandEnvWithProfile()`, alongside the existing `TERM` stripping
- Add test coverage verifying both vars are stripped

This is the same pattern as tmux: multiplexers should only advertise their own capabilities, not the outer terminal's.

## Testing

```bash
go test ./internal/mux/ -run TestPaneCommandEnv -v -count=100
```

## Review focus

- The comment explains *why* these vars are stripped — the DEC 2026 / DECSTBM connection is non-obvious
- Future work: implement actual DEC 2026 buffering in the vt emulator, which would allow re-enabling these optimizations

Closes LAB-684