### PR TITLE
Stabilize benchmark CI on constrained runners

### DIFF
--- a/internal/client/renderer_bench_test.go
+++ b/internal/client/renderer_bench_test.go
@@ -114,6 +114,7 @@ func BenchmarkRendererHandlePaneOutput(b *testing.B) {
 	for _, size := range []int{256, 4096, 32768} {
 		b.Run(fmt.Sprintf("bytes_%d", size), func(b *testing.B) {
 			r, _ := benchRendererWithContent(1)
+			defer r.Close()
 			payload := benchTerminalPayload(size)
 
 			b.SetBytes(int64(size))
@@ -208,6 +209,7 @@ func BenchmarkRendererHandlePaneOutputVisibility(b *testing.B) {
 
 	b.Run("visible", func(b *testing.B) {
 		r := NewWithScrollback(width, layoutHeight+1, mux.DefaultScrollbackLines)
+		defer r.Close()
 		r.HandleLayout(layout)
 
 		b.SetBytes(int64(payloadSize))
@@ -221,6 +223,7 @@ func BenchmarkRendererHandlePaneOutputVisibility(b *testing.B) {
 
 	b.Run("hidden", func(b *testing.B) {
 		r := NewWithScrollback(width, layoutHeight+1, mux.DefaultScrollbackLines)
+		defer r.Close()
 		r.HandleLayout(layout)
 
 		b.SetBytes(int64(payloadSize))
@@ -237,6 +240,7 @@ func BenchmarkRendererCaptureJSON(b *testing.B) {
 	for _, panes := range []int{1, 20} {
 		b.Run(fmt.Sprintf("panes_%d/build", panes), func(b *testing.B) {
 			r, status := benchRendererWithContent(panes)
+			defer r.Close()
 
 			b.ReportAllocs()
 			b.ResetTimer()
@@ -249,6 +253,7 @@ func BenchmarkRendererCaptureJSON(b *testing.B) {
 
 		b.Run(fmt.Sprintf("panes_%d/marshal", panes), func(b *testing.B) {
 			r, status := benchRendererWithContent(panes)
+			defer r.Close()
 			capture, ok := r.captureJSONValue(status)
 			if !ok {
 				b.Fatal("captureJSONValue returned no layout")
@@ -272,12 +277,14 @@ func BenchmarkRendererHandleLayout(b *testing.B) {
 		target := benchLayoutSnapshot(panes, width, layoutHeight)
 		b.Run(fmt.Sprintf("panes_%d", panes), func(b *testing.B) {
 			b.ReportAllocs()
-			for b.Loop() {
+			for i := 0; i < b.N; i++ {
 				b.StopTimer()
 				r := NewWithScrollback(width, layoutHeight+1, mux.DefaultScrollbackLines)
 				r.HandleLayout(base)
 				b.StartTimer()
 				r.HandleLayout(target)
+				b.StopTimer()
+				r.Close()
 			}
 		})
 	}

--- a/test/bench_test.go
+++ b/test/bench_test.go
@@ -13,6 +13,12 @@ import (
 	"github.com/weill-labs/amux/internal/server"
 )
 
+func throughputBenchCommand(i int) (marker, command string) {
+	marker = fmt.Sprintf("DONE-%04d", i)
+	command = fmt.Sprintf("marker=$(printf 'DONE-%%04d' %d); seq 1 10000; printf '%%s\\n' \"$marker\"", i)
+	return marker, command
+}
+
 // ---------------------------------------------------------------------------
 // TmuxBenchHarness — lightweight tmux wrapper for comparison benchmarks
 // ---------------------------------------------------------------------------
@@ -239,11 +245,16 @@ func BenchmarkThroughput(b *testing.B) {
 	b.Run("amux", func(b *testing.B) {
 		b.StopTimer()
 		h := newServerHarness(b)
-		b.StartTimer()
+		h.waitIdle("pane-1")
 		for i := range b.N {
-			marker := fmt.Sprintf("DONE-%04d", i)
-			h.sendKeys("pane-1", fmt.Sprintf("seq 1 10000; echo %s", marker), "Enter")
+			marker, command := throughputBenchCommand(i)
+			b.StartTimer()
+			h.sendKeys("pane-1", command, "Enter")
 			h.waitForTimeout("pane-1", marker, "30s")
+			b.StopTimer()
+			// Wait for the prompt to settle before injecting the next command.
+			// Slow runners can render the marker before the shell is fully idle.
+			h.waitIdle("pane-1")
 		}
 	})
 
@@ -252,8 +263,8 @@ func BenchmarkThroughput(b *testing.B) {
 		th := newTmuxBenchHarness(b)
 		b.StartTimer()
 		for i := range b.N {
-			marker := fmt.Sprintf("DONE-%04d", i)
-			th.run("send-keys", "-t", th.session, fmt.Sprintf("seq 1 10000; echo %s", marker), "Enter")
+			marker, command := throughputBenchCommand(i)
+			th.run("send-keys", "-t", th.session, command, "Enter")
 			deadline := time.Now().Add(30 * time.Second)
 			for time.Now().Before(deadline) {
 				out := th.run("capture-pane", "-t", th.session, "-p")
@@ -273,18 +284,25 @@ func BenchmarkThroughputPersistent(b *testing.B) {
 	b.Run("amux", func(b *testing.B) {
 		b.StopTimer()
 		h := newServerHarness(b)
-		b.StartTimer()
+		h.waitIdle("pane-1")
 		for i := range b.N {
-			marker := fmt.Sprintf("DONE-%04d", i)
+			marker, command := throughputBenchCommand(i)
 
-			msg := h.client.runCommand("send-keys", "pane-1", fmt.Sprintf("seq 1 10000; echo %s", marker), "Enter")
+			b.StartTimer()
+			msg := h.client.runCommandWithTimeout(45*time.Second, "send-keys", "pane-1", command, "Enter")
 			if msg.CmdErr != "" {
 				b.Fatalf("send-keys failed: %s", msg.CmdErr)
 			}
 
-			msg = h.client.runCommand("wait", "content", "pane-1", marker, "--timeout", "30s")
+			msg = h.client.runCommandWithTimeout(45*time.Second, "wait", "content", "pane-1", marker, "--timeout", "30s")
 			if msg.CmdErr != "" {
 				b.Fatalf("wait-for failed: %s", msg.CmdErr)
+			}
+			b.StopTimer()
+
+			msg = h.client.runCommandWithTimeout(45*time.Second, "wait", "idle", "pane-1", "--timeout", "20s")
+			if msg.CmdErr != "" {
+				b.Fatalf("wait-idle failed: %s", msg.CmdErr)
 			}
 		}
 	})

--- a/test/headless_client_test.go
+++ b/test/headless_client_test.go
@@ -44,6 +44,8 @@ type headlessCommand struct {
 	reply chan *server.Message
 }
 
+const defaultHeadlessCommandTimeout = 10 * time.Second
+
 func dialHeadlessSocket(sockPath string, timeout time.Duration) (net.Conn, error) {
 	_ = timeout // timeout is exercised by the layout wait below in newHeadlessClient
 	return net.Dial("unix", sockPath)
@@ -196,6 +198,10 @@ func (hc *headlessClient) sendUIEvent(name string) {
 // runCommand sends a server command over the attached client connection and
 // waits for the single CmdResult reply.
 func (hc *headlessClient) runCommand(cmdName string, args ...string) *server.Message {
+	return hc.runCommandWithTimeout(defaultHeadlessCommandTimeout, cmdName, args...)
+}
+
+func (hc *headlessClient) runCommandWithTimeout(timeout time.Duration, cmdName string, args ...string) *server.Message {
 	req := headlessCommand{
 		msg: &server.Message{
 			Type:    server.MsgTypeCommand,
@@ -216,7 +222,7 @@ func (hc *headlessClient) runCommand(cmdName string, args ...string) *server.Mes
 	select {
 	case msg := <-req.reply:
 		return msg
-	case <-time.After(10 * time.Second):
+	case <-time.After(timeout):
 		return &server.Message{Type: server.MsgTypeCmdResult, CmdErr: "timeout waiting for command result"}
 	case <-hc.closing:
 		select {


### PR DESCRIPTION
## Motivation
Benchmark CI was flaking on constrained macOS GitHub Actions runners in two places: the client layout benchmark could accumulate enough renderer state to get killed, and the throughput benchmarks could race the shell prompt between iterations and time out waiting for the final marker.

## Summary
- close benchmark renderers so `BenchmarkRendererHandleLayout` does not leak actor goroutines and emulator state across iterations
- make throughput benchmarks wait for pane idle outside the timed window so each iteration starts from a settled shell prompt
- generate throughput completion markers at runtime so `wait content` measures the final output marker instead of matching echoed command input
- add a configurable timeout helper for headless benchmark commands so persistent benchmark waits can honor the same longer timeout budget as the command under test

## Testing
- `go test ./internal/client -run '^$' -bench 'BenchmarkRendererHandleLayout/panes_20$' -benchmem -count=3`
- `go test ./test -run '^$' -bench 'BenchmarkThroughput' -benchtime=10x -count=1`
- `go test ./... -timeout 120s`

## Review Focus
- whether the idle barrier is the right place to remove iteration-to-iteration shell overlap without changing the benchmarked throughput window
- whether the runtime-generated marker command is the simplest reliable way to prevent `wait content` from matching echoed input
- whether the renderer benchmark cleanup is sufficient, or if any other benchmark paths should also be hardened later

## Baseline numbers
Hardware: `Linux hetzner-1 6.8.0-90-generic x86_64`, `AMD EPYC-Milan Processor`

| Benchmark | ns/op | B/op | allocs/op |
| --- | ---: | ---: | ---: |
| `BenchmarkRendererHandleLayout/panes_20-8` | 8,704,413 | 91,736,576 | 10,329 |
| `BenchmarkThroughput/amux-8` | 107,207,046 | n/a | n/a |
| `BenchmarkThroughputPersistent/amux-8` | 99,335,228 | n/a | n/a |
| `BenchmarkThroughput/tmux-8` | 45,673,188 | n/a | n/a |

Closes LAB-1035
