### PR TITLE
Add pane rename command

### DIFF
--- a/internal/cli/cli_commands_layout.go
+++ b/internal/cli/cli_commands_layout.go
@@ -100,6 +100,13 @@ func layoutCLICommands() map[string]commandHandler {
 			}
 			return inv.runSessionCommand("focus", []string{args[0]})
 		},
+		"rename": func(inv invocation, args []string) int {
+			if len(args) < 2 {
+				fmt.Fprintln(inv.runtime.Stderr, renameUsage)
+				return 1
+			}
+			return inv.runSessionCommand("rename", args)
+		},
 		"kill": func(inv invocation, args []string) int {
 			if err := server.ValidateKillCommandArgs(args); err != nil {
 				fmt.Fprintln(inv.runtime.Stderr, server.FormatKillCommandError(err, "amux"))

--- a/internal/cli/cli_parse.go
+++ b/internal/cli/cli_parse.go
@@ -45,6 +45,7 @@ var canonicalSessionCommands = map[string]sessionCommandSpec{
 	"next-window":   {connectName: "next-window", usage: nextWindowUsage, argMode: sessionCommandNoArgs},
 	"prev-window":   {connectName: "prev-window", usage: prevWindowUsage, argMode: sessionCommandNoArgs},
 	"last-window":   {connectName: "last-window", usage: lastWindowUsage, argMode: sessionCommandNoArgs},
+	"rename":        {connectName: "rename", minArgs: 2, usage: renameUsage, argMode: sessionCommandForwardArgs},
 	"reconnect":     {connectName: "reconnect", minArgs: 1, usage: reconnectUsage, argMode: sessionCommandFirstArg},
 	"reload-server": {connectName: "reload-server", usage: reloadServerUsage, argMode: sessionCommandNoArgs},
 	"rename-window": {connectName: "rename-window", minArgs: 1, usage: renameWindowUsage, argMode: sessionCommandFirstArg},

--- a/internal/cli/cli_usage.go
+++ b/internal/cli/cli_usage.go
@@ -24,6 +24,7 @@ const (
 	listWindowsUsage  = "usage: amux list-windows"
 	reconnectUsage    = "usage: amux reconnect <host>"
 	reloadServerUsage = "usage: amux reload-server"
+	renameUsage       = "usage: amux rename <pane> <new-name>"
 	renameWindowUsage = "usage: amux rename-window <name>"
 	resetUsage        = "usage: amux reset <pane>"
 	respawnUsage      = "usage: amux respawn <pane>"
@@ -70,6 +71,7 @@ var commandUsageByName = map[string]string{
 	"next-window":      nextWindowUsage,
 	"prev-window":      prevWindowUsage,
 	"last-window":      lastWindowUsage,
+	"rename":           renameUsage,
 	"reconnect":        reconnectUsage,
 	"reload-server":    reloadServerUsage,
 	"rename-window":    renameWindowUsage,
@@ -194,6 +196,7 @@ Usage:
   amux [-s session] kill <pane>        Kill a pane
   amux [-s session] undo              Undo last pane close
   amux [-s session] focus <pane>       Focus a pane by name or ID
+  amux [-s session] rename <pane> <n>  Rename a pane
   amux [-s session] lead [pane]
   amux [-s session] lead --clear
                                        Set or clear the lead pane

--- a/internal/cli/main_test.go
+++ b/internal/cli/main_test.go
@@ -206,6 +206,13 @@ func TestResolveCanonicalSessionCommand(t *testing.T) {
 			wantHandled: true,
 		},
 		{
+			name:        "rename forwards pane and new name",
+			args:        []string{"rename", "pane-1", "logs"},
+			wantCmd:     "rename",
+			wantArgs:    []string{"pane-1", "logs"},
+			wantHandled: true,
+		},
+		{
 			name:        "list forwards args",
 			args:        []string{"list", "--no-cwd"},
 			wantCmd:     "list",
@@ -244,6 +251,12 @@ func TestResolveCanonicalSessionCommand(t *testing.T) {
 			args:        []string{"unsplice"},
 			wantHandled: true,
 			wantErrText: "usage: amux unsplice <host>",
+		},
+		{
+			name:        "rename needs pane and new name",
+			args:        []string{"rename", "pane-1"},
+			wantHandled: true,
+			wantErrText: "usage: amux rename <pane> <new-name>",
 		},
 	}
 
@@ -544,6 +557,12 @@ func TestMaybePrintCommandHelp(t *testing.T) {
 			wantStdout:  "usage: amux last-window\n",
 		},
 		{
+			name:        "rename help",
+			args:        []string{"rename", "--help"},
+			wantHandled: true,
+			wantStdout:  "usage: amux rename <pane> <new-name>\n",
+		},
+		{
 			name:        "help after command args stays unhandled",
 			args:        []string{"send-keys", "pane-1", "--help"},
 			wantHandled: false,
@@ -675,6 +694,14 @@ func TestRunMainDispatchesCommands(t *testing.T) {
 			wantExit: 0,
 			wantCalls: []cliCall{
 				{kind: "server-command", session: resolvedSessionMarker, cmd: "last-window"},
+			},
+		},
+		{
+			name:     "rename dispatches through server",
+			args:     []string{"rename", "pane-1", "logs"},
+			wantExit: 0,
+			wantCalls: []cliCall{
+				{kind: "server-command", session: resolvedSessionMarker, cmd: "rename", args: []string{"pane-1", "logs"}},
 			},
 		},
 		{

--- a/internal/server/command_queue_test.go
+++ b/internal/server/command_queue_test.go
@@ -73,6 +73,66 @@ func TestQueuedCommandRenameWindow(t *testing.T) {
 	assertSessionLayoutConsistent(t, sess)
 }
 
+func TestQueuedCommandRenamePane(t *testing.T) {
+	t.Parallel()
+
+	srv, sess, cleanup := newCommandTestSession(t)
+	defer cleanup()
+
+	p1 := newTestPane(sess, 1, "pane-1")
+	p2 := newTestPane(sess, 2, "pane-2")
+	w := newTestWindowWithPanes(t, sess, 1, "window-1", p1, p2)
+	sess.Windows = []*mux.Window{w}
+	sess.ActiveWindowID = w.ID
+	sess.Panes = w.Panes()
+
+	before := sess.generation.Load()
+	res := runTestCommand(t, srv, sess, "rename", "pane-1", "logs")
+
+	if res.cmdErr != "" {
+		t.Fatalf("rename error: %s", res.cmdErr)
+	}
+	if !strings.Contains(res.output, "Renamed pane-1 to logs") {
+		t.Fatalf("rename output = %q", res.output)
+	}
+	if p1.Meta.Name != "logs" {
+		t.Fatalf("pane name = %q, want %q", p1.Meta.Name, "logs")
+	}
+	if sess.generation.Load() <= before {
+		t.Fatal("expected layout generation to increment")
+	}
+	assertSessionLayoutConsistent(t, sess)
+}
+
+func TestQueuedCommandRenamePaneRejectsDuplicateNameAcrossWindows(t *testing.T) {
+	t.Parallel()
+
+	srv, sess, cleanup := newCommandTestSession(t)
+	defer cleanup()
+
+	p1 := newTestPane(sess, 1, "pane-1")
+	p2 := newTestPane(sess, 2, "pane-2")
+	w1 := newTestWindowWithPanes(t, sess, 1, "window-1", p1)
+	w2 := newTestWindowWithPanes(t, sess, 2, "window-2", p2)
+	sess.Windows = []*mux.Window{w1, w2}
+	sess.ActiveWindowID = w1.ID
+	sess.Panes = []*mux.Pane{p1, p2}
+
+	before := sess.generation.Load()
+	res := runTestCommand(t, srv, sess, "rename", "pane-1", "pane-2")
+
+	if res.cmdErr != `pane "pane-2" already exists` {
+		t.Fatalf("rename duplicate error = %q, want %q", res.cmdErr, `pane "pane-2" already exists`)
+	}
+	if p1.Meta.Name != "pane-1" {
+		t.Fatalf("pane name = %q, want %q", p1.Meta.Name, "pane-1")
+	}
+	if got := sess.generation.Load(); got != before {
+		t.Fatalf("generation = %d, want %d", got, before)
+	}
+	assertSessionLayoutConsistent(t, sess)
+}
+
 func TestQueuedCommandResizeWindow(t *testing.T) {
 	t.Parallel()
 

--- a/internal/server/command_queue_test.go
+++ b/internal/server/command_queue_test.go
@@ -102,6 +102,22 @@ func TestQueuedCommandRenamePane(t *testing.T) {
 		t.Fatal("expected layout generation to increment")
 	}
 	assertSessionLayoutConsistent(t, sess)
+
+	beforeNoop := sess.generation.Load()
+	res = runTestCommand(t, srv, sess, "rename", "logs", "logs")
+
+	if res.cmdErr != "" {
+		t.Fatalf("self-rename error: %s", res.cmdErr)
+	}
+	if res.output != "Pane name unchanged\n" {
+		t.Fatalf("self-rename output = %q, want %q", res.output, "Pane name unchanged\n")
+	}
+	if p1.Meta.Name != "logs" {
+		t.Fatalf("pane name after self-rename = %q, want %q", p1.Meta.Name, "logs")
+	}
+	if got := sess.generation.Load(); got != beforeNoop {
+		t.Fatalf("generation after self-rename = %d, want %d", got, beforeNoop)
+	}
 }
 
 func TestQueuedCommandRenamePaneRejectsDuplicateNameAcrossWindows(t *testing.T) {

--- a/internal/server/commands.go
+++ b/internal/server/commands.go
@@ -164,6 +164,7 @@ var commandRegistry = map[string]CommandHandler{
 	"list":                cmdList,
 	"split":               cmdSplit,
 	"focus":               cmdFocus,
+	"rename":              cmdRename,
 	"capture":             cmdCapture,
 	"debug-frames":        cmdDebugFrames,
 	"spawn":               cmdSpawn,

--- a/internal/server/commands/layout/commands.go
+++ b/internal/server/commands/layout/commands.go
@@ -19,6 +19,7 @@ const (
 type Context interface {
 	Split(actorPaneID uint32, args SplitArgs) commandpkg.Result
 	Focus(actorPaneID uint32, direction string) commandpkg.Result
+	Rename(actorPaneID uint32, paneRef, name string) commandpkg.Result
 	Spawn(actorPaneID uint32, args SpawnArgs) commandpkg.Result
 	Zoom(actorPaneID uint32, paneRef string) commandpkg.Result
 	Reset(actorPaneID uint32, paneRef string) commandpkg.Result
@@ -74,6 +75,13 @@ func Focus(ctx Context, actorPaneID uint32, args []string) commandpkg.Result {
 		direction = args[0]
 	}
 	return ctx.Focus(actorPaneID, direction)
+}
+
+func Rename(ctx Context, actorPaneID uint32, args []string) commandpkg.Result {
+	if len(args) != 2 {
+		return commandpkg.Result{Err: fmt.Errorf("usage: rename <pane> <new-name>")}
+	}
+	return ctx.Rename(actorPaneID, args[0], args[1])
 }
 
 func Spawn(ctx Context, actorPaneID uint32, args []string) commandpkg.Result {

--- a/internal/server/commands/layout/commands_test.go
+++ b/internal/server/commands/layout/commands_test.go
@@ -15,6 +15,12 @@ type fakeLayoutContext struct {
 	splitCalled      bool
 	splitResult      commandpkg.Result
 
+	renameActorPaneID uint32
+	renamePaneRef     string
+	renameName        string
+	renameCalled      bool
+	renameResult      commandpkg.Result
+
 	spawnActorPaneID uint32
 	spawnArgs        SpawnArgs
 	spawnCalled      bool
@@ -77,6 +83,14 @@ func (f *fakeLayoutContext) Spawn(actorPaneID uint32, args SpawnArgs) commandpkg
 	f.spawnArgs = args
 	f.spawnCalled = true
 	return f.spawnResult
+}
+
+func (f *fakeLayoutContext) Rename(actorPaneID uint32, paneRef, name string) commandpkg.Result {
+	f.renameActorPaneID = actorPaneID
+	f.renamePaneRef = paneRef
+	f.renameName = name
+	f.renameCalled = true
+	return f.renameResult
 }
 
 func (f *fakeLayoutContext) Zoom(uint32, string) commandpkg.Result {
@@ -228,6 +242,57 @@ func TestFocusDefaultsToNext(t *testing.T) {
 	}
 	if got.Output != "focused\n" {
 		t.Fatalf("result output = %q, want %q", got.Output, "focused\n")
+	}
+}
+
+func TestRenameParsesArgsAndDelegates(t *testing.T) {
+	t.Parallel()
+
+	ctx := &fakeLayoutContext{
+		renameResult: commandpkg.Result{Output: "renamed\n"},
+	}
+
+	got := Rename(ctx, 9, []string{"pane-1", "logs"})
+
+	if !ctx.renameCalled {
+		t.Fatal("Rename() did not call context")
+	}
+	if ctx.renameActorPaneID != 9 {
+		t.Fatalf("actorPaneID = %d, want 9", ctx.renameActorPaneID)
+	}
+	if ctx.renamePaneRef != "pane-1" {
+		t.Fatalf("paneRef = %q, want %q", ctx.renamePaneRef, "pane-1")
+	}
+	if ctx.renameName != "logs" {
+		t.Fatalf("name = %q, want %q", ctx.renameName, "logs")
+	}
+	if got.Output != "renamed\n" {
+		t.Fatalf("result output = %q, want %q", got.Output, "renamed\n")
+	}
+}
+
+func TestRenameRejectsInvalidArgs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{name: "missing pane", wantErr: "usage: rename <pane> <new-name>"},
+		{name: "missing name", args: []string{"pane-1"}, wantErr: "usage: rename <pane> <new-name>"},
+		{name: "extra arg", args: []string{"pane-1", "logs", "extra"}, wantErr: "usage: rename <pane> <new-name>"},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := Rename(&fakeLayoutContext{}, 3, tt.args).Err; got == nil || got.Error() != tt.wantErr {
+				t.Fatalf("Rename(%v) error = %v, want %q", tt.args, got, tt.wantErr)
+			}
+		})
 	}
 }
 

--- a/internal/server/commands_layout.go
+++ b/internal/server/commands_layout.go
@@ -551,13 +551,16 @@ func runRename(ctx *CommandContext, actorPaneID uint32, paneRef, name string) co
 		if err != nil {
 			return commandMutationResult{err: err}
 		}
+		oldName := pane.Meta.Name
+		if oldName == name {
+			return commandMutationResult{output: "Pane name unchanged\n"}
+		}
 		for _, candidate := range mctx.Panes {
-			if candidate.Meta.Name == name {
+			if candidate.ID != pane.ID && candidate.Meta.Name == name {
 				return commandMutationResult{err: fmt.Errorf("pane %q already exists", name)}
 			}
 		}
 
-		oldName := pane.Meta.Name
 		pane.Meta.Name = name
 		mctx.prunePaneEventSubs(oldName)
 		return commandMutationResult{

--- a/internal/server/commands_layout.go
+++ b/internal/server/commands_layout.go
@@ -559,6 +559,7 @@ func runRename(ctx *CommandContext, actorPaneID uint32, paneRef, name string) co
 
 		oldName := pane.Meta.Name
 		pane.Meta.Name = name
+		mctx.prunePaneEventSubs(oldName)
 		return commandMutationResult{
 			output:          fmt.Sprintf("Renamed %s to %s\n", oldName, name),
 			broadcastLayout: true,

--- a/internal/server/commands_layout.go
+++ b/internal/server/commands_layout.go
@@ -376,6 +376,10 @@ func (ctx layoutCommandContext) Focus(actorPaneID uint32, direction string) comm
 	return runFocus(ctx.CommandContext, actorPaneID, direction)
 }
 
+func (ctx layoutCommandContext) Rename(actorPaneID uint32, paneRef, name string) commandpkg.Result {
+	return runRename(ctx.CommandContext, actorPaneID, paneRef, name)
+}
+
 func (ctx layoutCommandContext) Spawn(actorPaneID uint32, args layoutcmd.SpawnArgs) commandpkg.Result {
 	return runSpawn(ctx.CommandContext, actorPaneID, args)
 }
@@ -539,6 +543,31 @@ func runFocus(ctx *CommandContext, actorPaneID uint32, direction string) command
 
 func cmdFocus(ctx *CommandContext) {
 	ctx.applyCommandResult(layoutcmd.Focus(layoutCommandContext{ctx}, ctx.ActorPaneID, ctx.Args))
+}
+
+func runRename(ctx *CommandContext, actorPaneID uint32, paneRef, name string) commandpkg.Result {
+	return toCommandResult(ctx.Sess.enqueueCommandMutation(func(mctx *MutationContext) commandMutationResult {
+		pane, _, err := mctx.resolvePaneAcrossWindowsForActor(actorPaneID, paneRef)
+		if err != nil {
+			return commandMutationResult{err: err}
+		}
+		for _, candidate := range mctx.Panes {
+			if candidate.Meta.Name == name {
+				return commandMutationResult{err: fmt.Errorf("pane %q already exists", name)}
+			}
+		}
+
+		oldName := pane.Meta.Name
+		pane.Meta.Name = name
+		return commandMutationResult{
+			output:          fmt.Sprintf("Renamed %s to %s\n", oldName, name),
+			broadcastLayout: true,
+		}
+	}))
+}
+
+func cmdRename(ctx *CommandContext) {
+	ctx.applyCommandResult(layoutcmd.Rename(layoutCommandContext{ctx}, ctx.ActorPaneID, ctx.Args))
 }
 
 func runSpawn(ctx *CommandContext, actorPaneID uint32, args layoutcmd.SpawnArgs) commandpkg.Result {

--- a/internal/server/session_events_layout.go
+++ b/internal/server/session_events_layout.go
@@ -300,6 +300,13 @@ func (ctx *MutationContext) emitEvent(ev Event) {
 	})
 }
 
+func (ctx *MutationContext) prunePaneEventSubs(paneName string) {
+	_ = mutationContextDo(ctx, func(sess *Session) error {
+		sess.prunePaneEventSubs(paneName)
+		return nil
+	})
+}
+
 func (ctx *MutationContext) ensureInitialWindowLocked(srv *Server, cols, rows int, preferred *clientConn) (ensureInitialWindowResult, error) {
 	return mutationContextCall(ctx, func(sess *Session) (ensureInitialWindowResult, error) {
 		return sess.ensureInitialWindowLocked(srv, cols, rows, preferred)


### PR DESCRIPTION
## Motivation
Pane names are currently fixed after creation, which makes it awkward to relabel long-lived panes as their role changes. This adds a dedicated rename command while keeping pane references unambiguous by rejecting duplicate names across the session.

## Summary
- add `amux rename <pane> <new-name>` to the CLI/session command tables and server command registry
- update the server-side layout command layer to rename a resolved pane, reject duplicate session-wide names, and emit a layout broadcast
- prune stale pane-name event subscriptions when a pane is renamed so old `events --pane <name>` filters do not accidentally match a future pane that reuses the name
- add CLI parser/help coverage plus queued server command tests for successful rename and duplicate-name rejection across windows

## Testing
- `go test ./internal/server/commands/layout -run 'TestRename' -count=100`
- `go test ./internal/server -run 'TestQueuedCommandRenamePane' -count=100`
- `go test ./internal/cli -run 'TestResolveCanonicalSessionCommand|TestMaybePrintCommandHelp|TestRunMainDispatchesCommands' -count=100`
- `go test ./... -timeout 120s`

## Review focus
- the duplicate-name check is session-wide rather than window-local because pane refs must stay unique across the session
- rename now drops stale pane-name event subscriptions keyed to the old name; look at that behavior if you want to verify the cleanup boundary

Closes LAB-1125
