### PR TITLE
Allow spawn auto placement in a specific window

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ The public CLI keeps one command path per concept: target sessions with `-s`, cr
 | Command | Description |
 |---------|-------------|
 | `amux list [--no-cwd]` | List panes with metadata (including cwd by default) |
-| `amux spawn [--auto] [--at <pane>] [--vertical\|--horizontal] [--root] [--focus] [--name NAME] [--host HOST] [--task TASK] [--color COLOR]` | Create a new pane using default spawn, column-fill auto spawn, or targeted split placement |
+| `amux spawn [--auto] [--at <pane>] [--window <name\|id>] [--vertical\|--horizontal] [--root] [--focus] [--name NAME] [--host HOST] [--task TASK] [--color COLOR]` | Create a new pane using default spawn, column-fill auto spawn, or targeted split placement |
 | `amux focus <pane\|direction>` | Focus by name, ID, or direction (left/right/up/down/next) |
 | `amux zoom [pane]` | Toggle zoom on a pane |
 | `amux kill [pane]` | Kill a pane (default: active) |
@@ -324,7 +324,7 @@ The public CLI keeps one command path per concept: target sessions with `-s`, cr
 `move` first checks whether both panes are siblings in the same split group. When they are, it reorders only that group. Otherwise it falls back to the existing root-level-group behavior, so moving `pane-3` can still move an entire column or row when the panes are in different branches.
 `move up` and `move down` are shorthand for nudging a pane one slot earlier or later within its current split group.
 `move --to-column` instead moves exactly one pane into the target pane's logical column and appends it to the bottom of that stack.
-`spawn` is the canonical pane-creation command. Use plain `spawn` for the default vertical split path, `spawn --auto` for column-fill placement that rebalances after each insert, and `spawn --at ...` for targeted splits. These layout mutations keep focus unless you add `--focus`. When the active pane is zoomed, they preserve the zoom and keep the focused pane unchanged unless `--focus` is set.
+`spawn` is the canonical pane-creation command. Use plain `spawn` for the default vertical split path, `spawn --auto` for column-fill placement that rebalances after each insert, `spawn --window ...` to target another window's active pane, and `spawn --auto --window ...` to run auto-placement in that window. Use `spawn --at ...` for targeted pane splits. These layout mutations keep focus unless you add `--focus`. When the active pane is zoomed, they preserve the zoom and keep the focused pane unchanged unless `--focus` is set.
 Higher-level prompt delegation now lives at the script layer: compose `wait idle`, `send-keys`, `wait busy`, and `wait exited` or `wait ready` to match the workflow you want.
 
 ### Agent API

--- a/internal/cli/cli_parse.go
+++ b/internal/cli/cli_parse.go
@@ -208,6 +208,7 @@ func ParseMoveArgs(args []string) (string, []string, error) {
 
 type spawnCLIOptions struct {
 	at             string
+	window         string
 	dir            mux.SplitDir
 	hasExplicitDir bool
 	auto           bool
@@ -238,6 +239,12 @@ func ParseSpawnCommandArgs(args []string) (string, []string, error) {
 				return "", nil, fmt.Errorf(spawnUsage)
 			}
 			opts.at = args[i+1]
+			i++
+		case "--window":
+			if i+1 >= len(args) {
+				return "", nil, fmt.Errorf(spawnUsage)
+			}
+			opts.window = args[i+1]
 			i++
 		case "--vertical":
 			if err := setDir(mux.SplitVertical); err != nil {
@@ -282,12 +289,18 @@ func ParseSpawnCommandArgs(args []string) (string, []string, error) {
 		}
 	}
 
+	if opts.window != "" && opts.at != "" {
+		return "", nil, fmt.Errorf(spawnUsage)
+	}
 	if opts.auto && (opts.at != "" || opts.root || opts.hasExplicitDir) {
 		return "", nil, fmt.Errorf(spawnUsage)
 	}
 
 	cmdArgs := make([]string, 0, 10)
 	if opts.auto {
+		if opts.window != "" {
+			cmdArgs = append(cmdArgs, "--window", opts.window)
+		}
 		if opts.focus {
 			cmdArgs = append(cmdArgs, "--focus")
 		}
@@ -309,6 +322,9 @@ func ParseSpawnCommandArgs(args []string) (string, []string, error) {
 
 	if opts.at != "" {
 		cmdArgs = append(cmdArgs, "--at", opts.at)
+	}
+	if opts.window != "" {
+		cmdArgs = append(cmdArgs, "--window", opts.window)
 	}
 	if opts.root {
 		cmdArgs = append(cmdArgs, "--root")

--- a/internal/cli/cli_usage.go
+++ b/internal/cli/cli_usage.go
@@ -14,7 +14,7 @@ const (
 	leadUsage         = "usage: amux lead [pane] | amux lead --clear"
 	metaUsage         = "usage: amux meta <set|get|rm> ..."
 	moveUsage         = "usage: amux move <pane> up|down | amux move <pane> (--before <target>|--after <target>|--to-column <target>)"
-	spawnUsage        = "usage: amux spawn [--auto] [--at <pane>] [--vertical|--horizontal] [--root] [--focus] [--name NAME] [--host HOST] [--task TASK] [--color COLOR]"
+	spawnUsage        = "usage: amux spawn [--auto] [--at <pane>] [--window <name|id>] [--vertical|--horizontal] [--root] [--focus] [--name NAME] [--host HOST] [--task TASK] [--color COLOR]"
 	swapUsage         = "usage: amux swap <pane1> <pane2> [--tree] | amux swap forward | amux swap backward"
 	cursorUsage       = "usage: amux cursor <layout|clipboard|ui> [--client <id>]"
 	disconnectUsage   = "usage: amux disconnect <host>"
@@ -170,7 +170,7 @@ Usage:
                                        Simulate mouse input through an attached client
   amux [-s session] broadcast (--panes <pane,pane,...> | --window <index|name> | --match <glob>) [--hex] <keys>...
                                        Send the same keystrokes to multiple panes
-  amux [-s session] spawn [--auto] [--at <pane>] [--vertical|--horizontal] [--root] [--focus] [--name NAME] [--host HOST] [--task TASK] [--color COLOR]
+  amux [-s session] spawn [--auto] [--at <pane>] [--window <name|id>] [--vertical|--horizontal] [--root] [--focus] [--name NAME] [--host HOST] [--task TASK] [--color COLOR]
                                        Create a new pane using default spawn, column-fill auto spawn, or targeted split placement
   amux [-s session] zoom [pane]        Toggle zoom (maximize) a pane
   amux [-s session] swap <p1> <p2> [--tree]

--- a/internal/cli/main_test.go
+++ b/internal/cli/main_test.go
@@ -25,14 +25,18 @@ func TestParseSpawnCommandArgs(t *testing.T) {
 		{name: "default spawn", args: nil, wantCmd: "spawn", wantArgs: []string{}},
 		{name: "focused spawn", args: []string{"--focus"}, wantCmd: "spawn", wantArgs: []string{"--focus"}},
 		{name: "auto spawn", args: []string{"--auto"}, wantCmd: "spawn", wantArgs: []string{"--auto"}},
+		{name: "auto spawn in named window", args: []string{"--auto", "--window", "logs"}, wantCmd: "spawn", wantArgs: []string{"--window", "logs", "--auto"}},
 		{name: "targeted spawn at pane", args: []string{"--at", "pane-1"}, wantCmd: "spawn", wantArgs: []string{"--at", "pane-1"}},
+		{name: "targeted spawn in named window", args: []string{"--window", "logs"}, wantCmd: "spawn", wantArgs: []string{"--window", "logs"}},
 		{name: "targeted spawn active vertical", args: []string{"--vertical"}, wantCmd: "spawn", wantArgs: []string{"--vertical"}},
 		{name: "targeted spawn root vertical", args: []string{"--at", "pane-1", "--root", "--vertical"}, wantCmd: "spawn", wantArgs: []string{"--at", "pane-1", "--root", "--vertical"}},
 		{name: "targeted spawn with metadata", args: []string{"--at", "pane-1", "--task", "build", "--color", "blue"}, wantCmd: "spawn", wantArgs: []string{"--at", "pane-1", "--task", "build", "--color", "blue"}},
 		{name: "conflicting directions", args: []string{"--vertical", "--horizontal"}, wantErrText: spawnUsage},
 		{name: "auto conflicts with explicit placement", args: []string{"--auto", "--vertical"}, wantErrText: spawnUsage},
+		{name: "window conflicts with explicit pane target", args: []string{"--window", "logs", "--at", "pane-1"}, wantErrText: spawnUsage},
 		{name: "spiral rejected", args: []string{"--spiral"}, wantErrText: spawnUsage},
 		{name: "missing at value", args: []string{"--at"}, wantErrText: spawnUsage},
+		{name: "missing window value", args: []string{"--window"}, wantErrText: spawnUsage},
 		{name: "unknown arg", args: []string{"pane-1"}, wantErrText: spawnUsage},
 	}
 

--- a/internal/server/commands/layout/args.go
+++ b/internal/server/commands/layout/args.go
@@ -16,6 +16,7 @@ const (
 
 type createPaneArgs struct {
 	PaneRef      string
+	WindowRef    string
 	RootLevel    bool
 	Dir          mux.SplitDir
 	Auto         bool
@@ -60,6 +61,7 @@ func parseCreatePaneArgs(mode createPaneMode, args []string) (createPaneArgs, er
 		specs = append(specs,
 			cmdflags.FlagSpec{Name: "--auto", Type: cmdflags.FlagTypeBool},
 			cmdflags.FlagSpec{Name: "--at", Type: cmdflags.FlagTypeString},
+			cmdflags.FlagSpec{Name: "--window", Type: cmdflags.FlagTypeString},
 			cmdflags.FlagSpec{Name: "--root", Type: cmdflags.FlagTypeBool},
 			cmdflags.FlagSpec{Name: "--vertical", Type: cmdflags.FlagTypeBool},
 			cmdflags.FlagSpec{Name: "--horizontal", Type: cmdflags.FlagTypeBool},
@@ -79,6 +81,7 @@ func parseCreatePaneArgs(mode createPaneMode, args []string) (createPaneArgs, er
 	if mode == createPaneModeSpawn {
 		parsed.Auto = flags.Bool("--auto")
 		parsed.PaneRef = flags.String("--at")
+		parsed.WindowRef = flags.String("--window")
 		parsed.RootLevel = flags.Bool("--root")
 		parsed.HostExplicit = flags.Seen("--host")
 	}
@@ -128,10 +131,13 @@ func parseCreatePaneArgs(mode createPaneMode, args []string) (createPaneArgs, er
 	if len(positionals) > 0 {
 		return createPaneArgs{}, fmt.Errorf("unknown spawn arg %q", positionals[0])
 	}
+	if parsed.WindowRef != "" && parsed.PaneRef != "" {
+		return createPaneArgs{}, fmt.Errorf("spawn --window cannot be combined with --at")
+	}
 	if parsed.Auto && (parsed.PaneRef != "" || parsed.RootLevel || hasExplicitDir) {
 		return createPaneArgs{}, fmt.Errorf("spawn --auto cannot be combined with explicit placement")
 	}
-	if (parsed.PaneRef != "" || parsed.RootLevel) && !hasExplicitDir {
+	if (parsed.PaneRef != "" || (parsed.WindowRef != "" && !parsed.Auto) || parsed.RootLevel) && !hasExplicitDir {
 		parsed.Dir = mux.SplitHorizontal
 	}
 	return parsed, nil
@@ -163,6 +169,7 @@ func ParseSplitArgs(args []string) (SplitArgs, error) {
 
 type SpawnArgs struct {
 	PaneRef      string
+	WindowRef    string
 	RootLevel    bool
 	Dir          mux.SplitDir
 	Meta         mux.PaneMeta
@@ -182,6 +189,7 @@ func ParseSpawnArgs(args []string) (SpawnArgs, error) {
 	}
 	return SpawnArgs{
 		PaneRef:   parsed.PaneRef,
+		WindowRef: parsed.WindowRef,
 		RootLevel: parsed.RootLevel,
 		Dir:       parsed.Dir,
 		Meta: mux.PaneMeta{

--- a/internal/server/commands/layout/args_test.go
+++ b/internal/server/commands/layout/args_test.go
@@ -52,6 +52,16 @@ func TestParseCreatePaneArgs(t *testing.T) {
 			},
 		},
 		{
+			name: "spawn parses window target",
+			mode: createPaneModeSpawn,
+			args: []string{"--window", "logs", "--name", "worker"},
+			want: createPaneArgs{
+				WindowRef: "logs",
+				Dir:       mux.SplitHorizontal,
+				Name:      "worker",
+			},
+		},
+		{
 			name:    "spawn rejects split-only pane refs",
 			mode:    createPaneModeSpawn,
 			args:    []string{"pane-1"},
@@ -215,6 +225,31 @@ func TestParseSpawnArgs(t *testing.T) {
 			},
 		},
 		{
+			name: "parses auto mode with window target",
+			args: []string{"--auto", "--window", "logs", "--name", "worker-1"},
+			want: SpawnArgs{
+				Auto:      true,
+				WindowRef: "logs",
+				Dir:       mux.SplitVertical,
+				Meta: mux.PaneMeta{
+					Name: "worker-1",
+					Host: mux.DefaultHost,
+				},
+			},
+		},
+		{
+			name: "parses window targeted spawn placement",
+			args: []string{"--window", "logs", "--name", "worker-1"},
+			want: SpawnArgs{
+				WindowRef: "logs",
+				Dir:       mux.SplitHorizontal,
+				Meta: mux.PaneMeta{
+					Name: "worker-1",
+					Host: mux.DefaultHost,
+				},
+			},
+		},
+		{
 			name: "parses targeted spawn placement",
 			args: []string{"--at", "pane-1", "--name", "worker-1"},
 			want: SpawnArgs{
@@ -269,6 +304,11 @@ func TestParseSpawnArgs(t *testing.T) {
 			name:    "rejects auto with explicit target",
 			args:    []string{"--auto", "--at", "pane-1"},
 			wantErr: "spawn --auto cannot be combined with explicit placement",
+		},
+		{
+			name:    "rejects window with explicit pane target",
+			args:    []string{"--window", "logs", "--at", "pane-1"},
+			wantErr: "spawn --window cannot be combined with --at",
 		},
 		{
 			name:    "rejects spiral flag",

--- a/internal/server/commands_layout.go
+++ b/internal/server/commands_layout.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/weill-labs/amux/internal/mux"
@@ -72,6 +73,7 @@ const (
 
 type createPaneRequest struct {
 	paneRef      string
+	windowRef    string
 	hostName     string
 	hostExplicit bool
 	name         string
@@ -121,7 +123,7 @@ type respawnTarget struct {
 }
 
 func runCreatePane(ctx *CommandContext, actorPaneID uint32, command string, placement createPanePlacement, req createPaneRequest, keepFocus bool) commandpkg.Result {
-	snapshot, err := queryCreatePaneSnapshot(ctx.Sess, actorPaneID, command, placement, req.paneRef)
+	snapshot, err := queryCreatePaneSnapshot(ctx.Sess, actorPaneID, command, placement, req.paneRef, req.windowRef)
 	if err != nil {
 		return commandpkg.Result{Err: err}
 	}
@@ -180,12 +182,11 @@ func runCreatePane(ctx *CommandContext, actorPaneID uint32, command string, plac
 	}))
 }
 
-func queryCreatePaneSnapshot(sess *Session, actorPaneID uint32, command string, placement createPanePlacement, paneRef string) (createPaneSnapshot, error) {
+func queryCreatePaneSnapshot(sess *Session, actorPaneID uint32, command string, placement createPanePlacement, paneRef, windowRef string) (createPaneSnapshot, error) {
 	return enqueueSessionQuery(sess, func(sess *Session) (createPaneSnapshot, error) {
 		if placement == createPanePlacementColumnFill {
-			return queryColumnFillCreatePaneSnapshot(sess, actorPaneID, command)
+			return queryColumnFillCreatePaneSnapshot(sess, actorPaneID, command, windowRef)
 		}
-		w := sess.windowForActor(actorPaneID)
 		if paneRef != "" {
 			pane, resolvedWindow, err := sess.resolvePaneAcrossWindowsForActor(actorPaneID, paneRef)
 			if err != nil {
@@ -204,6 +205,10 @@ func queryCreatePaneSnapshot(sess *Session, actorPaneID uint32, command string, 
 				treatLeadPaneAsWindowRef: command == "spawn",
 			}, nil
 		}
+		w, err := resolveCreatePaneTargetWindow(sess, actorPaneID, command, windowRef)
+		if err != nil {
+			return createPaneSnapshot{}, err
+		}
 		if w == nil {
 			return createPaneSnapshot{}, createPaneWindowError(command)
 		}
@@ -221,10 +226,30 @@ func queryCreatePaneSnapshot(sess *Session, actorPaneID uint32, command string, 
 	})
 }
 
-func queryColumnFillCreatePaneSnapshot(sess *Session, actorPaneID uint32, command string) (createPaneSnapshot, error) {
+func resolveCreatePaneTargetWindow(sess *Session, actorPaneID uint32, command, windowRef string) (*mux.Window, error) {
+	if windowRef != "" {
+		if windowID, err := strconv.Atoi(windowRef); err == nil {
+			if w := sess.windowByID(uint32(windowID)); w != nil {
+				return w, nil
+			}
+		}
+		w := sess.resolveWindow(windowRef)
+		if w == nil {
+			return nil, fmt.Errorf("window %q not found", windowRef)
+		}
+		return w, nil
+	}
 	w := sess.windowForActor(actorPaneID)
 	if w == nil {
-		return createPaneSnapshot{}, createPaneWindowError(command)
+		return nil, createPaneWindowError(command)
+	}
+	return w, nil
+}
+
+func queryColumnFillCreatePaneSnapshot(sess *Session, actorPaneID uint32, command, windowRef string) (createPaneSnapshot, error) {
+	w, err := resolveCreatePaneTargetWindow(sess, actorPaneID, command, windowRef)
+	if err != nil {
+		return createPaneSnapshot{}, err
 	}
 
 	plan, err := w.PlanColumnFillSpawn()
@@ -439,6 +464,7 @@ func createPaneRequestFromSpawnArgs(args layoutcmd.SpawnArgs) createPaneRequest 
 	}
 	return createPaneRequest{
 		paneRef:      args.PaneRef,
+		windowRef:    args.WindowRef,
 		hostName:     hostName,
 		hostExplicit: args.HostExplicit,
 		name:         args.Meta.Name,

--- a/internal/server/spawn_auto_command_test.go
+++ b/internal/server/spawn_auto_command_test.go
@@ -142,3 +142,217 @@ func TestCommandSpawnAutoRootSplitsWhenColumnsAreFull(t *testing.T) {
 		t.Fatalf("new root column should span the full window height, got %+v", state)
 	}
 }
+
+func TestCommandSpawnAutoTargetsSpecifiedWindow(t *testing.T) {
+	t.Parallel()
+
+	srv, sess, cleanup := newCommandTestSession(t)
+	defer cleanup()
+
+	p1 := newTestPane(sess, 1, "pane-1")
+	p2 := newTestPane(sess, 2, "pane-2")
+	p3 := newTestPane(sess, 3, "pane-3")
+	p4 := newTestPane(sess, 4, "pane-4")
+
+	mainWindow := mux.NewWindow(p1, 80, 23)
+	mainWindow.ID = 1
+	mainWindow.Name = "main"
+
+	logsWindow := mux.NewWindow(p2, 80, 23)
+	logsWindow.ID = 4
+	logsWindow.Name = "logs"
+	if _, err := logsWindow.SplitPaneWithOptions(p2.ID, mux.SplitHorizontal, p3, mux.SplitOptions{}); err != nil {
+		t.Fatalf("Split pane-2 horizontally: %v", err)
+	}
+	if _, err := logsWindow.SplitRoot(mux.SplitVertical, p4); err != nil {
+		t.Fatalf("SplitRoot pane-4: %v", err)
+	}
+
+	setSessionLayoutForTest(t, sess, mainWindow.ID, []*mux.Window{mainWindow, logsWindow}, p1, p2, p3, p4)
+
+	res := runTestCommand(t, srv, sess, "spawn", "--auto", "--window", "4", "--name", "worker-5")
+	if res.cmdErr != "" {
+		t.Fatalf("spawn --auto --window failed: %s", res.cmdErr)
+	}
+
+	state := mustSessionQuery(t, sess, func(sess *Session) struct {
+		activeWindowID uint32
+		workerWindowID uint32
+		p2X            int
+		p3X            int
+		p4X            int
+		p5X            int
+		p4H            int
+		p5H            int
+	} {
+		worker, err := sess.findPaneByRef("worker-5")
+		if err != nil {
+			return struct {
+				activeWindowID uint32
+				workerWindowID uint32
+				p2X            int
+				p3X            int
+				p4X            int
+				p5X            int
+				p4H            int
+				p5H            int
+			}{}
+		}
+		workerWindow := sess.findWindowByPaneID(worker.ID)
+		p2Cell := logsWindow.Root.FindPane(p2.ID)
+		p3Cell := logsWindow.Root.FindPane(p3.ID)
+		p4Cell := logsWindow.Root.FindPane(p4.ID)
+		p5Cell := logsWindow.Root.FindPane(worker.ID)
+		if workerWindow == nil || p2Cell == nil || p3Cell == nil || p4Cell == nil || p5Cell == nil {
+			return struct {
+				activeWindowID uint32
+				workerWindowID uint32
+				p2X            int
+				p3X            int
+				p4X            int
+				p5X            int
+				p4H            int
+				p5H            int
+			}{}
+		}
+		return struct {
+			activeWindowID uint32
+			workerWindowID uint32
+			p2X            int
+			p3X            int
+			p4X            int
+			p5X            int
+			p4H            int
+			p5H            int
+		}{
+			activeWindowID: sess.ActiveWindowID,
+			workerWindowID: workerWindow.ID,
+			p2X:            p2Cell.X,
+			p3X:            p3Cell.X,
+			p4X:            p4Cell.X,
+			p5X:            p5Cell.X,
+			p4H:            p4Cell.H,
+			p5H:            p5Cell.H,
+		}
+	})
+
+	if state.activeWindowID != mainWindow.ID {
+		t.Fatalf("active window = %d, want %d", state.activeWindowID, mainWindow.ID)
+	}
+	if state.workerWindowID != logsWindow.ID {
+		t.Fatalf("worker window = %d, want %d", state.workerWindowID, logsWindow.ID)
+	}
+	if state.p2X != state.p3X {
+		t.Fatalf("pane-2 and pane-3 should remain in the original logs column: %+v", state)
+	}
+	if state.p4X != state.p5X {
+		t.Fatalf("auto spawn should place pane-4 and worker-5 in the shortest logs column: %+v", state)
+	}
+	if state.p2X == state.p5X {
+		t.Fatalf("worker-5 should be placed in a different logs column from pane-2/pane-3: %+v", state)
+	}
+	if state.p4H != state.p5H {
+		t.Fatalf("auto spawn should equalize row heights in the targeted window column: %+v", state)
+	}
+}
+
+func TestCommandSpawnTargetsSpecifiedWindowActivePane(t *testing.T) {
+	t.Parallel()
+
+	srv, sess, cleanup := newCommandTestSession(t)
+	defer cleanup()
+
+	p1 := newTestPane(sess, 1, "pane-1")
+	p2 := newTestPane(sess, 2, "pane-2")
+	p3 := newTestPane(sess, 3, "pane-3")
+
+	mainWindow := mux.NewWindow(p1, 80, 23)
+	mainWindow.ID = 1
+	mainWindow.Name = "main"
+
+	logsWindow := mux.NewWindow(p2, 80, 23)
+	logsWindow.ID = 2
+	logsWindow.Name = "logs"
+	if _, err := logsWindow.SplitPaneWithOptions(p2.ID, mux.SplitHorizontal, p3, mux.SplitOptions{}); err != nil {
+		t.Fatalf("Split pane-2 horizontally: %v", err)
+	}
+	logsWindow.FocusPane(p2)
+
+	setSessionLayoutForTest(t, sess, mainWindow.ID, []*mux.Window{mainWindow, logsWindow}, p1, p2, p3)
+
+	res := runTestCommand(t, srv, sess, "spawn", "--window", "logs", "--name", "worker-4")
+	if res.cmdErr != "" {
+		t.Fatalf("spawn --window failed: %s", res.cmdErr)
+	}
+
+	state := mustSessionQuery(t, sess, func(sess *Session) struct {
+		activeWindowID uint32
+		workerWindowID uint32
+		workerX        int
+		workerY        int
+		p2X            int
+		p2Y            int
+		p3Y            int
+	} {
+		worker, err := sess.findPaneByRef("worker-4")
+		if err != nil {
+			return struct {
+				activeWindowID uint32
+				workerWindowID uint32
+				workerX        int
+				workerY        int
+				p2X            int
+				p2Y            int
+				p3Y            int
+			}{}
+		}
+		workerWindow := sess.findWindowByPaneID(worker.ID)
+		workerCell := logsWindow.Root.FindPane(worker.ID)
+		p2Cell := logsWindow.Root.FindPane(p2.ID)
+		p3Cell := logsWindow.Root.FindPane(p3.ID)
+		if workerWindow == nil || workerCell == nil || p2Cell == nil || p3Cell == nil {
+			return struct {
+				activeWindowID uint32
+				workerWindowID uint32
+				workerX        int
+				workerY        int
+				p2X            int
+				p2Y            int
+				p3Y            int
+			}{}
+		}
+		return struct {
+			activeWindowID uint32
+			workerWindowID uint32
+			workerX        int
+			workerY        int
+			p2X            int
+			p2Y            int
+			p3Y            int
+		}{
+			activeWindowID: sess.ActiveWindowID,
+			workerWindowID: workerWindow.ID,
+			workerX:        workerCell.X,
+			workerY:        workerCell.Y,
+			p2X:            p2Cell.X,
+			p2Y:            p2Cell.Y,
+			p3Y:            p3Cell.Y,
+		}
+	})
+
+	if state.activeWindowID != mainWindow.ID {
+		t.Fatalf("active window = %d, want %d", state.activeWindowID, mainWindow.ID)
+	}
+	if state.workerWindowID != logsWindow.ID {
+		t.Fatalf("worker window = %d, want %d", state.workerWindowID, logsWindow.ID)
+	}
+	if state.workerX != state.p2X {
+		t.Fatalf("worker-4 should split the targeted window active pane column: %+v", state)
+	}
+	if state.workerY <= state.p2Y {
+		t.Fatalf("worker-4 should be placed below pane-2 after the split: %+v", state)
+	}
+	if state.workerY >= state.p3Y {
+		t.Fatalf("worker-4 should split pane-2, not pane-3: %+v", state)
+	}
+}


### PR DESCRIPTION
## Motivation
orca needs to target a specific window while still using spawn auto placement. Before this change, `amux spawn --auto` rejected any explicit target, so workers could not be auto-placed in a non-active window.

## Summary
- add `--window` parsing to spawn and allow it with `--auto` while rejecting `--window` with `--at`
- route spawn placement through the selected window so non-auto spawns split that window's active pane and auto spawns plan column fill in that window
- update CLI and README docs and add parser plus server command coverage for named and numeric window targets

## Testing
- `go test ./internal/server/commands/layout -run 'TestParseCreatePaneArgs|TestParseSpawnArgs' -count=100`
- `go test ./internal/server -run 'TestCommandSpawnAuto(AppendsToShortestUnderfilledColumnAndEqualizes|RootSplitsWhenColumnsAreFull|TargetsSpecifiedWindow)$|TestCommandSpawnTargetsSpecifiedWindowActivePane' -count=100`
- `go test ./internal/server ./internal/server/commands/layout ./internal/cli`

## Review Focus
- confirm the spawn validation matrix: `--window + --auto` allowed, `--window + --at` rejected, and `--auto` still rejects explicit placement flags
- check the selected-window resolution path, especially the numeric window ID fallback used by `spawn --window <name-or-id>`

Closes LAB-1040