### PR TITLE
Unset inherited amux env before package tests run

### DIFF
--- a/internal/cli/testmain_test.go
+++ b/internal/cli/testmain_test.go
@@ -1,0 +1,13 @@
+package cli
+
+import (
+	"os"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	_ = os.Unsetenv("AMUX_SESSION")
+	_ = os.Unsetenv("TMUX")
+
+	os.Exit(m.Run())
+}

--- a/test/harness_test.go
+++ b/test/harness_test.go
@@ -83,6 +83,9 @@ func privateAmuxBin(tb testing.TB) string {
 }
 
 func TestMain(m *testing.M) {
+	_ = os.Unsetenv("AMUX_SESSION")
+	_ = os.Unsetenv("TMUX")
+
 	socketDir := fmt.Sprintf("/tmp/amux-%d", os.Getuid())
 	lockPath, err := writeTestRunLock(socketDir, os.Getpid())
 	if err != nil {


### PR DESCRIPTION
## Motivation
Running `go test ./...` from inside an amux pane inherits `AMUX_SESSION` and `TMUX`, which makes package tests observe the caller's amux session unless each package clears those variables before its tests start. `test` already had a package `TestMain`; `internal/cli` did not.

## Summary
- unset `AMUX_SESSION` and `TMUX` at the top of `test.TestMain`
- add `internal/cli/TestMain` that clears the same inherited variables before that package's tests run

## Testing
- `go test ./internal/cli -timeout 120s`
- `go test ./... -timeout 120s` from this clone with inherited `AMUX_SESSION=main` from the parent amux pane
  - currently fails on `github.com/weill-labs/amux/test` in `TestPaneClose`, `TestRespawnPreservesPaneMetadataAndCwdWhileResettingState`, and `TestMouseScrollWheelIgnoredInAltScreenWithoutMouseMode`
- `go test ./test -run 'TestPaneClose|TestRespawnPreservesPaneMetadataAndCwdWhileResettingState|TestMouseScrollWheelIgnoredInAltScreenWithoutMouseMode' -count=1 -timeout 120s`
  - reproduces the same `./test` failures above on current `origin/main`

## Review focus
- confirm package-level env cleanup belongs in `TestMain` for both affected test packages
- confirm the new `internal/cli` `TestMain` stays minimal and does not interfere with tests that set `AMUX_SESSION` or `TMUX` explicitly with `t.Setenv`

Closes LAB-785
