### PR TITLE
Print detach reasons when amux exits

### DIFF
--- a/internal/client/attach.go
+++ b/internal/client/attach.go
@@ -1,18 +1,22 @@
 package client
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"net"
 	"os"
 	"os/signal"
 	"runtime/coverage"
+	"runtime/debug"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
 	uv "github.com/charmbracelet/ultraviolet"
 	"github.com/muesli/termenv"
+	"github.com/weill-labs/amux/internal/checkpoint"
 	"github.com/weill-labs/amux/internal/config"
 	"github.com/weill-labs/amux/internal/copymode"
 	"github.com/weill-labs/amux/internal/mouse"
@@ -23,17 +27,141 @@ import (
 	"golang.org/x/term"
 )
 
-func waitForRunSessionEnd(done <-chan struct{}, triggerReload <-chan struct{}, reload func()) {
+type runSessionDeps struct {
+	stdin             *os.File
+	stdout            *os.File
+	stderr            io.Writer
+	ensureDaemon      func(string, time.Duration) error
+	dial              func(network, address string) (net.Conn, error)
+	resolveExecutable func() (string, error)
+	execSelf          func(execPath string, sender *messageSender, restoreTerminal func()) error
+}
+
+type sessionExitState struct {
+	mu     sync.Mutex
+	notice string
+}
+
+func (s *sessionExitState) set(notice string) {
+	if notice == "" {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.notice == "" {
+		s.notice = notice
+	}
+}
+
+func (s *sessionExitState) get() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.notice
+}
+
+func defaultRunSessionDeps() runSessionDeps {
+	return runSessionDeps{
+		stdin:             os.Stdin,
+		stdout:            os.Stdout,
+		stderr:            os.Stderr,
+		ensureDaemon:      proto.EnsureDaemon,
+		dial:              net.Dial,
+		resolveExecutable: reload.ResolveExecutable,
+		execSelf:          execSelf,
+	}
+}
+
+func waitForRunSessionEnd(done <-chan struct{}, triggerReload <-chan struct{}) bool {
 	select {
 	case <-done:
 		select {
 		case <-triggerReload:
-			reload()
+			return true
 		default:
+			return false
 		}
 	case <-triggerReload:
-		reload()
+		return true
 	}
+}
+
+func isConnectionLostError(err error) bool {
+	if err == nil {
+		return false
+	}
+	return errors.Is(err, io.EOF) ||
+		errors.Is(err, net.ErrClosed) ||
+		strings.Contains(err.Error(), "use of closed network connection") ||
+		strings.Contains(err.Error(), "broken pipe") ||
+		strings.Contains(err.Error(), "connection reset by peer")
+}
+
+func isSocketNotFoundError(err error) bool {
+	if err == nil {
+		return false
+	}
+	return errors.Is(err, os.ErrNotExist) || strings.Contains(err.Error(), "no such file or directory")
+}
+
+func formatAttachError(err error) error {
+	if err == nil {
+		return nil
+	}
+	switch {
+	case errors.Is(err, errAttachProtocol):
+		return fmt.Errorf("attach failed: protocol error: %v", err)
+	case isSocketNotFoundError(err):
+		return fmt.Errorf("attach failed: socket not found")
+	case isConnectionLostError(err):
+		return fmt.Errorf("attach failed: connection lost")
+	default:
+		return fmt.Errorf("attach failed: %w", err)
+	}
+}
+
+func disconnectNoticeForReadError(err error) string {
+	if err == nil {
+		return ""
+	}
+	if isConnectionLostError(err) {
+		return "detached: connection lost"
+	}
+	return "detached: protocol error"
+}
+
+func formatDetachNotice(text, fallback string) string {
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return fallback
+	}
+	if strings.HasPrefix(text, "detached:") {
+		return text
+	}
+	return "detached: " + text
+}
+
+func clientBuildHash() string {
+	if info, ok := debug.ReadBuildInfo(); ok {
+		for _, setting := range info.Settings {
+			if setting.Key == "vcs.revision" && len(setting.Value) >= 7 {
+				return setting.Value[:7]
+			}
+		}
+	}
+	return "dev"
+}
+
+func currentClientVersion() string {
+	return fmt.Sprintf("%s (checkpoint v%d)", clientBuildHash(), checkpoint.ServerCheckpointVersion)
+}
+
+func hotReloadDetachNotice(serverVersion string) string {
+	serverVersion = strings.TrimSpace(serverVersion)
+	clientVersion := currentClientVersion()
+	if serverVersion != "" && serverVersion != clientVersion {
+		return fmt.Sprintf("detached: binary version mismatch (client %s, server %s) — run make install", clientVersion, serverVersion)
+	}
+	return "detached: server requested hot-reload"
 }
 
 func dragMotionCoalescingActive(drag *dragState) bool {
@@ -280,6 +408,10 @@ func terminalExitSequence(caps proto.ClientCapabilities) string {
 // RunSession connects to an existing server or starts one, then enters raw
 // terminal mode for interactive use.
 func RunSession(sessionName string, getTermSize func(int) (int, int, error)) error {
+	return runSessionWithDeps(sessionName, getTermSize, defaultRunSessionDeps())
+}
+
+func runSessionWithDeps(sessionName string, getTermSize func(int) (int, int, error), deps runSessionDeps) error {
 	cfg, err := config.Load(config.DefaultPath())
 	if err != nil {
 		return fmt.Errorf("loading config: %w", err)
@@ -298,18 +430,22 @@ func RunSession(sessionName string, getTermSize func(int) (int, int, error)) err
 	}()
 	kb := config.DefaultKeybindings()
 	scrollbackLines := cfg.EffectiveScrollbackLines()
-	stdin := os.Stdin
-	stdout := os.Stdout
+	stdin := deps.stdin
+	stdout := deps.stdout
+	stderr := deps.stderr
+	if stderr == nil {
+		stderr = io.Discard
+	}
 
 	sockPath := proto.SocketPath(sessionName)
 
-	if err := proto.EnsureDaemon(sessionName, 5*time.Second); err != nil {
-		return err
+	if err := deps.ensureDaemon(sessionName, 5*time.Second); err != nil {
+		return formatAttachError(err)
 	}
 
-	conn, err := net.Dial("unix", sockPath)
+	conn, err := deps.dial("unix", sockPath)
 	if err != nil {
-		return fmt.Errorf("connecting to server: %w", err)
+		return formatAttachError(err)
 	}
 	defer conn.Close()
 	sender := newMessageSender(conn)
@@ -338,7 +474,7 @@ func RunSession(sessionName string, getTermSize func(int) (int, int, error)) err
 		AttachColorProfile: attachProfile,
 		AttachCapabilities: attachCaps,
 	}); err != nil {
-		return fmt.Errorf("sending attach: %w", err)
+		return formatAttachError(err)
 	}
 
 	// Client-side renderer with per-pane emulators
@@ -351,7 +487,7 @@ func RunSession(sessionName string, getTermSize func(int) (int, int, error)) err
 		})
 	}
 	if err := readAttachBootstrap(conn, reader, cr); err != nil {
-		return fmt.Errorf("reading attach bootstrap: %w", err)
+		return formatAttachError(err)
 	}
 
 	// Enter raw mode + alternate screen only once there is enough bootstrap
@@ -362,10 +498,16 @@ func RunSession(sessionName string, getTermSize func(int) (int, int, error)) err
 		return fmt.Errorf("raw mode: %w", err)
 	}
 	stdout.Write([]byte(terminalEnterSequence(negotiatedAttachCaps)))
-	defer func() {
+	terminalRestored := false
+	restoreTerminal := func() {
+		if terminalRestored {
+			return
+		}
+		terminalRestored = true
 		stdout.Write([]byte(terminalExitSequence(negotiatedAttachCaps)))
-		term.Restore(fd, oldState)
-	}()
+		_ = term.Restore(fd, oldState)
+	}
+	defer restoreTerminal()
 
 	if initial := cr.Render(true); initial != "" {
 		io.WriteString(stdout, wrapSynchronizedFrame(initial))
@@ -374,7 +516,8 @@ func RunSession(sessionName string, getTermSize func(int) (int, int, error)) err
 	// Resolve the current binary once so explicit reloads and server reload
 	// notices can re-exec the client into the replacement binary.
 	triggerReload := make(chan struct{}, 1)
-	execPath, _ := reload.ResolveExecutable()
+	execPath, _ := deps.resolveExecutable()
+	exitState := &sessionExitState{}
 
 	// Channel for injecting keystrokes from type-keys (server → client).
 	type injectedInput struct {
@@ -395,6 +538,7 @@ func RunSession(sessionName string, getTermSize func(int) (int, int, error)) err
 		for {
 			msg, err := reader.ReadMsg()
 			if err != nil {
+				exitState.set(disconnectNoticeForReadError(err))
 				return
 			}
 			switch msg.Type {
@@ -411,6 +555,7 @@ func RunSession(sessionName string, getTermSize func(int) (int, int, error)) err
 			case proto.MsgTypeCopyMode:
 				msgCh <- &RenderMsg{Typ: RenderMsgCopyMode, PaneID: msg.PaneID}
 			case proto.MsgTypeExit:
+				exitState.set(formatDetachNotice(msg.Text, "detached: session exited"))
 				msgCh <- &RenderMsg{Typ: RenderMsgExit}
 				return
 			case proto.MsgTypeBell:
@@ -430,7 +575,8 @@ func RunSession(sessionName string, getTermSize func(int) (int, int, error)) err
 				default:
 				}
 			case proto.MsgTypeServerReload:
-				// Server is reloading — re-exec ourselves to reconnect
+				// Server is reloading — re-exec ourselves to reconnect.
+				exitState.set(hotReloadDetachNotice(msg.Text))
 				select {
 				case triggerReload <- struct{}{}:
 				default:
@@ -559,6 +705,7 @@ func RunSession(sessionName string, getTermSize func(int) (int, int, error)) err
 					}
 					_ = sender.Send(&proto.Message{Type: proto.MsgTypeDetach})
 					_ = sender.Flush()
+					exitState.set("detached: client requested detach")
 					disconnectRequested = true
 					return true
 				case "reload":
@@ -568,6 +715,7 @@ func RunSession(sessionName string, getTermSize func(int) (int, int, error)) err
 						})
 						*forward = nil
 					}
+					exitState.set("detached: client requested hot-reload")
 					select {
 					case triggerReload <- struct{}{}:
 					default:
@@ -1048,16 +1196,26 @@ func RunSession(sessionName string, getTermSize func(int) (int, int, error)) err
 		}
 	}()
 
-	waitForRunSessionEnd(done, triggerReload, func() {
+	if waitForRunSessionEnd(done, triggerReload) {
+		if exitState.get() == "" {
+			exitState.set("detached: server requested hot-reload")
+		}
 		if clientPprof != nil {
 			clientPprof.close()
 			clientPprof = nil
 		}
 		if execPath != "" {
-			ExecSelf(execPath, sender, fd, oldState, negotiatedAttachCaps)
+			if err := deps.execSelf(execPath, sender, restoreTerminal); err != nil {
+				restoreTerminal()
+				return fmt.Errorf("%s: %w", exitState.get(), err)
+			}
+			return nil
 		}
-		// ExecSelf replaces the process; if we get here, exec failed fatally
-	})
+	}
+	if notice := exitState.get(); notice != "" {
+		restoreTerminal()
+		_, _ = fmt.Fprintln(stderr, notice)
+	}
 	return nil
 }
 
@@ -1101,22 +1259,19 @@ func formatKeyName(b byte) string {
 	}
 }
 
-// ExecSelf replaces the current process with the binary at execPath.
-// Pre-validates the binary before tearing down the connection.
-func ExecSelf(execPath string, sender *messageSender, fd int, oldState *term.State, caps proto.ClientCapabilities) {
+func execSelf(execPath string, sender *messageSender, restoreTerminal func()) error {
 	// Pre-validate: binary must exist and be accessible
 	if _, err := os.Stat(execPath); err != nil {
-		return
+		return err
 	}
 
 	// Clean disconnect from server
 	_ = sender.Send(&proto.Message{Type: proto.MsgTypeDetach})
 	_ = sender.Flush()
-	sender.conn.Close()
+	_ = sender.conn.Close()
 
 	// Restore terminal state
-	term.Restore(fd, oldState)
-	os.Stdout.Write([]byte(terminalExitSequence(caps)))
+	restoreTerminal()
 
 	// Flush coverage data before exec (which replaces the process image
 	// without running atexit handlers). No-op if not built with -cover.
@@ -1125,10 +1280,16 @@ func ExecSelf(execPath string, sender *messageSender, fd int, oldState *term.Sta
 	}
 
 	// Replace process
-	err := syscall.Exec(execPath, os.Args, os.Environ())
-	if err != nil {
-		// Unrecoverable — connection is closed
-		os.Stderr.WriteString("amux: reload failed: " + err.Error() + "\n")
-		os.Exit(1)
-	}
+	return syscall.Exec(execPath, os.Args, os.Environ())
+}
+
+// ExecSelf replaces the current process with the binary at execPath.
+// Pre-validates the binary before tearing down the connection.
+func ExecSelf(execPath string, sender *messageSender, fd int, oldState *term.State, caps proto.ClientCapabilities) {
+	_ = execSelf(execPath, sender, func() {
+		if oldState != nil {
+			_ = term.Restore(fd, oldState)
+		}
+		os.Stdout.Write([]byte(terminalExitSequence(caps)))
+	})
 }

--- a/internal/client/attach_bootstrap.go
+++ b/internal/client/attach_bootstrap.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"time"
@@ -8,6 +9,8 @@ import (
 	"github.com/weill-labs/amux/internal/config"
 	"github.com/weill-labs/amux/internal/proto"
 )
+
+var errAttachProtocol = errors.New("attach protocol error")
 
 type attachBootstrapMessage struct {
 	msg *proto.Message
@@ -125,7 +128,7 @@ func readAttachBootstrap(conn net.Conn, reader *proto.Reader, cr *ClientRenderer
 		default:
 			bufferedMsg, ok := newAttachBootstrapMessage(msg)
 			if !ok {
-				return fmt.Errorf("unexpected attach bootstrap message type %d before layout", msg.Type)
+				return fmt.Errorf("%w: unexpected attach bootstrap message type %d before layout", errAttachProtocol, msg.Type)
 			}
 			buffered = append(buffered, bufferedMsg)
 		}

--- a/internal/client/attach_session_test.go
+++ b/internal/client/attach_session_test.go
@@ -20,85 +20,63 @@ import (
 	"github.com/weill-labs/amux/internal/render"
 )
 
-type ptyOutputCollector struct {
-	ptmx    *os.File
+type asyncOutputCollector struct {
 	mu      sync.Mutex
 	buf     strings.Builder
 	updates chan struct{}
 	done    chan struct{}
+}
+
+type ptyOutputCollector struct {
+	*asyncOutputCollector
 }
 
 type streamOutputCollector struct {
-	reader  io.Reader
-	mu      sync.Mutex
-	buf     strings.Builder
-	updates chan struct{}
-	done    chan struct{}
+	*asyncOutputCollector
+}
+
+func newAsyncOutputCollector(reader io.Reader) *asyncOutputCollector {
+	c := &asyncOutputCollector{
+		updates: make(chan struct{}, 1),
+		done:    make(chan struct{}),
+	}
+	go func() {
+		defer close(c.done)
+		buf := make([]byte, 4096)
+		for {
+			n, err := reader.Read(buf)
+			if n > 0 {
+				c.mu.Lock()
+				c.buf.Write(buf[:n])
+				c.mu.Unlock()
+				select {
+				case c.updates <- struct{}{}:
+				default:
+				}
+			}
+			if err != nil {
+				return
+			}
+		}
+	}()
+	return c
 }
 
 func newPTYOutputCollector(ptmx *os.File) *ptyOutputCollector {
-	c := &ptyOutputCollector{
-		ptmx:    ptmx,
-		updates: make(chan struct{}, 1),
-		done:    make(chan struct{}),
-	}
-	go func() {
-		defer close(c.done)
-		buf := make([]byte, 4096)
-		for {
-			n, err := ptmx.Read(buf)
-			if n > 0 {
-				c.mu.Lock()
-				c.buf.Write(buf[:n])
-				c.mu.Unlock()
-				select {
-				case c.updates <- struct{}{}:
-				default:
-				}
-			}
-			if err != nil {
-				return
-			}
-		}
-	}()
-	return c
+	return &ptyOutputCollector{asyncOutputCollector: newAsyncOutputCollector(ptmx)}
 }
 
 func newStreamOutputCollector(reader io.Reader) *streamOutputCollector {
-	c := &streamOutputCollector{
-		reader:  reader,
-		updates: make(chan struct{}, 1),
-		done:    make(chan struct{}),
-	}
-	go func() {
-		defer close(c.done)
-		buf := make([]byte, 4096)
-		for {
-			n, err := c.reader.Read(buf)
-			if n > 0 {
-				c.mu.Lock()
-				c.buf.Write(buf[:n])
-				c.mu.Unlock()
-				select {
-				case c.updates <- struct{}{}:
-				default:
-				}
-			}
-			if err != nil {
-				return
-			}
-		}
-	}()
-	return c
+	return &streamOutputCollector{asyncOutputCollector: newAsyncOutputCollector(reader)}
 }
 
-func (c *ptyOutputCollector) snapshot() string {
+func (c *asyncOutputCollector) snapshot() string {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	return c.buf.String()
 }
 
-func (c *ptyOutputCollector) waitContains(t *testing.T, want string) string {
+func (c *asyncOutputCollector) waitContains(t *testing.T, source, want string) string {
 	t.Helper()
 
 	deadline := time.After(5 * time.Second)
@@ -109,14 +87,18 @@ func (c *ptyOutputCollector) waitContains(t *testing.T, want string) string {
 		select {
 		case <-c.updates:
 		case <-deadline:
-			t.Fatalf("pty output never contained %q; got %q", want, c.snapshot())
+			t.Fatalf("%s never contained %q; got %q", source, want, c.snapshot())
 		case <-c.done:
 			if got := c.snapshot(); strings.Contains(got, want) {
 				return got
 			}
-			t.Fatalf("pty output ended before containing %q; got %q", want, c.snapshot())
+			t.Fatalf("%s ended before containing %q; got %q", source, want, c.snapshot())
 		}
 	}
+}
+
+func (c *ptyOutputCollector) waitContains(t *testing.T, want string) string {
+	return c.asyncOutputCollector.waitContains(t, "pty output", want)
 }
 
 func (c *ptyOutputCollector) waitContainsWithin(want string, timeout time.Duration) bool {
@@ -135,31 +117,8 @@ func (c *ptyOutputCollector) waitContainsWithin(want string, timeout time.Durati
 	}
 }
 
-func (c *streamOutputCollector) snapshot() string {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	return c.buf.String()
-}
-
 func (c *streamOutputCollector) waitContains(t *testing.T, want string) string {
-	t.Helper()
-
-	deadline := time.After(5 * time.Second)
-	for {
-		if got := c.snapshot(); strings.Contains(got, want) {
-			return got
-		}
-		select {
-		case <-c.updates:
-		case <-deadline:
-			t.Fatalf("stream output never contained %q; got %q", want, c.snapshot())
-		case <-c.done:
-			if got := c.snapshot(); strings.Contains(got, want) {
-				return got
-			}
-			t.Fatalf("stream output ended before containing %q; got %q", want, c.snapshot())
-		}
-	}
+	return c.asyncOutputCollector.waitContains(t, "stream output", want)
 }
 
 type runSessionHarness struct {

--- a/internal/client/attach_session_test.go
+++ b/internal/client/attach_session_test.go
@@ -28,6 +28,14 @@ type ptyOutputCollector struct {
 	done    chan struct{}
 }
 
+type streamOutputCollector struct {
+	reader  io.Reader
+	mu      sync.Mutex
+	buf     strings.Builder
+	updates chan struct{}
+	done    chan struct{}
+}
+
 func newPTYOutputCollector(ptmx *os.File) *ptyOutputCollector {
 	c := &ptyOutputCollector{
 		ptmx:    ptmx,
@@ -39,6 +47,34 @@ func newPTYOutputCollector(ptmx *os.File) *ptyOutputCollector {
 		buf := make([]byte, 4096)
 		for {
 			n, err := ptmx.Read(buf)
+			if n > 0 {
+				c.mu.Lock()
+				c.buf.Write(buf[:n])
+				c.mu.Unlock()
+				select {
+				case c.updates <- struct{}{}:
+				default:
+				}
+			}
+			if err != nil {
+				return
+			}
+		}
+	}()
+	return c
+}
+
+func newStreamOutputCollector(reader io.Reader) *streamOutputCollector {
+	c := &streamOutputCollector{
+		reader:  reader,
+		updates: make(chan struct{}, 1),
+		done:    make(chan struct{}),
+	}
+	go func() {
+		defer close(c.done)
+		buf := make([]byte, 4096)
+		for {
+			n, err := c.reader.Read(buf)
 			if n > 0 {
 				c.mu.Lock()
 				c.buf.Write(buf[:n])
@@ -99,6 +135,33 @@ func (c *ptyOutputCollector) waitContainsWithin(want string, timeout time.Durati
 	}
 }
 
+func (c *streamOutputCollector) snapshot() string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.buf.String()
+}
+
+func (c *streamOutputCollector) waitContains(t *testing.T, want string) string {
+	t.Helper()
+
+	deadline := time.After(5 * time.Second)
+	for {
+		if got := c.snapshot(); strings.Contains(got, want) {
+			return got
+		}
+		select {
+		case <-c.updates:
+		case <-deadline:
+			t.Fatalf("stream output never contained %q; got %q", want, c.snapshot())
+		case <-c.done:
+			if got := c.snapshot(); strings.Contains(got, want) {
+				return got
+			}
+			t.Fatalf("stream output ended before containing %q; got %q", want, c.snapshot())
+		}
+	}
+}
+
 type runSessionHarness struct {
 	t        *testing.T
 	session  string
@@ -108,6 +171,7 @@ type runSessionHarness struct {
 	ptmx   *os.File
 	tty    *os.File
 	output *ptyOutputCollector
+	stderr *streamOutputCollector
 
 	attachCh chan *proto.Message
 	msgCh    chan *proto.Message
@@ -149,10 +213,20 @@ func newRunSessionHarness(t *testing.T, sizeFn func(int) (int, int, error)) *run
 
 	prevStdin := os.Stdin
 	prevStdout := os.Stdout
+	prevStderr := os.Stderr
 	os.Stdin = tty
 	os.Stdout = tty
+	stderrR, stderrW, err := os.Pipe()
+	if err != nil {
+		listener.Close()
+		_ = ptmx.Close()
+		_ = tty.Close()
+		t.Fatalf("os.Pipe(stderr): %v", err)
+	}
+	os.Stderr = stderrW
 
 	output := newPTYOutputCollector(ptmx)
+	stderr := newStreamOutputCollector(stderrR)
 	h := &runSessionHarness{
 		t:        t,
 		session:  session,
@@ -161,6 +235,7 @@ func newRunSessionHarness(t *testing.T, sizeFn func(int) (int, int, error)) *run
 		ptmx:     ptmx,
 		tty:      tty,
 		output:   output,
+		stderr:   stderr,
 		attachCh: make(chan *proto.Message, 1),
 		msgCh:    make(chan *proto.Message, 64),
 		runErr:   make(chan error, 1),
@@ -174,6 +249,9 @@ func newRunSessionHarness(t *testing.T, sizeFn func(int) (int, int, error)) *run
 	t.Cleanup(func() {
 		os.Stdin = prevStdin
 		os.Stdout = prevStdout
+		os.Stderr = prevStderr
+		_ = stderrW.Close()
+		_ = stderrR.Close()
 		_ = listener.Close()
 		h.closeConn()
 		_ = ptmx.Close()
@@ -999,6 +1077,7 @@ func TestRunSessionHandlesServerMessagesAndInteractiveInput(t *testing.T) {
 	if err := h.waitRunResult(t); err != nil {
 		t.Fatalf("RunSession() = %v, want nil", err)
 	}
+	h.stderr.waitContains(t, "detached: session exited")
 	h.output.waitContains(t, render.AltScreenExit)
 }
 
@@ -1226,10 +1305,35 @@ func TestRunSessionDetachFlushesPendingInput(t *testing.T) {
 	if err := h.waitRunResult(t); err != nil {
 		t.Fatalf("RunSession() = %v, want nil", err)
 	}
+	h.stderr.waitContains(t, "detached: client requested detach")
 
 	t.Run("rejects legacy keys config", func(t *testing.T) {
 		assertRunSessionRejectsLegacyKeysConfig(t)
 	})
+}
+
+func TestRunSessionPrintsDetachReasonWhenConnectionLost(t *testing.T) {
+	// Not parallel: newRunSessionHarness uses t.Setenv and swaps os.Stdin/os.Stdout/os.Stderr.
+	h := newRunSessionHarness(t, func(int) (int, int, error) {
+		return 80, 24, nil
+	})
+
+	attach := h.waitAttach(t)
+	if attach.Type != proto.MsgTypeAttach {
+		t.Fatalf("attach type = %d, want %d", attach.Type, proto.MsgTypeAttach)
+	}
+
+	h.send(t, &proto.Message{Type: proto.MsgTypeLayout, Layout: sessionLayoutSnapshot(h.session)})
+	h.send(t, &proto.Message{Type: proto.MsgTypePaneOutput, PaneID: 1, PaneData: []byte("left")})
+	h.send(t, &proto.Message{Type: proto.MsgTypePaneOutput, PaneID: 2, PaneData: []byte("right")})
+	h.output.waitContains(t, render.AltScreenEnter)
+
+	h.closeConn()
+
+	if err := h.waitRunResult(t); err != nil {
+		t.Fatalf("RunSession() = %v, want nil", err)
+	}
+	h.stderr.waitContains(t, "detached: connection lost")
 }
 
 func TestRunSessionEnablesPprofEndpointWhenConfigured(t *testing.T) {
@@ -1295,6 +1399,28 @@ func TestRunSessionReturnsClientPprofSetupError(t *testing.T) {
 	})
 	if err == nil || !strings.Contains(err.Error(), "enabling client pprof debug endpoint failed") {
 		t.Fatalf("RunSession() error = %v, want client pprof setup failure", err)
+	}
+}
+
+func TestRunSessionWrapsAttachBootstrapProtocolError(t *testing.T) {
+	// Not parallel: newRunSessionHarness uses t.Setenv and swaps os.Stdin/os.Stdout/os.Stderr.
+	h := newRunSessionHarness(t, func(int) (int, int, error) {
+		return 80, 24, nil
+	})
+
+	attach := h.waitAttach(t)
+	if attach.Type != proto.MsgTypeAttach {
+		t.Fatalf("attach type = %d, want %d", attach.Type, proto.MsgTypeAttach)
+	}
+
+	h.send(t, &proto.Message{Type: proto.MsgTypeExit})
+
+	err := h.waitRunResult(t)
+	if err == nil {
+		t.Fatal("RunSession() error = nil, want attach bootstrap protocol error")
+	}
+	if !strings.Contains(err.Error(), "attach failed: protocol error") {
+		t.Fatalf("RunSession() error = %v, want attach failed protocol error", err)
 	}
 }
 

--- a/internal/client/attach_test.go
+++ b/internal/client/attach_test.go
@@ -2,7 +2,11 @@ package client
 
 import (
 	"errors"
+	"fmt"
+	"io"
 	"net"
+	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -214,13 +218,7 @@ func TestWaitForRunSessionEnd(t *testing.T) {
 		if reloadReady {
 			triggerReload <- struct{}{}
 		}
-		reloaded := false
-
-		waitForRunSessionEnd(done, triggerReload, func() {
-			reloaded = true
-		})
-
-		return reloaded
+		return waitForRunSessionEnd(done, triggerReload)
 	}
 
 	t.Run("done without reload returns", func(t *testing.T) {
@@ -248,6 +246,59 @@ func TestWaitForRunSessionEnd(t *testing.T) {
 			}
 		}
 	})
+}
+
+func TestFormatAttachError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{name: "protocol error", err: fmt.Errorf("%w: bad bootstrap", errAttachProtocol), want: "attach failed: protocol error"},
+		{name: "socket missing", err: os.ErrNotExist, want: "attach failed: socket not found"},
+		{name: "connection lost", err: io.EOF, want: "attach failed: connection lost"},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := formatAttachError(tt.err)
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("formatAttachError(%v) = %v, want substring %q", tt.err, err, tt.want)
+			}
+		})
+	}
+}
+
+func TestHotReloadDetachNotice(t *testing.T) {
+	t.Parallel()
+
+	clientVersion := currentClientVersion()
+
+	tests := []struct {
+		name          string
+		serverVersion string
+		wantContains  string
+	}{
+		{name: "matching version", serverVersion: clientVersion, wantContains: "detached: server requested hot-reload"},
+		{name: "mismatched version", serverVersion: clientVersion + "-other", wantContains: "detached: binary version mismatch"},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := hotReloadDetachNotice(tt.serverVersion)
+			if !strings.Contains(got, tt.wantContains) {
+				t.Fatalf("hotReloadDetachNotice(%q) = %q, want substring %q", tt.serverVersion, got, tt.wantContains)
+			}
+		})
+	}
 }
 
 func TestDispatchQueuedMouseInputChunksCoalescesConsecutiveDragMotions(t *testing.T) {

--- a/internal/server/checkpoint.go
+++ b/internal/server/checkpoint.go
@@ -133,7 +133,7 @@ func (s *Server) Reload(execPath string) error {
 	// Deliver the reload notice only after checkpointing succeeds so a failed
 	// checkpoint doesn't disrupt attached clients.
 	for _, c := range clients {
-		c.sendBroadcastSync(&Message{Type: MsgTypeServerReload})
+		c.sendBroadcastSync(&Message{Type: MsgTypeServerReload, Text: BuildVersion})
 	}
 	if _, err := enqueueSessionQuery(sess, func(sess *Session) (struct{}, error) {
 		sess.disconnectClientsForReload(clients)

--- a/internal/server/commands.go
+++ b/internal/server/commands.go
@@ -53,7 +53,7 @@ func (ctx *CommandContext) replyCommandMutation(res commandMutationResult) {
 		_ = ctx.CC.Flush()
 	}
 	if res.sendExit {
-		ctx.Sess.broadcast(&Message{Type: MsgTypeExit})
+		ctx.Sess.broadcast(&Message{Type: MsgTypeExit, Text: "session exited"})
 	}
 	if res.shutdownServer {
 		go ctx.Srv.Shutdown()

--- a/internal/server/session_events_pane.go
+++ b/internal/server/session_events_pane.go
@@ -51,7 +51,7 @@ func (s *Session) handleFinalizedPaneRemoval(paneID uint32, closePane bool, reas
 		s.closePaneAsync(removed.pane)
 	}
 	if removed.sendExit {
-		s.broadcastNow(&Message{Type: MsgTypeExit})
+		s.broadcastNow(&Message{Type: MsgTypeExit, Text: "session exited"})
 		s.wantShutdown = true
 		return
 	}


### PR DESCRIPTION
## Motivation
After some SSH reconnects, `amux` can attach and then immediately return to the shell without printing any reason. The client was dropping out on reload, disconnect, and protocol-error paths without telling the user what happened, which made the hot-reload workaround hard to discover.

## Summary
- classify attach bootstrap and socket failures into clearer `attach failed:` errors
- print detach notices for session exit, explicit detach, connection loss, protocol errors, and hot-reload exits
- include server version text on hot-reload and exit messages so the client can surface a binary mismatch hint when relevant
- add regression coverage for detach notices plus focused unit coverage for attach error and hot-reload notice classification

## Testing
- `go test ./internal/client -run 'Test(WaitForRunSessionEnd|FormatAttachError|HotReloadDetachNotice|RunSession(HandlesServerMessagesAndInteractiveInput|DetachFlushesPendingInput|PrintsDetachReasonWhenConnectionLost|WrapsAttachBootstrapProtocolError))' -count=100`
- `go test ./... -timeout 120s`

## Review focus
- check the client-side notice classification in `internal/client/attach.go`, especially the split between attach failures and post-attach detaches
- verify the server-side `Text` payload reuse on `MsgTypeServerReload` and `MsgTypeExit` is the right protocol surface for these reasons
- confirm the binary-mismatch hint should only appear on hot-reload exits when the client/server version strings differ

Closes LAB-1240
