### PR TITLE
Fix UTF-8 paste corruption across client input chunks

### DIFF
--- a/internal/client/attach.go
+++ b/internal/client/attach.go
@@ -65,6 +65,15 @@ func drainQueuedStdinChunks(first []byte, stdinCh <-chan []byte) (chunks [][]byt
 	}
 }
 
+func flushBufferedBytes(buf *[]byte, handle func([]byte) bool) bool {
+	if len(*buf) == 0 {
+		return false
+	}
+	data := append([]byte(nil), (*buf)...)
+	*buf = (*buf)[:0]
+	return handle(data)
+}
+
 func dispatchQueuedMouseInputChunks(
 	parser *mouse.Parser,
 	chunks [][]byte,
@@ -100,20 +109,11 @@ func dispatchQueuedMouseInputChunks(
 		pendingMotion = &evCopy
 	}
 
-	flushPendingBytes := func() bool {
-		if len(pendingBytes) == 0 {
-			return false
-		}
-		data := append([]byte(nil), pendingBytes...)
-		pendingBytes = pendingBytes[:0]
-		return handleBytes(data)
-	}
-
 	for _, chunk := range chunks {
 		for i := 0; i < len(chunk); i++ {
 			ev, isMouse, flushed := parser.Feed(chunk[i])
 			if isMouse {
-				if flushPendingBytes() {
+				if flushBufferedBytes(&pendingBytes, handleBytes) {
 					return true
 				}
 				dispatchMouse(ev)
@@ -132,7 +132,7 @@ func dispatchQueuedMouseInputChunks(
 		}
 	}
 
-	if flushPendingBytes() {
+	if flushBufferedBytes(&pendingBytes, handleBytes) {
 		return true
 	}
 	flushPendingMotion()
@@ -1000,19 +1000,11 @@ func RunSession(sessionName string, getTermSize func(int) (int, int, error)) err
 				)
 			} else {
 				var pendingDecodedInput []byte
-				flushPendingDecodedInput := func() bool {
-					if len(pendingDecodedInput) == 0 {
-						return false
-					}
-					data := append([]byte(nil), pendingDecodedInput...)
-					pendingDecodedInput = pendingDecodedInput[:0]
-					return decodeAndDispatch(data)
-				}
 				for i := 0; i < len(raw) && !shouldExit; i++ {
 					ev, isMouse, flushed := mouseParser.Feed(raw[i])
 
 					if isMouse {
-						shouldExit = flushPendingDecodedInput()
+						shouldExit = flushBufferedBytes(&pendingDecodedInput, decodeAndDispatch)
 						if shouldExit {
 							break
 						}
@@ -1028,7 +1020,7 @@ func RunSession(sessionName string, getTermSize func(int) (int, int, error)) err
 				// stay buffered in the parser and complete on the next read.
 				if !shouldExit {
 					pendingDecodedInput = append(pendingDecodedInput, mouseParser.FlushPending()...)
-					shouldExit = flushPendingDecodedInput()
+					shouldExit = flushBufferedBytes(&pendingDecodedInput, decodeAndDispatch)
 				}
 			}
 

--- a/internal/client/attach.go
+++ b/internal/client/attach.go
@@ -73,6 +73,7 @@ func dispatchQueuedMouseInputChunks(
 	handleBytes func([]byte) bool,
 ) bool {
 	var pendingMotion *mouse.Event
+	var pendingBytes []byte
 
 	flushPendingMotion := func() {
 		if pendingMotion == nil {
@@ -99,10 +100,22 @@ func dispatchQueuedMouseInputChunks(
 		pendingMotion = &evCopy
 	}
 
+	flushPendingBytes := func() bool {
+		if len(pendingBytes) == 0 {
+			return false
+		}
+		data := append([]byte(nil), pendingBytes...)
+		pendingBytes = pendingBytes[:0]
+		return handleBytes(data)
+	}
+
 	for _, chunk := range chunks {
 		for i := 0; i < len(chunk); i++ {
 			ev, isMouse, flushed := parser.Feed(chunk[i])
 			if isMouse {
+				if flushPendingBytes() {
+					return true
+				}
 				dispatchMouse(ev)
 				continue
 			}
@@ -110,19 +123,18 @@ func dispatchQueuedMouseInputChunks(
 				continue
 			}
 			flushPendingMotion()
-			if handleBytes(flushed) {
-				return true
-			}
+			pendingBytes = append(pendingBytes, flushed...)
 		}
 
 		if flushed := parser.FlushPending(); len(flushed) > 0 {
 			flushPendingMotion()
-			if handleBytes(flushed) {
-				return true
-			}
+			pendingBytes = append(pendingBytes, flushed...)
 		}
 	}
 
+	if flushPendingBytes() {
+		return true
+	}
 	flushPendingMotion()
 	return false
 }
@@ -711,14 +723,23 @@ func RunSession(sessionName string, getTermSize func(int) (int, int, error)) err
 		stdinCh := make(chan []byte, 4)
 		go func() {
 			defer close(stdinCh)
+			var pendingUTF8 []byte
 			for {
 				n, err := stdin.Read(buf)
+				if n > 0 {
+					cp := append(append([]byte(nil), pendingUTF8...), buf[:n]...)
+					ready, pending := splitTrailingIncompleteUTF8(cp)
+					pendingUTF8 = append(pendingUTF8[:0], pending...)
+					if len(ready) > 0 {
+						stdinCh <- ready
+					}
+				}
 				if err != nil {
+					if len(pendingUTF8) > 0 {
+						stdinCh <- append([]byte(nil), pendingUTF8...)
+					}
 					return
 				}
-				cp := make([]byte, n)
-				copy(cp, buf[:n])
-				stdinCh <- cp
 			}
 		}()
 
@@ -978,22 +999,36 @@ func RunSession(sessionName string, getTermSize func(int) (int, int, error)) err
 					decodeAndDispatch,
 				)
 			} else {
+				var pendingDecodedInput []byte
+				flushPendingDecodedInput := func() bool {
+					if len(pendingDecodedInput) == 0 {
+						return false
+					}
+					data := append([]byte(nil), pendingDecodedInput...)
+					pendingDecodedInput = pendingDecodedInput[:0]
+					return decodeAndDispatch(data)
+				}
 				for i := 0; i < len(raw) && !shouldExit; i++ {
 					ev, isMouse, flushed := mouseParser.Feed(raw[i])
 
 					if isMouse {
+						shouldExit = flushPendingDecodedInput()
+						if shouldExit {
+							break
+						}
 						dispatchMouse(ev)
 						continue
 					}
 
-					shouldExit = decodeAndDispatch(flushed)
+					pendingDecodedInput = append(pendingDecodedInput, flushed...)
 				}
 
 				// Flush a standalone Escape at the end of a read so Esc then j
 				// does not coalesce into Alt+j. Split CSI and mouse sequences
 				// stay buffered in the parser and complete on the next read.
 				if !shouldExit {
-					shouldExit = decodeAndDispatch(mouseParser.FlushPending())
+					pendingDecodedInput = append(pendingDecodedInput, mouseParser.FlushPending()...)
+					shouldExit = flushPendingDecodedInput()
 				}
 			}
 

--- a/internal/client/input_keys.go
+++ b/internal/client/input_keys.go
@@ -13,6 +13,25 @@ type decodedInputEvent struct {
 	event uv.Event
 }
 
+func splitTrailingIncompleteUTF8(raw []byte) (complete []byte, pending []byte) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+
+	start := len(raw) - 1
+	for start >= 0 && len(raw)-start < utf8.UTFMax && !utf8.RuneStart(raw[start]) {
+		start--
+	}
+	if start < 0 || !utf8.RuneStart(raw[start]) {
+		return raw, nil
+	}
+	if utf8.FullRune(raw[start:]) {
+		return raw, nil
+	}
+
+	return raw[:start], raw[start:]
+}
+
 func decodeInputEvents(raw []byte) []decodedInputEvent {
 	decoder := uv.EventDecoder{}
 	events := make([]decodedInputEvent, 0, len(raw))

--- a/internal/client/input_keys_test.go
+++ b/internal/client/input_keys_test.go
@@ -2,6 +2,8 @@ package client
 
 import (
 	"bytes"
+	"strconv"
+	"strings"
 	"testing"
 
 	uv "github.com/charmbracelet/ultraviolet"
@@ -95,6 +97,94 @@ func TestNormalizeLocalInput(t *testing.T) {
 
 			if got := normalizeLocalInput(tt.input); !bytes.Equal(got, tt.want) {
 				t.Fatalf("normalizeLocalInput(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSplitTrailingIncompleteUTF8(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		input        []byte
+		wantComplete []byte
+		wantPending  []byte
+	}{
+		{
+			name:         "ascii stays complete",
+			input:        []byte("hello"),
+			wantComplete: []byte("hello"),
+		},
+		{
+			name:         "complete multibyte rune stays complete",
+			input:        []byte("→"),
+			wantComplete: []byte("→"),
+		},
+		{
+			name:         "three-byte prefix is deferred",
+			input:        []byte("A\xe2"),
+			wantComplete: []byte("A"),
+			wantPending:  []byte{0xe2},
+		},
+		{
+			name:        "emoji prefix is deferred",
+			input:       []byte{0xf0, 0x9f},
+			wantPending: []byte{0xf0, 0x9f},
+		},
+		{
+			name:         "invalid continuation byte is preserved",
+			input:        []byte{0x80},
+			wantComplete: []byte{0x80},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			gotComplete, gotPending := splitTrailingIncompleteUTF8(tt.input)
+			if !bytes.Equal(gotComplete, tt.wantComplete) {
+				t.Fatalf("complete = %q, want %q", gotComplete, tt.wantComplete)
+			}
+			if !bytes.Equal(gotPending, tt.wantPending) {
+				t.Fatalf("pending = %q, want %q", gotPending, tt.wantPending)
+			}
+		})
+	}
+}
+
+func TestSplitTrailingIncompleteUTF8RoundTripsChunkedPaste(t *testing.T) {
+	t.Parallel()
+
+	payload := []byte(strings.Repeat("→ 72°F — 22°C — 🙂漢字\n", 128))
+	chunkSizes := []int{2, 3, 5, 4095, 4097}
+
+	for _, chunkSize := range chunkSizes {
+		chunkSize := chunkSize
+		t.Run(strconv.Itoa(chunkSize), func(t *testing.T) {
+			t.Parallel()
+
+			var (
+				got     []byte
+				pending []byte
+			)
+
+			for start := 0; start < len(payload); start += chunkSize {
+				end := start + chunkSize
+				if end > len(payload) {
+					end = len(payload)
+				}
+				chunk := append(append([]byte(nil), pending...), payload[start:end]...)
+				ready, tail := splitTrailingIncompleteUTF8(chunk)
+				got = append(got, ready...)
+				pending = append(pending[:0], tail...)
+			}
+			got = append(got, pending...)
+
+			if !bytes.Equal(got, payload) {
+				t.Fatalf("round-tripped payload mismatch for chunk size %d", chunkSize)
 			}
 		})
 	}

--- a/test/pty_client_input_test.go
+++ b/test/pty_client_input_test.go
@@ -1,9 +1,11 @@
 package test
 
 import (
+	"crypto/sha256"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -86,5 +88,130 @@ func TestPTYClientLargePasteDeliversFullLine(t *testing.T) {
 	}
 	if err := client.waitError(); err != nil {
 		t.Fatalf("PTY client exited with error: %v\nOutput:\n%s", err, client.outputString())
+	}
+}
+
+func TestPTYClientLargeUTF8PasteDeliversFullPayload(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		chunkSize int
+	}{
+		{name: "4095-byte chunks", chunkSize: 4095},
+		{name: "4097-byte chunks", chunkSize: 4097},
+	}
+
+	payload := largeUTF8PastePayload()
+	expectedSHA := fmt.Sprintf("%x", sha256.Sum256(payload))
+	expectedBytes := len(payload)
+	const sentinel = "__LAB1100_UTF8_END__"
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if !chunkBoundariesSplitUTF8(payload, tt.chunkSize) {
+				t.Fatalf("chunk size %d never splits a UTF-8 rune boundary", tt.chunkSize)
+			}
+
+			h := newServerHarness(t)
+			client := newPTYClientHarness(t, h)
+
+			probeScriptPath := filepath.Join(os.TempDir(), fmt.Sprintf("amux-lab1100-paste-probe-%s-%d.py", h.session, tt.chunkSize))
+			probeScript := `#!/usr/bin/env python3
+import hashlib
+import os
+import sys
+import termios
+import tty
+
+sentinel = ` + strconv.Quote(sentinel) + `.encode()
+fd = sys.stdin.fileno()
+orig = termios.tcgetattr(fd)
+try:
+    tty.setraw(fd)
+    os.write(1, b"__READY__\n")
+    buf = bytearray()
+    while True:
+        ch = os.read(fd, 1)
+        if not ch:
+            break
+        buf += ch
+        if buf.endswith(sentinel):
+            del buf[-len(sentinel):]
+            break
+    digest = hashlib.sha256(bytes(buf)).hexdigest().encode()
+    os.write(1, b"__BYTES=%d__\n" % len(buf))
+    os.write(1, b"__SHA=" + digest + b"__\n")
+finally:
+    termios.tcsetattr(fd, termios.TCSADRAIN, orig)
+`
+			if err := os.WriteFile(probeScriptPath, []byte(probeScript), 0o755); err != nil {
+				t.Fatalf("write probe script: %v", err)
+			}
+			t.Cleanup(func() { os.Remove(probeScriptPath) })
+
+			client.sendText(probeScriptPath)
+			client.sendText("\r")
+
+			if !client.waitForOutput("__READY__", 10*time.Second) {
+				t.Fatalf("probe did not signal readiness\nOutput:\n%s", client.outputString())
+			}
+
+			writeUTF8Chunks(t, client, payload, tt.chunkSize)
+			client.write([]byte(sentinel))
+
+			wantBytes := fmt.Sprintf("__BYTES=%d__", expectedBytes)
+			h.waitFor("pane-1", wantBytes)
+			paneOut := h.runCmd("capture", "pane-1")
+			flatPaneOut := strings.ReplaceAll(paneOut, "\n", "")
+			if !strings.Contains(flatPaneOut, wantBytes) {
+				t.Fatalf("probe did not report full paste length %q\nPane:\n%s", wantBytes, paneOut)
+			}
+
+			wantSHA := "__SHA=" + expectedSHA + "__"
+			if !strings.Contains(flatPaneOut, wantSHA) {
+				t.Fatalf("probe did not report full paste SHA %q\nPane:\n%s", wantSHA, paneOut)
+			}
+		})
+	}
+}
+
+func largeUTF8PastePayload() []byte {
+	var b strings.Builder
+	for i := 0; b.Len() < 18_118; i++ {
+		fmt.Fprintf(&b, "ROW%03d → 72°F — 22°C — north↔south — alphaβ gammaδ — emoji🙂漢字 END%03d\n", i, i)
+	}
+	return []byte(b.String())
+}
+
+func chunkBoundariesSplitUTF8(payload []byte, chunkSize int) bool {
+	for i := chunkSize; i < len(payload); i += chunkSize {
+		if i > 0 && i < len(payload) && !isUTF8Boundary(payload, i) {
+			return true
+		}
+	}
+	return false
+}
+
+func isUTF8Boundary(payload []byte, idx int) bool {
+	if idx <= 0 || idx >= len(payload) {
+		return true
+	}
+	return (payload[idx] & 0xc0) != 0x80
+}
+
+func writeUTF8Chunks(t *testing.T, client *ptyClientHarness, payload []byte, chunkSize int) {
+	t.Helper()
+
+	for start := 0; start < len(payload); start += chunkSize {
+		end := start + chunkSize
+		if end > len(payload) {
+			end = len(payload)
+		}
+		client.write(payload[start:end])
+		time.Sleep(2 * time.Millisecond)
 	}
 }


### PR DESCRIPTION
## Motivation
Large pasted UTF-8 payloads could be corrupted before they ever reached the pane. The client input path fed ordinary bytes back from the mouse parser one byte at a time, so multi-byte characters were decoded as separate fragments, which produced replacement characters and dropped the rest of the paste.

## Summary
- preserve trailing incomplete UTF-8 bytes across stdin read boundaries before decoding client input
- batch contiguous non-mouse bytes before running the client input decoder so UTF-8 runes are not split byte-by-byte
- add unit coverage for incomplete UTF-8 buffering and a PTY integration regression that pastes a large multi-byte payload in split chunk sizes and verifies exact byte-for-byte delivery

## Testing
- `go test ./internal/client -run '^(TestSplitTrailingIncompleteUTF8|TestSplitTrailingIncompleteUTF8RoundTripsChunkedPaste)$' -count=100`
- `go test ./test -run '^TestPTYClientLargeUTF8PasteDeliversFullPayload$' -count=20`
- `go test ./test -run '^TestUnsupportedPrefixKeyShowsFeedback$' -count=20`
- `go test ./test -run '^TestMetaSetClearsBranch$' -count=100`
- `go test ./... -timeout 120s` *(hit an unrelated intermittent failure in `TestMetaSetClearsBranch`; isolated rerun above passed 100/100)*

## Review focus
- verify the client-side diagnosis: the corruption came from input decoding/buffering, not from the PTY short-write retry path in `mux.writeAll`
- check the ordering guarantees around mouse events versus buffered non-mouse bytes in `internal/client/attach.go`
- confirm the new PTY regression covers the user-visible large UTF-8 paste path without overfitting to one chunk size

Closes LAB-1100
