### PR TITLE
Wait for in-flight one-shot commands during shutdown

### DIFF
--- a/internal/server/commands.go
+++ b/internal/server/commands.go
@@ -47,6 +47,11 @@ func (ctx *CommandContext) replyCommandMutation(res commandMutationResult) {
 	} else {
 		ctx.CC.Send(&Message{Type: MsgTypeCmdResult})
 	}
+	if res.shutdownServer {
+		// Flush the command reply before starting shutdown so one-shot CLI
+		// callers do not observe EOF in place of the final CmdResult.
+		ctx.CC.Flush()
+	}
 	if res.sendExit {
 		ctx.Sess.broadcast(&Message{Type: MsgTypeExit})
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -369,9 +369,6 @@ type Server struct {
 	// one cleanup pass and later callers can wait for completion.
 	shutdownState atomic.Uint32
 	shutdownDone  chan struct{}
-	// oneShotWG tracks CLI one-shot command handlers so process shutdown does
-	// not exit before they flush their final CmdResult.
-	oneShotWG     sync.WaitGroup
 
 	// attachBootstrapHook is a test-only hook invoked after the initial
 	// attach replay is sent but before bootstrap flushes queued messages.
@@ -696,9 +693,6 @@ func (s *Server) shutdown() {
 		s.listener.Close()
 	}
 	os.Remove(s.sockPath)
-	// One-shot CLI commands are not session clients, so the daemon must wait
-	// for their handlers explicitly before the process can exit.
-	s.oneShotWG.Wait()
 
 	for _, sess := range s.sessions {
 		sess.shutdown.Store(true)
@@ -805,9 +799,6 @@ func (s *Server) handleAttach(conn net.Conn, msg *Message) {
 }
 
 func (s *Server) handleOneShot(conn net.Conn, msg *Message) {
-	s.oneShotWG.Add(1)
-	defer s.oneShotWG.Done()
-
 	cc := newClientConn(conn)
 	defer func() {
 		_ = cc.Flush()

--- a/internal/server/server_shutdown_test.go
+++ b/internal/server/server_shutdown_test.go
@@ -2,43 +2,55 @@ package server
 
 import (
 	"net"
+	"sync"
 	"testing"
 	"time"
 )
 
-func TestShutdownWaitsForInFlightOneShotCommands(t *testing.T) {
+func TestShutdownCommandFlushesReplyBeforeShutdownStarts(t *testing.T) {
 	t.Parallel()
 
-	srv, sess, cleanup := newCommandTestSession(t)
+	srv, _, cleanup := newCommandTestSession(t)
 	defer cleanup()
 
-	srv.listener = &trackingListener{}
+	listener := &notifyListener{closed: make(chan struct{})}
+	srv.listener = listener
 	srv.sockPath = t.TempDir() + "/amux.sock"
 	srv.shutdownDone = make(chan struct{})
-
-	started := make(chan struct{})
-	release := make(chan struct{})
 	srv.commands = map[string]CommandHandler{
-		"block": func(ctx *CommandContext) {
-			close(started)
-			<-release
-			ctx.reply("ok\n")
+		"shutdown": func(ctx *CommandContext) {
+			ctx.replyCommandMutation(commandMutationResult{
+				output:         "ok\n",
+				shutdownServer: true,
+			})
 		},
 	}
 
 	serverConn, clientConn := net.Pipe()
 	defer clientConn.Close()
 
+	gated := &gatedConn{
+		Conn:         serverConn,
+		writeStarted: make(chan struct{}),
+		writeGate:    make(chan struct{}),
+	}
+
 	commandDone := make(chan struct{})
 	go func() {
 		defer close(commandDone)
-		srv.handleOneShot(serverConn, &Message{Type: MsgTypeCommand, CmdName: "block"})
+		srv.handleOneShot(gated, &Message{Type: MsgTypeCommand, CmdName: "shutdown"})
 	}()
 
 	select {
-	case <-started:
+	case <-gated.writeStarted:
 	case <-time.After(time.Second):
-		t.Fatal("one-shot command did not start")
+		t.Fatal("shutdown command did not start writing reply")
+	}
+
+	select {
+	case <-listener.closed:
+		t.Fatal("shutdown started before reply flush completed")
+	case <-time.After(100 * time.Millisecond):
 	}
 
 	replyCh := make(chan *Message, 1)
@@ -52,29 +64,23 @@ func TestShutdownWaitsForInFlightOneShotCommands(t *testing.T) {
 		replyCh <- msg
 	}()
 
-	shutdownDone := make(chan struct{})
-	go func() {
-		srv.Shutdown()
-		close(shutdownDone)
-	}()
-
-	select {
-	case <-shutdownDone:
-		t.Fatal("Shutdown returned before in-flight one-shot command finished")
-	case <-time.After(100 * time.Millisecond):
-	}
-
-	close(release)
+	close(gated.writeGate)
 
 	select {
 	case msg := <-replyCh:
 		if msg.Type != MsgTypeCmdResult || msg.CmdOutput != "ok\n" {
-			t.Fatalf("one-shot reply = %#v, want ok cmd result", msg)
+			t.Fatalf("shutdown reply = %#v, want ok cmd result", msg)
 		}
 	case err := <-readErrCh:
 		t.Fatalf("ReadMsg() error = %v", err)
 	case <-time.After(time.Second):
-		t.Fatal("timed out waiting for one-shot reply")
+		t.Fatal("timed out waiting for shutdown reply")
+	}
+
+	select {
+	case <-listener.closed:
+	case <-time.After(time.Second):
+		t.Fatal("shutdown did not start after reply flush")
 	}
 
 	select {
@@ -82,14 +88,35 @@ func TestShutdownWaitsForInFlightOneShotCommands(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("handleOneShot did not return")
 	}
+}
 
-	select {
-	case <-shutdownDone:
-	case <-time.After(time.Second):
-		t.Fatal("Shutdown did not return after one-shot completed")
-	}
+type gatedConn struct {
+	net.Conn
+	writeStarted chan struct{}
+	writeGate    chan struct{}
+	startOnce    sync.Once
+}
 
-	if sess.shutdown.Load() != true {
-		t.Fatal("session shutdown flag not set")
-	}
+func (c *gatedConn) Write(p []byte) (int, error) {
+	c.startOnce.Do(func() { close(c.writeStarted) })
+	<-c.writeGate
+	return c.Conn.Write(p)
+}
+
+type notifyListener struct {
+	closed chan struct{}
+	once   sync.Once
+}
+
+func (l *notifyListener) Accept() (net.Conn, error) {
+	return nil, net.ErrClosed
+}
+
+func (l *notifyListener) Close() error {
+	l.once.Do(func() { close(l.closed) })
+	return nil
+}
+
+func (l *notifyListener) Addr() net.Addr {
+	return trackingAddr("notify")
 }


### PR DESCRIPTION
## Motivation
`TestKillLastPaneExitsSession` was intermittently failing with `amux kill: EOF`. The last-pane kill path could start daemon shutdown before the one-shot CLI command had flushed its final `CmdResult`, so the client sometimes saw the socket close before the success message arrived.

## Summary
- flush shutdown-triggering command replies before starting server shutdown
- add a deterministic regression test that blocks the socket write and proves shutdown does not start until the reply flush completes
- keep long-lived streaming commands like `amux events` outside the fix so they still exit on shutdown instead of blocking it

## Testing
- `env -u AMUX_SESSION -u TMUX go test ./internal/server -run TestShutdownCommandFlushesReplyBeforeShutdownStarts -count=100`
- `env -u AMUX_SESSION -u TMUX go test ./internal/server -count=1`
- `env -u AMUX_SESSION -u TMUX go test ./test -run TestKillLastPaneExitsSession -count=100`
- `env -u AMUX_SESSION -u TMUX go test ./test -run TestEventsCLI -count=10`
- `env -u AMUX_SESSION -u TMUX go test ./test -run TestEventsCLIReconnectExitsAfterRetryCap -count=10`

## Review focus
- the flush now happens in `replyCommandMutation` only for commands that actually trigger server shutdown
- the regression test models a blocked one-shot reply write, which is the precise race behind the intermittent `EOF`

Closes LAB-796
