### PR TITLE
Prevent harness capture subprocesses from wedging on timeout

### DIFF
--- a/test/server_harness_test.go
+++ b/test/server_harness_test.go
@@ -61,6 +61,8 @@ var harnessBlockedEnvKeys = map[string]struct{}{
 	"TMUX":         {},
 }
 
+const harnessCommandWaitDelay = 250 * time.Millisecond
+
 // newServerHarnessWithSize starts a server harness with a custom terminal size.
 func newServerHarnessWithSize(tb testing.TB, cols, rows int) *ServerHarness {
 	return newServerHarnessWithConfig(tb, cols, rows, "")
@@ -457,6 +459,14 @@ func (h *ServerHarness) commandWithContext(ctx context.Context, args ...string) 
 	}
 	env = appendHarnessExtraEnv(env, h.extraEnv)
 	cmd.Env = env
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.Setpgid = true
+	cmd.WaitDelay = harnessCommandWaitDelay
+	cmd.Cancel = func() error {
+		return killCmdProcessGroup(cmd)
+	}
 	return cmd
 }
 


### PR DESCRIPTION
## Motivation
`TestFocusByName` occasionally hangs on Linux CI while `captureJSON()` waits for `amux capture --format json` to exit. The server-side capture path is already bounded, but the harness CLI subprocesses were still using the default `os/exec` cancellation behavior, which risks wedging `Wait` when a timed-out subprocess leaves descendants behind.

## Summary
- add a regression test that asserts `commandWithContext` configures timed CLI subprocesses with process-group cancellation and a non-zero `WaitDelay`
- run harness CLI subprocesses in their own process group so timeout cancellation can kill the whole subprocess tree
- set a bounded `WaitDelay` on harness CLI subprocesses so timed-out commands cannot wedge `Wait`

## Testing
- `env -u AMUX_SESSION -u TMUX go test ./test/ -run TestCommandWithContextSetsProcessGroupKillAndWaitDelay -count=100`
- `env -u AMUX_SESSION -u TMUX go test ./test/ -run TestFocusByName -count=100 -timeout 120s`
- `env -u AMUX_SESSION -u TMUX go test ./test/ -run 'Test(Focus|Debug)' -count=1`

## Review Focus
- `commandWithContext` now configures every short-lived harness CLI subprocess with `Setpgid`, `WaitDelay`, and a process-group `Cancel`; check that this scope is tight enough for the flaky capture path without changing unrelated server behavior.
- I inspected the server capture/snapshot path and did not find an unbounded wait there: attach retries are capped and `runClientCaptureRequest` already times out after `captureResponseTimeout`, so this PR intentionally keeps the fix in the harness subprocess path.

Closes LAB-749
