### PR TITLE
Switch benchmark CI from macOS to Linux runners

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   benchmark:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6.0.2
         with:
@@ -35,7 +35,7 @@ jobs:
 
       - name: Install tmux
         if: steps.changes.outputs.code_changed == 'true'
-        run: brew install tmux
+        run: sudo apt-get update && sudo apt-get install -y tmux
 
       - name: Install benchmark tools
         if: steps.changes.outputs.code_changed == 'true'


### PR DESCRIPTION
## Motivation

macOS 3-core runners cost $0.062/min vs Linux at $0.006/min — 10x cheaper. March had $422 in macOS runner costs from benchmarks alone. The benchmarks test throughput, rendering, and input latency which are platform-independent.

## Summary

- Change `runs-on: macos-latest` → `runs-on: ubuntu-latest`
- Change `brew install tmux` → `sudo apt-get install -y tmux`

## Testing

The benchmark workflow will run on the next push to main after merge. Benchmark numbers will shift (different hardware) but trends remain comparable since all future runs will be on the same Linux runner type.

## Review focus

Confirm no macOS-specific dependencies in the benchmark tests (there aren't — they use PTYs and tmux which work identically on Linux).