### PR TITLE
Extract crash checkpoint coordination from Session

### DIFF
--- a/internal/server/checkpoint_coordinator.go
+++ b/internal/server/checkpoint_coordinator.go
@@ -1,0 +1,270 @@
+package server
+
+import (
+	"os"
+	"time"
+
+	"github.com/weill-labs/amux/internal/checkpoint"
+)
+
+const (
+	defaultCheckpointDebounce = 500 * time.Millisecond
+	defaultCheckpointPeriodic = 30 * time.Second
+)
+
+type crashCheckpointCoordinator interface {
+	Trigger()
+	Stop()
+	Write()
+	WriteNow() (string, error)
+}
+
+type CheckpointCoordinatorConfig struct {
+	Clock                   Clock
+	Debounce                time.Duration
+	Periodic                time.Duration
+	SessionName             func() string
+	SessionStart            func() time.Time
+	BuildCrashCheckpoint    func() *checkpoint.CrashCheckpoint
+	IsShuttingDown          func() bool
+	OnCheckpointWritten     func(string)
+	LogCheckpointWrite      func(string, time.Duration, error)
+	LogDirectoryUnavailable func(error)
+	WriteCrash              func(*checkpoint.CrashCheckpoint, string, time.Time) error
+	MkdirAll                func(string, os.FileMode) error
+}
+
+// CheckpointCoordinator owns crash checkpoint scheduling and file writes for a session.
+type CheckpointCoordinator struct {
+	clock                   Clock
+	debounce                time.Duration
+	periodic                time.Duration
+	sessionName             func() string
+	sessionStart            func() time.Time
+	buildCrashCheckpoint    func() *checkpoint.CrashCheckpoint
+	isShuttingDown          func() bool
+	onCheckpointWritten     func(string)
+	logCheckpointWrite      func(string, time.Duration, error)
+	logDirectoryUnavailable func(error)
+	writeCrash              func(*checkpoint.CrashCheckpoint, string, time.Time) error
+	mkdirAll                func(string, os.FileMode) error
+	trigger                 chan struct{}
+	stop                    chan struct{}
+	done                    chan struct{}
+}
+
+func NewCheckpointCoordinator(cfg CheckpointCoordinatorConfig) *CheckpointCoordinator {
+	coord := &CheckpointCoordinator{
+		clock:                   cfg.Clock,
+		debounce:                cfg.Debounce,
+		periodic:                cfg.Periodic,
+		sessionName:             cfg.SessionName,
+		sessionStart:            cfg.SessionStart,
+		buildCrashCheckpoint:    cfg.BuildCrashCheckpoint,
+		isShuttingDown:          cfg.IsShuttingDown,
+		onCheckpointWritten:     cfg.OnCheckpointWritten,
+		logCheckpointWrite:      cfg.LogCheckpointWrite,
+		logDirectoryUnavailable: cfg.LogDirectoryUnavailable,
+		writeCrash:              cfg.WriteCrash,
+		mkdirAll:                cfg.MkdirAll,
+		trigger:                 make(chan struct{}, 1),
+		stop:                    make(chan struct{}),
+		done:                    make(chan struct{}),
+	}
+	if coord.clock == nil {
+		coord.clock = RealClock{}
+	}
+	if coord.debounce == 0 {
+		coord.debounce = defaultCheckpointDebounce
+	}
+	if coord.periodic == 0 {
+		coord.periodic = defaultCheckpointPeriodic
+	}
+	if coord.sessionName == nil {
+		coord.sessionName = func() string { return "" }
+	}
+	if coord.sessionStart == nil {
+		coord.sessionStart = func() time.Time { return time.Time{} }
+	}
+	if coord.buildCrashCheckpoint == nil {
+		coord.buildCrashCheckpoint = func() *checkpoint.CrashCheckpoint { return nil }
+	}
+	if coord.isShuttingDown == nil {
+		coord.isShuttingDown = func() bool { return false }
+	}
+	if coord.onCheckpointWritten == nil {
+		coord.onCheckpointWritten = func(string) {}
+	}
+	if coord.logCheckpointWrite == nil {
+		coord.logCheckpointWrite = func(string, time.Duration, error) {}
+	}
+	if coord.logDirectoryUnavailable == nil {
+		coord.logDirectoryUnavailable = func(error) {}
+	}
+	if coord.writeCrash == nil {
+		coord.writeCrash = checkpoint.WriteCrash
+	}
+	if coord.mkdirAll == nil {
+		coord.mkdirAll = os.MkdirAll
+	}
+
+	coord.ensureCheckpointDir()
+	go coord.loop()
+	return coord
+}
+
+func (c *CheckpointCoordinator) ensureCheckpointDir() {
+	if err := c.mkdirAll(checkpoint.CrashCheckpointDir(), 0700); err != nil {
+		c.logDirectoryUnavailable(err)
+	}
+}
+
+func (c *CheckpointCoordinator) Trigger() {
+	if c == nil {
+		return
+	}
+	select {
+	case c.trigger <- struct{}{}:
+	default:
+	}
+}
+
+func (c *CheckpointCoordinator) Stop() {
+	if c == nil || c.stop == nil || c.done == nil {
+		return
+	}
+	select {
+	case <-c.done:
+		return
+	default:
+	}
+	close(c.stop)
+	<-c.done
+}
+
+func (c *CheckpointCoordinator) loop() {
+	defer close(c.done)
+
+	var debounceTimer Timer
+	var debounceC <-chan time.Time
+	periodicTimer := c.clock.NewTimer(c.periodic)
+	defer stopTimer(periodicTimer)
+
+	for {
+		select {
+		case <-c.stop:
+			if debounceTimer != nil {
+				stopTimer(debounceTimer)
+			}
+			return
+		case <-c.trigger:
+			drainCheckpointTriggers(c.trigger)
+			if debounceTimer == nil {
+				debounceTimer = c.clock.NewTimer(c.debounce)
+			} else {
+				resetTimer(debounceTimer, c.debounce)
+			}
+			debounceC = debounceTimer.C()
+		case <-debounceC:
+			c.Write()
+			debounceC = nil
+		case <-periodicTimer.C():
+			c.Write()
+			periodicTimer.Reset(c.periodic)
+		}
+	}
+}
+
+func drainCheckpointTriggers(trigger <-chan struct{}) {
+	for {
+		select {
+		case <-trigger:
+		default:
+			return
+		}
+	}
+}
+
+func (c *CheckpointCoordinator) Write() {
+	if c == nil || c.isShuttingDown() {
+		return
+	}
+	_, _ = c.WriteNow()
+}
+
+func (c *CheckpointCoordinator) WriteNow() (string, error) {
+	if c == nil {
+		return "", nil
+	}
+
+	started := c.clock.Now()
+	cp := c.buildCrashCheckpoint()
+	if cp == nil {
+		return "", nil
+	}
+
+	sessionName := c.sessionName()
+	startTime := c.sessionStart()
+	path := checkpoint.CrashCheckpointPathTimestamped(sessionName, startTime)
+	if err := c.writeCrash(cp, sessionName, startTime); err != nil {
+		c.logCheckpointWrite(path, c.clock.Now().Sub(started), err)
+		return "", err
+	}
+	c.onCheckpointWritten(path)
+	c.logCheckpointWrite(path, c.clock.Now().Sub(started), nil)
+	return path, nil
+}
+
+func newSessionCheckpointCoordinator(sess *Session) crashCheckpointCoordinator {
+	if sess == nil {
+		return nil
+	}
+	return NewCheckpointCoordinator(CheckpointCoordinatorConfig{
+		Clock:                sess.clock(),
+		SessionName:          func() string { return sess.Name },
+		SessionStart:         func() time.Time { return sess.startedAt },
+		BuildCrashCheckpoint: sess.buildCrashCheckpoint,
+		IsShuttingDown:       func() bool { return sess.shutdown.Load() },
+		OnCheckpointWritten: func(path string) {
+			sess.enqueueEvent(crashCheckpointWrittenEvent{path: path})
+		},
+		LogCheckpointWrite: func(path string, duration time.Duration, err error) {
+			sess.logCheckpointWrite("crash", path, duration, err)
+		},
+		LogDirectoryUnavailable: func(err error) {
+			sess.logger.Warn("crash checkpoint dir unavailable",
+				"event", "checkpoint_write",
+				"checkpoint_kind", "crash",
+				"error", err,
+			)
+		},
+	})
+}
+
+func (s *Session) triggerCrashCheckpoint() {
+	if s == nil || s.checkpointCoordinator == nil {
+		return
+	}
+	s.checkpointCoordinator.Trigger()
+}
+
+func (s *Session) stopCrashCheckpointLoop() {
+	if s == nil || s.checkpointCoordinator == nil {
+		return
+	}
+	s.checkpointCoordinator.Stop()
+}
+
+func (s *Session) writeCrashCheckpointNow() (string, error) {
+	if s == nil || s.checkpointCoordinator == nil {
+		return "", nil
+	}
+	return s.checkpointCoordinator.WriteNow()
+}
+
+func (s *Session) writeCrashCheckpoint() {
+	if s == nil || s.checkpointCoordinator == nil {
+		return
+	}
+	s.checkpointCoordinator.Write()
+}

--- a/internal/server/checkpoint_coordinator_test.go
+++ b/internal/server/checkpoint_coordinator_test.go
@@ -46,12 +46,12 @@ func TestCheckpointCoordinatorTriggerDebouncesWrites(t *testing.T) {
 	})
 	defer coord.Stop()
 
+	clock.AwaitTimers(1)
+
+	coord.Trigger()
+	coord.Trigger()
+
 	clock.AwaitTimers(2)
-
-	coord.Trigger()
-	coord.Trigger()
-
-	clock.AwaitTimers(3)
 	clock.Advance(499 * time.Millisecond)
 
 	select {
@@ -98,14 +98,14 @@ func TestCheckpointCoordinatorWritesPeriodically(t *testing.T) {
 	})
 	defer coord.Stop()
 
-	clock.AwaitTimers(2)
+	clock.AwaitTimers(1)
 
 	clock.Advance(30 * time.Second)
 	if got := awaitCheckpointWrite(t, writes); got != "periodic-session" {
 		t.Fatalf("first periodic checkpoint session = %q, want periodic-session", got)
 	}
 
-	clock.AwaitTimers(3)
+	clock.AwaitTimers(2)
 	clock.Advance(30 * time.Second)
 	if got := awaitCheckpointWrite(t, writes); got != "periodic-session" {
 		t.Fatalf("second periodic checkpoint session = %q, want periodic-session", got)
@@ -192,9 +192,9 @@ func TestCheckpointCoordinatorWriteSkipsWhenShuttingDown(t *testing.T) {
 	t.Parallel()
 
 	coord := NewCheckpointCoordinator(CheckpointCoordinatorConfig{
-		SessionName:     func() string { return "shutdown-session" },
-		SessionStart:    func() time.Time { return time.Date(2026, time.April, 5, 11, 0, 0, 0, time.UTC) },
-		IsShuttingDown:  func() bool { return true },
+		SessionName:    func() string { return "shutdown-session" },
+		SessionStart:   func() time.Time { return time.Date(2026, time.April, 5, 11, 0, 0, 0, time.UTC) },
+		IsShuttingDown: func() bool { return true },
 		BuildCrashCheckpoint: func() *checkpoint.CrashCheckpoint {
 			t.Fatal("BuildCrashCheckpoint called while shutting down")
 			return nil
@@ -232,7 +232,7 @@ func TestCheckpointCoordinatorStopPreventsFutureWrites(t *testing.T) {
 		},
 	})
 
-	clock.AwaitTimers(2)
+	clock.AwaitTimers(1)
 	coord.Stop()
 	coord.Stop()
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -106,11 +106,8 @@ type Session struct {
 	// The event loop owns the single in-flight request and queued requests.
 	capture *captureForwarder
 
-	// Crash checkpoint — non-blocking trigger from broadcastLayout().
-	// The crashCheckpointLoop goroutine debounces and writes periodically.
-	crashCheckpointTrigger chan struct{}
-	crashCheckpointStop    chan struct{}
-	crashCheckpointDone    chan struct{} // closed when loop exits
+	// Crash checkpoint coordination owns debounce/periodic scheduling and disk writes.
+	checkpointCoordinator crashCheckpointCoordinator
 
 	// Async session event loop — phase 1 serializes callback-driven writes.
 	sessionEvents    chan sessionEvent
@@ -327,95 +324,6 @@ func (s *Session) buildCrashCheckpoint() *checkpoint.CrashCheckpoint {
 	return snap.cp
 }
 
-// startCrashCheckpointLoop starts the background goroutine that writes crash
-// checkpoints on layout and pane-output changes (debounced 500ms) and periodic
-// full snapshots (every 30s).
-func (s *Session) startCrashCheckpointLoop() {
-	// Ensure the checkpoint directory exists before tests or tooling watch it.
-	// Writes still happen lazily on layout changes.
-	if err := os.MkdirAll(checkpoint.CrashCheckpointDir(), 0700); err != nil {
-		s.logger.Warn("crash checkpoint dir unavailable",
-			"event", "checkpoint_write",
-			"checkpoint_kind", "crash",
-			"error", err,
-		)
-	}
-	s.crashCheckpointTrigger = make(chan struct{}, 1)
-	s.crashCheckpointStop = make(chan struct{})
-	s.crashCheckpointDone = make(chan struct{})
-	go s.crashCheckpointLoop()
-}
-
-func (s *Session) stopCrashCheckpointLoop() {
-	if s.crashCheckpointStop == nil || s.crashCheckpointDone == nil {
-		return
-	}
-	select {
-	case <-s.crashCheckpointDone:
-		return
-	default:
-	}
-	close(s.crashCheckpointStop)
-	<-s.crashCheckpointDone
-}
-
-// crashCheckpointLoop debounces checkpoint triggers and writes crash
-// checkpoints periodically. Runs until crashCheckpointStop is closed.
-func (s *Session) crashCheckpointLoop() {
-	defer close(s.crashCheckpointDone)
-
-	const debounce = 500 * time.Millisecond
-	const periodic = 30 * time.Second
-
-	debounceTimer := time.NewTimer(debounce)
-	debounceTimer.Stop()
-	periodicTicker := time.NewTicker(periodic)
-	defer periodicTicker.Stop()
-
-	for {
-		select {
-		case <-s.crashCheckpointStop:
-			debounceTimer.Stop()
-			return
-
-		case <-s.crashCheckpointTrigger:
-			// Layout changed — debounce before writing
-			debounceTimer.Reset(debounce)
-
-		case <-debounceTimer.C:
-			s.writeCrashCheckpoint()
-
-		case <-periodicTicker.C:
-			s.writeCrashCheckpoint()
-		}
-	}
-}
-
-func (s *Session) writeCrashCheckpointNow() (string, error) {
-	started := time.Now()
-	cp := s.buildCrashCheckpoint()
-	if cp == nil {
-		return "", nil
-	}
-	path := checkpoint.CrashCheckpointPathTimestamped(s.Name, s.startedAt)
-	if err := checkpoint.WriteCrash(cp, s.Name, s.startedAt); err != nil {
-		s.logCheckpointWrite("crash", path, time.Since(started), err)
-		return "", err
-	}
-	s.enqueueEvent(crashCheckpointWrittenEvent{path: path})
-	s.logCheckpointWrite("crash", path, time.Since(started), nil)
-	return path, nil
-}
-
-// writeCrashCheckpoint builds and writes a crash checkpoint to disk.
-// Skips writing if the session is shutting down (clean shutdown removes the checkpoint).
-func (s *Session) writeCrashCheckpoint() {
-	if s.shutdown.Load() {
-		return
-	}
-	_, _ = s.writeCrashCheckpointNow()
-}
-
 func (s *Session) hasClient(cc *clientConn) bool {
 	return s.ensureClientManager().hasClient(cc)
 }
@@ -535,7 +443,7 @@ func newSessionWithLogger(name string, scrollbackLines int, logger *charmlog.Log
 	sess.capture = newCaptureForwarder()
 	sess.input = newInputRouter()
 	sess.undo = newUndoManager()
-	sess.startCrashCheckpointLoop()
+	sess.checkpointCoordinator = newSessionCheckpointCoordinator(sess)
 	sess.startEventLoop()
 	return sess
 }

--- a/internal/server/session_bench_test.go
+++ b/internal/server/session_bench_test.go
@@ -91,11 +91,7 @@ func (s *Session) benchBroadcastLayoutNow(w io.Writer) error {
 		}
 	}
 	s.emitEvent(Event{Type: EventLayout, Generation: gen, ActivePane: activePaneName})
-
-	select {
-	case s.crashCheckpointTrigger <- struct{}{}:
-	default:
-	}
+	s.triggerCrashCheckpoint()
 
 	return nil
 }

--- a/internal/server/session_broadcast.go
+++ b/internal/server/session_broadcast.go
@@ -97,11 +97,7 @@ func (s *Session) broadcastPaneOutputNow(paneID uint32, data []byte, seq uint64)
 		s.emitPaneTerminalEventIfChanged(p)
 	}
 	s.emitEvent(Event{Type: EventOutput, PaneID: paneID, PaneName: paneName, Host: host})
-
-	select {
-	case s.crashCheckpointTrigger <- struct{}{}:
-	default:
-	}
+	s.triggerCrashCheckpoint()
 }
 
 func (s *Session) broadcastPaneHistoryNow(paneID uint32, history []string) {
@@ -111,10 +107,7 @@ func (s *Session) broadcastPaneHistoryNow(paneID uint32, history []string) {
 		c.sendPaneMessage(msg)
 	}
 
-	select {
-	case s.crashCheckpointTrigger <- struct{}{}:
-	default:
-	}
+	s.triggerCrashCheckpoint()
 }
 
 func (s *Session) notifyLayoutWaiters(gen uint64) {
@@ -149,10 +142,7 @@ func (s *Session) broadcastLayoutNow() {
 	}
 	s.emitEvent(Event{Type: EventLayout, Generation: gen, ActivePane: activePaneName})
 
-	select {
-	case s.crashCheckpointTrigger <- struct{}{}:
-	default:
-	}
+	s.triggerCrashCheckpoint()
 }
 
 // broadcastLayout sends the current layout snapshot to all clients


### PR DESCRIPTION
**Motivation**
Crash checkpoint scheduling, trigger channels, and file writes currently live directly on `Session`, which mixes persistence coordination into the session lifecycle and makes the timing logic hard to test in isolation.
This refactor extracts that responsibility into a focused coordinator without changing the crash checkpoint contract used by the rest of the server.

**Summary**
- Add `CheckpointCoordinator` in `internal/server/checkpoint_coordinator.go` to own debounce and periodic scheduling, checkpoint file writes, and the crash-checkpoint write callbacks into session audit and event plumbing.
- Replace the session-owned crash checkpoint trigger and stop channels with a coordinator reference plus small session wrapper methods used by broadcast and shutdown paths.
- Add isolated coordinator tests for debounced triggers, periodic writes, shutdown skipping, stop semantics, and on-disk crash checkpoint writes.

**Testing**
- `env -u AMUX_SESSION -u TMUX go test ./internal/server -run "TestCheckpointCoordinator" -count=100`
- `env -u AMUX_SESSION -u TMUX go test ./internal/server/... -count=3`
- `env -u AMUX_SESSION -u TMUX go vet ./...`

**Review focus**
- Check the callback boundary in `internal/server/checkpoint_coordinator.go` to confirm `Session` now only supplies state and hooks while the coordinator owns scheduling and writes.
- Verify the trigger draining and nil-initialized debounce timer preserve the old non-blocking broadcast semantics while keeping the timing logic isolated and testable.

Closes LAB-779
