### PR TITLE
Choose shortest column for column-fill spawn

### DIFF
--- a/internal/mux/column_fill.go
+++ b/internal/mux/column_fill.go
@@ -33,11 +33,18 @@ func (w *Window) PlanColumnFillSpawn() (ColumnFillSpawnPlan, error) {
 	}
 
 	maxPanesPerColumn := len(columns) + 1
-	for _, column := range columns {
+	var target *columnFillColumn
+	for i := range columns {
+		column := &columns[i]
 		if len(column.leaves) >= maxPanesPerColumn {
 			continue
 		}
-		bottom := column.leaves[len(column.leaves)-1]
+		if target == nil || len(column.leaves) < len(target.leaves) {
+			target = column
+		}
+	}
+	if target != nil {
+		bottom := target.leaves[len(target.leaves)-1]
 		return ColumnFillSpawnPlan{
 			InheritPaneID:     bottom.Pane.ID,
 			SplitTargetPaneID: bottom.Pane.ID,

--- a/internal/mux/column_fill.go
+++ b/internal/mux/column_fill.go
@@ -33,18 +33,18 @@ func (w *Window) PlanColumnFillSpawn() (ColumnFillSpawnPlan, error) {
 	}
 
 	maxPanesPerColumn := len(columns) + 1
-	var target *columnFillColumn
+	var shortestColumn *columnFillColumn
 	for i := range columns {
 		column := &columns[i]
 		if len(column.leaves) >= maxPanesPerColumn {
 			continue
 		}
-		if target == nil || len(column.leaves) < len(target.leaves) {
-			target = column
+		if shortestColumn == nil || len(column.leaves) < len(shortestColumn.leaves) {
+			shortestColumn = column
 		}
 	}
-	if target != nil {
-		bottom := target.leaves[len(target.leaves)-1]
+	if shortestColumn != nil {
+		bottom := shortestColumn.leaves[len(shortestColumn.leaves)-1]
 		return ColumnFillSpawnPlan{
 			InheritPaneID:     bottom.Pane.ID,
 			SplitTargetPaneID: bottom.Pane.ID,

--- a/internal/mux/column_fill_test.go
+++ b/internal/mux/column_fill_test.go
@@ -125,10 +125,10 @@ func TestPlanColumnFillSpawnUsesLogicalRootWhenLeadAnchored(t *testing.T) {
 	if plan.RootSplit {
 		t.Fatal("RootSplit = true, want false")
 	}
-	if plan.InheritPaneID != p3.ID {
-		t.Fatalf("InheritPaneID = %d, want %d", plan.InheritPaneID, p3.ID)
+	if plan.InheritPaneID != p4.ID {
+		t.Fatalf("InheritPaneID = %d, want %d", plan.InheritPaneID, p4.ID)
 	}
-	if plan.SplitTargetPaneID != p3.ID {
-		t.Fatalf("SplitTargetPaneID = %d, want %d", plan.SplitTargetPaneID, p3.ID)
+	if plan.SplitTargetPaneID != p4.ID {
+		t.Fatalf("SplitTargetPaneID = %d, want %d", plan.SplitTargetPaneID, p4.ID)
 	}
 }

--- a/internal/mux/column_fill_test.go
+++ b/internal/mux/column_fill_test.go
@@ -2,7 +2,7 @@ package mux
 
 import "testing"
 
-func TestPlanColumnFillSpawnSplitsBottomPaneOfFirstUnderfilledColumn(t *testing.T) {
+func TestPlanColumnFillSpawnSplitsBottomPaneOfShortestUnderfilledColumn(t *testing.T) {
 	t.Parallel()
 
 	p1 := fakePaneID(1)
@@ -32,11 +32,41 @@ func TestPlanColumnFillSpawnSplitsBottomPaneOfFirstUnderfilledColumn(t *testing.
 	if plan.RootSplit {
 		t.Fatal("RootSplit = true, want false")
 	}
-	if plan.InheritPaneID != p3.ID {
-		t.Fatalf("InheritPaneID = %d, want %d", plan.InheritPaneID, p3.ID)
+	if plan.InheritPaneID != p4.ID {
+		t.Fatalf("InheritPaneID = %d, want %d", plan.InheritPaneID, p4.ID)
 	}
-	if plan.SplitTargetPaneID != p3.ID {
-		t.Fatalf("SplitTargetPaneID = %d, want %d", plan.SplitTargetPaneID, p3.ID)
+	if plan.SplitTargetPaneID != p4.ID {
+		t.Fatalf("SplitTargetPaneID = %d, want %d", plan.SplitTargetPaneID, p4.ID)
+	}
+}
+
+func TestPlanColumnFillSpawnPrefersLeftmostColumnOnHeightTie(t *testing.T) {
+	t.Parallel()
+
+	p1 := fakePaneID(1)
+	p2 := fakePaneID(2)
+	p3 := fakePaneID(3)
+
+	w := NewWindow(p1, 120, 24)
+	if _, err := w.SplitRoot(SplitVertical, p2); err != nil {
+		t.Fatalf("SplitRoot pane-2: %v", err)
+	}
+	if _, err := w.SplitPaneWithOptions(p2.ID, SplitVertical, p3, SplitOptions{}); err != nil {
+		t.Fatalf("Split pane-2 vertically: %v", err)
+	}
+
+	plan, err := w.PlanColumnFillSpawn()
+	if err != nil {
+		t.Fatalf("PlanColumnFillSpawn: %v", err)
+	}
+	if plan.RootSplit {
+		t.Fatal("RootSplit = true, want false")
+	}
+	if plan.InheritPaneID != p1.ID {
+		t.Fatalf("InheritPaneID = %d, want %d", plan.InheritPaneID, p1.ID)
+	}
+	if plan.SplitTargetPaneID != p1.ID {
+		t.Fatalf("SplitTargetPaneID = %d, want %d", plan.SplitTargetPaneID, p1.ID)
 	}
 }
 

--- a/internal/server/spawn_auto_command_test.go
+++ b/internal/server/spawn_auto_command_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/weill-labs/amux/internal/mux"
 )
 
-func TestCommandSpawnAutoAppendsToFirstUnderfilledColumnAndEqualizes(t *testing.T) {
+func TestCommandSpawnAutoAppendsToShortestUnderfilledColumnAndEqualizes(t *testing.T) {
 	t.Parallel()
 
 	srv, sess, cleanup := newCommandTestSession(t)
@@ -38,6 +38,7 @@ func TestCommandSpawnAutoAppendsToFirstUnderfilledColumnAndEqualizes(t *testing.
 		p4X int
 		p1H int
 		p2H int
+		p3H int
 		p4H int
 	} {
 		w := sess.activeWindow()
@@ -50,6 +51,7 @@ func TestCommandSpawnAutoAppendsToFirstUnderfilledColumnAndEqualizes(t *testing.
 				p4X int
 				p1H int
 				p2H int
+				p3H int
 				p4H int
 			}{}
 		}
@@ -60,6 +62,7 @@ func TestCommandSpawnAutoAppendsToFirstUnderfilledColumnAndEqualizes(t *testing.
 			p4X int
 			p1H int
 			p2H int
+			p3H int
 			p4H int
 		}{
 			p1X: w.Root.FindPane(p1.ID).X,
@@ -68,17 +71,21 @@ func TestCommandSpawnAutoAppendsToFirstUnderfilledColumnAndEqualizes(t *testing.
 			p4X: w.Root.FindPane(p4.ID).X,
 			p1H: w.Root.FindPane(p1.ID).H,
 			p2H: w.Root.FindPane(p2.ID).H,
+			p3H: w.Root.FindPane(p3.ID).H,
 			p4H: w.Root.FindPane(p4.ID).H,
 		}
 	})
 
-	if state.p1X != state.p2X || state.p1X != state.p4X {
-		t.Fatalf("auto spawn should keep pane-1, pane-2, and worker-4 in the same column: %+v", state)
+	if state.p1X != state.p2X {
+		t.Fatalf("auto spawn should keep pane-1 and pane-2 in the original column: %+v", state)
 	}
-	if state.p3X == state.p4X {
-		t.Fatalf("auto spawn should leave pane-3 in a different column: %+v", state)
+	if state.p3X != state.p4X {
+		t.Fatalf("auto spawn should place pane-3 and worker-4 in the shortest column: %+v", state)
 	}
-	if state.p1H != state.p2H || state.p2H != state.p4H {
+	if state.p1X == state.p4X {
+		t.Fatalf("auto spawn should leave pane-1/pane-2 in a different column from worker-4: %+v", state)
+	}
+	if state.p3H != state.p4H {
 		t.Fatalf("auto spawn should equalize row heights in the filled column: %+v", state)
 	}
 }

--- a/internal/server/spawn_auto_command_test.go
+++ b/internal/server/spawn_auto_command_test.go
@@ -36,8 +36,6 @@ func TestCommandSpawnAutoAppendsToShortestUnderfilledColumnAndEqualizes(t *testi
 		p2X int
 		p3X int
 		p4X int
-		p1H int
-		p2H int
 		p3H int
 		p4H int
 	} {
@@ -49,8 +47,6 @@ func TestCommandSpawnAutoAppendsToShortestUnderfilledColumnAndEqualizes(t *testi
 				p2X int
 				p3X int
 				p4X int
-				p1H int
-				p2H int
 				p3H int
 				p4H int
 			}{}
@@ -60,8 +56,6 @@ func TestCommandSpawnAutoAppendsToShortestUnderfilledColumnAndEqualizes(t *testi
 			p2X int
 			p3X int
 			p4X int
-			p1H int
-			p2H int
 			p3H int
 			p4H int
 		}{
@@ -69,8 +63,6 @@ func TestCommandSpawnAutoAppendsToShortestUnderfilledColumnAndEqualizes(t *testi
 			p2X: w.Root.FindPane(p2.ID).X,
 			p3X: w.Root.FindPane(p3.ID).X,
 			p4X: w.Root.FindPane(p4.ID).X,
-			p1H: w.Root.FindPane(p1.ID).H,
-			p2H: w.Root.FindPane(p2.ID).H,
 			p3H: w.Root.FindPane(p3.ID).H,
 			p4H: w.Root.FindPane(p4.ID).H,
 		}


### PR DESCRIPTION
## Motivation
Column-fill auto spawn was choosing the first column under the fill threshold, which could skip a shorter column further to the right and leave the layout uneven. This change makes auto spawn fill the shortest eligible column first while preserving the existing threshold before a root split.

## Summary
- choose the shortest under-threshold column in `PlanColumnFillSpawn`, keeping leftmost tie-breaking by preserving the first minimum
- update column-fill unit tests for shortest-column selection, leftmost tie behavior, and lead-anchored logical-root behavior
- update the server-level auto-spawn test to assert the new shortest-column placement

## Testing
- `go test ./internal/mux/ -run TestPlanColumnFillSpawn -count=100 -parallel=4`
- `go test ./internal/server -run TestCommandSpawnAuto -count=100 -parallel=4`
- `go test ./... -timeout 120s`

## Review focus
- confirm the planner only picks a column when it is still below `len(columns) + 1`, and only falls back to a root split when every column is at that threshold
- confirm equal-height columns still choose the leftmost column, including through the logical-root path used by lead-anchored layouts

Closes LAB-1032
