### PR TITLE
Bump vt fork for incremental draw fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -49,4 +49,4 @@ require (
 
 replace github.com/charmbracelet/ultraviolet => github.com/weill-labs/ultraviolet v0.0.0-20260404003102-9344cbfc286f
 
-replace github.com/charmbracelet/x/vt => github.com/weill-labs/x/vt v0.0.0-20260403023638-cf27de05135b
+replace github.com/charmbracelet/x/vt => github.com/weill-labs/x/vt v0.0.0-20260405171640-a431c2ea2459

--- a/go.sum
+++ b/go.sum
@@ -74,6 +74,8 @@ github.com/weill-labs/ultraviolet v0.0.0-20260404003102-9344cbfc286f h1:JMTFuQ/0
 github.com/weill-labs/ultraviolet v0.0.0-20260404003102-9344cbfc286f/go.mod h1:Vo8TffMf0q7Uho/n8e6XpBZvOWtd3g39yX+9P5rRutA=
 github.com/weill-labs/x/vt v0.0.0-20260403023638-cf27de05135b h1:4kqqzRMI8ppJ1Iq/NPh73B/T5I4WZNqLqWvPiKPqvag=
 github.com/weill-labs/x/vt v0.0.0-20260403023638-cf27de05135b/go.mod h1:2djWW5EeP5QlpztEYYbbyyzUyyxVD71mWVQguNISHcM=
+github.com/weill-labs/x/vt v0.0.0-20260405171640-a431c2ea2459 h1:TubqLfeuy0VvLVKOUoWLrDjgDGJX1VqDcJOV6RjnGE4=
+github.com/weill-labs/x/vt v0.0.0-20260405171640-a431c2ea2459/go.mod h1:2djWW5EeP5QlpztEYYbbyyzUyyxVD71mWVQguNISHcM=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJuqunuUZ/Dhy/avygyECGrLceyNeo4LiM=
 golang.org/x/crypto v0.49.0 h1:+Ng2ULVvLHnJ/ZFEq4KdcDd/cfjrrjjNSXNzxg0Y4U4=


### PR DESCRIPTION
## Motivation

LAB-717 is fixed in the vt fork, but amux still pointed at the older vt pseudo-version. This PR pulls in the redraw fix so incremental pane draws stop paying the old full-slice damage scan and `FillArea` pass.

## Summary

- bump the `github.com/charmbracelet/x/vt` replace to `github.com/weill-labs/x/vt v0.0.0-20260405171640-a431c2ea2459`
- pull in the vt redraw changes from https://github.com/weill-labs/x/pull/6
- refresh `go.sum` for the new vt fork commit

## Testing

```bash
env -u AMUX_SESSION -u TMUX go test ./internal/mux -run 'TestVTEmulator|TestRenderWithCursor|TestHasCursorBlock'
env -u AMUX_SESSION -u TMUX go test ./... -timeout 120s
env -u AMUX_SESSION -u TMUX go test ./test -run 'TestSendKeysEncodeParityMatrix/backspace_alias' -count=3
env -u AMUX_SESSION -u TMUX go test ./test -run 'TestFocusNavigationThreePanes' -count=3
```

The full `go test ./...` run hit unrelated `test/` integration flakes in `TestSendKeysEncodeParityMatrix/backspace_alias` and `TestFocusNavigationThreePanes`; both passed on targeted reruns with `-count=3`.

## Review focus

- the amux diff is only the vt pin; the substantive code review is the dependent vt PR: https://github.com/weill-labs/x/pull/6
- whether the new vt pseudo-version is the right dependency point for LAB-717 without pulling in unrelated fork changes

Closes LAB-717
