### PR TITLE
Defer hidden-window client emulators until needed

### DIFF
--- a/internal/client/renderer.go
+++ b/internal/client/renderer.go
@@ -78,7 +78,6 @@ func (r *Renderer) HandleLayout(snap *proto.LayoutSnapshot) bool {
 			activeWinID:     snap.ActiveWindowID,
 			scrollbackLines: prev.scrollbackLines,
 		}
-		nextEmulators := make(map[uint32]mux.TerminalEmulator)
 
 		allPanes := snap.Panes
 		activeRoot := snap.Root
@@ -98,22 +97,6 @@ func (r *Renderer) HandleLayout(snap *proto.LayoutSnapshot) bool {
 		for _, ps := range allPanes {
 			next.paneOrder = append(next.paneOrder, ps.ID)
 			next.paneInfo[ps.ID] = ps
-			emu := prevEmulators[ps.ID]
-			if emu == nil {
-				w, h := proto.FindPaneDimensions(snap, activeRoot, ps.ID, mux.PaneContentHeight)
-				emu = mux.NewVTEmulatorWithDrainAndScrollback(w, h, prev.scrollbackLines)
-			}
-			nextEmulators[ps.ID] = emu
-		}
-
-		// Close emulators for panes that no longer exist in the layout.
-		// Each emulator has a drain goroutine that blocks on io.Pipe.Read;
-		// without Close() the goroutine and pipe FDs leak.
-		for id, emu := range prevEmulators {
-			if _, exists := nextEmulators[id]; !exists {
-				delete(st.pendingPaneOutput, id)
-				_ = emu.Close()
-			}
 		}
 
 		next.layout = mux.RebuildLayout(activeRoot)
@@ -125,6 +108,29 @@ func (r *Renderer) HandleLayout(snap *proto.LayoutSnapshot) bool {
 			next.layout.ResizeAll(next.width, clientLayoutH)
 		}
 		next.visiblePaneIDs = next.visiblePaneSet(clientLayoutH)
+		nextEmulators := make(map[uint32]mux.TerminalEmulator, len(prevEmulators)+len(next.visiblePaneIDs))
+		for _, ps := range allPanes {
+			if emu := prevEmulators[ps.ID]; emu != nil {
+				nextEmulators[ps.ID] = emu
+				continue
+			}
+			if next.layout == nil || next.layout.FindByPaneID(ps.ID) == nil {
+				continue
+			}
+			w, h := proto.FindPaneDimensions(snap, activeRoot, ps.ID, mux.PaneContentHeight)
+			nextEmulators[ps.ID] = mux.NewVTEmulatorWithDrainAndScrollback(w, h, next.scrollbackLines)
+		}
+
+		// Close emulators for panes that no longer exist in the layout.
+		// Each emulator has a drain goroutine that blocks on io.Pipe.Read;
+		// without Close() the goroutine and pipe FDs leak.
+		for id, emu := range prevEmulators {
+			if _, exists := next.paneInfo[id]; exists {
+				continue
+			}
+			delete(st.pendingPaneOutput, id)
+			_ = emu.Close()
+		}
 		st.warmVisiblePanes(next, nextEmulators)
 		r.resizeSnapshotEmulators(next, nextEmulators)
 
@@ -162,12 +168,15 @@ func (r *Renderer) HandleLayout(snap *proto.LayoutSnapshot) bool {
 // pane is visible. Hidden panes buffer output and replay it lazily on demand.
 func (r *Renderer) HandlePaneOutput(paneID uint32, data []byte) bool {
 	return withRendererActorValue(r, func(st *rendererActorState) bool {
-		emu := st.emulators[paneID]
-		if emu == nil {
+		if _, ok := st.snapshot.paneInfo[paneID]; !ok {
 			return false
 		}
 		if !st.snapshot.paneVisible(paneID) {
 			st.bufferPaneOutput(paneID, data)
+			return false
+		}
+		emu := st.ensurePaneEmulator(paneID)
+		if emu == nil {
 			return false
 		}
 		st.warmPaneOutput(paneID, st.emulators)
@@ -199,12 +208,15 @@ func captureTerminalCursorState(emu mux.TerminalEmulator) terminalCursorState {
 
 func (r *Renderer) HandlePaneOutputInfo(paneID uint32, data []byte, trackCursor bool) paneOutputRenderInfo {
 	return withRendererActorValue(r, func(st *rendererActorState) paneOutputRenderInfo {
-		emu := st.emulators[paneID]
-		if emu == nil {
+		if _, ok := st.snapshot.paneInfo[paneID]; !ok {
 			return paneOutputRenderInfo{}
 		}
 		if !st.snapshot.paneVisible(paneID) {
 			st.bufferPaneOutput(paneID, data)
+			return paneOutputRenderInfo{}
+		}
+		emu := st.ensurePaneEmulator(paneID)
+		if emu == nil {
 			return paneOutputRenderInfo{}
 		}
 		st.warmPaneOutput(paneID, st.emulators)
@@ -492,11 +504,11 @@ func (r *Renderer) CaptureJSONWithHistory(agentStatus map[uint32]proto.PaneAgent
 func (r *Renderer) CapturePaneText(paneID uint32, includeANSI bool) string {
 	return withRendererActorValue(r, func(st *rendererActorState) string {
 		snap := st.snapshot
-		st.warmPaneOutput(paneID, st.emulators)
-		emu, ok := st.emulators[paneID]
-		if !ok {
+		emu := st.ensurePaneEmulator(paneID)
+		if emu == nil {
 			return ""
 		}
+		st.warmPaneOutput(paneID, st.emulators)
 		if includeANSI {
 			return filterRenderedANSI(emu.Render(), snap.capabilities)
 		}
@@ -573,11 +585,11 @@ func (r *Renderer) WindowSnapshots() ([]proto.WindowSnapshot, uint32) {
 }
 
 func (r *Renderer) buildCapturePane(st *rendererActorState, snap *rendererSnapshot, paneID uint32, agentStatus map[uint32]proto.PaneAgentStatus, includeHistory bool, baseHistory []proto.StyledLine) (proto.CapturePane, bool) {
-	st.warmPaneOutput(paneID, st.emulators)
-	emu, ok := st.emulators[paneID]
-	if !ok {
+	emu := st.ensurePaneEmulator(paneID)
+	if emu == nil {
 		return proto.CapturePane{}, false
 	}
+	st.warmPaneOutput(paneID, st.emulators)
 	info, ok := snap.paneInfo[paneID]
 	if !ok {
 		return proto.CapturePane{}, false

--- a/internal/client/renderer.go
+++ b/internal/client/renderer.go
@@ -114,7 +114,7 @@ func (r *Renderer) HandleLayout(snap *proto.LayoutSnapshot) bool {
 				nextEmulators[ps.ID] = emu
 				continue
 			}
-			if next.layout == nil || next.layout.FindByPaneID(ps.ID) == nil {
+			if !next.paneInActiveLayout(ps.ID) {
 				continue
 			}
 			w, h := proto.FindPaneDimensions(snap, activeRoot, ps.ID, mux.PaneContentHeight)

--- a/internal/client/renderer_queries.go
+++ b/internal/client/renderer_queries.go
@@ -265,11 +265,11 @@ func (r *Renderer) PaneBufferSnapshotStyled(paneID uint32, baseHistory []proto.S
 	snap := paneBufferSnapshot{}
 	ok := false
 	r.withActor(func(st *rendererActorState) {
-		st.warmPaneOutput(paneID, st.emulators)
-		emu, exists := st.emulators[paneID]
-		if !exists {
+		emu := st.ensurePaneEmulator(paneID)
+		if emu == nil {
 			return
 		}
+		st.warmPaneOutput(paneID, st.emulators)
 		snap = capturePaneBufferSnapshotStyled(emu, proto.CloneStyledLines(baseHistory), st.snapshot.scrollbackLines)
 		ok = true
 	})

--- a/internal/client/renderer_state.go
+++ b/internal/client/renderer_state.go
@@ -88,6 +88,24 @@ func (s *rendererSnapshot) visiblePaneSet(layoutHeight int) map[uint32]struct{} 
 	return visible
 }
 
+func (s *rendererSnapshot) paneDimensions(paneID uint32) (int, int, bool) {
+	if s.layout != nil {
+		if cell := s.layout.FindByPaneID(paneID); cell != nil {
+			return cell.W, mux.PaneContentHeight(cell.H), true
+		}
+	}
+	for _, ws := range s.windows {
+		if cell := proto.FindCellInSnapshot(ws.Root, paneID); cell != nil {
+			return cell.W, mux.PaneContentHeight(cell.H), true
+		}
+	}
+	layoutHeight := s.height - render.GlobalBarHeight
+	if s.width <= 0 || layoutHeight <= 0 {
+		return 0, 0, false
+	}
+	return s.width, mux.PaneContentHeight(layoutHeight), true
+}
+
 func cloneWindowSnapshots(src []proto.WindowSnapshot) []proto.WindowSnapshot {
 	return append([]proto.WindowSnapshot(nil), src...)
 }
@@ -139,6 +157,25 @@ func (st *rendererActorState) bufferPaneOutput(paneID uint32, data []byte) {
 		st.pendingPaneOutput[paneID] = buf
 	}
 	buf.appendChunk(data)
+}
+
+func (st *rendererActorState) ensurePaneEmulator(paneID uint32) mux.TerminalEmulator {
+	if paneID == 0 {
+		return nil
+	}
+	if emu := st.emulators[paneID]; emu != nil {
+		return emu
+	}
+	if _, ok := st.snapshot.paneInfo[paneID]; !ok {
+		return nil
+	}
+	width, height, ok := st.snapshot.paneDimensions(paneID)
+	if !ok {
+		return nil
+	}
+	emu := mux.NewVTEmulatorWithDrainAndScrollback(width, height, st.snapshot.scrollbackLines)
+	st.emulators[paneID] = emu
+	return emu
 }
 
 func (st *rendererActorState) warmPaneOutput(paneID uint32, emulators map[uint32]mux.TerminalEmulator) {

--- a/internal/client/renderer_state.go
+++ b/internal/client/renderer_state.go
@@ -74,6 +74,10 @@ func (s *rendererSnapshot) paneVisible(paneID uint32) bool {
 	return ok
 }
 
+func (s *rendererSnapshot) paneInActiveLayout(paneID uint32) bool {
+	return s.layout != nil && s.layout.FindByPaneID(paneID) != nil
+}
+
 func (s *rendererSnapshot) visiblePaneSet(layoutHeight int) map[uint32]struct{} {
 	root := s.visibleLayout(layoutHeight)
 	if root == nil {

--- a/internal/client/renderer_visibility_test.go
+++ b/internal/client/renderer_visibility_test.go
@@ -38,6 +38,33 @@ func paneScreenContains(t *testing.T, r *Renderer, paneID uint32, substr string)
 	return found
 }
 
+func paneHasEmulator(t *testing.T, r *Renderer, paneID uint32) bool {
+	t.Helper()
+
+	var ok bool
+	r.withActor(func(st *rendererActorState) {
+		_, ok = st.emulators[paneID]
+	})
+	return ok
+}
+
+func TestClientRendererHiddenWindowPaneStaysColdAfterLayout(t *testing.T) {
+	t.Parallel()
+
+	cr := NewClientRenderer(80, 24)
+	cr.HandleLayout(multiWindow80x23())
+
+	if !paneHasEmulator(t, cr.renderer, 1) {
+		t.Fatal("visible pane should allocate an emulator during layout")
+	}
+	if !paneHasEmulator(t, cr.renderer, 2) {
+		t.Fatal("second visible pane should allocate an emulator during layout")
+	}
+	if paneHasEmulator(t, cr.renderer, 3) {
+		t.Fatal("hidden window pane should stay cold until it becomes visible or is captured")
+	}
+}
+
 func TestClientRendererHiddenPaneOutputStaysColdUntilCapture(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Motivation
TestReadAttachBootstrapKeepsPeakHeapUnderBound started flaking after the x/vt bump because the client created an emulator for every pane in every window during attach bootstrap. Each hidden-window emulator now carries a 4 MiB parser buffer, so the bootstrap fixture could exceed the 256 MiB heap cap before GC ran.

## Summary
- create emulators eagerly only for panes in the active window, keeping inactive-window panes as metadata plus buffered output
- lazily materialize hidden-window emulators when capture or copy-mode needs them, and keep zoomed panes in the active window on the eager path so resize callbacks still fire
- add a regression test proving panes in inactive windows stay cold after layout until they become visible or are explicitly captured

## Testing
- `env -u AMUX_SESSION -u TMUX go test ./internal/client -run 'TestClientRendererHidden(WindowPaneStaysColdAfterLayout|PaneOutputStaysColdUntilCapture|PaneOutputFlushesWhenPaneBecomesVisible|PaneOutputFlushesOnCopyModeEntry)$' -count=100`
- `env -u AMUX_SESSION -u TMUX go test -run TestReadAttachBootstrapKeepsPeakHeapUnderBound -count=100 -timeout 120s ./internal/client/`
- `env -u AMUX_SESSION -u TMUX go test ./internal/client -count=1`
- `go test -run TestReadAttachBootstrapKeepsPeakHeapUnderBound -memprofile mem.prof ./internal/client/`

## Review focus
- `Renderer.HandleLayout` now creates client emulators for the active window only; inactive windows rely on buffered output plus `ensurePaneEmulator` when first accessed.
- Capture/copy-mode paths now create hidden-window emulators on demand; look at the buffer flush order around `ensurePaneEmulator`.
- The active-window eager path intentionally still includes non-visible zoom siblings so `OnPaneResize` behavior stays unchanged.

Closes LAB-991
