### PR TITLE
Track .orca directory, ignore clone pool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,5 +34,8 @@ merged-coverage.txt
 unit-coverage.txt
 tmux-src/
 
+# orca clone pool (large, machine-local)
+.orca/pool/
+
 # Firebase MCP plugin debug log (written to CWD on session start)
 firebase-debug.log


### PR DESCRIPTION
## Summary
- Track `.orca/` so orca config and state files are version-controlled
- Ignore `.orca/pool/` which contains full git clones (machine-local, large)

## Testing
- `git status` confirms `.orca/pool/` is ignored, `.orca/` itself is tracked

🤖 Generated with [Claude Code](https://claude.com/claude-code)