### PR TITLE
Flush reload-server reply before hot-reload exec

### DIFF
--- a/internal/server/commands.go
+++ b/internal/server/commands.go
@@ -68,6 +68,13 @@ func (s commandStreamSender) Send(msg *proto.Message) error {
 	return s.cc.Send(msg)
 }
 
+func (s commandStreamSender) Flush() error {
+	if s.cc == nil {
+		return nil
+	}
+	return s.cc.Flush()
+}
+
 func (ctx *CommandContext) applyCommandResult(res commandpkg.Result) {
 	switch {
 	case res.Mutate != nil:

--- a/internal/server/commands/remote/reload_test.go
+++ b/internal/server/commands/remote/reload_test.go
@@ -1,9 +1,13 @@
 package remote
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/weill-labs/amux/internal/proto"
+	commandpkg "github.com/weill-labs/amux/internal/server/commands"
 )
 
 func TestRequestedReloadExecPathNormalizesProvidedPath(t *testing.T) {
@@ -38,4 +42,70 @@ func TestRequestedReloadExecPathRejectsMissingBinary(t *testing.T) {
 	if _, err := RequestedReloadExecPath([]string{ReloadServerExecPathFlag, missingPath}); err == nil {
 		t.Fatalf("RequestedReloadExecPath(%q) should fail", missingPath)
 	}
+}
+
+func TestReloadServerFlushesReplyBeforeReload(t *testing.T) {
+	t.Parallel()
+
+	sender := &reloadTestSender{}
+	ctx := reloadTestContext{
+		execPath: "/tmp/amux",
+		onReload: func(execPath string) error {
+			if execPath != "/tmp/amux" {
+				return fmt.Errorf("execPath = %q, want /tmp/amux", execPath)
+			}
+			if !sender.flushed {
+				return fmt.Errorf("reload started before reply flush")
+			}
+			return nil
+		},
+	}
+
+	res := ReloadServer(ctx, nil)
+	if res.Stream == nil {
+		t.Fatal("ReloadServer() should stream the reload notice")
+	}
+	if err := res.Stream(sender); err != nil {
+		t.Fatalf("res.Stream() error = %v", err)
+	}
+	if len(sender.msgs) != 1 {
+		t.Fatalf("sent %d messages, want 1", len(sender.msgs))
+	}
+	if got := sender.msgs[0].CmdOutput; got != "Server reloading...\n" {
+		t.Fatalf("reload notice = %q, want %q", got, "Server reloading...\n")
+	}
+}
+
+type reloadTestContext struct {
+	execPath string
+	onReload func(string) error
+}
+
+func (ctx reloadTestContext) HostStatuses() map[string]string { return nil }
+
+func (ctx reloadTestContext) DisconnectHost(string) error { return nil }
+
+func (ctx reloadTestContext) ReconnectHost(string) error { return nil }
+
+func (ctx reloadTestContext) ResolveReloadExecPath() (string, error) { return ctx.execPath, nil }
+
+func (ctx reloadTestContext) ReloadServer(execPath string) error { return ctx.onReload(execPath) }
+
+func (ctx reloadTestContext) UnspliceHost(string) commandpkg.Result { return commandpkg.Result{} }
+
+func (ctx reloadTestContext) InjectProxy(string) commandpkg.Result { return commandpkg.Result{} }
+
+type reloadTestSender struct {
+	msgs    []*proto.Message
+	flushed bool
+}
+
+func (s *reloadTestSender) Send(msg *proto.Message) error {
+	s.msgs = append(s.msgs, msg)
+	return nil
+}
+
+func (s *reloadTestSender) Flush() error {
+	s.flushed = true
+	return nil
 }

--- a/internal/server/commands/remote/reload_test.go
+++ b/internal/server/commands/remote/reload_test.go
@@ -76,6 +76,21 @@ func TestReloadServerFlushesReplyBeforeReload(t *testing.T) {
 	}
 }
 
+func TestReloadServerReturnsFlushError(t *testing.T) {
+	t.Parallel()
+
+	res := ReloadServer(reloadTestContext{execPath: "/tmp/amux"}, nil)
+	if res.Stream == nil {
+		t.Fatal("ReloadServer() should stream the reload notice")
+	}
+
+	wantErr := fmt.Errorf("flush failed")
+	err := res.Stream(&reloadTestSender{flushErr: wantErr})
+	if err == nil || err.Error() != wantErr.Error() {
+		t.Fatalf("res.Stream() error = %v, want %v", err, wantErr)
+	}
+}
+
 type reloadTestContext struct {
 	execPath string
 	onReload func(string) error
@@ -96,8 +111,9 @@ func (ctx reloadTestContext) UnspliceHost(string) commandpkg.Result { return com
 func (ctx reloadTestContext) InjectProxy(string) commandpkg.Result { return commandpkg.Result{} }
 
 type reloadTestSender struct {
-	msgs    []*proto.Message
-	flushed bool
+	msgs     []*proto.Message
+	flushed  bool
+	flushErr error
 }
 
 func (s *reloadTestSender) Send(msg *proto.Message) error {
@@ -107,5 +123,5 @@ func (s *reloadTestSender) Send(msg *proto.Message) error {
 
 func (s *reloadTestSender) Flush() error {
 	s.flushed = true
-	return nil
+	return s.flushErr
 }

--- a/internal/server/commands/remote/remote.go
+++ b/internal/server/commands/remote/remote.go
@@ -80,6 +80,11 @@ func ReloadServer(ctx Context, args []string) commandpkg.Result {
 			}); err != nil {
 				return err
 			}
+			// Reload may exec immediately, so wait for the queued command reply to
+			// reach the client before the server replaces its process image.
+			if err := sender.Flush(); err != nil {
+				return err
+			}
 			return ctx.ReloadServer(execPath)
 		},
 	}

--- a/internal/server/commands/result.go
+++ b/internal/server/commands/result.go
@@ -32,4 +32,5 @@ type PaneRender struct {
 
 type StreamSender interface {
 	Send(*proto.Message) error
+	Flush() error
 }

--- a/internal/server/commands_test.go
+++ b/internal/server/commands_test.go
@@ -49,3 +49,51 @@ func TestReplyCommandMutationFlushesCmdResultBeforeExit(t *testing.T) {
 		t.Fatal("expected the client writer to attempt a command-result write")
 	}
 }
+
+func TestCommandStreamSenderFlushWithoutClientIsNoop(t *testing.T) {
+	t.Parallel()
+
+	if err := (commandStreamSender{}).Flush(); err != nil {
+		t.Fatalf("Flush() error = %v, want nil", err)
+	}
+}
+
+func TestCommandStreamSenderFlushDelegatesToClient(t *testing.T) {
+	t.Parallel()
+
+	conn := newBlockingWriteConn()
+	cc := newClientConn(conn)
+	t.Cleanup(cc.Close)
+
+	if err := cc.Send(&Message{Type: MsgTypeCmdResult, CmdOutput: "ok\n"}); err != nil {
+		t.Fatalf("Send() error = %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- (commandStreamSender{cc: cc}).Flush()
+	}()
+
+	select {
+	case err := <-done:
+		t.Fatalf("Flush() returned early with %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(conn.release)
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Flush() error = %v, want nil", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Flush() did not return after the client write was released")
+	}
+
+	select {
+	case <-conn.writeSeen:
+	case <-time.After(time.Second):
+		t.Fatal("expected Flush() to wait for the client write")
+	}
+}


### PR DESCRIPTION
## Motivation
`TestReloadServer` was flaky because `reload-server` queued the `Server reloading...` reply and could enter the hot-reload exec path before that reply reached the client socket. When that happened, one-shot callers observed `amux reload-server: EOF` instead of the final command result.

## Summary
- add a `Flush()` barrier to streamed command senders
- flush the reload notice before invoking `Server.Reload()`
- add a regression test that models the async sender and fails if reload starts before the reply is flushed

## Testing
- `go test ./internal/server/commands/remote -run 'TestReloadServerFlushesReplyBeforeReload|TestRequestedReloadExecPath' -count=100`
- `go test ./internal/server -run 'TestCmdReloadServer|TestReplyCommandMutationFlushesCmdResultBeforeExit|TestShutdownCommandFlushesReplyBeforeShutdownStarts' -count=100`
- `go test -run TestReloadServer -count=100 -parallel=4 -timeout 300s ./test/`
- `go test ./... -timeout 120s`

## Review focus
- the new `StreamSender.Flush()` contract is only implemented by the server-side command sender used for streamed command replies
- `reload-server` now waits for the queued command result to drain before `Server.Reload()` can `exec`

Closes LAB-1036
