### PR TITLE
Add ssh attach for local-client remote-server sessions

### DIFF
--- a/internal/cli/cli_commands_ssh.go
+++ b/internal/cli/cli_commands_ssh.go
@@ -1,0 +1,47 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/weill-labs/amux/internal/config"
+	"github.com/weill-labs/amux/internal/sshutil"
+)
+
+func sshCLICommands() map[string]commandHandler {
+	return map[string]commandHandler{
+		"ssh": func(inv invocation, args []string) int {
+			if len(args) != 1 {
+				fmt.Fprintln(inv.runtime.Stderr, sshUsage)
+				return 1
+			}
+
+			target, err := resolveCLISSHTarget(args[0])
+			if err != nil {
+				fmt.Fprintf(inv.runtime.Stderr, "amux: %v\n", err)
+				return 1
+			}
+			if err := inv.runtime.RunSSHSession(target); err != nil {
+				fmt.Fprintf(inv.runtime.Stderr, "amux: %v\n", err)
+				return 1
+			}
+			return 0
+		},
+	}
+}
+
+func resolveCLISSHTarget(raw string) (sshutil.SSHTarget, error) {
+	cfg, err := config.Load(config.DefaultPath())
+	if err != nil {
+		return sshutil.SSHTarget{}, fmt.Errorf("loading config: %w", err)
+	}
+
+	target, err := sshutil.ParseTarget(raw, "ubuntu")
+	if err != nil {
+		return sshutil.SSHTarget{}, err
+	}
+	if !strings.Contains(raw, "@") {
+		target.User = cfg.HostUser(target.Host)
+	}
+	return target, nil
+}

--- a/internal/cli/cli_commands_ssh_test.go
+++ b/internal/cli/cli_commands_ssh_test.go
@@ -1,0 +1,40 @@
+package cli
+
+import (
+	"os"
+	"testing"
+)
+
+func TestResolveCLISSHTargetKeepsExplicitUser(t *testing.T) {
+	configPath := t.TempDir() + "/config.toml"
+	if err := os.WriteFile(configPath, []byte(`
+[hosts.builder]
+user = "deploy"
+`), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	t.Setenv("AMUX_CONFIG", configPath)
+
+	target, err := resolveCLISSHTarget("alice@builder:work")
+	if err != nil {
+		t.Fatalf("resolveCLISSHTarget() error = %v", err)
+	}
+	if target.User != "alice" {
+		t.Fatalf("resolveCLISSHTarget() user = %q, want alice", target.User)
+	}
+	if target.Host != "builder" || target.Session != "work" {
+		t.Fatalf("resolveCLISSHTarget() = %#v, want builder/work target", target)
+	}
+}
+
+func TestResolveCLISSHTargetReturnsConfigError(t *testing.T) {
+	configPath := t.TempDir() + "/config.toml"
+	if err := os.WriteFile(configPath, []byte("["), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	t.Setenv("AMUX_CONFIG", configPath)
+
+	if _, err := resolveCLISSHTarget("builder"); err == nil {
+		t.Fatal("resolveCLISSHTarget() error = nil, want config parse failure")
+	}
+}

--- a/internal/cli/cli_dispatch.go
+++ b/internal/cli/cli_dispatch.go
@@ -4,12 +4,15 @@ import (
 	"fmt"
 	"io"
 	"os"
+
+	"github.com/weill-labs/amux/internal/sshutil"
 )
 
 type Runtime struct {
 	Stdout             io.Writer
 	Stderr             io.Writer
 	AttachSession      func(string) error
+	RunSSHSession      func(sshutil.SSHTarget) error
 	WriteVersionOutput func(io.Writer, []string) error
 	InstallTerminfo    func() error
 	RunDebugCommand    func(string, []string)
@@ -41,6 +44,7 @@ func buildCLICommands() map[string]commandHandler {
 	addCLICommands(commands, layoutCLICommands())
 	addCLICommands(commands, windowCLICommands())
 	addCLICommands(commands, remoteCLICommands())
+	addCLICommands(commands, sshCLICommands())
 	return commands
 }
 

--- a/internal/cli/cli_usage.go
+++ b/internal/cli/cli_usage.go
@@ -31,6 +31,7 @@ const (
 	resizeWindowUsage = "usage: amux resize-window <cols> <rows>"
 	rotateUsage       = "usage: amux rotate [--reverse]"
 	selectWindowUsage = "usage: amux select-window <index|name>"
+	sshUsage          = "usage: amux ssh <user@host[:session] | host[:session]>"
 	statusUsage       = "usage: amux status"
 	unspliceUsage     = "usage: amux unsplice <host>"
 	undoUsage         = "usage: amux undo"
@@ -82,6 +83,7 @@ var commandUsageByName = map[string]string{
 	"rotate":           rotateUsage,
 	"select-window":    selectWindowUsage,
 	"send-keys":        sendKeysUsage,
+	"ssh":              sshUsage,
 	"spawn":            spawnUsage,
 	"status":           statusUsage,
 	"undo":             undoUsage,
@@ -217,6 +219,7 @@ Usage:
                                        Resize window to cols x rows
   amux [-s session] events [--filter type1,type2] [--pane <ref>] [--host <name>] [--client <id>] [--no-reconnect]
                                        Stream events as NDJSON (layout, output, idle, busy, exited, client-connect, client-disconnect, display-panes-*, choose-*, copy-mode-*, input-*, reconnect)
+  amux ssh <user@host[:session]>      Attach local client to a remote amux server over SSH
   amux [-s session] hosts              List configured remote hosts + status
   amux [-s session] disconnect <host>  Drop SSH connection to a host
   amux [-s session] reconnect <host>   Reconnect to a remote host

--- a/internal/cli/main_test.go
+++ b/internal/cli/main_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"io"
 	"os"
 	"reflect"
@@ -816,6 +817,12 @@ func TestRunMainHelpAndUsageErrors(t *testing.T) {
 			wantExit:   1,
 			wantStderr: sendKeysUsage + "\n",
 		},
+		{
+			name:       "ssh usage error stays in dispatch layer",
+			args:       []string{"ssh"},
+			wantExit:   1,
+			wantStderr: sshUsage + "\n",
+		},
 	}
 
 	for _, tt := range tests {
@@ -837,6 +844,24 @@ func TestRunMainHelpAndUsageErrors(t *testing.T) {
 	}
 }
 
+func TestRunMainSSHRuntimeError(t *testing.T) {
+	configPath := writeRuntimeConfig(t, `
+[hosts.builder]
+user = "deploy"
+`)
+	t.Setenv("AMUX_CONFIG", configPath)
+
+	h := newCLIRuntimeHarness()
+	h.runSSHSessionErr = errors.New("boom")
+
+	if exitCode := RunWithRuntime([]string{"ssh", "builder"}, h.runtime()); exitCode != 1 {
+		t.Fatalf("RunWithRuntime() exit = %d, want 1", exitCode)
+	}
+	if got := h.stderr.String(); got != "amux: boom\n" {
+		t.Fatalf("stderr = %q, want %q", got, "amux: boom\n")
+	}
+}
+
 type cliCall struct {
 	kind    string
 	session string
@@ -854,6 +879,7 @@ type cliRuntimeHarness struct {
 	usageCalls        int
 	shouldTakeover    bool
 	tryTakeoverResult bool
+	runSSHSessionErr  error
 	calls             []cliCall
 }
 
@@ -918,7 +944,7 @@ func (h *cliRuntimeHarness) runtime() Runtime {
 		RunSSHSession: func(target sshutil.SSHTarget) error {
 			targetCopy := target
 			h.calls = append(h.calls, cliCall{kind: "ssh", target: &targetCopy})
-			return nil
+			return h.runSSHSessionErr
 		},
 		CheckNesting: func(sessionName string) {
 			h.calls = append(h.calls, cliCall{kind: "check-nesting", session: sessionName})

--- a/internal/cli/main_test.go
+++ b/internal/cli/main_test.go
@@ -255,12 +255,6 @@ func TestResolveCanonicalSessionCommand(t *testing.T) {
 			wantErrText: "usage: amux unsplice <host>",
 		},
 		{
-			name:        "ssh needs a target",
-			args:        []string{"ssh"},
-			wantHandled: true,
-			wantErrText: "usage: amux ssh <user@host[:session] | host[:session]>",
-		},
-		{
 			name:        "rename needs pane and new name",
 			args:        []string{"rename", "pane-1"},
 			wantHandled: true,

--- a/internal/cli/main_test.go
+++ b/internal/cli/main_test.go
@@ -4,12 +4,14 @@ import (
 	"bytes"
 	"encoding/json"
 	"io"
+	"os"
 	"reflect"
 	"strconv"
 	"strings"
 	"testing"
 
 	"github.com/weill-labs/amux/internal/checkpoint"
+	"github.com/weill-labs/amux/internal/sshutil"
 )
 
 func TestParseSpawnCommandArgs(t *testing.T) {
@@ -251,6 +253,12 @@ func TestResolveCanonicalSessionCommand(t *testing.T) {
 			args:        []string{"unsplice"},
 			wantHandled: true,
 			wantErrText: "usage: amux unsplice <host>",
+		},
+		{
+			name:        "ssh needs a target",
+			args:        []string{"ssh"},
+			wantHandled: true,
+			wantErrText: "usage: amux ssh <user@host[:session] | host[:session]>",
 		},
 		{
 			name:        "rename needs pane and new name",
@@ -728,6 +736,28 @@ func TestRunMainDispatchesCommands(t *testing.T) {
 				{kind: "server-command", session: resolvedSessionMarker, cmd: "disconnect", args: []string{"host-a"}},
 			},
 		},
+		{
+			name: "ssh command dispatches through runtime",
+			args: []string{"ssh", "builder:work"},
+			env: map[string]string{
+				"AMUX_CONFIG": writeRuntimeConfig(t, `
+[hosts.builder]
+user = "deploy"
+`),
+			},
+			wantExit: 0,
+			wantCalls: []cliCall{
+				{
+					kind: "ssh",
+					target: &sshutil.SSHTarget{
+						User:    "deploy",
+						Host:    "builder",
+						Port:    "22",
+						Session: "work",
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -819,6 +849,7 @@ type cliCall struct {
 	cmd     string
 	args    []string
 	managed bool
+	target  *sshutil.SSHTarget
 }
 
 const resolvedSessionMarker = "__resolved_session__"
@@ -890,6 +921,11 @@ func (h *cliRuntimeHarness) runtime() Runtime {
 				args:    append([]string(nil), args...),
 			})
 		},
+		RunSSHSession: func(target sshutil.SSHTarget) error {
+			targetCopy := target
+			h.calls = append(h.calls, cliCall{kind: "ssh", target: &targetCopy})
+			return nil
+		},
 		CheckNesting: func(sessionName string) {
 			h.calls = append(h.calls, cliCall{kind: "check-nesting", session: sessionName})
 		},
@@ -904,4 +940,14 @@ func (h *cliRuntimeHarness) runtime() Runtime {
 			h.usageCalls++
 		},
 	}
+}
+
+func writeRuntimeConfig(t *testing.T, content string) string {
+	t.Helper()
+
+	path := t.TempDir() + "/config.toml"
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	return path
 }

--- a/internal/cli/runtime_entry.go
+++ b/internal/cli/runtime_entry.go
@@ -71,6 +71,7 @@ func defaultRuntime(buildCommit string) Runtime {
 		AttachSession: func(sessionName string) error {
 			return client.RunSession(sessionName, term.GetSize)
 		},
+		RunSSHSession: client.RunSSHSession,
 		WriteVersionOutput: func(w io.Writer, args []string) error {
 			return writeVersionOutput(buildCommit, w, args)
 		},

--- a/internal/cli/runtime_entry_test.go
+++ b/internal/cli/runtime_entry_test.go
@@ -1,0 +1,12 @@
+package cli
+
+import "testing"
+
+func TestDefaultRuntimeWiresRunSSHSession(t *testing.T) {
+	t.Parallel()
+
+	runtime := defaultRuntime("")
+	if runtime.RunSSHSession == nil {
+		t.Fatal("defaultRuntime() should wire RunSSHSession")
+	}
+}

--- a/internal/client/ssh_attach.go
+++ b/internal/client/ssh_attach.go
@@ -33,6 +33,15 @@ type sshRunSessionOps struct {
 }
 
 func RunSSHSession(target sshutil.SSHTarget) error {
+	return runSSHSession(target, term.GetSize, defaultSSHRunSessionOps(), runSessionWithDeps)
+}
+
+func runSSHSession(
+	target sshutil.SSHTarget,
+	getTermSize func(int) (int, int, error),
+	ops sshRunSessionOps,
+	runner func(string, func(int) (int, int, error), runSessionDeps) error,
+) error {
 	resolved, err := resolveSSHSessionTarget(target)
 	if err != nil {
 		return err
@@ -41,7 +50,7 @@ func RunSSHSession(target sshutil.SSHTarget) error {
 	state := &sshSessionState{}
 	defer state.close()
 
-	return runSessionWithDeps(resolved.Session, term.GetSize, sshRunSessionDeps(resolved, state, defaultSSHRunSessionOps()))
+	return runner(resolved.Session, getTermSize, sshRunSessionDeps(resolved, state, ops))
 }
 
 func resolveSSHSessionTarget(target sshutil.SSHTarget) (sshSessionTarget, error) {

--- a/internal/client/ssh_attach.go
+++ b/internal/client/ssh_attach.go
@@ -1,0 +1,162 @@
+package client
+
+import (
+	"fmt"
+	"net"
+	"time"
+
+	"github.com/weill-labs/amux/internal/config"
+	"github.com/weill-labs/amux/internal/remote"
+	"github.com/weill-labs/amux/internal/sshutil"
+	"golang.org/x/crypto/ssh"
+	"golang.org/x/term"
+)
+
+type sshSessionTarget struct {
+	sshutil.SSHTarget
+	Address      string
+	IdentityFile string
+}
+
+type sshSessionState struct {
+	client   *ssh.Client
+	sockPath string
+}
+
+type sshRunSessionOps struct {
+	buildSSHConfig     func(string, string) (*ssh.ClientConfig, error)
+	sshDial            func(string, string, *ssh.ClientConfig) (*ssh.Client, error)
+	sshOutput          func(*ssh.Client, string) (string, error)
+	deployBinary       func(*ssh.Client, string) error
+	ensureRemoteServer func(*ssh.Client, string, string) error
+	dialRemoteSocket   func(*ssh.Client, string) (net.Conn, error)
+}
+
+func RunSSHSession(target sshutil.SSHTarget) error {
+	resolved, err := resolveSSHSessionTarget(target)
+	if err != nil {
+		return err
+	}
+
+	state := &sshSessionState{}
+	defer state.close()
+
+	return runSessionWithDeps(resolved.Session, term.GetSize, sshRunSessionDeps(resolved, state, defaultSSHRunSessionOps()))
+}
+
+func resolveSSHSessionTarget(target sshutil.SSHTarget) (sshSessionTarget, error) {
+	cfg, err := config.Load(config.DefaultPath())
+	if err != nil {
+		return sshSessionTarget{}, fmt.Errorf("loading config: %w", err)
+	}
+
+	resolved := sshSessionTarget{
+		SSHTarget: target,
+		Address:   target.Host,
+	}
+	if hostCfg, ok := cfg.Hosts[target.Host]; ok {
+		resolved.IdentityFile = hostCfg.IdentityFile
+		if hostCfg.Address != "" {
+			resolved.Address = hostCfg.Address
+		}
+	}
+	resolved.Address = resolveSSHAddress(resolved.Address, target.Port)
+	return resolved, nil
+}
+
+func defaultSSHRunSessionOps() sshRunSessionOps {
+	return sshRunSessionOps{
+		buildSSHConfig:     sshutil.BuildSSHConfig,
+		sshDial:            ssh.Dial,
+		sshOutput:          sshutil.SSHOutput,
+		deployBinary:       remote.DeployBinary,
+		ensureRemoteServer: sshutil.EnsureRemoteServer,
+		dialRemoteSocket:   sshutil.DialRemoteSocket,
+	}
+}
+
+func sshRunSessionDeps(target sshSessionTarget, state *sshSessionState, ops sshRunSessionOps) runSessionDeps {
+	deps := defaultRunSessionDeps()
+	deps.ensureDaemon = func(sessionName string, timeout time.Duration) error {
+		sshCfg, err := ops.buildSSHConfig(target.User, target.IdentityFile)
+		if err != nil {
+			return fmt.Errorf("building SSH config: %w", err)
+		}
+
+		sshClient, err := ops.sshDial("tcp", target.Address, sshCfg)
+		if err != nil {
+			return fmt.Errorf("SSH dial: %w", err)
+		}
+
+		remoteUID, err := ops.sshOutput(sshClient, "id -u")
+		if err != nil {
+			_ = sshClient.Close()
+			return fmt.Errorf("querying remote UID: %w", err)
+		}
+
+		// Keep deploy best-effort so connection still works when upload fails.
+		_ = ops.deployBinary(sshClient, clientBuildHash())
+
+		sockPath := sshutil.RemoteSocketPath(remoteUID, sessionName)
+		if err := ops.ensureRemoteServer(sshClient, sockPath, sessionName); err != nil {
+			_ = sshClient.Close()
+			return fmt.Errorf("starting remote server: %w", err)
+		}
+		if err := waitForSSHRemoteSocket(sshClient, sockPath, timeout, ops.sshOutput); err != nil {
+			_ = sshClient.Close()
+			return err
+		}
+
+		state.set(sshClient, sockPath)
+		return nil
+	}
+	deps.dial = func(string, string) (net.Conn, error) {
+		if state.client == nil || state.sockPath == "" {
+			return nil, fmt.Errorf("ssh client not initialized")
+		}
+		return ops.dialRemoteSocket(state.client, state.sockPath)
+	}
+	return deps
+}
+
+func waitForSSHRemoteSocket(client *ssh.Client, sockPath string, timeout time.Duration, sshOutput func(*ssh.Client, string) (string, error)) error {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		out, err := sshOutput(client, fmt.Sprintf("test -S %s && echo ok", sockPath))
+		if err == nil && out == "ok" {
+			return nil
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	return fmt.Errorf("socket %s did not appear within %v", sockPath, timeout)
+}
+
+func resolveSSHAddress(addr, port string) string {
+	if hasExplicitPort(addr) {
+		return addr
+	}
+	if port != "" && port != "22" {
+		return addr + ":" + port
+	}
+	return sshutil.NormalizeAddr(addr)
+}
+
+func hasExplicitPort(addr string) bool {
+	_, _, err := net.SplitHostPort(addr)
+	return err == nil
+}
+
+func (s *sshSessionState) close() {
+	if s.client == nil {
+		return
+	}
+	_ = s.client.Close()
+	s.client = nil
+	s.sockPath = ""
+}
+
+func (s *sshSessionState) set(client *ssh.Client, sockPath string) {
+	s.close()
+	s.client = client
+	s.sockPath = sockPath
+}

--- a/internal/client/ssh_attach.go
+++ b/internal/client/ssh_attach.go
@@ -78,35 +78,10 @@ func defaultSSHRunSessionOps() sshRunSessionOps {
 func sshRunSessionDeps(target sshSessionTarget, state *sshSessionState, ops sshRunSessionOps) runSessionDeps {
 	deps := defaultRunSessionDeps()
 	deps.ensureDaemon = func(sessionName string, timeout time.Duration) error {
-		sshCfg, err := ops.buildSSHConfig(target.User, target.IdentityFile)
+		sshClient, sockPath, err := connectSSHSession(target, sessionName, timeout, ops)
 		if err != nil {
-			return fmt.Errorf("building SSH config: %w", err)
-		}
-
-		sshClient, err := ops.sshDial("tcp", target.Address, sshCfg)
-		if err != nil {
-			return fmt.Errorf("SSH dial: %w", err)
-		}
-
-		remoteUID, err := ops.sshOutput(sshClient, "id -u")
-		if err != nil {
-			_ = sshClient.Close()
-			return fmt.Errorf("querying remote UID: %w", err)
-		}
-
-		// Keep deploy best-effort so connection still works when upload fails.
-		_ = ops.deployBinary(sshClient, clientBuildHash())
-
-		sockPath := sshutil.RemoteSocketPath(remoteUID, sessionName)
-		if err := ops.ensureRemoteServer(sshClient, sockPath, sessionName); err != nil {
-			_ = sshClient.Close()
-			return fmt.Errorf("starting remote server: %w", err)
-		}
-		if err := waitForSSHRemoteSocket(sshClient, sockPath, timeout, ops.sshOutput); err != nil {
-			_ = sshClient.Close()
 			return err
 		}
-
 		state.set(sshClient, sockPath)
 		return nil
 	}
@@ -119,16 +94,52 @@ func sshRunSessionDeps(target sshSessionTarget, state *sshSessionState, ops sshR
 	return deps
 }
 
+func connectSSHSession(target sshSessionTarget, sessionName string, timeout time.Duration, ops sshRunSessionOps) (*ssh.Client, string, error) {
+	sshCfg, err := ops.buildSSHConfig(target.User, target.IdentityFile)
+	if err != nil {
+		return nil, "", fmt.Errorf("building SSH config: %w", err)
+	}
+
+	sshClient, err := ops.sshDial("tcp", target.Address, sshCfg)
+	if err != nil {
+		return nil, "", fmt.Errorf("SSH dial: %w", err)
+	}
+
+	remoteUID, err := ops.sshOutput(sshClient, "id -u")
+	if err != nil {
+		_ = sshClient.Close()
+		return nil, "", fmt.Errorf("querying remote UID: %w", err)
+	}
+
+	// Keep deploy best-effort so connection still works when upload fails.
+	_ = ops.deployBinary(sshClient, clientBuildHash())
+
+	sockPath := sshutil.RemoteSocketPath(remoteUID, sessionName)
+	if err := ops.ensureRemoteServer(sshClient, sockPath, sessionName); err != nil {
+		_ = sshClient.Close()
+		return nil, "", fmt.Errorf("starting remote server: %w", err)
+	}
+	if err := waitForSSHRemoteSocket(sshClient, sockPath, timeout, ops.sshOutput); err != nil {
+		_ = sshClient.Close()
+		return nil, "", err
+	}
+	return sshClient, sockPath, nil
+}
+
 func waitForSSHRemoteSocket(client *ssh.Client, sockPath string, timeout time.Duration, sshOutput func(*ssh.Client, string) (string, error)) error {
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
-		out, err := sshOutput(client, fmt.Sprintf("test -S %s && echo ok", sockPath))
+		out, err := sshOutput(client, remoteSocketProbeCmd(sockPath))
 		if err == nil && out == "ok" {
 			return nil
 		}
 		time.Sleep(100 * time.Millisecond)
 	}
 	return fmt.Errorf("socket %s did not appear within %v", sockPath, timeout)
+}
+
+func remoteSocketProbeCmd(sockPath string) string {
+	return fmt.Sprintf("test -S %s && echo ok", sockPath)
 }
 
 func resolveSSHAddress(addr, port string) string {

--- a/internal/client/ssh_attach.go
+++ b/internal/client/ssh_attach.go
@@ -98,6 +98,8 @@ func sshRunSessionDeps(target sshSessionTarget, state *sshSessionState, ops sshR
 		if state.client == nil || state.sockPath == "" {
 			return nil, fmt.Errorf("ssh client not initialized")
 		}
+		// Ignore the local dial arguments: the remote socket path is established
+		// during ensureDaemon after we know the remote UID.
 		return ops.dialRemoteSocket(state.client, state.sockPath)
 	}
 	return deps

--- a/internal/client/ssh_attach_test.go
+++ b/internal/client/ssh_attach_test.go
@@ -1,0 +1,206 @@
+package client
+
+import (
+	"errors"
+	"net"
+	"os"
+	"testing"
+	"time"
+
+	"golang.org/x/crypto/ssh"
+
+	"github.com/weill-labs/amux/internal/sshutil"
+)
+
+func TestResolveSSHSessionTargetUsesConfiguredAddressAndIdentity(t *testing.T) {
+	t.Parallel()
+
+	configPath := t.TempDir() + "/config.toml"
+	if err := os.WriteFile(configPath, []byte(`
+[hosts.builder]
+address = "10.0.0.5:2222"
+identity_file = "/tmp/id_builder"
+`), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	t.Setenv("AMUX_CONFIG", configPath)
+
+	target, err := resolveSSHSessionTarget(sshutil.SSHTarget{
+		User:    "deploy",
+		Host:    "builder",
+		Port:    "22",
+		Session: "work",
+	})
+	if err != nil {
+		t.Fatalf("resolveSSHSessionTarget() error = %v", err)
+	}
+	if target.Address != "10.0.0.5:2222" {
+		t.Fatalf("resolveSSHSessionTarget() address = %q, want %q", target.Address, "10.0.0.5:2222")
+	}
+	if target.IdentityFile != "/tmp/id_builder" {
+		t.Fatalf("resolveSSHSessionTarget() identity file = %q, want %q", target.IdentityFile, "/tmp/id_builder")
+	}
+}
+
+func TestSSHRunSessionDepsEnsureDaemonAndDial(t *testing.T) {
+	t.Parallel()
+
+	state := &sshSessionState{}
+	sshClient := new(ssh.Client)
+	sshConfig := &ssh.ClientConfig{}
+	connClient, connServer := net.Pipe()
+	t.Cleanup(func() {
+		_ = connClient.Close()
+		_ = connServer.Close()
+	})
+
+	var calls []string
+	deps := sshRunSessionDeps(sshSessionTarget{
+		SSHTarget: sshutil.SSHTarget{
+			User:    "alice",
+			Host:    "builder",
+			Port:    "22",
+			Session: "work",
+		},
+		Address:      "10.0.0.5:2222",
+		IdentityFile: "/tmp/id_builder",
+	}, state, sshRunSessionOps{
+		buildSSHConfig: func(user, identityFile string) (*ssh.ClientConfig, error) {
+			calls = append(calls, "build-config")
+			if user != "alice" {
+				t.Fatalf("buildSSHConfig user = %q, want alice", user)
+			}
+			if identityFile != "/tmp/id_builder" {
+				t.Fatalf("buildSSHConfig identityFile = %q, want /tmp/id_builder", identityFile)
+			}
+			return sshConfig, nil
+		},
+		sshDial: func(network, addr string, cfg *ssh.ClientConfig) (*ssh.Client, error) {
+			calls = append(calls, "ssh-dial")
+			if network != "tcp" {
+				t.Fatalf("sshDial network = %q, want tcp", network)
+			}
+			if addr != "10.0.0.5:2222" {
+				t.Fatalf("sshDial addr = %q, want 10.0.0.5:2222", addr)
+			}
+			if cfg != sshConfig {
+				t.Fatal("sshDial received unexpected client config")
+			}
+			return sshClient, nil
+		},
+		sshOutput: func(client *ssh.Client, cmd string) (string, error) {
+			calls = append(calls, "ssh-output:"+cmd)
+			if client != sshClient {
+				t.Fatal("sshOutput received unexpected client")
+			}
+			switch cmd {
+			case "id -u":
+				return "1001", nil
+			case "test -S /tmp/amux-1001/work && echo ok":
+				return "ok", nil
+			default:
+				t.Fatalf("sshOutput cmd = %q, want id -u or socket probe", cmd)
+				return "", nil
+			}
+		},
+		deployBinary: func(client *ssh.Client, buildHash string) error {
+			calls = append(calls, "deploy")
+			if client != sshClient {
+				t.Fatal("deployBinary received unexpected client")
+			}
+			if buildHash == "" {
+				t.Fatal("deployBinary buildHash should not be empty")
+			}
+			return nil
+		},
+		ensureRemoteServer: func(client *ssh.Client, sockPath, sessionName string) error {
+			calls = append(calls, "ensure-remote")
+			if client != sshClient {
+				t.Fatal("ensureRemoteServer received unexpected client")
+			}
+			if sockPath != "/tmp/amux-1001/work" {
+				t.Fatalf("ensureRemoteServer sockPath = %q, want /tmp/amux-1001/work", sockPath)
+			}
+			if sessionName != "work" {
+				t.Fatalf("ensureRemoteServer sessionName = %q, want work", sessionName)
+			}
+			return nil
+		},
+		dialRemoteSocket: func(client *ssh.Client, sockPath string) (net.Conn, error) {
+			calls = append(calls, "dial-remote-socket")
+			if client != sshClient {
+				t.Fatal("dialRemoteSocket received unexpected client")
+			}
+			if sockPath != "/tmp/amux-1001/work" {
+				t.Fatalf("dialRemoteSocket sockPath = %q, want /tmp/amux-1001/work", sockPath)
+			}
+			return connClient, nil
+		},
+	})
+
+	if err := deps.ensureDaemon("work", 200*time.Millisecond); err != nil {
+		t.Fatalf("ensureDaemon() error = %v", err)
+	}
+	conn, err := deps.dial("unix", "/tmp/ignored")
+	if err != nil {
+		t.Fatalf("dial() error = %v", err)
+	}
+	if conn != connClient {
+		t.Fatal("dial() returned unexpected connection")
+	}
+
+	wantCalls := []string{
+		"build-config",
+		"ssh-dial",
+		"ssh-output:id -u",
+		"deploy",
+		"ensure-remote",
+		"ssh-output:test -S /tmp/amux-1001/work && echo ok",
+		"dial-remote-socket",
+	}
+	if len(calls) != len(wantCalls) {
+		t.Fatalf("calls = %v, want %v", calls, wantCalls)
+	}
+	for i := range wantCalls {
+		if calls[i] != wantCalls[i] {
+			t.Fatalf("calls[%d] = %q, want %q", i, calls[i], wantCalls[i])
+		}
+	}
+}
+
+func TestSSHRunSessionDepsIgnoresDeployFailure(t *testing.T) {
+	t.Parallel()
+
+	state := &sshSessionState{}
+	sshClient := new(ssh.Client)
+
+	deps := sshRunSessionDeps(sshSessionTarget{
+		SSHTarget: sshutil.SSHTarget{
+			User:    "alice",
+			Host:    "builder",
+			Port:    "22",
+			Session: "main",
+		},
+		Address: "builder:22",
+	}, state, sshRunSessionOps{
+		buildSSHConfig: func(string, string) (*ssh.ClientConfig, error) { return &ssh.ClientConfig{}, nil },
+		sshDial:        func(string, string, *ssh.ClientConfig) (*ssh.Client, error) { return sshClient, nil },
+		sshOutput: func(_ *ssh.Client, cmd string) (string, error) {
+			switch cmd {
+			case "id -u":
+				return "1000", nil
+			case "test -S /tmp/amux-1000/main && echo ok":
+				return "ok", nil
+			default:
+				return "", nil
+			}
+		},
+		deployBinary:       func(*ssh.Client, string) error { return errors.New("deploy failed") },
+		ensureRemoteServer: func(*ssh.Client, string, string) error { return nil },
+		dialRemoteSocket:   func(*ssh.Client, string) (net.Conn, error) { return nil, nil },
+	})
+
+	if err := deps.ensureDaemon("main", 200*time.Millisecond); err != nil {
+		t.Fatalf("ensureDaemon() error = %v, want deploy failure to be ignored", err)
+	}
+}

--- a/internal/client/ssh_attach_test.go
+++ b/internal/client/ssh_attach_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"net"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -11,6 +12,84 @@ import (
 
 	"github.com/weill-labs/amux/internal/sshutil"
 )
+
+func TestDefaultSSHRunSessionOps(t *testing.T) {
+	t.Parallel()
+
+	ops := defaultSSHRunSessionOps()
+	if ops.buildSSHConfig == nil || ops.sshDial == nil || ops.sshOutput == nil || ops.deployBinary == nil || ops.ensureRemoteServer == nil || ops.dialRemoteSocket == nil {
+		t.Fatalf("defaultSSHRunSessionOps() = %#v, want all hooks wired", ops)
+	}
+}
+
+func TestRunSSHSessionReturnsConfigLoadError(t *testing.T) {
+	configPath := t.TempDir() + "/config.toml"
+	if err := os.WriteFile(configPath, []byte("["), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	t.Setenv("AMUX_CONFIG", configPath)
+
+	err := RunSSHSession(sshutil.SSHTarget{
+		User:    "deploy",
+		Host:    "builder",
+		Port:    "22",
+		Session: "work",
+	})
+	if err == nil {
+		t.Fatal("RunSSHSession() error = nil, want config load failure")
+	}
+	if !strings.Contains(err.Error(), "loading config") {
+		t.Fatalf("RunSSHSession() error = %q, want loading config", err.Error())
+	}
+}
+
+func TestRunSSHSessionUsesRunner(t *testing.T) {
+	configPath := t.TempDir() + "/config.toml"
+	if err := os.WriteFile(configPath, []byte(`
+[hosts.builder]
+address = "10.0.0.5:2222"
+identity_file = "/tmp/id_builder"
+`), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	t.Setenv("AMUX_CONFIG", configPath)
+
+	getSize := func(int) (int, int, error) { return 80, 24, nil }
+	ops := sshRunSessionOps{
+		buildSSHConfig:     func(string, string) (*ssh.ClientConfig, error) { return &ssh.ClientConfig{}, nil },
+		sshDial:            func(string, string, *ssh.ClientConfig) (*ssh.Client, error) { return new(ssh.Client), nil },
+		sshOutput:          func(*ssh.Client, string) (string, error) { return "", nil },
+		deployBinary:       func(*ssh.Client, string) error { return nil },
+		ensureRemoteServer: func(*ssh.Client, string, string) error { return nil },
+		dialRemoteSocket:   func(*ssh.Client, string) (net.Conn, error) { return nil, nil },
+	}
+
+	called := false
+	err := runSSHSession(sshutil.SSHTarget{
+		User:    "deploy",
+		Host:    "builder",
+		Port:    "22",
+		Session: "work",
+	}, getSize, ops, func(sessionName string, gotGetSize func(int) (int, int, error), deps runSessionDeps) error {
+		called = true
+		if sessionName != "work" {
+			t.Fatalf("runner sessionName = %q, want work", sessionName)
+		}
+		if gotGetSize == nil {
+			t.Fatal("runner getTermSize should be wired")
+		}
+		if deps.ensureDaemon == nil || deps.dial == nil {
+			t.Fatal("runner deps should include SSH ensureDaemon and dial hooks")
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("runSSHSession() error = %v", err)
+	}
+	if !called {
+		t.Fatal("runner was not called")
+	}
+}
 
 func TestResolveSSHSessionTargetUsesConfiguredAddressAndIdentity(t *testing.T) {
 	configPath := t.TempDir() + "/config.toml"
@@ -37,6 +116,32 @@ identity_file = "/tmp/id_builder"
 	}
 	if target.IdentityFile != "/tmp/id_builder" {
 		t.Fatalf("resolveSSHSessionTarget() identity file = %q, want %q", target.IdentityFile, "/tmp/id_builder")
+	}
+}
+
+func TestResolveSSHAddress(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		addr string
+		port string
+		want string
+	}{
+		{name: "preserve explicit port", addr: "builder:2222", port: "22", want: "builder:2222"},
+		{name: "apply custom target port", addr: "builder", port: "2200", want: "builder:2200"},
+		{name: "default to port 22", addr: "builder", port: "22", want: "builder:22"},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := resolveSSHAddress(tt.addr, tt.port); got != tt.want {
+				t.Fatalf("resolveSSHAddress(%q, %q) = %q, want %q", tt.addr, tt.port, got, tt.want)
+			}
+		})
 	}
 }
 

--- a/internal/client/ssh_attach_test.go
+++ b/internal/client/ssh_attach_test.go
@@ -13,8 +13,6 @@ import (
 )
 
 func TestResolveSSHSessionTargetUsesConfiguredAddressAndIdentity(t *testing.T) {
-	t.Parallel()
-
 	configPath := t.TempDir() + "/config.toml"
 	if err := os.WriteFile(configPath, []byte(`
 [hosts.builder]

--- a/internal/remote/deploy.go
+++ b/internal/remote/deploy.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 
 	"golang.org/x/crypto/ssh"
+
+	"github.com/weill-labs/amux/internal/sshutil"
 )
 
 const remoteInstallPath = "$HOME/.local/bin/amux"
@@ -241,17 +243,7 @@ func remoteReleaseInstallCmd(url, archiveName string) string {
 
 // sshOutput runs a command on the remote and returns trimmed stdout.
 func sshOutput(client *ssh.Client, cmd string) (string, error) {
-	sess, err := client.NewSession()
-	if err != nil {
-		return "", err
-	}
-	defer sess.Close()
-
-	out, err := sess.Output(cmd)
-	if err != nil {
-		return "", err
-	}
-	return strings.TrimSpace(string(out)), nil
+	return sshutil.SSHOutput(client, cmd)
 }
 
 // sshRunErr runs a command on the remote and returns the error.

--- a/internal/remote/host_conn.go
+++ b/internal/remote/host_conn.go
@@ -630,15 +630,6 @@ func ensureRemoteServer(client *ssh.Client, sockPath, sessionName string) error 
 	return sshutil.EnsureRemoteServer(client, sockPath, sessionName)
 }
 
-// buildEnsureServerCmd returns the shell command that starts amux _server if
-// the socket doesn't already exist.
-func buildEnsureServerCmd(sockPath, sessionName string) string {
-	return fmt.Sprintf(
-		`if [ ! -S %s ]; then AMUX=${AMUX_BIN:-$(command -v ~/.local/bin/amux 2>/dev/null || command -v amux 2>/dev/null || echo amux)}; "$AMUX" install-terminfo || exit 1; nohup "$AMUX" _server %s </dev/null >/dev/null 2>&1 & for i in 1 2 3 4 5 6 7 8 9 10; do [ -S %s ] && break; sleep 0.2; done; fi`,
-		sockPath, sessionName, sockPath,
-	)
-}
-
 // socketPath returns the expected amux socket path on the remote host.
 func socketPath(remoteUID, sessionName string) string {
 	return sshutil.RemoteSocketPath(remoteUID, sessionName)

--- a/internal/remote/host_conn.go
+++ b/internal/remote/host_conn.go
@@ -10,11 +10,11 @@ import (
 
 	charmlog "github.com/charmbracelet/log"
 	"golang.org/x/crypto/ssh"
-	"golang.org/x/crypto/ssh/agent"
 
 	"github.com/weill-labs/amux/internal/auditlog"
 	"github.com/weill-labs/amux/internal/config"
 	"github.com/weill-labs/amux/internal/proto"
+	"github.com/weill-labs/amux/internal/sshutil"
 )
 
 // HostConn manages a single SSH connection to a remote host and multiplexes
@@ -36,9 +36,9 @@ type HostConn struct {
 	logger    *charmlog.Logger
 
 	// Actor-owned state — accessed only from eventLoop goroutine.
-	state     ConnState
-	sshClient *ssh.Client
-	amuxConn  net.Conn // persistent attach connection for pane I/O
+	state      ConnState
+	sshClient  *ssh.Client
+	amuxConn   net.Conn // persistent attach connection for pane I/O
 	amuxReader *proto.Reader
 	amuxWriter *proto.Writer
 
@@ -615,67 +615,19 @@ func parseSpawnOutput(output string) (uint32, error) {
 
 // buildSSHConfig builds the SSH client configuration using agent auth and key files.
 func (hc *HostConn) buildSSHConfig() (*ssh.ClientConfig, error) {
-	var authMethods []ssh.AuthMethod
-
-	keyPaths := []string{
-		os.ExpandEnv("$HOME/.ssh/id_ed25519"),
-		os.ExpandEnv("$HOME/.ssh/id_rsa"),
+	cfg, err := sshutil.BuildSSHConfig(hc.config.User, hc.config.IdentityFile)
+	if err != nil {
+		return nil, err
 	}
-	if hc.config.IdentityFile != "" {
-		keyPaths = append([]string{hc.config.IdentityFile}, keyPaths...)
+	if os.Getenv("AMUX_SSH_INSECURE") != "1" {
+		cfg.HostKeyCallback = hostKeyCallback("", hc.logger)
 	}
-	for _, keyPath := range keyPaths {
-		key, err := os.ReadFile(keyPath)
-		if err != nil {
-			continue
-		}
-		signer, err := ssh.ParsePrivateKey(key)
-		if err != nil {
-			continue
-		}
-		authMethods = append(authMethods, ssh.PublicKeys(signer))
-	}
-
-	if sock := os.Getenv("SSH_AUTH_SOCK"); sock != "" {
-		conn, err := net.Dial("unix", sock)
-		if err == nil {
-			agentClient := agent.NewClient(conn)
-			authMethods = append(authMethods, ssh.PublicKeysCallback(agentClient.Signers))
-		}
-	}
-
-	if len(authMethods) == 0 {
-		return nil, fmt.Errorf("no SSH auth methods available (no agent, no key files)")
-	}
-
-	user := hc.config.User
-	if user == "" {
-		user = "ubuntu"
-	}
-
-	var hkCallback ssh.HostKeyCallback
-	if os.Getenv("AMUX_SSH_INSECURE") == "1" {
-		hkCallback = ssh.InsecureIgnoreHostKey()
-	} else {
-		hkCallback = hostKeyCallback("", hc.logger)
-	}
-
-	return &ssh.ClientConfig{
-		User:            user,
-		Auth:            authMethods,
-		HostKeyCallback: hkCallback,
-	}, nil
+	return cfg, nil
 }
 
 // ensureRemoteServer starts the remote amux server if it's not already running.
 func ensureRemoteServer(client *ssh.Client, sockPath, sessionName string) error {
-	sess, err := client.NewSession()
-	if err != nil {
-		return err
-	}
-	defer sess.Close()
-	cmd := buildEnsureServerCmd(sockPath, sessionName)
-	return sess.Run(cmd)
+	return sshutil.EnsureRemoteServer(client, sockPath, sessionName)
 }
 
 // buildEnsureServerCmd returns the shell command that starts amux _server if
@@ -689,7 +641,7 @@ func buildEnsureServerCmd(sockPath, sessionName string) string {
 
 // socketPath returns the expected amux socket path on the remote host.
 func socketPath(remoteUID, sessionName string) string {
-	return fmt.Sprintf("/tmp/amux-%s/%s", remoteUID, sessionName)
+	return sshutil.RemoteSocketPath(remoteUID, sessionName)
 }
 
 // ManagedSessionName returns the session name to use on the remote server.
@@ -716,62 +668,12 @@ func waitForSocket(client *ssh.Client, sockPath string, timeout time.Duration) e
 
 // dialRemoteSocket connects to the remote amux Unix socket.
 func (hc *HostConn) dialRemoteSocket(client *ssh.Client, sockPath string) (net.Conn, error) {
-	conn, err := client.Dial("unix", sockPath)
-	if err == nil {
-		return conn, nil
-	}
-
-	tcpConn, tcpErr := hc.dialRemoteSocketTCP(client, sockPath)
-	if tcpErr != nil {
-		return nil, fmt.Errorf("unix dial failed (%w) and TCP fallback failed (%w)", err, tcpErr)
-	}
-	return tcpConn, nil
-}
-
-func (hc *HostConn) dialRemoteSocketTCP(client *ssh.Client, sockPath string) (net.Conn, error) {
-	port, err := hc.startSocatBridge(client, sockPath)
-	if err != nil {
-		return nil, err
-	}
-
-	tcpConn, err := client.Dial("tcp", fmt.Sprintf("127.0.0.1:%d", port))
-	if err != nil {
-		return nil, err
-	}
-	return tcpConn, nil
-}
-
-// startSocatBridge launches socat on the remote to bridge a TCP port to the
-// Unix socket.
-func (hc *HostConn) startSocatBridge(client *ssh.Client, sockPath string) (int, error) {
-	out, err := sshOutput(client, fmt.Sprintf(
-		`port=$(python3 -c "import socket; s=socket.socket(); s.bind(('',0)); print(s.getsockname()[1]); s.close()" 2>/dev/null || shuf -i 49152-65535 -n 1); `+
-			`nohup socat TCP-LISTEN:$port,bind=127.0.0.1,fork,reuseaddr UNIX-CONNECT:%s </dev/null >/dev/null 2>&1 & `+
-			`sleep 0.3; echo $port`, sockPath))
-	if err != nil {
-		return 0, fmt.Errorf("starting socat: %w", err)
-	}
-
-	var port int
-	fmt.Sscanf(out, "%d", &port)
-	if port == 0 {
-		return 0, fmt.Errorf("could not parse socat port from: %s", out)
-	}
-	return port, nil
-}
-
-// hasPort returns true if the address already includes a port.
-func hasPort(addr string) bool {
-	_, _, err := net.SplitHostPort(addr)
-	return err == nil
+	return sshutil.DialRemoteSocket(client, sockPath)
 }
 
 // normalizeAddr ensures the address has a port, defaulting to :22.
 func normalizeAddr(addr string) string {
-	if !hasPort(addr) {
-		return addr + ":22"
-	}
-	return addr
+	return sshutil.NormalizeAddr(addr)
 }
 
 func addrOrFallback(values ...string) string {

--- a/internal/remote/host_conn_test.go
+++ b/internal/remote/host_conn_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/weill-labs/amux/internal/config"
 	"github.com/weill-labs/amux/internal/proto"
+	"github.com/weill-labs/amux/internal/sshutil"
 )
 
 // testInActor runs fn inside the HostConn actor goroutine and waits for it
@@ -39,7 +40,7 @@ func testInActor(hc *HostConn, fn func(*HostConn)) {
 func TestBuildEnsureServerCmd(t *testing.T) {
 	t.Parallel()
 
-	cmd := buildEnsureServerCmd("/tmp/amux-1000/main", "main@myhost")
+	cmd := sshutil.BuildEnsureServerCmd("/tmp/amux-1000/main", "main@myhost")
 
 	if !strings.Contains(cmd, `[ ! -S /tmp/amux-1000/main ]`) {
 		t.Error("command should check socket existence")

--- a/internal/remote/hostkey.go
+++ b/internal/remote/hostkey.go
@@ -1,113 +1,19 @@
 package remote
 
 import (
-	"errors"
-	"fmt"
-	"net"
-	"os"
-	"path/filepath"
-
 	charmlog "github.com/charmbracelet/log"
-	"github.com/weill-labs/amux/internal/auditlog"
+	"github.com/weill-labs/amux/internal/sshutil"
 	"golang.org/x/crypto/ssh"
-	"golang.org/x/crypto/ssh/knownhosts"
 )
 
-// hostKeyCallback returns an ssh.HostKeyCallback that implements TOFU
-// (Trust On First Use) against the OpenSSH known_hosts file.
-//
-// On each invocation the callback re-reads knownHostsPath to pick up
-// entries written by concurrent connections. If knownHostsPath is "",
-// defaultKnownHostsPath() is used.
 func hostKeyCallback(knownHostsPath string, loggers ...*charmlog.Logger) ssh.HostKeyCallback {
-	logger := auditlog.Discard()
-	if len(loggers) > 0 && loggers[0] != nil {
-		logger = loggers[0]
-	}
-	return func(hostname string, remote net.Addr, key ssh.PublicKey) error {
-		path := knownHostsPath
-		if path == "" {
-			var err error
-			path, err = defaultKnownHostsPath()
-			if err != nil {
-				return fmt.Errorf("amux: cannot determine known_hosts path: %w", err)
-			}
-		}
-
-		if _, err := os.Stat(path); err == nil {
-			cb, err := knownhosts.New(path)
-			if err != nil {
-				return fmt.Errorf("amux: failed to parse %s: %w", path, err)
-			}
-
-			err = cb(hostname, remote, key)
-			if err == nil {
-				return nil // known host, key matches
-			}
-
-			var revokedErr *knownhosts.RevokedError
-			if errors.As(err, &revokedErr) {
-				return err // hard reject
-			}
-
-			var keyErr *knownhosts.KeyError
-			if errors.As(err, &keyErr) {
-				if len(keyErr.Want) > 0 {
-					return hostKeyChangedError(hostname, keyErr)
-				}
-				// len(Want) == 0: unknown host, fall through to TOFU
-			} else {
-				return err // unexpected error, propagate
-			}
-		}
-
-		// TOFU: trust this key and record it
-		if err := appendKnownHost(path, hostname, key); err != nil {
-			return fmt.Errorf("amux: failed to save host key: %w", err)
-		}
-		logger.Info("trusted new ssh host key",
-			"event", "ssh_hostkey_trust",
-			"host", hostname,
-			"key_type", key.Type(),
-			"known_hosts", path,
-		)
-		return nil
-	}
+	return sshutil.HostKeyCallback(knownHostsPath, loggers...)
 }
 
-// hostKeyChangedError formats a user-facing error when a host key has changed.
-func hostKeyChangedError(hostname string, keyErr *knownhosts.KeyError) error {
-	want := keyErr.Want[0]
-	return fmt.Errorf(`amux: SSH host key verification failed for %s
-@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
-@    WARNING: REMOTE HOST IDENTIFICATION HAS CHANGED!    @
-@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
-The host key for %s has changed.
-Known key: %s in %s:%d
-To fix: remove the old key with
-  ssh-keygen -R %s`, hostname, hostname, want.Key.Type(), want.Filename, want.Line, hostname)
-}
-
-// appendKnownHost writes a new known_hosts entry. It creates the parent
-// directory and file if they don't exist.
 func appendKnownHost(path, hostname string, key ssh.PublicKey) error {
-	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
-		return err
-	}
-	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
-	if err != nil {
-		return err
-	}
-	defer f.Close()
-	_, err = fmt.Fprintln(f, knownhosts.Line([]string{hostname}, key))
-	return err
+	return sshutil.AppendKnownHost(path, hostname, key)
 }
 
-// defaultKnownHostsPath returns ~/.ssh/known_hosts.
 func defaultKnownHostsPath() (string, error) {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(home, ".ssh", "known_hosts"), nil
+	return sshutil.DefaultKnownHostsPath()
 }

--- a/internal/remote/hostkey_test.go
+++ b/internal/remote/hostkey_test.go
@@ -262,6 +262,20 @@ func TestDefaultKnownHostsPathEmptyHome(t *testing.T) {
 	}
 }
 
+func TestDefaultKnownHostsPath(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	got, err := defaultKnownHostsPath()
+	if err != nil {
+		t.Fatalf("defaultKnownHostsPath() error = %v", err)
+	}
+	want := filepath.Join(tmpDir, ".ssh", "known_hosts")
+	if got != want {
+		t.Fatalf("defaultKnownHostsPath() = %q, want %q", got, want)
+	}
+}
+
 func TestBuildSSHConfigWiresHostKeyCallback(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)

--- a/internal/sshutil/sshutil.go
+++ b/internal/sshutil/sshutil.go
@@ -1,0 +1,242 @@
+package sshutil
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+
+	charmlog "github.com/charmbracelet/log"
+	"github.com/weill-labs/amux/internal/auditlog"
+	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/agent"
+	"golang.org/x/crypto/ssh/knownhosts"
+)
+
+func BuildSSHConfig(user, identityFile string) (*ssh.ClientConfig, error) {
+	var authMethods []ssh.AuthMethod
+
+	keyPaths := []string{
+		os.ExpandEnv("$HOME/.ssh/id_ed25519"),
+		os.ExpandEnv("$HOME/.ssh/id_rsa"),
+	}
+	if identityFile != "" {
+		keyPaths = append([]string{identityFile}, keyPaths...)
+	}
+	for _, keyPath := range keyPaths {
+		key, err := os.ReadFile(keyPath)
+		if err != nil {
+			continue
+		}
+		signer, err := ssh.ParsePrivateKey(key)
+		if err != nil {
+			continue
+		}
+		authMethods = append(authMethods, ssh.PublicKeys(signer))
+	}
+
+	if sock := os.Getenv("SSH_AUTH_SOCK"); sock != "" {
+		conn, err := net.Dial("unix", sock)
+		if err == nil {
+			agentClient := agent.NewClient(conn)
+			authMethods = append(authMethods, ssh.PublicKeysCallback(agentClient.Signers))
+		}
+	}
+
+	if len(authMethods) == 0 {
+		return nil, fmt.Errorf("no SSH auth methods available (no agent, no key files)")
+	}
+
+	if user == "" {
+		user = "ubuntu"
+	}
+
+	var hostKeyCallback ssh.HostKeyCallback
+	if os.Getenv("AMUX_SSH_INSECURE") == "1" {
+		hostKeyCallback = ssh.InsecureIgnoreHostKey()
+	} else {
+		hostKeyCallback = HostKeyCallback("")
+	}
+
+	return &ssh.ClientConfig{
+		User:            user,
+		Auth:            authMethods,
+		HostKeyCallback: hostKeyCallback,
+	}, nil
+}
+
+func HostKeyCallback(knownHostsPath string, loggers ...*charmlog.Logger) ssh.HostKeyCallback {
+	logger := auditlog.Discard()
+	if len(loggers) > 0 && loggers[0] != nil {
+		logger = loggers[0]
+	}
+
+	return func(hostname string, remote net.Addr, key ssh.PublicKey) error {
+		path := knownHostsPath
+		if path == "" {
+			var err error
+			path, err = DefaultKnownHostsPath()
+			if err != nil {
+				return fmt.Errorf("amux: cannot determine known_hosts path: %w", err)
+			}
+		}
+
+		if _, err := os.Stat(path); err == nil {
+			cb, err := knownhosts.New(path)
+			if err != nil {
+				return fmt.Errorf("amux: failed to parse %s: %w", path, err)
+			}
+
+			err = cb(hostname, remote, key)
+			if err == nil {
+				return nil
+			}
+
+			var revokedErr *knownhosts.RevokedError
+			if errors.As(err, &revokedErr) {
+				return err
+			}
+
+			var keyErr *knownhosts.KeyError
+			if errors.As(err, &keyErr) {
+				if len(keyErr.Want) > 0 {
+					return hostKeyChangedError(hostname, keyErr)
+				}
+			} else {
+				return err
+			}
+		}
+
+		if err := AppendKnownHost(path, hostname, key); err != nil {
+			return fmt.Errorf("amux: failed to save host key: %w", err)
+		}
+		logger.Info("trusted new ssh host key",
+			"event", "ssh_hostkey_trust",
+			"host", hostname,
+			"key_type", key.Type(),
+			"known_hosts", path,
+		)
+		return nil
+	}
+}
+
+func EnsureRemoteServer(client *ssh.Client, sockPath, sessionName string) error {
+	sess, err := client.NewSession()
+	if err != nil {
+		return err
+	}
+	defer sess.Close()
+	return sess.Run(buildEnsureServerCmd(sockPath, sessionName))
+}
+
+func DialRemoteSocket(client *ssh.Client, sockPath string) (net.Conn, error) {
+	conn, err := client.Dial("unix", sockPath)
+	if err == nil {
+		return conn, nil
+	}
+
+	tcpConn, tcpErr := dialRemoteSocketTCP(client, sockPath)
+	if tcpErr != nil {
+		return nil, fmt.Errorf("unix dial failed (%w) and TCP fallback failed (%w)", err, tcpErr)
+	}
+	return tcpConn, nil
+}
+
+func SSHOutput(client *ssh.Client, cmd string) (string, error) {
+	sess, err := client.NewSession()
+	if err != nil {
+		return "", err
+	}
+	defer sess.Close()
+
+	out, err := sess.Output(cmd)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func RemoteSocketPath(remoteUID, sessionName string) string {
+	return fmt.Sprintf("/tmp/amux-%s/%s", remoteUID, sessionName)
+}
+
+func NormalizeAddr(addr string) string {
+	if !hasPort(addr) {
+		return addr + ":22"
+	}
+	return addr
+}
+
+func AppendKnownHost(path, hostname string, key ssh.PublicKey) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	_, err = fmt.Fprintln(f, knownhosts.Line([]string{hostname}, key))
+	return err
+}
+
+func DefaultKnownHostsPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".ssh", "known_hosts"), nil
+}
+
+func buildEnsureServerCmd(sockPath, sessionName string) string {
+	return fmt.Sprintf(
+		`if [ ! -S %s ]; then AMUX=${AMUX_BIN:-$(command -v ~/.local/bin/amux 2>/dev/null || command -v amux 2>/dev/null || echo amux)}; "$AMUX" install-terminfo || exit 1; nohup "$AMUX" _server %s </dev/null >/dev/null 2>&1 & for i in 1 2 3 4 5 6 7 8 9 10; do [ -S %s ] && break; sleep 0.2; done; fi`,
+		sockPath, sessionName, sockPath,
+	)
+}
+
+func dialRemoteSocketTCP(client *ssh.Client, sockPath string) (net.Conn, error) {
+	port, err := startSocatBridge(client, sockPath)
+	if err != nil {
+		return nil, err
+	}
+
+	return client.Dial("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+}
+
+func startSocatBridge(client *ssh.Client, sockPath string) (int, error) {
+	out, err := SSHOutput(client, fmt.Sprintf(
+		`port=$(python3 -c "import socket; s=socket.socket(); s.bind(('',0)); print(s.getsockname()[1]); s.close()" 2>/dev/null || shuf -i 49152-65535 -n 1); `+
+			`nohup socat TCP-LISTEN:$port,bind=127.0.0.1,fork,reuseaddr UNIX-CONNECT:%s </dev/null >/dev/null 2>&1 & `+
+			`sleep 0.3; echo $port`, sockPath))
+	if err != nil {
+		return 0, fmt.Errorf("starting socat: %w", err)
+	}
+
+	var port int
+	fmt.Sscanf(out, "%d", &port)
+	if port == 0 {
+		return 0, fmt.Errorf("could not parse socat port from: %s", out)
+	}
+	return port, nil
+}
+
+func hostKeyChangedError(hostname string, keyErr *knownhosts.KeyError) error {
+	want := keyErr.Want[0]
+	return fmt.Errorf(`amux: SSH host key verification failed for %s
+@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+@    WARNING: REMOTE HOST IDENTIFICATION HAS CHANGED!    @
+@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+The host key for %s has changed.
+Known key: %s in %s:%d
+To fix: remove the old key with
+  ssh-keygen -R %s`, hostname, hostname, want.Key.Type(), want.Filename, want.Line, hostname)
+}
+
+func hasPort(addr string) bool {
+	_, _, err := net.SplitHostPort(addr)
+	return err == nil
+}

--- a/internal/sshutil/sshutil.go
+++ b/internal/sshutil/sshutil.go
@@ -128,7 +128,7 @@ func EnsureRemoteServer(client *ssh.Client, sockPath, sessionName string) error 
 		return err
 	}
 	defer sess.Close()
-	return sess.Run(buildEnsureServerCmd(sockPath, sessionName))
+	return sess.Run(BuildEnsureServerCmd(sockPath, sessionName))
 }
 
 func DialRemoteSocket(client *ssh.Client, sockPath string) (net.Conn, error) {
@@ -191,7 +191,9 @@ func DefaultKnownHostsPath() (string, error) {
 	return filepath.Join(home, ".ssh", "known_hosts"), nil
 }
 
-func buildEnsureServerCmd(sockPath, sessionName string) string {
+// BuildEnsureServerCmd returns the shell command that starts amux _server if
+// the socket does not already exist.
+func BuildEnsureServerCmd(sockPath, sessionName string) string {
 	return fmt.Sprintf(
 		`if [ ! -S %s ]; then AMUX=${AMUX_BIN:-$(command -v ~/.local/bin/amux 2>/dev/null || command -v amux 2>/dev/null || echo amux)}; "$AMUX" install-terminfo || exit 1; nohup "$AMUX" _server %s </dev/null >/dev/null 2>&1 & for i in 1 2 3 4 5 6 7 8 9 10; do [ -S %s ] && break; sleep 0.2; done; fi`,
 		sockPath, sessionName, sockPath,

--- a/internal/sshutil/sshutil_test.go
+++ b/internal/sshutil/sshutil_test.go
@@ -1,0 +1,385 @@
+package sshutil
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/binary"
+	"encoding/pem"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"golang.org/x/crypto/ssh"
+)
+
+func TestNormalizeAddr(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		addr string
+		want string
+	}{
+		{name: "bare hostname", addr: "myhost", want: "myhost:22"},
+		{name: "bare ip", addr: "10.0.0.1", want: "10.0.0.1:22"},
+		{name: "address with port", addr: "10.0.0.1:2222", want: "10.0.0.1:2222"},
+		{name: "bare ipv6", addr: "::1", want: "::1:22"},
+		{name: "bracketed ipv6 with port", addr: "[::1]:2200", want: "[::1]:2200"},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := NormalizeAddr(tt.addr); got != tt.want {
+				t.Fatalf("NormalizeAddr(%q) = %q, want %q", tt.addr, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRemoteSocketPath(t *testing.T) {
+	t.Parallel()
+
+	if got := RemoteSocketPath("1000", "main@test"); got != "/tmp/amux-1000/main@test" {
+		t.Fatalf("RemoteSocketPath() = %q, want %q", got, "/tmp/amux-1000/main@test")
+	}
+}
+
+func TestBuildSSHConfigUsesDefaultUserAndTOFUCallback(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+	t.Setenv("SSH_AUTH_SOCK", "")
+
+	sshDir := filepath.Join(tmpDir, ".ssh")
+	if err := os.MkdirAll(sshDir, 0o700); err != nil {
+		t.Fatalf("mkdir .ssh: %v", err)
+	}
+	writeTestKey(t, filepath.Join(sshDir, "id_ed25519"))
+
+	cfg, err := BuildSSHConfig("", "")
+	if err != nil {
+		t.Fatalf("BuildSSHConfig() error = %v", err)
+	}
+	if cfg.User != "ubuntu" {
+		t.Fatalf("BuildSSHConfig() user = %q, want ubuntu", cfg.User)
+	}
+
+	key := testHostKey(t)
+	if err := cfg.HostKeyCallback("example.com:22", fakeAddr{"1.2.3.4:22"}, key); err != nil {
+		t.Fatalf("HostKeyCallback() error = %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(sshDir, "known_hosts"))
+	if err != nil {
+		t.Fatalf("read known_hosts: %v", err)
+	}
+	if !strings.Contains(string(data), "example.com") {
+		t.Fatalf("known_hosts = %q, want entry for example.com", string(data))
+	}
+}
+
+func TestSSHOutput(t *testing.T) {
+	t.Parallel()
+
+	ts := startTestSSH(t)
+
+	out, err := SSHOutput(ts.Client, "echo hello")
+	if err != nil {
+		t.Fatalf("SSHOutput() error = %v", err)
+	}
+	if out != "hello" {
+		t.Fatalf("SSHOutput() = %q, want %q", out, "hello")
+	}
+}
+
+func TestEnsureRemoteServer(t *testing.T) {
+	t.Parallel()
+
+	ts := startTestSSH(t)
+	writeFakeRemoteAmux(t, ts)
+
+	sessionName := "main@test"
+	sockPath := RemoteSocketPath("1000", sessionName)
+	actualSockPath := RemoteSocketPath(fmt.Sprintf("%d", os.Getuid()), sessionName)
+	_ = os.Remove(sockPath)
+	_ = os.Remove(actualSockPath)
+	_ = os.MkdirAll(filepath.Dir(sockPath), 0o755)
+	t.Cleanup(func() {
+		_ = os.Remove(sockPath)
+		_ = os.Remove(actualSockPath)
+	})
+
+	if err := EnsureRemoteServer(ts.Client, sockPath, sessionName); err != nil {
+		t.Fatalf("EnsureRemoteServer() error = %v", err)
+	}
+
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		out, err := SSHOutput(ts.Client, fmt.Sprintf("test -S %s && echo ok", actualSockPath))
+		if err == nil && out == "ok" {
+			return
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	t.Fatalf("remote socket %q did not appear", actualSockPath)
+}
+
+func TestDialRemoteSocketReportsFailure(t *testing.T) {
+	t.Parallel()
+
+	ts := startTestSSH(t)
+
+	_, err := DialRemoteSocket(ts.Client, "/tmp/amux-1000/missing")
+	if err == nil {
+		t.Fatal("DialRemoteSocket() error = nil, want failure")
+	}
+	if !strings.Contains(err.Error(), "TCP fallback failed") {
+		t.Fatalf("DialRemoteSocket() error = %q, want TCP fallback failure", err)
+	}
+}
+
+type fakeAddr struct{ addr string }
+
+func (a fakeAddr) Network() string { return "tcp" }
+func (a fakeAddr) String() string  { return a.addr }
+
+func testHostKey(t *testing.T) ssh.PublicKey {
+	t.Helper()
+
+	pub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey() error = %v", err)
+	}
+	key, err := ssh.NewPublicKey(pub)
+	if err != nil {
+		t.Fatalf("NewPublicKey() error = %v", err)
+	}
+	return key
+}
+
+type testSSH struct {
+	Client  *ssh.Client
+	HomeDir string
+	Addr    string
+}
+
+func startTestSSH(t *testing.T) *testSSH {
+	t.Helper()
+
+	pubEd, privEd, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generating key: %v", err)
+	}
+	sshPub, err := ssh.NewPublicKey(pubEd)
+	if err != nil {
+		t.Fatalf("converting public key: %v", err)
+	}
+
+	authorizedKeyBytes := sshPub.Marshal()
+	_, hostPriv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generating host key: %v", err)
+	}
+	hostSigner, err := ssh.NewSignerFromKey(hostPriv)
+	if err != nil {
+		t.Fatalf("creating host signer: %v", err)
+	}
+
+	homeDir := t.TempDir()
+	execEnv := os.Environ()
+	for i, entry := range execEnv {
+		if strings.HasPrefix(entry, "HOME=") {
+			execEnv[i] = "HOME=" + homeDir
+		}
+		if strings.HasPrefix(entry, "PATH=") {
+			execEnv[i] = "PATH=" + filepath.Join(homeDir, ".local", "bin") + ":/usr/bin:/bin"
+		}
+	}
+
+	serverCfg := &ssh.ServerConfig{
+		PublicKeyCallback: func(_ ssh.ConnMetadata, key ssh.PublicKey) (*ssh.Permissions, error) {
+			if bytes.Equal(key.Marshal(), authorizedKeyBytes) {
+				return &ssh.Permissions{}, nil
+			}
+			return nil, fmt.Errorf("unauthorized")
+		},
+	}
+	serverCfg.AddHostKey(hostSigner)
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Listen() error = %v", err)
+	}
+
+	var wg sync.WaitGroup
+	t.Cleanup(func() {
+		_ = ln.Close()
+		wg.Wait()
+	})
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			tcpConn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				handleSSHConn(tcpConn, serverCfg, execEnv)
+			}()
+		}
+	}()
+
+	signer, err := ssh.NewSignerFromKey(privEd)
+	if err != nil {
+		t.Fatalf("NewSignerFromKey() error = %v", err)
+	}
+	clientCfg := &ssh.ClientConfig{
+		User:            "testuser",
+		Auth:            []ssh.AuthMethod{ssh.PublicKeys(signer)},
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+	}
+	client, err := ssh.Dial("tcp", ln.Addr().String(), clientCfg)
+	if err != nil {
+		t.Fatalf("ssh.Dial() error = %v", err)
+	}
+	t.Cleanup(func() { _ = client.Close() })
+
+	return &testSSH{
+		Client:  client,
+		HomeDir: homeDir,
+		Addr:    ln.Addr().String(),
+	}
+}
+
+func handleSSHConn(tcpConn net.Conn, cfg *ssh.ServerConfig, execEnv []string) {
+	defer tcpConn.Close()
+
+	sshConn, chans, reqs, err := ssh.NewServerConn(tcpConn, cfg)
+	if err != nil {
+		return
+	}
+	defer sshConn.Close()
+	go ssh.DiscardRequests(reqs)
+
+	for newChannel := range chans {
+		if newChannel.ChannelType() != "session" {
+			_ = newChannel.Reject(ssh.UnknownChannelType, "unsupported")
+			continue
+		}
+		ch, chReqs, err := newChannel.Accept()
+		if err != nil {
+			continue
+		}
+		go handleSession(ch, chReqs, execEnv)
+	}
+}
+
+func handleSession(ch ssh.Channel, reqs <-chan *ssh.Request, execEnv []string) {
+	defer ch.Close()
+
+	for req := range reqs {
+		if req.Type != "exec" {
+			if req.WantReply {
+				_ = req.Reply(false, nil)
+			}
+			continue
+		}
+		if len(req.Payload) < 4 {
+			_ = req.Reply(false, nil)
+			continue
+		}
+		cmdLen := binary.BigEndian.Uint32(req.Payload[:4])
+		command := string(req.Payload[4 : 4+cmdLen])
+		_ = req.Reply(true, nil)
+
+		cmd := exec.Command("sh", "-c", command)
+		cmd.Env = execEnv
+		cmd.Stdout = ch
+		cmd.Stderr = ch.Stderr()
+		cmd.Stdin = ch
+
+		exitCode := 0
+		if err := cmd.Run(); err != nil {
+			if exitErr, ok := err.(*exec.ExitError); ok {
+				exitCode = exitErr.ExitCode()
+			} else {
+				exitCode = 1
+			}
+		}
+
+		exitMsg := make([]byte, 4)
+		binary.BigEndian.PutUint32(exitMsg, uint32(exitCode))
+		_, _ = ch.SendRequest("exit-status", false, exitMsg)
+		return
+	}
+}
+
+func writeTestKey(t *testing.T, path string) {
+	t.Helper()
+
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey() error = %v", err)
+	}
+	block, err := ssh.MarshalPrivateKey(priv, "")
+	if err != nil {
+		t.Fatalf("MarshalPrivateKey() error = %v", err)
+	}
+	if err := os.WriteFile(path, pem.EncodeToMemory(block), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+}
+
+func writeFakeRemoteAmux(t *testing.T, ts *testSSH) {
+	t.Helper()
+
+	path := filepath.Join(ts.HomeDir, ".local", "bin", "amux")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+
+	script := `#!/bin/sh
+set -eu
+case "${1:-}" in
+  install-terminfo)
+    exit 0
+    ;;
+  _server)
+    session="${2:?missing session}"
+    sock="/tmp/amux-$(id -u)/$session"
+    mkdir -p "$(dirname "$sock")"
+    python3 - "$sock" <<'PY' >/dev/null 2>&1 &
+import os, socket, sys, time
+sock = sys.argv[1]
+try:
+    os.unlink(sock)
+except FileNotFoundError:
+    pass
+s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+s.bind(sock)
+s.listen(1)
+time.sleep(5)
+s.close()
+PY
+    exit 0
+    ;;
+esac
+exit 1
+`
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+}

--- a/internal/sshutil/sshutil_test.go
+++ b/internal/sshutil/sshutil_test.go
@@ -107,7 +107,7 @@ func TestEnsureRemoteServer(t *testing.T) {
 	ts := startTestSSH(t)
 	writeFakeRemoteAmux(t, ts)
 
-	sessionName := "main@test"
+	sessionName := strings.ReplaceAll(t.Name(), "/", "-")
 	sockPath := RemoteSocketPath("1000", sessionName)
 	actualSockPath := RemoteSocketPath(fmt.Sprintf("%d", os.Getuid()), sessionName)
 	_ = os.Remove(sockPath)

--- a/internal/sshutil/sshutil_test.go
+++ b/internal/sshutil/sshutil_test.go
@@ -87,6 +87,32 @@ func TestBuildSSHConfigUsesDefaultUserAndTOFUCallback(t *testing.T) {
 	}
 }
 
+func TestBuildSSHConfigInsecureEnvVar(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+	t.Setenv("SSH_AUTH_SOCK", "")
+	t.Setenv("AMUX_SSH_INSECURE", "1")
+
+	sshDir := filepath.Join(tmpDir, ".ssh")
+	if err := os.MkdirAll(sshDir, 0o700); err != nil {
+		t.Fatalf("mkdir .ssh: %v", err)
+	}
+	writeTestKey(t, filepath.Join(sshDir, "id_ed25519"))
+
+	cfg, err := BuildSSHConfig("", "")
+	if err != nil {
+		t.Fatalf("BuildSSHConfig() error = %v", err)
+	}
+
+	key := testHostKey(t)
+	if err := cfg.HostKeyCallback("example.com:22", fakeAddr{"1.2.3.4:22"}, key); err != nil {
+		t.Fatalf("HostKeyCallback() error = %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(sshDir, "known_hosts")); err == nil {
+		t.Fatal("known_hosts should not be created in insecure mode")
+	}
+}
+
 func TestSSHOutput(t *testing.T) {
 	t.Parallel()
 
@@ -98,6 +124,45 @@ func TestSSHOutput(t *testing.T) {
 	}
 	if out != "hello" {
 		t.Fatalf("SSHOutput() = %q, want %q", out, "hello")
+	}
+}
+
+func TestHostKeyCallbackRejectsChangedKey(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "known_hosts")
+	keyA := testHostKey(t)
+	keyB := testHostKey(t)
+
+	if err := AppendKnownHost(path, "example.com:22", keyA); err != nil {
+		t.Fatalf("AppendKnownHost() error = %v", err)
+	}
+
+	cb := HostKeyCallback(path)
+	err := cb("example.com:22", fakeAddr{"1.2.3.4:22"}, keyB)
+	if err == nil {
+		t.Fatal("HostKeyCallback() error = nil, want changed-host failure")
+	}
+	if !strings.Contains(err.Error(), "CHANGED") {
+		t.Fatalf("HostKeyCallback() error = %q, want changed-host warning", err)
+	}
+	if !strings.Contains(err.Error(), "ssh-keygen -R") {
+		t.Fatalf("HostKeyCallback() error = %q, want ssh-keygen guidance", err)
+	}
+}
+
+func TestDefaultKnownHostsPath(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	got, err := DefaultKnownHostsPath()
+	if err != nil {
+		t.Fatalf("DefaultKnownHostsPath() error = %v", err)
+	}
+	want := filepath.Join(tmpDir, ".ssh", "known_hosts")
+	if got != want {
+		t.Fatalf("DefaultKnownHostsPath() = %q, want %q", got, want)
 	}
 }
 

--- a/internal/sshutil/target.go
+++ b/internal/sshutil/target.go
@@ -1,0 +1,94 @@
+package sshutil
+
+import (
+	"fmt"
+	"strings"
+)
+
+type SSHTarget struct {
+	User    string
+	Host    string
+	Port    string
+	Session string
+}
+
+func ParseTarget(raw, defaultUser string) (SSHTarget, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return SSHTarget{}, fmt.Errorf("ssh target is required")
+	}
+
+	target := SSHTarget{
+		User:    defaultUser,
+		Port:    "22",
+		Session: "main",
+	}
+	if target.User == "" {
+		target.User = "ubuntu"
+	}
+
+	if at := strings.LastIndex(raw, "@"); at >= 0 {
+		if at == 0 {
+			return SSHTarget{}, fmt.Errorf("ssh target user is required")
+		}
+		target.User = raw[:at]
+		raw = raw[at+1:]
+	}
+	if target.User == "" {
+		return SSHTarget{}, fmt.Errorf("ssh target user is required")
+	}
+	if raw == "" {
+		return SSHTarget{}, fmt.Errorf("ssh target host is required")
+	}
+
+	host, session, err := splitTargetHostSession(raw)
+	if err != nil {
+		return SSHTarget{}, err
+	}
+	target.Host = host
+	if session != "" {
+		target.Session = session
+	}
+	return target, nil
+}
+
+func splitTargetHostSession(raw string) (host, session string, err error) {
+	if strings.HasPrefix(raw, "[") {
+		end := strings.Index(raw, "]")
+		if end < 0 {
+			return "", "", fmt.Errorf("invalid ssh target %q", raw)
+		}
+		host = raw[1:end]
+		rest := raw[end+1:]
+		switch {
+		case rest == "":
+			return host, "", nil
+		case !strings.HasPrefix(rest, ":"):
+			return "", "", fmt.Errorf("invalid ssh target %q", raw)
+		default:
+			session = rest[1:]
+		}
+	} else {
+		parts := strings.Split(raw, ":")
+		switch len(parts) {
+		case 1:
+			host = parts[0]
+		case 2:
+			host = parts[0]
+			session = parts[1]
+		default:
+			return "", "", fmt.Errorf("invalid ssh target %q", raw)
+		}
+	}
+
+	if host == "" {
+		return "", "", fmt.Errorf("ssh target host is required")
+	}
+	if session == "" && strings.HasSuffix(raw, ":") {
+		return "", "", fmt.Errorf("ssh target session is required")
+	}
+	if strings.Contains(session, ":") {
+		return "", "", fmt.Errorf("invalid ssh target %q", raw)
+	}
+	return host, session, nil
+}

--- a/internal/sshutil/target_test.go
+++ b/internal/sshutil/target_test.go
@@ -1,0 +1,125 @@
+package sshutil
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseTarget(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		raw         string
+		defaultUser string
+		want        SSHTarget
+		wantErr     string
+	}{
+		{
+			name:        "explicit user and default session",
+			raw:         "alice@example.com",
+			defaultUser: "ubuntu",
+			want: SSHTarget{
+				User:    "alice",
+				Host:    "example.com",
+				Port:    "22",
+				Session: "main",
+			},
+		},
+		{
+			name:        "default user with explicit session",
+			raw:         "builder:work",
+			defaultUser: "deploy",
+			want: SSHTarget{
+				User:    "deploy",
+				Host:    "builder",
+				Port:    "22",
+				Session: "work",
+			},
+		},
+		{
+			name:        "explicit user and session",
+			raw:         "alice@example.com:logs",
+			defaultUser: "ubuntu",
+			want: SSHTarget{
+				User:    "alice",
+				Host:    "example.com",
+				Port:    "22",
+				Session: "logs",
+			},
+		},
+		{
+			name:        "bracketed ipv6 host",
+			raw:         "alice@[::1]:dev",
+			defaultUser: "ubuntu",
+			want: SSHTarget{
+				User:    "alice",
+				Host:    "::1",
+				Port:    "22",
+				Session: "dev",
+			},
+		},
+		{
+			name:        "bracketed ipv6 default session",
+			raw:         "[::1]",
+			defaultUser: "ubuntu",
+			want: SSHTarget{
+				User:    "ubuntu",
+				Host:    "::1",
+				Port:    "22",
+				Session: "main",
+			},
+		},
+		{
+			name:        "empty target",
+			raw:         "",
+			defaultUser: "ubuntu",
+			wantErr:     "ssh target",
+		},
+		{
+			name:        "missing user before at-sign",
+			raw:         "@example.com",
+			defaultUser: "ubuntu",
+			wantErr:     "user",
+		},
+		{
+			name:        "missing host after user",
+			raw:         "alice@",
+			defaultUser: "ubuntu",
+			wantErr:     "host",
+		},
+		{
+			name:        "extra session separator",
+			raw:         "example.com:one:two",
+			defaultUser: "ubuntu",
+			wantErr:     "invalid",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := ParseTarget(tt.raw, tt.defaultUser)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("ParseTarget(%q, %q) error = nil, want substring %q", tt.raw, tt.defaultUser, tt.wantErr)
+				}
+				if got != (SSHTarget{}) {
+					t.Fatalf("ParseTarget(%q, %q) target = %#v, want zero value on error", tt.raw, tt.defaultUser, got)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("ParseTarget(%q, %q) error = %q, want substring %q", tt.raw, tt.defaultUser, err.Error(), tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParseTarget(%q, %q) error = %v", tt.raw, tt.defaultUser, err)
+			}
+			if got != tt.want {
+				t.Fatalf("ParseTarget(%q, %q) = %#v, want %#v", tt.raw, tt.defaultUser, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Motivation
`amux` already has a transport-agnostic client/server protocol and existing SSH deployment/tunneling code, but there was no direct way to run the TUI client locally against a remote server over SSH. This adds the `amux ssh` workflow from LAB-1257 / GitHub issue #702 so local rendering can attach to a remote daemon without adding a second protocol stack.

## Summary
- extract shared SSH helpers into `internal/sshutil`, including config/auth setup, host key handling, remote socket dialing, remote server startup, socket path helpers, command output, and SSH target parsing
- add `internal/client/ssh_attach.go` so the existing attach path can reuse `runSessionWithDeps` with SSH-backed `ensureDaemon` and `dial` closures
- add `amux ssh <user@host[:session]>` CLI wiring, including `hosts.toml` user defaults and runtime hookup
- keep `internal/remote` behavior stable via thin wrapper functions and add focused tests for the extracted helpers and SSH attach dependency construction

## Testing
- `go test ./internal/sshutil -run 'TestParseTarget|TestNormalizeAddr|TestRemoteSocketPath|TestBuildSSHConfigUsesDefaultUserAndTOFUCallback|TestSSHOutput|TestEnsureRemoteServer|TestDialRemoteSocketReportsFailure' -count=100`
- `go test ./internal/client -run 'TestResolveSSHSessionTargetUsesConfiguredAddressAndIdentity|TestSSHRunSessionDepsEnsureDaemonAndDial|TestSSHRunSessionDepsIgnoresDeployFailure' -count=100`
- `go test ./internal/cli -run 'TestResolveCanonicalSessionCommand|TestRunMainDispatchesCommands' -count=100`
- `go test ./internal/sshutil ./internal/remote ./internal/client ./internal/cli -p 1 -count=1`
- `go test ./... -timeout 120s`

Known unrelated failures from the full-suite run:
- `internal/mux`: `TestAgentStatusTracksBusyAndIdle`
- `test`: `TestSendKeysSpecialKeys`
- `test`: `TestCaptureJSON_AgentStatus_Busy`

## Review focus
- confirm the new `internal/sshutil` API cleanly preserves `internal/remote` behavior while remaining usable from the client path
- check the split between CLI-side target parsing/default-user resolution and client-side host config resolution for SSH address and identity file selection
- verify the SSH attach path keeps deploy best-effort, verifies the remote socket before attach, and reuses the existing interactive attach flow without forking protocol logic

Closes LAB-1257
