### PR TITLE
Cover hidden-window resize on window switch

### DIFF
--- a/test/headless_client_test.go
+++ b/test/headless_client_test.go
@@ -184,6 +184,13 @@ func (hc *headlessClient) resize(cols, rows int) {
 	})
 }
 
+// resizeTerminal mirrors a real interactive client resize: update the local
+// renderer immediately, then notify the server so the session relayouts.
+func (hc *headlessClient) resizeTerminal(cols, rows int) {
+	hc.renderer.Resize(cols, rows)
+	hc.resize(cols, rows)
+}
+
 func (hc *headlessClient) sendUIEvent(name string) {
 	conn := hc.currentConn()
 	if conn == nil {

--- a/test/headless_client_test.go
+++ b/test/headless_client_test.go
@@ -171,7 +171,9 @@ func (hc *headlessClient) waitCommandReady() error {
 	return nil
 }
 
-// resize sends a MsgTypeResize to the server, simulating a terminal resize.
+// resize notifies the server about a terminal resize without changing the
+// local renderer. Tests that want the full interactive-client behavior should
+// use resizeTerminal.
 func (hc *headlessClient) resize(cols, rows int) {
 	conn := hc.currentConn()
 	if conn == nil {

--- a/test/window_test.go
+++ b/test/window_test.go
@@ -2,10 +2,12 @@ package test
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/weill-labs/amux/internal/mux"
 	"github.com/weill-labs/amux/internal/proto"
 )
 
@@ -366,6 +368,80 @@ func TestWindowSwitchResyncsStaleCursorState(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestWindowSwitchResizesHiddenWindowPanesToCurrentTerminal(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		switchFn func(*ServerHarness)
+	}{
+		{
+			name: "select-window",
+			switchFn: func(h *ServerHarness) {
+				h.runCmd("select-window", "2")
+			},
+		},
+		{
+			name: "next-window",
+			switchFn: func(h *ServerHarness) {
+				h.runCmd("next-window")
+			},
+		},
+		{
+			name: "prev-window",
+			switchFn: func(h *ServerHarness) {
+				h.runCmd("prev-window")
+			},
+		},
+		{
+			name: "last-window",
+			switchFn: func(h *ServerHarness) {
+				h.runCmd("last-window")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newServerHarness(t)
+			h.waitFor("pane-1", "$")
+
+			h.runCmd("new-window")
+			h.waitFor("pane-2", "$")
+
+			gen := h.generation()
+			h.runCmd("split", "pane-2", "v")
+			h.waitLayout(gen)
+			h.waitFor("pane-3", "$")
+
+			gen = h.generation()
+			h.runCmd("select-window", "1")
+			h.waitLayout(gen)
+
+			gen = h.generation()
+			h.client.resizeTerminal(120, 40)
+			h.waitLayout(gen)
+
+			gen = h.generation()
+			tt.switchFn(h)
+			h.waitLayout(gen)
+
+			capture := h.captureJSON()
+			wantPane2 := expectedSttySize(h.jsonPane(capture, "pane-2"))
+			wantPane3 := expectedSttySize(h.jsonPane(capture, "pane-3"))
+
+			h.runShellCommand("pane-2", "stty size", wantPane2)
+			h.runShellCommand("pane-3", "stty size", wantPane3)
+		})
+	}
+}
+
+func expectedSttySize(pane proto.CapturePane) string {
+	return fmt.Sprintf("%d %d", mux.PaneContentHeight(pane.Position.Height), pane.Position.Width)
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Motivation
LAB-1260 is about hidden windows relayouting to the current terminal size when they become active again. The resize-on-switch behavior is already present in the session code, but it was only covered by a server-level unit test; this PR adds an end-to-end regression so the interactive path stays locked down.

## Summary
- add a `headlessClient.resizeTerminal` helper that mirrors a real interactive resize by updating the local renderer before sending `MsgTypeResize`
- add an integration test that resizes the active client, switches back to a previously hidden split window, and verifies each pane's PTY size via `stty size`
- cover all window switch entry points: `select-window`, `next-window`, `prev-window`, and `last-window`

## Testing
- `go test ./test -run TestWindowSwitchResizesHiddenWindowPanesToCurrentTerminal -count=1`
- `go test ./test -run TestWindowSwitchResizesHiddenWindowPanesToCurrentTerminal -count=100`
- `go test ./... -timeout 120s`

## Review Focus
- Does `resizeTerminal` accurately model the real client resize path for integration tests?
- Is `stty size` the right end-to-end assertion for catching stale hidden-window pane dimensions across every switch command?

Closes LAB-1260
