### PR TITLE
Fix incorrect wait-idle command syntax in demo-recording skill

### DIFF
--- a/.agents/skills/demo-recording/SKILL.md
+++ b/.agents/skills/demo-recording/SKILL.md
@@ -39,7 +39,7 @@ The converter supports both v2 and v3, but v2 absolute timestamps are easier to 
 
 The driver runs inside asciinema's recorded PTY with a foreground/background split:
 
-1. **Background agent** waits for the amux server socket, then drives the demo via `amux` CLI commands (spawn, split, send-keys, wait-idle, capture)
+1. **Background agent** waits for the amux server socket, then drives the demo via `amux` CLI commands (spawn, split, send-keys, wait idle, capture)
 2. **Foreground amux client** renders the TUI into the PTY that asciinema records
 3. Agent kills the client (via saved PID) to end the recording
 


### PR DESCRIPTION
## Motivation

The demo-recording skill referenced `wait-idle` (hyphenated), but the actual CLI command is `amux wait idle` (space-separated subcommand). The hyphenated form doesn't exist and exits with code 1.

## Summary

- Fixed `wait-idle` → `wait idle` in `.agents/skills/demo-recording/SKILL.md`

Also fixed `wait-idle` and `wait-vt-idle` → `amux wait idle` in `~/.claude/skills/babysit-prs/SKILL.md` (outside this repo).

## Testing

```bash
amux wait --help  # confirms subcommand syntax: amux wait <idle|busy|exited|...>
```

## Review focus

One-line doc fix, no code changes.