### PR TITLE
Remove redundant env -u AMUX_SESSION guidance from CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,8 +53,6 @@ go test ./... -timeout 120s        # run all tests
 make coverage                      # merged unit + integration coverage (use this, not go test -coverprofile)
 ```
 
-**Reproduce CI from a clean shell when running inside `amux`/tmux.** Clipboard and harness behavior can change when `AMUX_SESSION` or `TMUX` are set. For CI-style verification from an attached pane, prefer `env -u AMUX_SESSION -u TMUX scripts/coverage.sh --ci`, and prefix other CI-style test commands the same way when you need the same environment.
-
 ### Testing Live
 
 See [README.md -- CLI Reference](README.md#cli-reference) for the full command reference. Key commands for testing:


### PR DESCRIPTION
## Motivation

The `env -u AMUX_SESSION -u TMUX` prefix guidance was added when the test harness didn't scrub ambient session variables. The harness now handles this at multiple levels:

- **Server spawn** (`server_harness_test.go:187`) — strips `AMUX_SESSION`, `AMUX_PANE`, `TMUX` from server process env
- **CLI subcommands** (`server_harness_test.go:495`) — strips from `commandWithContext`
- **Root test init** (`test/harness_test.go:86`, `internal/cli/testmain_test.go:9`) — unsets at `TestMain`
- **Hermetic helpers** (`test/script_helpers_test.go:11`, `internal/cli/main_cli_subprocess_test.go:107`) — strips from subprocess env

The guidance is now redundant and misleading — agents still include `env -u` prefixes in PR test sections despite it having no effect.

## Summary

- Remove the "Reproduce CI from a clean shell" paragraph from CLAUDE.md

## Testing

`go test ./... -timeout 120s` — no code changes, docs only.

## Review focus

Confirm no other docs reference this pattern that should also be updated.