### PR TITLE
Bump weill-labs/x/vt for 99.4% allocation reduction in throughput

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -49,4 +49,4 @@ require (
 
 replace github.com/charmbracelet/ultraviolet => github.com/weill-labs/ultraviolet v0.0.0-20260404003102-9344cbfc286f
 
-replace github.com/charmbracelet/x/vt => github.com/weill-labs/x/vt v0.0.0-20260405171640-a431c2ea2459
+replace github.com/charmbracelet/x/vt => github.com/weill-labs/x/vt v0.0.0-20260409003128-9ed944697a50

--- a/go.sum
+++ b/go.sum
@@ -72,10 +72,8 @@ github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcU
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/weill-labs/ultraviolet v0.0.0-20260404003102-9344cbfc286f h1:JMTFuQ/08wrGci+AIUA67OuIMHtJaF369KhWwBel6/g=
 github.com/weill-labs/ultraviolet v0.0.0-20260404003102-9344cbfc286f/go.mod h1:Vo8TffMf0q7Uho/n8e6XpBZvOWtd3g39yX+9P5rRutA=
-github.com/weill-labs/x/vt v0.0.0-20260403023638-cf27de05135b h1:4kqqzRMI8ppJ1Iq/NPh73B/T5I4WZNqLqWvPiKPqvag=
-github.com/weill-labs/x/vt v0.0.0-20260403023638-cf27de05135b/go.mod h1:2djWW5EeP5QlpztEYYbbyyzUyyxVD71mWVQguNISHcM=
-github.com/weill-labs/x/vt v0.0.0-20260405171640-a431c2ea2459 h1:TubqLfeuy0VvLVKOUoWLrDjgDGJX1VqDcJOV6RjnGE4=
-github.com/weill-labs/x/vt v0.0.0-20260405171640-a431c2ea2459/go.mod h1:2djWW5EeP5QlpztEYYbbyyzUyyxVD71mWVQguNISHcM=
+github.com/weill-labs/x/vt v0.0.0-20260409003128-9ed944697a50 h1:hu4HrZ76PQFt6d9sxzHbfkXlrrXlooBUobvIbGrYO90=
+github.com/weill-labs/x/vt v0.0.0-20260409003128-9ed944697a50/go.mod h1:2djWW5EeP5QlpztEYYbbyyzUyyxVD71mWVQguNISHcM=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJuqunuUZ/Dhy/avygyECGrLceyNeo4LiM=
 golang.org/x/crypto v0.49.0 h1:+Ng2ULVvLHnJ/ZFEq4KdcDd/cfjrrjjNSXNzxg0Y4U4=


### PR DESCRIPTION
## Motivation

Throughput benchmarks showed amux at 49K allocs/op vs tmux's 700, with the terminal emulator (charmbracelet/x/vt) accounting for 97% of allocations. LAB-979 tracked the optimization work in our fork (weill-labs/x).

## Summary

- Bump weill-labs/x/vt to 9ed9446 which includes:
  - Scrollback ring buffer replacing slices.Clone per scroll (weill-labs/x#7)
  - Cell pooling in handlePrint (weill-labs/x#7)
  - Dirty-row draw iteration (weill-labs/x#6)

## Benchmark results (AMD EPYC, Linux, 8 cores)

| Metric | Before | After | Change |
|---|---|---|---|
| Throughput/amux time | 138ms | 104ms | **-25%** |
| Throughput/amux allocs | 49,140 | 291 | **-99.4%** |
| Throughput/amux bytes | 4,506 KiB | 120 KiB | **-97.3%** |
| ThroughputPersistent time | 133ms | 103ms | **-23%** |
| ThroughputPersistent allocs | 48,630 | 269 | **-99.4%** |
| amux/tmux ratio | 3.7x | 3.1x | Narrowed |

amux now allocates fewer objects than tmux per iteration (291 vs 707).

benchstat confirms all amux improvements are statistically significant (p=0.008). tmux numbers unchanged as expected.

## Testing

```bash
go build ./... && go vet ./...
env -u AMUX_SESSION -u TMUX go test -run '^$' -bench='BenchmarkThroughput' -benchmem -count=5 ./test/ -timeout 300s
```

## Review focus

Dependency-only change (go.mod + go.sum). The actual code changes are in weill-labs/x PRs #5-#7.

Closes LAB-979