### PR TITLE
Prevent wide status glyphs from bleeding across panes

### DIFF
--- a/internal/render/helpbar.go
+++ b/internal/render/helpbar.go
@@ -32,7 +32,7 @@ func helpBarRowCount(overlay *HelpBarOverlay) int {
 	return len(helpBarRows(overlay))
 }
 
-func buildHelpBarRowChars(width int, row string) []styledChar {
+func buildHelpBarRowChars(width int, row string) []ScreenCell {
 	if width <= 0 {
 		return nil
 	}
@@ -40,15 +40,15 @@ func buildHelpBarRowChars(width int, row string) []styledChar {
 	bg := hexToColor(config.Surface0Hex)
 	baseStyle := uv.Style{Fg: hexToColor(config.TextColorHex), Bg: bg}
 	text := truncateRunes(strings.TrimSpace(row), max(width-1, 0))
-	chars := make([]styledChar, 0, width)
-	chars = appendStyledStr(chars, " ", baseStyle)
-	chars = appendStyledStr(chars, text, baseStyle)
+	cells := make([]ScreenCell, 0, width)
+	cells = appendStyledStr(cells, " ", baseStyle)
+	cells = appendStyledStr(cells, text, baseStyle)
 
 	fill := width - 1 - helpBarTextWidth(text)
 	if fill > 0 {
-		chars = appendStyledStr(chars, strings.Repeat(" ", fill), baseStyle)
+		cells = appendStyledStr(cells, strings.Repeat(" ", fill), baseStyle)
 	}
-	return chars
+	return cells
 }
 
 func buildHelpBarCells(g *ScreenGrid, overlay *HelpBarOverlay) {
@@ -64,9 +64,9 @@ func buildHelpBarCells(g *ScreenGrid, overlay *HelpBarOverlay) {
 	}
 	startY := g.Height - 1 - len(rows)
 	for rowIdx, row := range rows {
-		chars := buildHelpBarRowChars(g.Width, row)
-		for i := 0; i < g.Width && i < len(chars); i++ {
-			g.Set(i, startY+rowIdx, ScreenCell{Char: chars[i].ch, Width: 1, Style: chars[i].style})
+		cells := buildHelpBarRowChars(g.Width, row)
+		for i := 0; i < g.Width && i < len(cells); i++ {
+			g.Set(i, startY+rowIdx, cells[i])
 		}
 	}
 }

--- a/internal/render/helpbar.go
+++ b/internal/render/helpbar.go
@@ -32,7 +32,7 @@ func helpBarRowCount(overlay *HelpBarOverlay) int {
 	return len(helpBarRows(overlay))
 }
 
-func buildHelpBarRowChars(width int, row string) []ScreenCell {
+func buildHelpBarRowCells(width int, row string) []ScreenCell {
 	if width <= 0 {
 		return nil
 	}
@@ -41,12 +41,12 @@ func buildHelpBarRowChars(width int, row string) []ScreenCell {
 	baseStyle := uv.Style{Fg: hexToColor(config.TextColorHex), Bg: bg}
 	text := truncateRunes(strings.TrimSpace(row), max(width-1, 0))
 	cells := make([]ScreenCell, 0, width)
-	cells = appendStyledStr(cells, " ", baseStyle)
-	cells = appendStyledStr(cells, text, baseStyle)
+	cells = appendStyledCells(cells, " ", baseStyle)
+	cells = appendStyledCells(cells, text, baseStyle)
 
 	fill := width - 1 - helpBarTextWidth(text)
 	if fill > 0 {
-		cells = appendStyledStr(cells, strings.Repeat(" ", fill), baseStyle)
+		cells = appendStyledCells(cells, strings.Repeat(" ", fill), baseStyle)
 	}
 	return cells
 }
@@ -64,7 +64,7 @@ func buildHelpBarCells(g *ScreenGrid, overlay *HelpBarOverlay) {
 	}
 	startY := g.Height - 1 - len(rows)
 	for rowIdx, row := range rows {
-		cells := buildHelpBarRowChars(g.Width, row)
+		cells := buildHelpBarRowCells(g.Width, row)
 		for i := 0; i < g.Width && i < len(cells); i++ {
 			g.Set(i, startY+rowIdx, cells[i])
 		}

--- a/internal/render/overlay_status_test.go
+++ b/internal/render/overlay_status_test.go
@@ -649,6 +649,47 @@ func TestBuildStatusCellsClipsLongTaskToPaneWidth(t *testing.T) {
 	}
 }
 
+func TestBuildStatusCellsMarksWideConnStatusRune(t *testing.T) {
+	t.Parallel()
+
+	cell := mux.NewLeaf(&mux.Pane{ID: 1}, 0, 0, 32, 4)
+	grid := NewScreenGrid(32, 4)
+	buildStatusCells(grid, cell, true, &statusPaneData{
+		id:         1,
+		name:       "pane-1",
+		connStatus: "connected",
+		task:       "sync",
+		color:      config.TextColorHex,
+	})
+
+	var row strings.Builder
+	for x := 0; x < 32; x++ {
+		ch := grid.Get(x, 0).Char
+		if ch == "" {
+			ch = " "
+		}
+		row.WriteString(ch)
+	}
+
+	line := row.String()
+	start := strings.Index(line, "⚡")
+	if start < 0 {
+		t.Fatalf("status row %q missing connected marker", line)
+	}
+	if got := grid.Get(start, 0).Width; got != 2 {
+		t.Fatalf("connected marker width = %d, want 2", got)
+	}
+	if got := grid.Get(start+1, 0).Width; got != 0 {
+		t.Fatalf("connected marker continuation width = %d, want 0", got)
+	}
+	if got := grid.Get(start+2, 0).Char; got != " " {
+		t.Fatalf("cell after connected marker = %q, want task separator space", got)
+	}
+	if got := grid.Get(start+3, 0).Char; got != "s" {
+		t.Fatalf("task should start after the wide rune continuation, got %q", got)
+	}
+}
+
 func TestBuildGlobalBarCellsTruncatesMessages(t *testing.T) {
 	t.Parallel()
 

--- a/internal/render/overlay_status_test.go
+++ b/internal/render/overlay_status_test.go
@@ -672,7 +672,13 @@ func TestBuildStatusCellsMarksWideConnStatusRune(t *testing.T) {
 	}
 
 	line := row.String()
-	start := strings.Index(line, "⚡")
+	start := -1
+	for x := 0; x < 32; x++ {
+		if grid.Get(x, 0).Char == "⚡" {
+			start = x
+			break
+		}
+	}
 	if start < 0 {
 		t.Fatalf("status row %q missing connected marker", line)
 	}

--- a/internal/render/screen.go
+++ b/internal/render/screen.go
@@ -142,6 +142,10 @@ func emitDiffWithProfile(changes []CellChange, profile termenv.Profile) string {
 	expectX, expectY := -1, -1
 
 	for _, ch := range changes {
+		if ch.Cell.Width == 0 {
+			continue
+		}
+
 		// Emit CUP only when cursor is not at the expected position.
 		if ch.Y != expectY || ch.X != expectX {
 			writeCursorTo(&buf, ch.Y+1, ch.X+1)
@@ -522,12 +526,6 @@ func linkIsZero(link uv.Link) bool {
 	return link.URL == "" && link.Params == ""
 }
 
-// styledChar represents a single character with styling for status/bar rendering.
-type styledChar struct {
-	ch    string
-	style uv.Style
-}
-
 type paneStatusGridPalette struct {
 	background    uv.Style
 	pane          uv.Style
@@ -584,12 +582,24 @@ func (p paneStatusGridPalette) style(role paneStatusSegmentRole) uv.Style {
 	}
 }
 
-// appendStyledStr appends each rune of s as a styledChar with the given style.
-func appendStyledStr(chars []styledChar, s string, style uv.Style) []styledChar {
-	for _, r := range s {
-		chars = append(chars, styledChar{ch: string(r), style: style})
+// appendStyledStr expands s into styled screen cells so diff rendering honors
+// the display width of wide glyphs the same way the ANSI full-render path does.
+func appendStyledStr(cells []ScreenCell, s string, style uv.Style) []ScreenCell {
+	for len(s) > 0 {
+		cluster, clusterWidth := ansi.FirstGraphemeCluster(s, ansi.GraphemeWidth)
+		if cluster == "" {
+			break
+		}
+		if clusterWidth <= 0 {
+			clusterWidth = 1
+		}
+		cells = append(cells, ScreenCell{Char: cluster, Width: clusterWidth, Style: style})
+		for i := 1; i < clusterWidth; i++ {
+			cells = append(cells, ScreenCell{Char: " ", Width: 0, Style: style})
+		}
+		s = s[len(cluster):]
 	}
-	return chars
+	return cells
 }
 
 // buildStatusCells writes the per-pane status line into the grid cell-by-cell.
@@ -606,17 +616,17 @@ func buildStatusCellsPressed(g *ScreenGrid, cell *mux.LayoutCell, isActive, pres
 	bg := hexToColor(bgHex)
 	colorHex := paneStatusColorHex(pd)
 	palette := newPaneStatusGridPalette(colorHex, bg)
-	var chars []styledChar
+	var cells []ScreenCell
 	for _, segment := range buildPaneStatusSegments(cell.W, isActive, pd) {
-		chars = appendStyledStr(chars, segment.text, palette.style(segment.role))
+		cells = appendStyledStr(cells, segment.text, palette.style(segment.role))
 	}
 
 	// Write chars to grid, fill remaining with spaces.
 	fillCell := ScreenCell{Char: " ", Width: 1, Style: uv.Style{Bg: bg}}
 	for i := 0; i < cell.W; i++ {
 		sc := fillCell
-		if i < len(chars) {
-			sc = ScreenCell{Char: chars[i].ch, Width: 1, Style: chars[i].style}
+		if i < len(cells) {
+			sc = cells[i]
 		}
 		g.Set(cell.X+i, y, sc)
 	}
@@ -659,13 +669,13 @@ func buildGlobalBarCells(g *ScreenGrid, sessionName string, paneCount int, width
 	focusedStyle.Fg = hexToColor(config.BlueHex)
 	errorStyle := uv.Style{Fg: redFg, Bg: bg}
 
-	var chars []styledChar
+	var cells []ScreenCell
 	showHelp := globalBarShowsHelp(width, sessionName, paneCount, windows, message, now)
 
 	// " amux │ "
-	chars = appendStyledStr(chars, " ", baseStyle)
-	chars = appendStyledStr(chars, "amux", boldStyle)
-	chars = appendStyledStr(chars, " │ ", baseStyle)
+	cells = appendStyledStr(cells, " ", baseStyle)
+	cells = appendStyledStr(cells, "amux", boldStyle)
+	cells = appendStyledStr(cells, " │ ", baseStyle)
 
 	if tabs := buildGlobalBarWindowTabs(windows); len(tabs) > 0 {
 		for _, tab := range tabs {
@@ -674,18 +684,18 @@ func buildGlobalBarCells(g *ScreenGrid, sessionName string, paneCount int, width
 				style = boldStyle
 			}
 			style.Fg = hexToColor(globalBarTabColorHex(tab.window))
-			chars = appendStyledStr(chars, tab.display, style)
-			chars = appendStyledStr(chars, " ", baseStyle)
+			cells = appendStyledStr(cells, tab.display, style)
+			cells = appendStyledStr(cells, " ", baseStyle)
 		}
-		chars = appendStyledStr(chars, "│ ", baseStyle)
+		cells = appendStyledStr(cells, "│ ", baseStyle)
 	} else {
-		chars = appendStyledStr(chars, sessionName+" ", baseStyle)
+		cells = appendStyledStr(cells, sessionName+" ", baseStyle)
 	}
 
 	rightText := ""
 	rightStyle := baseStyle
 	if message != "" {
-		maxText := width - len(chars) - 2
+		maxText := width - len(cells) - 2
 		rightText = " " + truncateRunes(message, maxText) + " "
 		rightStyle = errorStyle
 		message = ""
@@ -694,7 +704,7 @@ func buildGlobalBarCells(g *ScreenGrid, sessionName string, paneCount int, width
 	}
 
 	// Fill middle.
-	leftLen := len(chars)
+	leftLen := len(cells)
 	rightLen := len([]rune(rightText))
 	fill := width - leftLen - rightLen
 	if fill > 0 {
@@ -702,16 +712,16 @@ func buildGlobalBarCells(g *ScreenGrid, sessionName string, paneCount int, width
 		if len(messageRunes) > fill {
 			messageRunes = messageRunes[:fill]
 		}
-		chars = appendStyledStr(chars, string(messageRunes), baseStyle)
+		cells = appendStyledStr(cells, string(messageRunes), baseStyle)
 		for i := len(messageRunes); i < fill; i++ {
-			chars = append(chars, styledChar{ch: " ", style: baseStyle})
+			cells = append(cells, ScreenCell{Char: " ", Width: 1, Style: baseStyle})
 		}
 	}
-	chars = appendStyledStr(chars, rightText, rightStyle)
+	cells = appendStyledStr(cells, rightText, rightStyle)
 
 	// Write to grid.
-	for i := 0; i < width && i < len(chars); i++ {
-		g.Set(i, yPos, ScreenCell{Char: chars[i].ch, Width: 1, Style: chars[i].style})
+	for i := 0; i < width && i < len(cells); i++ {
+		g.Set(i, yPos, cells[i])
 	}
 }
 

--- a/internal/render/screen.go
+++ b/internal/render/screen.go
@@ -582,9 +582,9 @@ func (p paneStatusGridPalette) style(role paneStatusSegmentRole) uv.Style {
 	}
 }
 
-// appendStyledStr expands s into styled screen cells so diff rendering honors
+// appendStyledCells expands s into styled screen cells so diff rendering honors
 // the display width of wide glyphs the same way the ANSI full-render path does.
-func appendStyledStr(cells []ScreenCell, s string, style uv.Style) []ScreenCell {
+func appendStyledCells(cells []ScreenCell, s string, style uv.Style) []ScreenCell {
 	for len(s) > 0 {
 		cluster, clusterWidth := ansi.FirstGraphemeCluster(s, ansi.GraphemeWidth)
 		if cluster == "" {
@@ -618,10 +618,10 @@ func buildStatusCellsPressed(g *ScreenGrid, cell *mux.LayoutCell, isActive, pres
 	palette := newPaneStatusGridPalette(colorHex, bg)
 	var cells []ScreenCell
 	for _, segment := range buildPaneStatusSegments(cell.W, isActive, pd) {
-		cells = appendStyledStr(cells, segment.text, palette.style(segment.role))
+		cells = appendStyledCells(cells, segment.text, palette.style(segment.role))
 	}
 
-	// Write chars to grid, fill remaining with spaces.
+	// Write cells to grid, fill remaining with spaces.
 	fillCell := ScreenCell{Char: " ", Width: 1, Style: uv.Style{Bg: bg}}
 	for i := 0; i < cell.W; i++ {
 		sc := fillCell
@@ -673,9 +673,9 @@ func buildGlobalBarCells(g *ScreenGrid, sessionName string, paneCount int, width
 	showHelp := globalBarShowsHelp(width, sessionName, paneCount, windows, message, now)
 
 	// " amux │ "
-	cells = appendStyledStr(cells, " ", baseStyle)
-	cells = appendStyledStr(cells, "amux", boldStyle)
-	cells = appendStyledStr(cells, " │ ", baseStyle)
+	cells = appendStyledCells(cells, " ", baseStyle)
+	cells = appendStyledCells(cells, "amux", boldStyle)
+	cells = appendStyledCells(cells, " │ ", baseStyle)
 
 	if tabs := buildGlobalBarWindowTabs(windows); len(tabs) > 0 {
 		for _, tab := range tabs {
@@ -684,12 +684,12 @@ func buildGlobalBarCells(g *ScreenGrid, sessionName string, paneCount int, width
 				style = boldStyle
 			}
 			style.Fg = hexToColor(globalBarTabColorHex(tab.window))
-			cells = appendStyledStr(cells, tab.display, style)
-			cells = appendStyledStr(cells, " ", baseStyle)
+			cells = appendStyledCells(cells, tab.display, style)
+			cells = appendStyledCells(cells, " ", baseStyle)
 		}
-		cells = appendStyledStr(cells, "│ ", baseStyle)
+		cells = appendStyledCells(cells, "│ ", baseStyle)
 	} else {
-		cells = appendStyledStr(cells, sessionName+" ", baseStyle)
+		cells = appendStyledCells(cells, sessionName+" ", baseStyle)
 	}
 
 	rightText := ""
@@ -712,12 +712,12 @@ func buildGlobalBarCells(g *ScreenGrid, sessionName string, paneCount int, width
 		if len(messageRunes) > fill {
 			messageRunes = messageRunes[:fill]
 		}
-		cells = appendStyledStr(cells, string(messageRunes), baseStyle)
+		cells = appendStyledCells(cells, string(messageRunes), baseStyle)
 		for i := len(messageRunes); i < fill; i++ {
 			cells = append(cells, ScreenCell{Char: " ", Width: 1, Style: baseStyle})
 		}
 	}
-	cells = appendStyledStr(cells, rightText, rightStyle)
+	cells = appendStyledCells(cells, rightText, rightStyle)
 
 	// Write to grid.
 	for i := 0; i < width && i < len(cells); i++ {

--- a/internal/render/screen_test.go
+++ b/internal/render/screen_test.go
@@ -1262,6 +1262,51 @@ func TestRenderDiff_LongLines_TwoPanes(t *testing.T) {
 	}
 }
 
+func TestRenderDiff_StatusLineWideRuneMatchesRenderFullAcrossPanes(t *testing.T) {
+	t.Parallel()
+
+	pane1W := 32
+	pane2W := 32
+	width := pane1W + 1 + pane2W
+	height := 6
+	totalH := height + GlobalBarHeight
+
+	root := mkSplit(mux.SplitVertical, 0, 0, width, height,
+		mux.NewLeafByID(1, 0, 0, pane1W, height),
+		mux.NewLeafByID(2, pane1W+1, 0, pane2W, height),
+	)
+	lookup := func(id uint32) PaneData {
+		switch id {
+		case 1:
+			return &statusPaneData{
+				id:           1,
+				name:         "pane-1",
+				connStatus:   "connected",
+				task:         "sync-logs",
+				color:        config.TextColorHex,
+				screen:       "",
+				cursorHidden: true,
+			}
+		case 2:
+			return &statusPaneData{
+				id:           2,
+				name:         "pane-2",
+				color:        config.TextColorHex,
+				screen:       "",
+				cursorHidden: true,
+			}
+		}
+		return nil
+	}
+
+	comp := newTestCompositor(width, totalH, "test")
+	display := vt.NewSafeEmulator(width, totalH)
+
+	if err := oracleCheck(comp, display, root, 1, lookup, width, totalH); err != "" {
+		t.Error(err)
+	}
+}
+
 func TestRenderDiff_ColorOracle_LongLines(t *testing.T) {
 	t.Parallel()
 	pane1W := 20


### PR DESCRIPTION
## Motivation
Pane status rows were clipped correctly in the ANSI full-render path, but the diff/grid path treated wide glyphs like the connected-status `⚡` as single-column cells. In multi-column layouts that one-column drift let status text run into the next pane header.

## Summary
- add regressions for wide connected-status glyphs in both the status-cell builder and a two-pane `RenderDiff` oracle
- expand status/global/help bar text into width-aware screen cells so wide glyphs keep their continuation columns in the grid
- skip zero-width continuation cells when emitting diffs so wide glyphs do not get rewritten and cleared mid-row

## Testing
- `go test ./internal/render -run 'Test(BuildStatusCellsMarksWideConnStatusRune|RenderDiff_StatusLineWideRuneMatchesRenderFullAcrossPanes)$' -count=100`
- `go test ./internal/render/ -run TestGolden -count=1`
- `go test ./internal/render/ -timeout 30s`
- `go test ./test -run TestMetaSetRejectsInvalidTrackedPRJSONWithoutMutation -count=10 -timeout 120s`
- `go test ./... -timeout 120s`

## Review focus
- `emitDiffWithProfile` now skips zero-width continuation cells; the important question is whether that matches how the grid represents other wide glyphs across incremental updates
- `appendStyledCells` is now shared by pane status rows, the global bar, and the help bar so those grid paths all use the same display-width accounting as the ANSI path

Closes LAB-1235
