### PR TITLE
Include lead pane in root width equalization

### DIFF
--- a/internal/mux/equalize_test.go
+++ b/internal/mux/equalize_test.go
@@ -180,6 +180,78 @@ func TestWindowEqualizeIncludesLeadColumnWhenAnchored(t *testing.T) {
 	}
 }
 
+func TestWindowEqualizeIncludesLeadColumnWhenAnchoredWithSingleLogicalColumn(t *testing.T) {
+	t.Parallel()
+
+	p1 := fakePaneID(1)
+	p2 := fakePaneID(2)
+	w := NewWindow(p1, 80, 24)
+	if _, err := w.SplitRoot(SplitVertical, p2); err != nil {
+		t.Fatalf("SplitRoot pane-2: %v", err)
+	}
+	if !w.ResizePane(p1.ID, "right", 6) {
+		t.Fatal("ResizePane should skew the future lead column width")
+	}
+	if err := w.SetLead(p1.ID); err != nil {
+		t.Fatalf("SetLead: %v", err)
+	}
+
+	if !w.Equalize(true, false) {
+		t.Fatal("Equalize(widths=true, heights=false) = false, want true")
+	}
+
+	got := []int{w.Root.Children[0].W, w.logicalRoot().W}
+	want := []int{39, 40}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("root widths after equalize = %v, want %v", got, want)
+	}
+}
+
+func TestWindowEqualizeWidthHelpersWithoutAnchoredLead(t *testing.T) {
+	t.Parallel()
+
+	p1 := fakePaneID(1)
+	p2 := fakePaneID(2)
+	w := NewWindow(p1, 80, 24)
+
+	if w.equalizeWidthsNeeded(nil) {
+		t.Fatal("equalizeWidthsNeeded(nil) = true, want false")
+	}
+	if cols := w.anchoredLeadWidthColumns(); cols != nil {
+		t.Fatalf("anchoredLeadWidthColumns() = %v, want nil without a lead pane", cols)
+	}
+	if cols, sizes := w.anchoredLeadWidthTargets(); cols != nil || sizes != nil {
+		t.Fatalf("anchoredLeadWidthTargets() = (%v, %v), want (nil, nil) without a lead pane", cols, sizes)
+	}
+	if w.anchoredLeadColumnsWidthChanged() {
+		t.Fatal("anchoredLeadColumnsWidthChanged() = true, want false without a lead pane")
+	}
+
+	w.equalizeAnchoredLeadColumns()
+	if got := []int{w.Root.W, w.Root.H}; !reflect.DeepEqual(got, []int{80, 24}) {
+		t.Fatalf("equalizeAnchoredLeadColumns() changed root size = %v, want [80 24]", got)
+	}
+
+	if _, err := w.SplitRoot(SplitVertical, p2); err != nil {
+		t.Fatalf("SplitRoot pane-2: %v", err)
+	}
+	if !w.ResizePane(p1.ID, "right", 6) {
+		t.Fatal("ResizePane should skew root column widths")
+	}
+
+	logical := w.logicalRoot()
+	if !w.equalizeWidthsNeeded(logical) {
+		t.Fatal("equalizeWidthsNeeded(logical) = false, want true")
+	}
+	w.equalizeWidths(logical)
+
+	got := []int{w.Root.Children[0].W, w.Root.Children[1].W}
+	want := []int{39, 40}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("root widths after equalizeWidths(logical) = %v, want %v", got, want)
+	}
+}
+
 func TestWindowEqualizeVerticalBalancesNestedVisualColumns(t *testing.T) {
 	t.Parallel()
 

--- a/internal/mux/equalize_test.go
+++ b/internal/mux/equalize_test.go
@@ -129,7 +129,7 @@ func TestWindowEqualizeRebalancesNestedColumnsUnderHorizontalRoot(t *testing.T) 
 	}
 }
 
-func TestWindowEqualizeUsesLogicalRootWhenLeadAnchored(t *testing.T) {
+func TestWindowEqualizeIncludesLeadColumnWhenAnchored(t *testing.T) {
 	t.Parallel()
 
 	p1 := fakePaneID(1)
@@ -142,6 +142,9 @@ func TestWindowEqualizeUsesLogicalRootWhenLeadAnchored(t *testing.T) {
 	}
 	if _, err := w.SplitRoot(SplitVertical, p3); err != nil {
 		t.Fatalf("SplitRoot pane-3: %v", err)
+	}
+	if !w.ResizePane(p1.ID, "right", 6) {
+		t.Fatal("ResizePane should skew the future lead column width")
 	}
 	if err := w.SetLead(p1.ID); err != nil {
 		t.Fatalf("SetLead: %v", err)
@@ -158,20 +161,15 @@ func TestWindowEqualizeUsesLogicalRootWhenLeadAnchored(t *testing.T) {
 		t.Fatal("ResizePane should skew logical-root row heights")
 	}
 
-	leadWidth := w.Root.Children[0].W
 	if !w.Equalize(true, true) {
 		t.Fatal("Equalize(widths=true, heights=true) = false, want true")
 	}
 
-	if got := w.Root.Children[0].W; got != leadWidth {
-		t.Fatalf("lead width after equalize = %d, want %d", got, leadWidth)
-	}
-
 	logical := w.logicalRoot()
-	gotWidths := []int{logical.Children[0].W, logical.Children[1].W}
-	wantWidths := []int{26, 26}
+	gotWidths := []int{w.Root.Children[0].W, logical.Children[0].W, logical.Children[1].W}
+	wantWidths := []int{26, 26, 26}
 	if !reflect.DeepEqual(gotWidths, wantWidths) {
-		t.Fatalf("logical-root column widths after equalize = %v, want %v", gotWidths, wantWidths)
+		t.Fatalf("root column widths after equalize = %v, want %v", gotWidths, wantWidths)
 	}
 
 	leftColumn := logical.Children[0]

--- a/internal/mux/window_resize.go
+++ b/internal/mux/window_resize.go
@@ -159,9 +159,9 @@ func (w *Window) ResizePane(paneID uint32, direction string, delta int) bool {
 	return false
 }
 
-// Equalize rebalances the current logical root. When widths is true, vertical
-// splits within the logical root are redistributed evenly, including nested
-// vertical groups. When heights is true, rows within each logical column are
+// Equalize rebalances the window layout. When widths is true, vertical splits
+// are redistributed evenly, treating an anchored lead as part of the root
+// column set. When heights is true, rows within each logical column are
 // redistributed evenly. Returns true if the layout changed.
 func (w *Window) Equalize(widths, heights bool) bool {
 	w.assertOwner("Equalize")
@@ -174,7 +174,7 @@ func (w *Window) Equalize(widths, heights bool) bool {
 		return false
 	}
 
-	widthChanged := widths && logical.equalizeAxisNeeded(SplitVertical)
+	widthChanged := widths && w.equalizeWidthsNeeded(logical)
 
 	var columns []*LayoutCell
 	heightChanged := false
@@ -197,7 +197,7 @@ func (w *Window) Equalize(widths, heights bool) bool {
 	}
 
 	if widthChanged {
-		logical.equalizeAxisRecursive(SplitVertical)
+		w.equalizeWidths(logical)
 	}
 	if heightChanged {
 		for _, column := range columns {
@@ -211,6 +211,87 @@ func (w *Window) Equalize(widths, heights bool) bool {
 	w.Root.FixOffsets()
 	w.resizePTYs()
 	return true
+}
+
+func (w *Window) equalizeWidthsNeeded(logical *LayoutCell) bool {
+	if logical == nil {
+		return false
+	}
+	if !w.hasAnchoredLead() {
+		return logical.equalizeAxisNeeded(SplitVertical)
+	}
+	if w.anchoredLeadColumnsWidthChanged() {
+		return true
+	}
+	return logical.equalizeAxisNeeded(SplitVertical)
+}
+
+func (w *Window) equalizeWidths(logical *LayoutCell) {
+	if logical == nil {
+		return
+	}
+	if !w.hasAnchoredLead() {
+		logical.equalizeAxisRecursive(SplitVertical)
+		return
+	}
+	w.equalizeAnchoredLeadColumns()
+	logical.equalizeAxisRecursive(SplitVertical)
+}
+
+func (w *Window) anchoredLeadColumnsWidthChanged() bool {
+	columns := w.anchoredLeadWidthColumns()
+	if len(columns) < 2 {
+		return false
+	}
+	sizes := equalSplitSizes(w.Width, len(columns))
+	for i, column := range columns {
+		if column.W != sizes[i] {
+			return true
+		}
+	}
+	return false
+}
+
+func (w *Window) equalizeAnchoredLeadColumns() {
+	columns := w.anchoredLeadWidthColumns()
+	if len(columns) < 2 {
+		return
+	}
+
+	lead := w.Root.Children[0]
+	logical := w.Root.Children[1]
+	sizes := equalSplitSizes(w.Width, len(columns))
+	lead.ResizeSubtree(sizes[0], w.Root.H)
+
+	if len(columns) == 2 {
+		logical.ResizeSubtree(sizes[1], w.Root.H)
+		return
+	}
+
+	logicalW := 0
+	for i, size := range sizes[1:] {
+		if i > 0 {
+			logicalW++
+		}
+		logicalW += size
+	}
+	logical.ResizeSubtree(logicalW, w.Root.H)
+}
+
+func (w *Window) anchoredLeadWidthColumns() []*LayoutCell {
+	if !w.hasAnchoredLead() {
+		return nil
+	}
+
+	logical := w.logicalRoot()
+	columns := []*LayoutCell{w.Root.Children[0]}
+	if logical == nil {
+		return columns
+	}
+	if !logical.IsLeaf() && logical.Dir == SplitVertical {
+		return append(columns, logical.Children...)
+	}
+	return append(columns, logical)
 }
 
 func collectEqualizeColumns(root *LayoutCell) []*LayoutCell {

--- a/internal/mux/window_resize.go
+++ b/internal/mux/window_resize.go
@@ -239,11 +239,10 @@ func (w *Window) equalizeWidths(logical *LayoutCell) {
 }
 
 func (w *Window) anchoredLeadColumnsWidthChanged() bool {
-	columns := w.anchoredLeadWidthColumns()
+	columns, sizes := w.anchoredLeadWidthTargets()
 	if len(columns) < 2 {
 		return false
 	}
-	sizes := equalSplitSizes(w.Width, len(columns))
 	for i, column := range columns {
 		if column.W != sizes[i] {
 			return true
@@ -253,14 +252,13 @@ func (w *Window) anchoredLeadColumnsWidthChanged() bool {
 }
 
 func (w *Window) equalizeAnchoredLeadColumns() {
-	columns := w.anchoredLeadWidthColumns()
+	columns, sizes := w.anchoredLeadWidthTargets()
 	if len(columns) < 2 {
 		return
 	}
 
 	lead := w.Root.Children[0]
 	logical := w.Root.Children[1]
-	sizes := equalSplitSizes(w.Width, len(columns))
 	lead.ResizeSubtree(sizes[0], w.Root.H)
 
 	if len(columns) == 2 {
@@ -268,14 +266,7 @@ func (w *Window) equalizeAnchoredLeadColumns() {
 		return
 	}
 
-	logicalW := 0
-	for i, size := range sizes[1:] {
-		if i > 0 {
-			logicalW++
-		}
-		logicalW += size
-	}
-	logical.ResizeSubtree(logicalW, w.Root.H)
+	logical.ResizeSubtree(equalizedColumnGroupWidth(sizes[1:]), w.Root.H)
 }
 
 func (w *Window) anchoredLeadWidthColumns() []*LayoutCell {
@@ -292,6 +283,25 @@ func (w *Window) anchoredLeadWidthColumns() []*LayoutCell {
 		return append(columns, logical.Children...)
 	}
 	return append(columns, logical)
+}
+
+func (w *Window) anchoredLeadWidthTargets() ([]*LayoutCell, []int) {
+	columns := w.anchoredLeadWidthColumns()
+	if len(columns) < 2 {
+		return columns, nil
+	}
+	return columns, equalSplitSizes(w.Width, len(columns))
+}
+
+func equalizedColumnGroupWidth(sizes []int) int {
+	width := 0
+	for i, size := range sizes {
+		if i > 0 {
+			width++
+		}
+		width += size
+	}
+	return width
 }
 
 func collectEqualizeColumns(root *LayoutCell) []*LayoutCell {

--- a/internal/server/spawn_auto_command_test.go
+++ b/internal/server/spawn_auto_command_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/weill-labs/amux/internal/mux"
@@ -140,6 +141,106 @@ func TestCommandSpawnAutoRootSplitsWhenColumnsAreFull(t *testing.T) {
 	}
 	if state.p3H != 23 {
 		t.Fatalf("new root column should span the full window height, got %+v", state)
+	}
+}
+
+func TestCommandSpawnAutoRootSplitsAndEqualizesLeadColumn(t *testing.T) {
+	t.Parallel()
+
+	srv, sess, cleanup := newCommandTestSession(t)
+	defer cleanup()
+
+	p1 := newTestPane(sess, 1, "pane-1")
+	p2 := newTestPane(sess, 2, "pane-2")
+	p3 := newTestPane(sess, 3, "pane-3")
+	w := mux.NewWindow(p1, 80, 23)
+	w.ID = 1
+	w.Name = "main"
+	if _, err := w.SplitRoot(mux.SplitVertical, p2); err != nil {
+		t.Fatalf("SplitRoot pane-2: %v", err)
+	}
+	if err := w.SetLead(p1.ID); err != nil {
+		t.Fatalf("SetLead pane-1: %v", err)
+	}
+	if _, err := w.SplitPaneWithOptions(p2.ID, mux.SplitHorizontal, p3, mux.SplitOptions{}); err != nil {
+		t.Fatalf("Split pane-2 horizontally: %v", err)
+	}
+	setSessionLayoutForTest(t, sess, w.ID, []*mux.Window{w}, p1, p2, p3)
+
+	res := runTestCommand(t, srv, sess, "spawn", "--auto", "--name", "worker-4")
+	if res.cmdErr != "" {
+		t.Fatalf("spawn --auto failed: %s", res.cmdErr)
+	}
+
+	state := mustSessionQuery(t, sess, func(sess *Session) struct {
+		p1X int
+		p2X int
+		p3X int
+		p4X int
+		p1W int
+		p2W int
+		p3W int
+		p4W int
+	} {
+		w := sess.activeWindow()
+		p4, err := sess.findPaneByRef("worker-4")
+		if err != nil {
+			return struct {
+				p1X int
+				p2X int
+				p3X int
+				p4X int
+				p1W int
+				p2W int
+				p3W int
+				p4W int
+			}{}
+		}
+		p1Cell := w.Root.FindPane(p1.ID)
+		p2Cell := w.Root.FindPane(p2.ID)
+		p3Cell := w.Root.FindPane(p3.ID)
+		p4Cell := w.Root.FindPane(p4.ID)
+		if p1Cell == nil || p2Cell == nil || p3Cell == nil || p4Cell == nil {
+			return struct {
+				p1X int
+				p2X int
+				p3X int
+				p4X int
+				p1W int
+				p2W int
+				p3W int
+				p4W int
+			}{}
+		}
+		return struct {
+			p1X int
+			p2X int
+			p3X int
+			p4X int
+			p1W int
+			p2W int
+			p3W int
+			p4W int
+		}{
+			p1X: p1Cell.X,
+			p2X: p2Cell.X,
+			p3X: p3Cell.X,
+			p4X: p4Cell.X,
+			p1W: p1Cell.W,
+			p2W: p2Cell.W,
+			p3W: p3Cell.W,
+			p4W: p4Cell.W,
+		}
+	})
+
+	if state.p2X != state.p3X {
+		t.Fatalf("pane-2 and pane-3 should remain stacked in the middle column: %+v", state)
+	}
+	if state.p1X >= state.p2X || state.p2X >= state.p4X {
+		t.Fatalf("lead, logical, and spawned columns should remain left-to-right: %+v", state)
+	}
+	if got := []int{state.p1W, state.p2W, state.p3W, state.p4W}; !reflect.DeepEqual(got, []int{26, 26, 26, 26}) {
+		t.Fatalf("spawn --auto should equalize widths across lead and non-lead columns: %v", got)
 	}
 }
 


### PR DESCRIPTION
## Motivation
When a lead pane is anchored, equalize and column-fill root splits rebalance only the logical root. That leaves the lead column at its previous width and produces uneven root columns after `equalize` or `spawn --auto`.

## Summary
- teach `Window.Equalize` to size anchored lead layouts across the full root column set instead of only the logical root
- keep recursive width equalization for nested vertical groups inside the logical root after the root columns are rebalanced
- add mux and server regression coverage for direct equalize and `spawn --auto` root splits with a lead pane

## Testing
- `go test ./internal/mux/ -run WindowEqualize -count=100 -parallel=4`
- `go test ./internal/server -run TestCommandSpawnAutoRootSplitsAndEqualizesLeadColumn -count=100 -parallel=4`
- `go test ./... -timeout 120s`

## Review focus
- check the anchored-lead width planning in `internal/mux/window_resize.go`, especially the transition between full-root column sizing and recursive equalization inside the logical root

Closes LAB-1074