### PR TITLE
Clip pane status lines to pane width

### DIFF
--- a/internal/render/overlay_status_test.go
+++ b/internal/render/overlay_status_test.go
@@ -213,6 +213,30 @@ func TestRenderPaneStatusTruncatesMetadata(t *testing.T) {
 	}
 }
 
+func TestRenderPaneStatusClipsLongTaskToPaneWidth(t *testing.T) {
+	t.Parallel()
+
+	cell := mux.NewLeaf(&mux.Pane{ID: 1}, 0, 0, 24, 3)
+	buf := strings.Builder{}
+	renderPaneStatus(&buf, cell, true, &statusPaneData{
+		id:    1,
+		name:  "pane-1",
+		task:  "sync-build-with-a-very-long-name",
+		color: config.TextColorHex,
+	})
+
+	line := strings.SplitN(MaterializeGrid(buf.String(), 48, 1), "\n", 2)[0]
+	visible := string([]rune(line)[:cell.W])
+	if !strings.Contains(visible, "…") {
+		t.Fatalf("visible status line %q should include an ellipsis when clipped", visible)
+	}
+	for col, ch := range []rune(line)[cell.W:] {
+		if ch != ' ' {
+			t.Fatalf("status line spilled past pane width at col %d: %q in %q", cell.W+col, string(ch), line)
+		}
+	}
+}
+
 func TestRenderPaneStatusHintsWhenActivePaneHasNoIssueMetadata(t *testing.T) {
 	t.Parallel()
 
@@ -668,6 +692,35 @@ func TestBuildStatusCellsHintsWhenActivePaneHasNoIssueMetadata(t *testing.T) {
 		if !strings.Contains(line, want) {
 			t.Fatalf("status row %q missing %q", line, want)
 		}
+	}
+}
+
+func TestBuildStatusCellsClipsLongTaskToPaneWidth(t *testing.T) {
+	t.Parallel()
+
+	cell := mux.NewLeaf(&mux.Pane{ID: 1}, 0, 0, 24, 4)
+	grid := NewScreenGrid(24, 4)
+	buildStatusCells(grid, cell, true, &statusPaneData{
+		id:    1,
+		name:  "pane-1",
+		task:  "sync-build-with-a-very-long-name",
+		color: config.TextColorHex,
+	})
+
+	var row strings.Builder
+	for x := 0; x < 24; x++ {
+		ch := grid.Get(x, 0).Char
+		if ch == "" {
+			ch = " "
+		}
+		row.WriteString(ch)
+	}
+	line := strings.TrimRight(row.String(), " ")
+	if !strings.Contains(line, "sync") {
+		t.Fatalf("status row %q should keep the task prefix", line)
+	}
+	if !strings.Contains(line, "…") {
+		t.Fatalf("status row %q should include an ellipsis when clipped", line)
 	}
 }
 

--- a/internal/render/screen_test.go
+++ b/internal/render/screen_test.go
@@ -1418,9 +1418,8 @@ func TestRenderDiff_ColorOracle_TwoPanes(t *testing.T) {
 // --- Fuzz compositor (#169) ---
 
 // Fuzz-specific minimum pane dimensions. Larger than PaneMinSize (2) to avoid
-// triggering known oracle divergences where RenderFull's ANSI path doesn't clip
-// status text to pane width but BuildGrid does. Width=12 fits "● [pane-NN]",
-// height=4 fits status line + 2 content rows + 1 border.
+// overly cramped layouts where the status line leaves no useful content area.
+// Width=12 fits "● [pane-NN]", height=4 fits status line + 2 content rows + 1 border.
 const (
 	fuzzMinW = 12
 	fuzzMinH = 4

--- a/internal/render/statusbar.go
+++ b/internal/render/statusbar.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode"
 	"unicode/utf8"
 
 	"github.com/mattn/go-runewidth"
@@ -158,7 +159,7 @@ func buildPaneStatusSegments(cellWidth int, isActive bool, pd PaneData) []paneSt
 		segments = appendPaneStatusSegment(segments, pd.Task(), paneStatusSegmentText)
 	}
 
-	return segments
+	return clipPaneStatusSegments(segments, cellWidth)
 }
 
 func paneStatusSegmentsWidth(segments []paneStatusSegment) int {
@@ -167,6 +168,67 @@ func paneStatusSegmentsWidth(segments []paneStatusSegment) int {
 		usedWidth += runewidth.StringWidth(segment.text)
 	}
 	return usedWidth
+}
+
+func clipPaneStatusSegments(segments []paneStatusSegment, maxWidth int) []paneStatusSegment {
+	if maxWidth <= 0 || len(segments) == 0 {
+		return nil
+	}
+	if paneStatusSegmentsWidth(segments) <= maxWidth {
+		return segments
+	}
+	if maxWidth == 1 {
+		return []paneStatusSegment{{text: "…", role: paneStatusSegmentText}}
+	}
+
+	clipped := make([]paneStatusSegment, 0, len(segments)+1)
+	remaining := maxWidth - 1
+	ellipsisRole := paneStatusSegmentText
+
+	for _, segment := range segments {
+		segWidth := runewidth.StringWidth(segment.text)
+		if segWidth <= 0 {
+			continue
+		}
+		if segWidth <= remaining {
+			clipped = append(clipped, segment)
+			remaining -= segWidth
+			ellipsisRole = segment.role
+			continue
+		}
+
+		prefix := truncateRunewidth(segment.text, remaining)
+		if prefix != "" {
+			clipped = append(clipped, paneStatusSegment{text: prefix, role: segment.role})
+			ellipsisRole = segment.role
+		}
+		break
+	}
+
+	clipped = trimPaneStatusSegmentsRight(clipped)
+	if len(clipped) > 0 {
+		ellipsisRole = clipped[len(clipped)-1].role
+	}
+	return append(clipped, paneStatusSegment{text: "…", role: ellipsisRole})
+}
+
+func trimPaneStatusSegmentsRight(segments []paneStatusSegment) []paneStatusSegment {
+	for len(segments) > 0 {
+		last := segments[len(segments)-1]
+		trimmed := strings.TrimRightFunc(last.text, func(r rune) bool {
+			return unicode.IsSpace(r) || r == ','
+		})
+		if trimmed == last.text {
+			return segments
+		}
+		if trimmed == "" {
+			segments = segments[:len(segments)-1]
+			continue
+		}
+		segments[len(segments)-1].text = trimmed
+		return segments
+	}
+	return segments
 }
 
 // renderPaneStatus draws a per-pane status line at the top of a pane cell.


### PR DESCRIPTION
Motivation

Pane header text was only constrained implicitly by the grid renderer. The ANSI compositor path could emit more status text than the pane width, which let long task labels or metadata run past the pane boundary.

Summary

- clip the final pane status segment list to the pane width in the shared status builder
- trim trailing separators and spaces before appending an ellipsis when a pane header is clipped
- add regressions for both the raw ANSI pane-status renderer and the grid status-cell builder

Testing

- `env -u AMUX_SESSION -u TMUX go test ./internal/render -run 'TestRenderPaneStatusClipsLongTaskToPaneWidth|TestBuildStatusCellsClipsLongTaskToPaneWidth' -count=100`
- `env -u AMUX_SESSION -u TMUX go test ./... -timeout 120s`

Review focus

- The new `clipPaneStatusSegments` helper in `internal/render/statusbar.go` is the shared clamp point for both render paths.
- Bottom/global status rendering was checked separately; this change only touches per-pane status lines because the global bar already truncates to terminal width.

Closes LAB-990
