### PR TITLE
Preserve cleared branch overrides across refreshes

### DIFF
--- a/internal/mux/pane.go
+++ b/internal/mux/pane.go
@@ -127,7 +127,7 @@ type Pane struct {
 
 	// CWD/branch detection
 	liveCwd          string // last-detected CWD, not checkpointed
-	metaManualBranch bool   // true when GitBranch was set via escape sequence or CLI
+	metaManualBranch bool   // true when metadata owns branch state, including explicit empty clears
 }
 
 type paneBaseHistory struct {

--- a/internal/mux/pane_meta_kv.go
+++ b/internal/mux/pane_meta_kv.go
@@ -158,10 +158,16 @@ func applyPaneMetaKV(meta *PaneMeta) error {
 	return nil
 }
 
-func NormalizePaneMeta(meta *PaneMeta) (manualBranch bool, err error) {
-	if meta != nil && meta.KV != nil {
-		_, manualBranch = meta.KV[PaneMetaKeyBranch]
+func hasManualBranchOverride(meta *PaneMeta) bool {
+	if meta == nil || meta.KV == nil {
+		return false
 	}
+	_, ok := meta.KV[PaneMetaKeyBranch]
+	return ok
+}
+
+func NormalizePaneMeta(meta *PaneMeta) (manualBranch bool, err error) {
+	manualBranch = hasManualBranchOverride(meta)
 	hydrateReservedKV(meta)
 	if err := applyPaneMetaKV(meta); err != nil {
 		return false, err
@@ -176,7 +182,7 @@ func SetPaneMetaKV(meta *PaneMeta, key, value string) (manualBranch bool, err er
 	if err := applyPaneMetaKV(&next); err != nil {
 		return false, err
 	}
-	_, manualBranch = next.KV[PaneMetaKeyBranch]
+	manualBranch = hasManualBranchOverride(&next)
 	*meta = next
 	return manualBranch, nil
 }
@@ -191,7 +197,7 @@ func RemovePaneMetaKV(meta *PaneMeta, key string) (manualBranch bool, err error)
 	if err := applyPaneMetaKV(&next); err != nil {
 		return false, err
 	}
-	_, manualBranch = next.KV[PaneMetaKeyBranch]
+	manualBranch = hasManualBranchOverride(&next)
 	*meta = next
 	return manualBranch, nil
 }

--- a/internal/mux/pane_meta_kv.go
+++ b/internal/mux/pane_meta_kv.go
@@ -166,22 +166,17 @@ func NormalizePaneMeta(meta *PaneMeta) (manualBranch bool, err error) {
 	if err := applyPaneMetaKV(meta); err != nil {
 		return false, err
 	}
-	return manualBranch && meta != nil && meta.GitBranch != "", nil
+	return manualBranch, nil
 }
 
 func SetPaneMetaKV(meta *PaneMeta, key, value string) (manualBranch bool, err error) {
 	next := clonePaneMeta(meta)
 	hydrateReservedKV(&next)
 	next.KV[key] = value
-	manualBranch, err = func() (bool, error) {
-		if err := applyPaneMetaKV(&next); err != nil {
-			return false, err
-		}
-		return next.GitBranch != "", nil
-	}()
-	if err != nil {
+	if err := applyPaneMetaKV(&next); err != nil {
 		return false, err
 	}
+	_, manualBranch = next.KV[PaneMetaKeyBranch]
 	*meta = next
 	return manualBranch, nil
 }
@@ -193,15 +188,10 @@ func RemovePaneMetaKV(meta *PaneMeta, key string) (manualBranch bool, err error)
 	if len(next.KV) == 0 {
 		next.KV = nil
 	}
-	manualBranch, err = func() (bool, error) {
-		if err := applyPaneMetaKV(&next); err != nil {
-			return false, err
-		}
-		return next.GitBranch != "", nil
-	}()
-	if err != nil {
+	if err := applyPaneMetaKV(&next); err != nil {
 		return false, err
 	}
+	_, manualBranch = next.KV[PaneMetaKeyBranch]
 	*meta = next
 	return manualBranch, nil
 }

--- a/internal/mux/pane_test.go
+++ b/internal/mux/pane_test.go
@@ -244,6 +244,26 @@ func TestNewProxyPaneWithScrollbackPinsExplicitBranchKV(t *testing.T) {
 	}
 }
 
+func TestNewProxyPaneWithScrollbackPinsExplicitEmptyBranchKV(t *testing.T) {
+	t.Parallel()
+
+	p := NewProxyPaneWithScrollback(1, PaneMeta{
+		Name: "pane-1",
+		KV: map[string]string{
+			PaneMetaKeyBranch: "",
+		},
+	}, 80, 24, DefaultScrollbackLines, nil, nil, nil)
+
+	p.ApplyCwdBranch("/tmp/project", "auto-branch")
+
+	if !p.MetaManualBranch() {
+		t.Fatal("MetaManualBranch() = false, want true for explicit empty branch kv")
+	}
+	if p.Meta.GitBranch != "" {
+		t.Fatalf("GitBranch = %q, want empty explicit override preserved", p.Meta.GitBranch)
+	}
+}
+
 func TestSetOnMetaUpdateCallback(t *testing.T) {
 	t.Parallel()
 

--- a/internal/server/session_events_pane.go
+++ b/internal/server/session_events_pane.go
@@ -185,11 +185,7 @@ func (e metaUpdateEvent) handle(s *Session) {
 		_ = setPaneKVValue(p, mux.PaneMetaKeyPR, *e.update.PR)
 	}
 	if e.update.Branch != nil {
-		if *e.update.Branch == "" {
-			_ = removePaneKVValue(p, mux.PaneMetaKeyBranch)
-		} else {
-			_ = setPaneKVValue(p, mux.PaneMetaKeyBranch, *e.update.Branch)
-		}
+		_ = setPaneKVValue(p, mux.PaneMetaKeyBranch, *e.update.Branch)
 	}
 	s.broadcastLayoutNow()
 }

--- a/internal/server/session_events_test.go
+++ b/internal/server/session_events_test.go
@@ -1261,10 +1261,9 @@ func TestRemovePaneKVValueBranchResumesAutoDetect(t *testing.T) {
 	t.Parallel()
 
 	pane := newProxyPane(1, mux.PaneMeta{
-		Name:      "pane-1",
-		Host:      mux.DefaultHost,
-		Color:     "f5e0dc",
-		GitBranch: "old-branch",
+		Name:  "pane-1",
+		Host:  mux.DefaultHost,
+		Color: "f5e0dc",
 		KV: map[string]string{
 			mux.PaneMetaKeyBranch: "",
 		},
@@ -1272,6 +1271,9 @@ func TestRemovePaneKVValueBranchResumesAutoDetect(t *testing.T) {
 
 	if !pane.MetaManualBranch() {
 		t.Fatal("MetaManualBranch() = false, want explicit empty branch override")
+	}
+	if pane.Meta.GitBranch != "" {
+		t.Fatalf("git_branch = %q, want empty explicit override before remove", pane.Meta.GitBranch)
 	}
 
 	if err := removePaneKVValue(pane, mux.PaneMetaKeyBranch); err != nil {

--- a/internal/server/session_events_test.go
+++ b/internal/server/session_events_test.go
@@ -1246,10 +1246,44 @@ func TestMetaUpdateEventClearsBranch(t *testing.T) {
 		t.Fatalf("git_branch = %q, want empty after clear", pane.Meta.GitBranch)
 	}
 
-	// After clearing, auto-detect should work again
+	if !pane.MetaManualBranch() {
+		t.Fatal("MetaManualBranch() = false, want explicit clear to remain a manual override")
+	}
+
+	// Explicit branch clears must survive later auto-detect refreshes.
+	pane.ApplyCwdBranch("/tmp", "auto-branch")
+	if pane.Meta.GitBranch != "" {
+		t.Fatalf("git_branch = %q, want empty explicit clear preserved", pane.Meta.GitBranch)
+	}
+}
+
+func TestRemovePaneKVValueBranchResumesAutoDetect(t *testing.T) {
+	t.Parallel()
+
+	pane := newProxyPane(1, mux.PaneMeta{
+		Name:      "pane-1",
+		Host:      mux.DefaultHost,
+		Color:     "f5e0dc",
+		GitBranch: "old-branch",
+		KV: map[string]string{
+			mux.PaneMetaKeyBranch: "",
+		},
+	}, 80, 23, nil, nil, func(data []byte) (int, error) { return len(data), nil })
+
+	if !pane.MetaManualBranch() {
+		t.Fatal("MetaManualBranch() = false, want explicit empty branch override")
+	}
+
+	if err := removePaneKVValue(pane, mux.PaneMetaKeyBranch); err != nil {
+		t.Fatalf("removePaneKVValue(branch): %v", err)
+	}
+	if pane.MetaManualBranch() {
+		t.Fatal("MetaManualBranch() = true, want remove to resume auto-detect")
+	}
+
 	pane.ApplyCwdBranch("/tmp", "auto-branch")
 	if pane.Meta.GitBranch != "auto-branch" {
-		t.Fatalf("git_branch = %q, want auto-detect to resume after clear", pane.Meta.GitBranch)
+		t.Fatalf("git_branch = %q, want auto-detect to resume after remove", pane.Meta.GitBranch)
 	}
 }
 

--- a/test/set_meta_test.go
+++ b/test/set_meta_test.go
@@ -1,13 +1,8 @@
 package test
 
 import (
-	"fmt"
-	"os"
-	"os/exec"
-	"path/filepath"
 	"strings"
 	"testing"
-	"time"
 )
 
 func TestMetaSetSetsTaskAndBranch(t *testing.T) {
@@ -58,55 +53,6 @@ func TestMetaSetClearsBranch(t *testing.T) {
 	list = h.runCmd("list")
 	if strings.Contains(list, "feat/bar") {
 		t.Fatalf("branch should be cleared, got:\n%s", list)
-	}
-}
-
-func TestMetaSetClearsBranchAcrossIdleRefresh(t *testing.T) {
-	t.Parallel()
-
-	h := newServerHarnessWithOptions(t, 80, 24, "", false, false, "AMUX_DISABLE_META_REFRESH=0")
-
-	repoDir := filepath.Join(h.home, "clear-branch-repo")
-	if err := os.MkdirAll(repoDir, 0o755); err != nil {
-		t.Fatalf("MkdirAll(%q): %v", repoDir, err)
-	}
-	if out, err := exec.Command("git", "-C", repoDir, "init", "-b", "meta-branch").CombinedOutput(); err != nil {
-		t.Fatalf("git init repo: %v\n%s", err, out)
-	}
-	if out, err := exec.Command("git", "-C", repoDir, "config", "user.email", "amux-tests@example.com").CombinedOutput(); err != nil {
-		t.Fatalf("git config user.email: %v\n%s", err, out)
-	}
-	if out, err := exec.Command("git", "-C", repoDir, "config", "user.name", "amux tests").CombinedOutput(); err != nil {
-		t.Fatalf("git config user.name: %v\n%s", err, out)
-	}
-	if err := os.WriteFile(filepath.Join(repoDir, "README.md"), []byte("clear branch\n"), 0o644); err != nil {
-		t.Fatalf("write repo file: %v", err)
-	}
-	if out, err := exec.Command("git", "-C", repoDir, "add", "README.md").CombinedOutput(); err != nil {
-		t.Fatalf("git add: %v\n%s", err, out)
-	}
-	if out, err := exec.Command("git", "-C", repoDir, "commit", "-m", "init").CombinedOutput(); err != nil {
-		t.Fatalf("git commit: %v\n%s", err, out)
-	}
-
-	h.sendKeys("pane-1", fmt.Sprintf("cd %q && echo META_READY", repoDir), "Enter")
-	h.waitFor("pane-1", "META_READY")
-	h.waitIdle("pane-1")
-	waitForListMetadata(t, h, "meta-branch")
-
-	h.runCmd("meta", "set", "pane-1", "branch=")
-
-	h.sendKeys("pane-1", "printf 'REFRESH\\n'", "Enter")
-	h.waitFor("pane-1", "REFRESH")
-	h.waitIdle("pane-1")
-
-	deadline := time.Now().Add(3 * time.Second)
-	for time.Now().Before(deadline) {
-		list := h.runCmd("list")
-		if strings.Contains(list, "meta-branch") {
-			t.Fatalf("cleared branch should stay empty across idle refresh, got:\n%s", list)
-		}
-		time.Sleep(50 * time.Millisecond)
 	}
 }
 

--- a/test/set_meta_test.go
+++ b/test/set_meta_test.go
@@ -1,8 +1,13 @@
 package test
 
 import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestMetaSetSetsTaskAndBranch(t *testing.T) {
@@ -53,6 +58,55 @@ func TestMetaSetClearsBranch(t *testing.T) {
 	list = h.runCmd("list")
 	if strings.Contains(list, "feat/bar") {
 		t.Fatalf("branch should be cleared, got:\n%s", list)
+	}
+}
+
+func TestMetaSetClearsBranchAcrossIdleRefresh(t *testing.T) {
+	t.Parallel()
+
+	h := newServerHarnessWithOptions(t, 80, 24, "", false, false, "AMUX_DISABLE_META_REFRESH=0")
+
+	repoDir := filepath.Join(h.home, "clear-branch-repo")
+	if err := os.MkdirAll(repoDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q): %v", repoDir, err)
+	}
+	if out, err := exec.Command("git", "-C", repoDir, "init", "-b", "meta-branch").CombinedOutput(); err != nil {
+		t.Fatalf("git init repo: %v\n%s", err, out)
+	}
+	if out, err := exec.Command("git", "-C", repoDir, "config", "user.email", "amux-tests@example.com").CombinedOutput(); err != nil {
+		t.Fatalf("git config user.email: %v\n%s", err, out)
+	}
+	if out, err := exec.Command("git", "-C", repoDir, "config", "user.name", "amux tests").CombinedOutput(); err != nil {
+		t.Fatalf("git config user.name: %v\n%s", err, out)
+	}
+	if err := os.WriteFile(filepath.Join(repoDir, "README.md"), []byte("clear branch\n"), 0o644); err != nil {
+		t.Fatalf("write repo file: %v", err)
+	}
+	if out, err := exec.Command("git", "-C", repoDir, "add", "README.md").CombinedOutput(); err != nil {
+		t.Fatalf("git add: %v\n%s", err, out)
+	}
+	if out, err := exec.Command("git", "-C", repoDir, "commit", "-m", "init").CombinedOutput(); err != nil {
+		t.Fatalf("git commit: %v\n%s", err, out)
+	}
+
+	h.sendKeys("pane-1", fmt.Sprintf("cd %q && echo META_READY", repoDir), "Enter")
+	h.waitFor("pane-1", "META_READY")
+	h.waitIdle("pane-1")
+	waitForListMetadata(t, h, "meta-branch")
+
+	h.runCmd("meta", "set", "pane-1", "branch=")
+
+	h.sendKeys("pane-1", "printf 'REFRESH\\n'", "Enter")
+	h.waitFor("pane-1", "REFRESH")
+	h.waitIdle("pane-1")
+
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		list := h.runCmd("list")
+		if strings.Contains(list, "meta-branch") {
+			t.Fatalf("cleared branch should stay empty across idle refresh, got:\n%s", list)
+		}
+		time.Sleep(50 * time.Millisecond)
 	}
 }
 


### PR DESCRIPTION
## Motivation
`TestMetaSetClearsBranch` could flake under broad runs because `branch=` cleared the visible branch text but also dropped the manual-override bit. Any later async cwd/git refresh could legally repopulate the branch and undo the clear.

## Summary
- treat the presence of the `branch` metadata key as the manual-branch override, even when its value is empty
- make pane meta update events preserve empty branch clears instead of translating them into branch removal
- add fast regression coverage for explicit empty branch overrides and for `meta rm branch` resuming auto-detect

## Testing
- `go test ./internal/mux -run TestNewProxyPaneWithScrollbackPinsExplicitEmptyBranchKV -count=100`
- `go test ./internal/server -run 'TestMetaUpdateEventClearsBranch|TestRemovePaneKVValueBranchResumesAutoDetect' -count=100`
- `go test -run TestMetaSetClearsBranch -count=100 -parallel=4 -timeout 300s ./test/`
- `go test ./... -timeout 120s`

## Review focus
- `branch=` is now a persistent empty override, while `meta rm branch` is the path that re-enables auto-detect
- CLI metadata updates and in-pane meta update events now share the same empty-branch semantics

Closes LAB-1112
