### PR TITLE
Fix send-keys parity probe marker races

### DIFF
--- a/test/key_parity_test.go
+++ b/test/key_parity_test.go
@@ -27,16 +27,18 @@ func newRawReadMarkers(id int) rawReadMarkers {
 	}
 }
 
-func splitMarker(marker string) (string, string) {
+// Split runtime markers so wait-content only sees them after the probe emits
+// output, not while the shell is still echoing the Python source.
+func splitRuntimeMarker(marker string) (string, string) {
 	mid := len(marker) / 2
 	return marker[:mid], marker[mid:]
 }
 
 func rawReadCommandWithDeadline(byteCount int, timeout time.Duration, markers rawReadMarkers) string {
-	readyA, readyB := splitMarker(markers.ready)
-	hexA, hexB := splitMarker(markers.hex)
-	doneA, doneB := splitMarker(markers.done)
-	exitA, exitB := splitMarker(markers.exit)
+	readyA, readyB := splitRuntimeMarker(markers.ready)
+	hexA, hexB := splitRuntimeMarker(markers.hex)
+	doneA, doneB := splitRuntimeMarker(markers.done)
+	exitA, exitB := splitRuntimeMarker(markers.exit)
 
 	return fmt.Sprintf(`python3 -u -c 'import os,select,sys,termios,time,tty
 fd=sys.stdin.fileno()


### PR DESCRIPTION
## Motivation
`TestSendKeysEncodeParityMatrix/ctrl_a` was flaky because the parity probe could satisfy its wait markers from the shell-echoed Python source instead of the probe's runtime output. That let the test send `C-a` before the raw reader was actually armed and then assert against a viewport-only capture.

## Summary
- Split the raw probe markers inside the generated command so `wait content` only matches real probe output, not echoed source text.
- Probe the expected encoded byte count instead of the token spelling length.
- Read the final hex assertion from `capture --history` and add a focused regression test for marker splitting.

## Testing
- `go test ./test -run 'TestRawReadCommandWithDeadlineSplitsRuntimeMarkers$' -count=100`
- `go test ./test -run 'TestSendKeysEncodeParityMatrix/ctrl_a' -count=100`
- `go test ./test -run 'TestSendKeysEncodeParityMatrix$' -count=1`

## Review focus
- Check that the split marker construction removes false-positive `wait content` matches on echoed command text.
- Check that `capture --history` is the right assertion surface for probe output that can scroll off the live viewport.
- Check the encoded-byte-count probe sizing for control and alias tokens.

Closes LAB-797