### PR TITLE
Stabilize actor-targeting nested CLI test waits

### DIFF
--- a/test/actor_targeting_helpers_test.go
+++ b/test/actor_targeting_helpers_test.go
@@ -1,0 +1,45 @@
+package test
+
+import "testing"
+
+func TestShellSingleQuote(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "plain",
+			in:   "shared",
+			want: "'shared'",
+		},
+		{
+			name: "embedded single quote",
+			in:   "echo 'two words'",
+			want: `'echo '"'"'two words'"'"''`,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := shellSingleQuote(tt.in); got != tt.want {
+				t.Fatalf("shellSingleQuote(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNestedAmuxCommand(t *testing.T) {
+	t.Parallel()
+
+	got := nestedAmuxCommand("/tmp/amux", "session 1", "wait", "content", "shared", "WINDOW TWO", "--timeout", "5s")
+	want := "'/tmp/amux' -s 'session 1' 'wait' 'content' 'shared' 'WINDOW TWO' '--timeout' '5s'"
+	if got != want {
+		t.Fatalf("nestedAmuxCommand(...) = %q, want %q", got, want)
+	}
+}

--- a/test/actor_targeting_test.go
+++ b/test/actor_targeting_test.go
@@ -31,17 +31,16 @@ func TestExplicitPaneCommandsPreferActorWindowWithoutChangingFocus(t *testing.T)
 		t.Fatalf("active window index = %d, want 1 before actor-targeted commands", got)
 	}
 
-	h.sendKeys("3", amuxBin+" -s "+h.session+" send-keys shared 'echo ACTOR_ROUTE' Enter", "Enter")
+	h.sendKeys("3", nestedAmuxCommand(amuxBin, h.session, "send-keys", "shared", "echo ACTOR_ROUTE", "Enter"), "Enter")
 	h.waitFor("4", "ACTOR_ROUTE")
+	h.waitIdle("3")
 	if paneOne := h.runCmd("capture", "2"); strings.Contains(paneOne, "ACTOR_ROUTE") {
 		t.Fatalf("window-1 shared pane should not receive actor-routed input:\n%s", paneOne)
 	}
 
-	h.sendKeys("3", amuxBin+" -s "+h.session+" capture shared | grep WINDOW_TWO && echo CAPTURE_OK", "Enter")
-	h.waitFor("3", "CAPTURE_OK")
+	h.runShellCommand("3", nestedAmuxCommand(amuxBin, h.session, "capture", "shared")+" | grep WINDOW_TWO && echo CAPTURE_OK", "CAPTURE_OK")
 
-	h.sendKeys("3", amuxBin+" -s "+h.session+" wait content shared WINDOW_TWO --timeout 1s && echo WAIT_OK", "Enter")
-	h.waitFor("3", "WAIT_OK")
+	h.runShellCommand("3", nestedAmuxCommand(amuxBin, h.session, "wait", "content", "shared", "WINDOW_TWO", "--timeout", "5s")+" && echo WAIT_OK", "WAIT_OK")
 
 	if got := h.captureJSON().Window.Index; got != 1 {
 		t.Fatalf("active window index = %d, want 1 after actor-targeted commands", got)

--- a/test/actor_targeting_test.go
+++ b/test/actor_targeting_test.go
@@ -33,14 +33,14 @@ func TestExplicitPaneCommandsPreferActorWindowWithoutChangingFocus(t *testing.T)
 
 	h.sendKeys("3", nestedAmuxCommand(amuxBin, h.session, "send-keys", "shared", "echo ACTOR_ROUTE", "Enter"), "Enter")
 	h.waitFor("4", "ACTOR_ROUTE")
-	h.waitIdle("3")
+	h.waitIdleWithSettle("3", "25ms", "5s")
 	if paneOne := h.runCmd("capture", "2"); strings.Contains(paneOne, "ACTOR_ROUTE") {
 		t.Fatalf("window-1 shared pane should not receive actor-routed input:\n%s", paneOne)
 	}
 
-	h.runShellCommand("3", nestedAmuxCommand(amuxBin, h.session, "capture", "shared")+" | grep WINDOW_TWO && echo CAPTURE_OK", "CAPTURE_OK")
+	h.runShellCommandWithSettle("3", nestedAmuxCommand(amuxBin, h.session, "capture", "--history", "shared")+" | grep WINDOW_TWO && echo CAPTURE_OK", "CAPTURE_OK", "25ms")
 
-	h.runShellCommand("3", nestedAmuxCommand(amuxBin, h.session, "wait", "content", "shared", "WINDOW_TWO", "--timeout", "5s")+" && echo WAIT_OK", "WAIT_OK")
+	h.runShellCommandWithSettle("3", nestedAmuxCommand(amuxBin, h.session, "wait", "content", "shared", "WINDOW_TWO", "--timeout", "5s")+" && echo WAIT_OK", "WAIT_OK", "25ms")
 
 	if got := h.captureJSON().Window.Index; got != 1 {
 		t.Fatalf("active window index = %d, want 1 after actor-targeted commands", got)

--- a/test/server_harness_test.go
+++ b/test/server_harness_test.go
@@ -1700,6 +1700,19 @@ func (h *ServerHarness) runShellCommand(pane, command, marker string) {
 	h.waitIdle(pane)
 }
 
+func shellSingleQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'"'"'`) + "'"
+}
+
+func nestedAmuxCommand(binPath, session string, args ...string) string {
+	parts := make([]string, 0, len(args)+3)
+	parts = append(parts, shellSingleQuote(binPath), "-s", shellSingleQuote(session))
+	for _, arg := range args {
+		parts = append(parts, shellSingleQuote(arg))
+	}
+	return strings.Join(parts, " ")
+}
+
 func (h *ServerHarness) sendClientKeys(keys ...string) string {
 	h.tb.Helper()
 	pane := h.activePaneName()

--- a/test/server_harness_test.go
+++ b/test/server_harness_test.go
@@ -1700,19 +1700,6 @@ func (h *ServerHarness) runShellCommand(pane, command, marker string) {
 	h.waitIdle(pane)
 }
 
-func shellSingleQuote(s string) string {
-	return "'" + strings.ReplaceAll(s, "'", `'"'"'`) + "'"
-}
-
-func nestedAmuxCommand(binPath, session string, args ...string) string {
-	parts := make([]string, 0, len(args)+3)
-	parts = append(parts, shellSingleQuote(binPath), "-s", shellSingleQuote(session))
-	for _, arg := range args {
-		parts = append(parts, shellSingleQuote(arg))
-	}
-	return strings.Join(parts, " ")
-}
-
 func (h *ServerHarness) sendClientKeys(keys ...string) string {
 	h.tb.Helper()
 	pane := h.activePaneName()

--- a/test/server_harness_test.go
+++ b/test/server_harness_test.go
@@ -1265,6 +1265,16 @@ func (h *ServerHarness) waitIdle(pane string) {
 	}
 }
 
+func (h *ServerHarness) waitIdleWithSettle(pane, settle, timeout string) {
+	h.tb.Helper()
+	restore := h.pushWaitState(fmt.Sprintf("waiting for %s to become idle (settle %s, timeout %s)", pane, settle, timeout))
+	defer restore()
+	out := h.runCmd("wait", "idle", pane, "--settle", settle, "--timeout", timeout)
+	if strings.Contains(out, "timeout") || strings.Contains(out, "not found") {
+		h.tb.Fatalf("wait-idle %s settle=%s timeout=%s: %s\n%s", pane, settle, timeout, strings.TrimSpace(out), h.diagnosticSnapshot("wait-idle failure"))
+	}
+}
+
 // generation returns the current layout generation counter.
 func (h *ServerHarness) generation() uint64 {
 	h.tb.Helper()
@@ -1698,6 +1708,13 @@ func (h *ServerHarness) runShellCommand(pane, command, marker string) {
 	h.sendKeys(pane, command, "Enter")
 	h.waitFor(pane, marker)
 	h.waitIdle(pane)
+}
+
+func (h *ServerHarness) runShellCommandWithSettle(pane, command, marker, settle string) {
+	h.tb.Helper()
+	h.sendKeys(pane, command, "Enter")
+	h.waitFor(pane, marker)
+	h.waitIdleWithSettle(pane, settle, "5s")
 }
 
 func (h *ServerHarness) sendClientKeys(keys ...string) string {

--- a/test/shell_command_helpers_test.go
+++ b/test/shell_command_helpers_test.go
@@ -1,0 +1,16 @@
+package test
+
+import "strings"
+
+func shellSingleQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'"'"'`) + "'"
+}
+
+func nestedAmuxCommand(binPath, session string, args ...string) string {
+	parts := make([]string, 0, len(args)+3)
+	parts = append(parts, shellSingleQuote(binPath), "-s", shellSingleQuote(session))
+	for _, arg := range args {
+		parts = append(parts, shellSingleQuote(arg))
+	}
+	return strings.Join(parts, " ")
+}


### PR DESCRIPTION
## Motivation
`TestExplicitPaneCommandsPreferActorWindowWithoutChangingFocus` was flaky under full-suite parallel load. The test matched `CAPTURE_OK` from pane-3 before the nested shell command had actually finished, so the following nested `amux wait content ... --timeout 1s` could sit behind a still-running command and fail for timing reasons instead of actor-window resolution.

## Summary
- add test-only shell quoting and nested amux command helpers with direct unit coverage
- make the actor-targeting test wait for pane-3 shell idleness between nested CLI commands instead of only matching echoed output
- switch the capture assertion to `capture --history` so it stays on the server-owned direct path while still exercising actor-window name resolution
- use a short idle settle and a less brittle inner wait timeout so the 100x stress run completes quickly

## Testing
- `go test -run TestExplicitPaneCommandsPreferActorWindowWithoutChangingFocus -count=100 -parallel=4 -timeout 300s ./test/`
- `go test ./... -timeout 120s`

## Review focus
- the flake fix is intentionally test-only; production wait/content resolution code is unchanged
- `capture --history shared` still resolves the duplicate pane name through the actor pane's window, but avoids the slower client-forwarded capture path that was not relevant to this assertion
- the new short-settle shell helpers are only used by this nested-CLI test path, so they should not change harness behavior elsewhere

Closes LAB-1091
