### PR TITLE
Allow auto spawn pane hints to target windows

### DIFF
--- a/internal/server/commands/layout/args.go
+++ b/internal/server/commands/layout/args.go
@@ -134,10 +134,10 @@ func parseCreatePaneArgs(mode createPaneMode, args []string) (createPaneArgs, er
 	if parsed.WindowRef != "" && parsed.PaneRef != "" {
 		return createPaneArgs{}, fmt.Errorf("spawn --window cannot be combined with --at")
 	}
-	if parsed.Auto && (parsed.PaneRef != "" || parsed.RootLevel || hasExplicitDir) {
+	if parsed.Auto && (parsed.RootLevel || hasExplicitDir) {
 		return createPaneArgs{}, fmt.Errorf("spawn --auto cannot be combined with explicit placement")
 	}
-	if (parsed.PaneRef != "" || (parsed.WindowRef != "" && !parsed.Auto) || parsed.RootLevel) && !hasExplicitDir {
+	if (((parsed.PaneRef != "" || parsed.WindowRef != "") && !parsed.Auto) || parsed.RootLevel) && !hasExplicitDir {
 		parsed.Dir = mux.SplitHorizontal
 	}
 	return parsed, nil

--- a/internal/server/commands/layout/args_test.go
+++ b/internal/server/commands/layout/args_test.go
@@ -301,9 +301,17 @@ func TestParseSpawnArgs(t *testing.T) {
 			wantErr: "unknown flag: --bogus",
 		},
 		{
-			name:    "rejects auto with explicit target",
-			args:    []string{"--auto", "--at", "pane-1"},
-			wantErr: "spawn --auto cannot be combined with explicit placement",
+			name: "parses auto mode with pane target as window hint",
+			args: []string{"--auto", "--at", "pane-1", "--name", "worker-1"},
+			want: SpawnArgs{
+				Auto:    true,
+				PaneRef: "pane-1",
+				Dir:     mux.SplitVertical,
+				Meta: mux.PaneMeta{
+					Name: "worker-1",
+					Host: mux.DefaultHost,
+				},
+			},
 		},
 		{
 			name:    "rejects window with explicit pane target",

--- a/internal/server/commands_layout.go
+++ b/internal/server/commands_layout.go
@@ -129,7 +129,7 @@ func runCreatePane(ctx *CommandContext, actorPaneID uint32, command string, plac
 	}
 
 	switch {
-	case req.hostName == "" && snapshot.inheritProxy && (command == "split" || (command == "spawn" && req.paneRef != "")):
+	case req.hostName == "" && snapshot.inheritProxy && (command == "split" || (command == "spawn" && req.paneRef != "" && placement != createPanePlacementColumnFill)):
 		req.hostName = snapshot.inheritHost
 	}
 
@@ -185,6 +185,16 @@ func runCreatePane(ctx *CommandContext, actorPaneID uint32, command string, plac
 func queryCreatePaneSnapshot(sess *Session, actorPaneID uint32, command string, placement createPanePlacement, paneRef, windowRef string) (createPaneSnapshot, error) {
 	return enqueueSessionQuery(sess, func(sess *Session) (createPaneSnapshot, error) {
 		if placement == createPanePlacementColumnFill {
+			if paneRef != "" {
+				_, resolvedWindow, err := sess.resolvePaneAcrossWindowsForActor(actorPaneID, paneRef)
+				if err != nil {
+					return createPaneSnapshot{}, err
+				}
+				if resolvedWindow == nil {
+					return createPaneSnapshot{}, fmt.Errorf("pane not in any window")
+				}
+				windowRef = strconv.Itoa(int(resolvedWindow.ID))
+			}
 			return queryColumnFillCreatePaneSnapshot(sess, actorPaneID, command, windowRef)
 		}
 		if paneRef != "" {

--- a/internal/server/commands_layout.go
+++ b/internal/server/commands_layout.go
@@ -185,17 +185,11 @@ func runCreatePane(ctx *CommandContext, actorPaneID uint32, command string, plac
 func queryCreatePaneSnapshot(sess *Session, actorPaneID uint32, command string, placement createPanePlacement, paneRef, windowRef string) (createPaneSnapshot, error) {
 	return enqueueSessionQuery(sess, func(sess *Session) (createPaneSnapshot, error) {
 		if placement == createPanePlacementColumnFill {
-			if paneRef != "" {
-				_, resolvedWindow, err := sess.resolvePaneAcrossWindowsForActor(actorPaneID, paneRef)
-				if err != nil {
-					return createPaneSnapshot{}, err
-				}
-				if resolvedWindow == nil {
-					return createPaneSnapshot{}, fmt.Errorf("pane not in any window")
-				}
-				windowRef = strconv.Itoa(int(resolvedWindow.ID))
+			resolvedWindowRef, err := resolveCreatePaneWindowHint(sess, actorPaneID, paneRef, windowRef)
+			if err != nil {
+				return createPaneSnapshot{}, err
 			}
-			return queryColumnFillCreatePaneSnapshot(sess, actorPaneID, command, windowRef)
+			return queryColumnFillCreatePaneSnapshot(sess, actorPaneID, command, resolvedWindowRef)
 		}
 		if paneRef != "" {
 			pane, resolvedWindow, err := sess.resolvePaneAcrossWindowsForActor(actorPaneID, paneRef)
@@ -234,6 +228,20 @@ func queryCreatePaneSnapshot(sess *Session, actorPaneID uint32, command string, 
 			targetPaneID: w.ActivePane.ID,
 		}, nil
 	})
+}
+
+func resolveCreatePaneWindowHint(sess *Session, actorPaneID uint32, paneRef, windowRef string) (string, error) {
+	if paneRef == "" {
+		return windowRef, nil
+	}
+	_, resolvedWindow, err := sess.resolvePaneAcrossWindowsForActor(actorPaneID, paneRef)
+	if err != nil {
+		return "", err
+	}
+	if resolvedWindow == nil {
+		return "", fmt.Errorf("pane not in any window")
+	}
+	return strconv.Itoa(int(resolvedWindow.ID)), nil
 }
 
 func resolveCreatePaneTargetWindow(sess *Session, actorPaneID uint32, command, windowRef string) (*mux.Window, error) {

--- a/internal/server/spawn_auto_command_test.go
+++ b/internal/server/spawn_auto_command_test.go
@@ -256,6 +256,65 @@ func TestCommandSpawnAutoTargetsSpecifiedWindow(t *testing.T) {
 	}
 }
 
+func TestQueryCreatePaneSnapshotColumnFillPaneHintErrors(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		setup   func(t *testing.T, sess *Session) uint32
+		paneRef string
+		wantErr string
+	}{
+		{
+			name: "missing pane ref",
+			setup: func(t *testing.T, sess *Session) uint32 {
+				t.Helper()
+
+				p1 := newTestPane(sess, 1, "pane-1")
+				mainWindow := mux.NewWindow(p1, 80, 23)
+				mainWindow.ID = 1
+				mainWindow.Name = "main"
+				setSessionLayoutForTest(t, sess, mainWindow.ID, []*mux.Window{mainWindow}, p1)
+				return p1.ID
+			},
+			paneRef: "missing",
+			wantErr: `pane "missing" not found`,
+		},
+		{
+			name: "pane not in any window",
+			setup: func(t *testing.T, sess *Session) uint32 {
+				t.Helper()
+
+				p1 := newTestPane(sess, 1, "pane-1")
+				orphan := newTestPane(sess, 2, "orphan-pane")
+				mainWindow := mux.NewWindow(p1, 80, 23)
+				mainWindow.ID = 1
+				mainWindow.Name = "main"
+				setSessionLayoutForTest(t, sess, mainWindow.ID, []*mux.Window{mainWindow}, p1, orphan)
+				return p1.ID
+			},
+			paneRef: "orphan-pane",
+			wantErr: "pane not in any window",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, sess, cleanup := newCommandTestSession(t)
+			defer cleanup()
+
+			actorPaneID := tt.setup(t, sess)
+			_, err := queryCreatePaneSnapshot(sess, actorPaneID, "spawn", createPanePlacementColumnFill, tt.paneRef, "")
+			if err == nil || err.Error() != tt.wantErr {
+				t.Fatalf("queryCreatePaneSnapshot(..., %q) error = %v, want %q", tt.paneRef, err, tt.wantErr)
+			}
+		})
+	}
+}
+
 func TestCommandSpawnAutoUsesPaneTargetWindowHint(t *testing.T) {
 	t.Parallel()
 

--- a/internal/server/spawn_auto_command_test.go
+++ b/internal/server/spawn_auto_command_test.go
@@ -256,6 +256,119 @@ func TestCommandSpawnAutoTargetsSpecifiedWindow(t *testing.T) {
 	}
 }
 
+func TestCommandSpawnAutoUsesPaneTargetWindowHint(t *testing.T) {
+	t.Parallel()
+
+	srv, sess, cleanup := newCommandTestSession(t)
+	defer cleanup()
+
+	p1 := newTestPane(sess, 1, "pane-1")
+	p2 := newTestPane(sess, 2, "pane-2")
+	p3 := newTestPane(sess, 3, "pane-3")
+	p4 := newTestPane(sess, 4, "pane-4")
+
+	mainWindow := mux.NewWindow(p1, 80, 23)
+	mainWindow.ID = 1
+	mainWindow.Name = "main"
+
+	logsWindow := mux.NewWindow(p2, 80, 23)
+	logsWindow.ID = 4
+	logsWindow.Name = "logs"
+	if _, err := logsWindow.SplitPaneWithOptions(p2.ID, mux.SplitHorizontal, p3, mux.SplitOptions{}); err != nil {
+		t.Fatalf("Split pane-2 horizontally: %v", err)
+	}
+	if _, err := logsWindow.SplitRoot(mux.SplitVertical, p4); err != nil {
+		t.Fatalf("SplitRoot pane-4: %v", err)
+	}
+
+	setSessionLayoutForTest(t, sess, mainWindow.ID, []*mux.Window{mainWindow, logsWindow}, p1, p2, p3, p4)
+
+	res := runTestCommand(t, srv, sess, "spawn", "--auto", "--at", "pane-2", "--name", "worker-5")
+	if res.cmdErr != "" {
+		t.Fatalf("spawn --auto --at failed: %s", res.cmdErr)
+	}
+
+	state := mustSessionQuery(t, sess, func(sess *Session) struct {
+		activeWindowID uint32
+		workerWindowID uint32
+		p2X            int
+		p3X            int
+		p4X            int
+		p5X            int
+		p4H            int
+		p5H            int
+	} {
+		worker, err := sess.findPaneByRef("worker-5")
+		if err != nil {
+			return struct {
+				activeWindowID uint32
+				workerWindowID uint32
+				p2X            int
+				p3X            int
+				p4X            int
+				p5X            int
+				p4H            int
+				p5H            int
+			}{}
+		}
+		workerWindow := sess.findWindowByPaneID(worker.ID)
+		p2Cell := logsWindow.Root.FindPane(p2.ID)
+		p3Cell := logsWindow.Root.FindPane(p3.ID)
+		p4Cell := logsWindow.Root.FindPane(p4.ID)
+		p5Cell := logsWindow.Root.FindPane(worker.ID)
+		if workerWindow == nil || p2Cell == nil || p3Cell == nil || p4Cell == nil || p5Cell == nil {
+			return struct {
+				activeWindowID uint32
+				workerWindowID uint32
+				p2X            int
+				p3X            int
+				p4X            int
+				p5X            int
+				p4H            int
+				p5H            int
+			}{}
+		}
+		return struct {
+			activeWindowID uint32
+			workerWindowID uint32
+			p2X            int
+			p3X            int
+			p4X            int
+			p5X            int
+			p4H            int
+			p5H            int
+		}{
+			activeWindowID: sess.ActiveWindowID,
+			workerWindowID: workerWindow.ID,
+			p2X:            p2Cell.X,
+			p3X:            p3Cell.X,
+			p4X:            p4Cell.X,
+			p5X:            p5Cell.X,
+			p4H:            p4Cell.H,
+			p5H:            p5Cell.H,
+		}
+	})
+
+	if state.activeWindowID != mainWindow.ID {
+		t.Fatalf("active window = %d, want %d", state.activeWindowID, mainWindow.ID)
+	}
+	if state.workerWindowID != logsWindow.ID {
+		t.Fatalf("worker window = %d, want %d", state.workerWindowID, logsWindow.ID)
+	}
+	if state.p2X != state.p3X {
+		t.Fatalf("pane-2 and pane-3 should remain in the original logs column: %+v", state)
+	}
+	if state.p4X != state.p5X {
+		t.Fatalf("auto spawn should place pane-4 and worker-5 in the shortest logs column: %+v", state)
+	}
+	if state.p2X == state.p5X {
+		t.Fatalf("worker-5 should be placed in a different logs column from pane-2/pane-3: %+v", state)
+	}
+	if state.p4H != state.p5H {
+		t.Fatalf("auto spawn should equalize row heights in the pane-targeted window column: %+v", state)
+	}
+}
+
 func TestCommandSpawnTargetsSpecifiedWindowActivePane(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Motivation
`spawn --auto` already knows how to column-fill a specific window via `--window`, but it rejected `--at` outright. That blocked callers that only have a pane reference from directing auto-spawn into the pane's window.

## Summary
- allow `spawn --auto --at <pane>` to parse while keeping the pane reference as a window hint
- resolve auto-spawn pane hints to the owning window before running the column-fill planner
- keep auto-spawn on its normal placement defaults and add integration coverage that it fills the referenced pane's window, not the actor's window

## Testing
- `go test ./internal/server/commands/layout/ -run TestParseSpawnArgs -count=100`
- `go test ./internal/server/ -run TestCommandSpawnAuto -count=100 -parallel=4`
- `go test ./... -timeout 120s`

## Review focus
The main behavior change is in the column-fill snapshot path: `--at` now resolves to the referenced pane's window only for auto mode, and it should not trigger the normal explicit-pane remote-host inheritance path.

Closes LAB-1045
