### PR TITLE
Wait for hidden pane capture in zoom split test

### DIFF
--- a/test/amux_harness_test.go
+++ b/test/amux_harness_test.go
@@ -443,6 +443,20 @@ func (h *AmuxHarness) waitForCaptureJSON(fn func(proto.CaptureJSON) bool, timeou
 	)
 }
 
+func (h *AmuxHarness) waitForPaneCaptureJSON(pane string, timeout time.Duration) (proto.CapturePane, bool) {
+	h.tb.Helper()
+	return waitForPaneCaptureJSONWithLayout(
+		func() (proto.CapturePane, bool) {
+			return capturePaneJSONOrUnavailable(h.runCmd, pane)
+		},
+		h.generation,
+		func(afterGen uint64, waitFor time.Duration) bool {
+			return h.waitLayoutOrTimeout(afterGen, waitFor.String())
+		},
+		timeout,
+	)
+}
+
 // ---------------------------------------------------------------------------
 // Capture — inner compositor and outer rendered content
 // ---------------------------------------------------------------------------

--- a/test/capture_helpers_test.go
+++ b/test/capture_helpers_test.go
@@ -51,6 +51,18 @@ func capturePaneJSONFor(tb testing.TB, pane string, runCmd func(...string) strin
 	}
 }
 
+func capturePaneJSONOrUnavailable(runCmd func(...string) string, pane string) (proto.CapturePane, bool) {
+	raw := runCmd("capture", "--format", "json", pane)
+	var capture proto.CapturePane
+	if err := json.Unmarshal([]byte(raw), &capture); err == nil {
+		return capture, true
+	}
+	if isCaptureUnavailable(raw) || isTransientSessionQueryFailure(raw) || strings.Contains(raw, "not found") {
+		return proto.CapturePane{}, false
+	}
+	return proto.CapturePane{}, false
+}
+
 func isTransientSessionQueryFailure(raw string) bool {
 	raw = strings.TrimSpace(raw)
 	if raw == "" {

--- a/test/capture_predicates_test.go
+++ b/test/capture_predicates_test.go
@@ -7,6 +7,11 @@ import (
 )
 
 func captureHasActiveZoomedPane(capture proto.CaptureJSON, name string) bool {
+	for _, pane := range capture.Panes {
+		if pane.Name == name {
+			return pane.Active && pane.Zoomed
+		}
+	}
 	return false
 }
 

--- a/test/capture_predicates_test.go
+++ b/test/capture_predicates_test.go
@@ -1,0 +1,79 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/weill-labs/amux/internal/proto"
+)
+
+func captureHasActiveZoomedPane(capture proto.CaptureJSON, name string) bool {
+	return false
+}
+
+func TestCaptureHasActiveZoomedPane(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		capture proto.CaptureJSON
+		pane    string
+		want    bool
+	}{
+		{
+			name: "matching active zoomed pane",
+			capture: proto.CaptureJSON{
+				Panes: []proto.CapturePane{{
+					Name:   "pane-1",
+					Active: true,
+					Zoomed: true,
+				}},
+			},
+			pane: "pane-1",
+			want: true,
+		},
+		{
+			name: "matching pane without zoom",
+			capture: proto.CaptureJSON{
+				Panes: []proto.CapturePane{{
+					Name:   "pane-1",
+					Active: true,
+				}},
+			},
+			pane: "pane-1",
+			want: false,
+		},
+		{
+			name: "matching pane without focus",
+			capture: proto.CaptureJSON{
+				Panes: []proto.CapturePane{{
+					Name:   "pane-1",
+					Zoomed: true,
+				}},
+			},
+			pane: "pane-1",
+			want: false,
+		},
+		{
+			name: "different pane is active zoomed",
+			capture: proto.CaptureJSON{
+				Panes: []proto.CapturePane{
+					{Name: "pane-1"},
+					{Name: "pane-2", Active: true, Zoomed: true},
+				},
+			},
+			pane: "pane-1",
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := captureHasActiveZoomedPane(tt.capture, tt.pane); got != tt.want {
+				t.Fatalf("captureHasActiveZoomedPane(%q) = %v, want %v", tt.pane, got, tt.want)
+			}
+		})
+	}
+}

--- a/test/capture_wait.go
+++ b/test/capture_wait.go
@@ -6,18 +6,17 @@ import (
 	"github.com/weill-labs/amux/internal/proto"
 )
 
-func waitForCaptureJSONWithLayout(
-	capture func() proto.CaptureJSON,
+func waitForValueWithLayout[T any](
+	capture func() (T, bool),
 	generation func() uint64,
 	waitLayout func(afterGen uint64, timeout time.Duration) bool,
-	fn func(proto.CaptureJSON) bool,
 	timeout time.Duration,
-) (proto.CaptureJSON, bool) {
+) (T, bool) {
 	deadline := time.Now().Add(timeout)
 	gen := generation()
 	for time.Now().Before(deadline) {
-		got := capture()
-		if fn(got) {
+		got, ok := capture()
+		if ok {
 			return got, true
 		}
 
@@ -34,6 +33,23 @@ func waitForCaptureJSONWithLayout(
 		gen = generation()
 	}
 
-	got := capture()
-	return got, fn(got)
+	return capture()
+}
+
+func waitForCaptureJSONWithLayout(
+	capture func() proto.CaptureJSON,
+	generation func() uint64,
+	waitLayout func(afterGen uint64, timeout time.Duration) bool,
+	fn func(proto.CaptureJSON) bool,
+	timeout time.Duration,
+) (proto.CaptureJSON, bool) {
+	return waitForValueWithLayout(
+		func() (proto.CaptureJSON, bool) {
+			got := capture()
+			return got, fn(got)
+		},
+		generation,
+		waitLayout,
+		timeout,
+	)
 }

--- a/test/pane_capture_wait.go
+++ b/test/pane_capture_wait.go
@@ -1,0 +1,37 @@
+package test
+
+import (
+	"time"
+
+	"github.com/weill-labs/amux/internal/proto"
+)
+
+func waitForPaneCaptureJSONWithLayout(
+	capture func() (proto.CapturePane, bool),
+	generation func() uint64,
+	waitLayout func(afterGen uint64, timeout time.Duration) bool,
+	timeout time.Duration,
+) (proto.CapturePane, bool) {
+	deadline := time.Now().Add(timeout)
+	gen := generation()
+	for time.Now().Before(deadline) {
+		got, ok := capture()
+		if ok {
+			return got, true
+		}
+
+		waitFor := time.Until(deadline)
+		if waitFor > 250*time.Millisecond {
+			waitFor = 250 * time.Millisecond
+		}
+		if waitFor <= 0 {
+			waitFor = time.Millisecond
+		}
+		if !waitLayout(gen, waitFor) {
+			continue
+		}
+		gen = generation()
+	}
+
+	return capture()
+}

--- a/test/pane_capture_wait.go
+++ b/test/pane_capture_wait.go
@@ -12,26 +12,5 @@ func waitForPaneCaptureJSONWithLayout(
 	waitLayout func(afterGen uint64, timeout time.Duration) bool,
 	timeout time.Duration,
 ) (proto.CapturePane, bool) {
-	deadline := time.Now().Add(timeout)
-	gen := generation()
-	for time.Now().Before(deadline) {
-		got, ok := capture()
-		if ok {
-			return got, true
-		}
-
-		waitFor := time.Until(deadline)
-		if waitFor > 250*time.Millisecond {
-			waitFor = 250 * time.Millisecond
-		}
-		if waitFor <= 0 {
-			waitFor = time.Millisecond
-		}
-		if !waitLayout(gen, waitFor) {
-			continue
-		}
-		gen = generation()
-	}
-
-	return capture()
+	return waitForValueWithLayout(capture, generation, waitLayout, timeout)
 }

--- a/test/zoom_test.go
+++ b/test/zoom_test.go
@@ -503,8 +503,17 @@ func TestZoomSplitKeepsZoomAndFocus(t *testing.T) {
 			!strings.Contains(s, "[pane-3]")
 	})
 
-	capture := h.captureJSON()
+	capture, ok := h.waitForCaptureJSON(func(capture proto.CaptureJSON) bool {
+		// A zoomed compositor capture looks identical before and after the
+		// split. Wait for the hidden pane set to exist before asserting on it.
+		return len(capture.Panes) == 3 && captureHasActiveZoomedPane(capture, "pane-1")
+	}, 3*time.Second)
+	if !ok {
+		t.Fatalf("zoomed split never settled on a 3-pane active/zoomed capture.\nCapture:\n%s\nOuter:\n%s", h.runCmd("capture", "--format", "json"), h.captureOuter())
+	}
+
 	p1 := h.jsonPane(capture, "pane-1")
+	h.jsonPane(capture, "pane-3")
 	if !p1.Active || !p1.Zoomed {
 		t.Fatalf("pane-1 state after split = active:%v zoomed:%v, want true/true", p1.Active, p1.Zoomed)
 	}

--- a/test/zoom_test.go
+++ b/test/zoom_test.go
@@ -487,8 +487,20 @@ func TestZoomSplitKeepsZoomAndFocus(t *testing.T) {
 	h := newAmuxHarness(t)
 
 	h.splitH()
+	if capture, ok := h.waitForCaptureJSON(func(capture proto.CaptureJSON) bool {
+		return len(capture.Panes) == 2
+	}, 3*time.Second); !ok {
+		t.Fatalf("initial split never settled on a 2-pane capture.\nCapture:\n%s\nOuter:\n%s", h.runCmd("capture", "--format", "json"), h.captureOuter())
+	} else {
+		h.jsonPane(capture, "pane-2")
+	}
 
 	h.runCmd("zoom", "pane-1")
+	if _, ok := h.waitForCaptureJSON(func(capture proto.CaptureJSON) bool {
+		return captureHasActiveZoomedPane(capture, "pane-1")
+	}, 3*time.Second); !ok {
+		t.Fatalf("pane-1 never settled into active zoomed state.\nCapture:\n%s\nOuter:\n%s", h.runCmd("capture", "--format", "json"), h.captureOuter())
+	}
 	h.assertScreen("pane-1 zoomed before split", func(s string) bool {
 		return strings.Contains(s, "[pane-1]") && !strings.Contains(s, "[pane-2]")
 	})
@@ -503,17 +515,16 @@ func TestZoomSplitKeepsZoomAndFocus(t *testing.T) {
 			!strings.Contains(s, "[pane-3]")
 	})
 
-	capture, ok := h.waitForCaptureJSON(func(capture proto.CaptureJSON) bool {
-		// A zoomed compositor capture looks identical before and after the
-		// split. Wait for the hidden pane set to exist before asserting on it.
-		return len(capture.Panes) == 3 && captureHasActiveZoomedPane(capture, "pane-1")
-	}, 3*time.Second)
+	p3, ok := h.waitForPaneCaptureJSON("pane-3", 3*time.Second)
 	if !ok {
-		t.Fatalf("zoomed split never settled on a 3-pane active/zoomed capture.\nCapture:\n%s\nOuter:\n%s", h.runCmd("capture", "--format", "json"), h.captureOuter())
+		t.Fatalf("zoomed split never surfaced pane-3 in direct capture.\nCapture:\n%s\nPane-3:\n%s\nOuter:\n%s", h.runCmd("capture", "--format", "json"), h.runCmd("capture", "--format", "json", "pane-3"), h.captureOuter())
+	}
+	if p3.Name != "pane-3" {
+		t.Fatalf("pane-3 direct capture resolved unexpected pane %q", p3.Name)
 	}
 
+	capture := h.captureJSON()
 	p1 := h.jsonPane(capture, "pane-1")
-	h.jsonPane(capture, "pane-3")
 	if !p1.Active || !p1.Zoomed {
 		t.Fatalf("pane-1 state after split = active:%v zoomed:%v, want true/true", p1.Active, p1.Zoomed)
 	}


### PR DESCRIPTION
## Motivation
`TestZoomSplitKeepsZoomAndFocus` only proved that the session was still zoomed after the split keypress. Under full-suite parallel load, that state is indistinguishable from the pre-split state, so the test could assert on hidden-pane state before the zoomed split had actually finished.

## Summary
- wait for the initial `splitH()` to settle on a 2-pane capture before zooming `pane-1`
- wait for `pane-1` to settle into the active zoomed state, then wait for direct `capture --format json pane-3` to succeed before asserting hidden split state
- add focused test helpers for zoomed-pane predicates and hidden-pane capture waits, then dedupe the layout-driven wait loop used by those helpers

## Testing
- `go test -run TestZoomSplitKeepsZoomAndFocus -count=100 -parallel=4 -timeout 300s ./test/`
- `go test ./... -timeout 120s`
- `go test -run TestMetaSetSetsPRAppendedToBranch -count=10 ./test/`

## Review focus
The key change is the synchronization point after the zoomed split. Full-screen JSON capture only exposes the visible zoomed pane, so the test now waits on direct hidden-pane capture instead of assuming a layout generation bump means `pane-3` is queryable.

Closes LAB-1092
