### PR TITLE
Register color types with gob to fix attach bootstrap EOF

### DIFF
--- a/internal/proto/gob_register.go
+++ b/internal/proto/gob_register.go
@@ -9,10 +9,7 @@ import (
 
 func init() {
 	// Register concrete color types so gob can encode/decode the
-	// color.Color interface fields in uv.Style (used by StyledLine.Cells).
-	// Without these registrations, gob encoding of MsgTypePaneHistory
-	// messages containing styled cells fails with
-	// "type not registered for interface".
+	// color.Color interface fields in StyledLine.Cells.
 	gob.Register(ansi.BasicColor(0))
 	gob.Register(ansi.IndexedColor(0))
 	gob.Register(ansi.TrueColor(0))

--- a/internal/proto/wire_low_coverage_test.go
+++ b/internal/proto/wire_low_coverage_test.go
@@ -611,21 +611,8 @@ func TestPaneHistoryWithStyledCellsRoundTrips(t *testing.T) {
 		t.Fatalf("ReadMsg: %v", err)
 	}
 
-	if got.Type != MsgTypePaneHistory {
-		t.Fatalf("Type = %d, want %d", got.Type, MsgTypePaneHistory)
-	}
-	if got.PaneID != 42 {
-		t.Fatalf("PaneID = %d, want 42", got.PaneID)
-	}
-	if len(got.StyledHistory) != 2 {
-		t.Fatalf("len(StyledHistory) = %d, want 2", len(got.StyledHistory))
-	}
-	if len(got.StyledHistory[1].Cells) != 3 {
-		t.Fatalf("len(Cells) = %d, want 3", len(got.StyledHistory[1].Cells))
-	}
-	cell := got.StyledHistory[1].Cells[0]
-	if cell.Char != "s" || cell.Width != 1 {
-		t.Fatalf("cell[0] = %+v, want Char=s Width=1", cell)
+	if !reflect.DeepEqual(got, msg) {
+		t.Fatalf("round-trip mismatch:\n got = %+v\nwant = %+v", got, msg)
 	}
 }
 


### PR DESCRIPTION
## Motivation

Commit 4568036 added `StyledHistory` to the `MsgTypePaneHistory` wire
message for styled copy-mode scrollback. The `StyledLine.Cells` field
contains `uv.Style` which has `Fg`, `Bg`, `UnderlineColor` as
`color.Color` interfaces. Gob cannot encode interface values without
explicit `gob.Register()` calls, so the first pane history write during
attach bootstrap failed silently — `writeClientMessage` closed the
connection and every interactive client saw `reading attach bootstrap:
EOF`. One-shot commands (`capture`, `list-clients`) continued working
because they never send `StyledHistory` over gob.

## Summary

- Add `internal/proto/gob_register.go` with `init()` that registers
  `ansi.BasicColor`, `ansi.IndexedColor`, `ansi.TrueColor`,
  `ansi.RGBColor`, and `color.RGBA` with `encoding/gob`
- Add regression test that round-trips a `MsgTypePaneHistory` with
  styled cells through `WriteMsg`/`ReadMsg`

## Testing

```
go test -run TestPaneHistoryWithStyledCellsRoundTrips -v ./internal/proto/
go test -run TestPaneHistoryWithStyledCellsRoundTrips -count=100 ./internal/proto/
```

Verified live: `make install` triggered server hot-reload, after which
`amux` successfully completes bootstrap (3.9s for 26 panes) instead of
returning EOF.

## Review focus

- Are there other concrete `color.Color` types that could appear in
  terminal emulator output? The registered set covers the ansi package
  types and `color.RGBA`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)