### PR TITLE
Chunk large pane history during attach bootstrap

### DIFF
--- a/internal/client/attach_bootstrap.go
+++ b/internal/client/attach_bootstrap.go
@@ -41,7 +41,7 @@ func attachBootstrapPaneCount(layout *proto.LayoutSnapshot) int {
 	return count
 }
 
-func applyAttachBootstrapMessage(cr *ClientRenderer, msg attachBootstrapMessage) int {
+func applyAttachBootstrapReplayMessage(cr *ClientRenderer, msg attachBootstrapMessage) int {
 	switch msg.msg.Type {
 	case proto.MsgTypePaneHistory:
 		cr.AppendPaneHistoryMessage(msg.msg.PaneID, msg.msg.History, msg.msg.StyledHistory)
@@ -82,6 +82,19 @@ func readImmediateAttachCorrection(conn net.Conn, reader *proto.Reader, cr *Clie
 	}
 }
 
+func applyAttachBootstrapMessage(cr *ClientRenderer, msg attachBootstrapMessage) int {
+	switch msg.msg.Type {
+	case proto.MsgTypePaneHistory:
+		cr.HandlePaneHistoryMessage(msg.msg.PaneID, msg.msg.History, msg.msg.StyledHistory)
+		return 0
+	case proto.MsgTypePaneOutput:
+		cr.HandlePaneOutput(msg.msg.PaneID, msg.msg.PaneData)
+		return 1
+	default:
+		return 0
+	}
+}
+
 func readAttachBootstrapPaneReplays(conn net.Conn, reader *proto.Reader, cr *ClientRenderer, remainingOutputs int, timeout time.Duration) (int, error) {
 	if remainingOutputs <= 0 {
 		return 0, nil
@@ -108,7 +121,7 @@ func readAttachBootstrapPaneReplays(conn net.Conn, reader *proto.Reader, cr *Cli
 			// Exit bootstrap early and let later state continue via the normal loop.
 			return remainingOutputs, nil
 		}
-		remainingOutputs -= applyAttachBootstrapMessage(cr, bufferedMsg)
+		remainingOutputs -= applyAttachBootstrapReplayMessage(cr, bufferedMsg)
 	}
 	return 0, nil
 }
@@ -138,7 +151,7 @@ func readAttachBootstrap(conn net.Conn, reader *proto.Reader, cr *ClientRenderer
 
 	remainingOutputs := attachBootstrapPaneCount(layout)
 	for _, msg := range buffered {
-		remainingOutputs -= applyAttachBootstrapMessage(cr, msg)
+		remainingOutputs -= applyAttachBootstrapReplayMessage(cr, msg)
 	}
 
 	remainingOutputs, err := readAttachBootstrapPaneReplays(conn, reader, cr, remainingOutputs, config.BootstrapPaneReplayWait)

--- a/internal/client/attach_bootstrap.go
+++ b/internal/client/attach_bootstrap.go
@@ -44,7 +44,7 @@ func attachBootstrapPaneCount(layout *proto.LayoutSnapshot) int {
 func applyAttachBootstrapMessage(cr *ClientRenderer, msg attachBootstrapMessage) int {
 	switch msg.msg.Type {
 	case proto.MsgTypePaneHistory:
-		cr.HandlePaneHistoryMessage(msg.msg.PaneID, msg.msg.History, msg.msg.StyledHistory)
+		cr.AppendPaneHistoryMessage(msg.msg.PaneID, msg.msg.History, msg.msg.StyledHistory)
 		return 0
 	case proto.MsgTypePaneOutput:
 		cr.HandlePaneOutput(msg.msg.PaneID, msg.msg.PaneData)

--- a/internal/client/attach_bootstrap_chunk_test.go
+++ b/internal/client/attach_bootstrap_chunk_test.go
@@ -7,14 +7,14 @@ import (
 	"github.com/weill-labs/amux/internal/proto"
 )
 
-func TestApplyAttachBootstrapMessageAppendsPaneHistoryChunks(t *testing.T) {
+func TestApplyAttachBootstrapReplayMessageAppendsPaneHistoryChunks(t *testing.T) {
 	t.Parallel()
 
 	cr := NewClientRenderer(20, 4)
 	t.Cleanup(cr.renderer.Close)
 	cr.HandleLayout(singlePane20x3())
 
-	applyAttachBootstrapMessage(cr, attachBootstrapMessage{
+	applyAttachBootstrapReplayMessage(cr, attachBootstrapMessage{
 		msg: &proto.Message{
 			Type:          proto.MsgTypePaneHistory,
 			PaneID:        1,
@@ -22,7 +22,7 @@ func TestApplyAttachBootstrapMessageAppendsPaneHistoryChunks(t *testing.T) {
 			StyledHistory: []proto.StyledLine{{Text: "old-1"}},
 		},
 	})
-	applyAttachBootstrapMessage(cr, attachBootstrapMessage{
+	applyAttachBootstrapReplayMessage(cr, attachBootstrapMessage{
 		msg: &proto.Message{
 			Type:          proto.MsgTypePaneHistory,
 			PaneID:        1,
@@ -35,5 +35,29 @@ func TestApplyAttachBootstrapMessageAppendsPaneHistoryChunks(t *testing.T) {
 	want := []string{"old-1", "old-2", "old-3"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("bootstrap pane history = %v, want %v", got, want)
+	}
+}
+
+func TestApplyAttachBootstrapMessageReplacesPaneHistoryDuringCorrection(t *testing.T) {
+	t.Parallel()
+
+	cr := NewClientRenderer(20, 4)
+	t.Cleanup(cr.renderer.Close)
+	cr.HandleLayout(singlePane20x3())
+	cr.HandlePaneHistory(1, []string{"old-1", "old-2"})
+
+	applyAttachBootstrapMessage(cr, attachBootstrapMessage{
+		msg: &proto.Message{
+			Type:          proto.MsgTypePaneHistory,
+			PaneID:        1,
+			History:       []string{"reset"},
+			StyledHistory: []proto.StyledLine{{Text: "reset"}},
+		},
+	})
+
+	got := proto.StyledLineText(cr.loadState().baseHistory[1])
+	want := []string{"reset"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("correction pane history = %v, want %v", got, want)
 	}
 }

--- a/internal/client/attach_bootstrap_chunk_test.go
+++ b/internal/client/attach_bootstrap_chunk_test.go
@@ -1,0 +1,39 @@
+package client
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/weill-labs/amux/internal/proto"
+)
+
+func TestApplyAttachBootstrapMessageAppendsPaneHistoryChunks(t *testing.T) {
+	t.Parallel()
+
+	cr := NewClientRenderer(20, 4)
+	t.Cleanup(cr.renderer.Close)
+	cr.HandleLayout(singlePane20x3())
+
+	applyAttachBootstrapMessage(cr, attachBootstrapMessage{
+		msg: &proto.Message{
+			Type:          proto.MsgTypePaneHistory,
+			PaneID:        1,
+			History:       []string{"old-1"},
+			StyledHistory: []proto.StyledLine{{Text: "old-1"}},
+		},
+	})
+	applyAttachBootstrapMessage(cr, attachBootstrapMessage{
+		msg: &proto.Message{
+			Type:          proto.MsgTypePaneHistory,
+			PaneID:        1,
+			History:       []string{"old-2", "old-3"},
+			StyledHistory: []proto.StyledLine{{Text: "old-2"}, {Text: "old-3"}},
+		},
+	})
+
+	got := proto.StyledLineText(cr.loadState().baseHistory[1])
+	want := []string{"old-1", "old-2", "old-3"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("bootstrap pane history = %v, want %v", got, want)
+	}
+}

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -87,6 +87,13 @@ func (cr *ClientRenderer) HandlePaneHistory(paneID uint32, lines []string) {
 	cr.HandlePaneHistoryStyled(paneID, plainStyledHistory(lines))
 }
 
+// AppendPaneHistory appends retained server history for a pane during attach
+// bootstrap chunk replay. History is oldest-first and excludes the visible
+// screen.
+func (cr *ClientRenderer) AppendPaneHistory(paneID uint32, lines []string) {
+	cr.AppendPaneHistoryStyled(paneID, plainStyledHistory(lines))
+}
+
 // HandlePaneHistoryStyled stores retained server history with frozen cells for
 // a pane during attach bootstrap.
 func (cr *ClientRenderer) HandlePaneHistoryStyled(paneID uint32, lines []proto.StyledLine) {
@@ -97,12 +104,30 @@ func (cr *ClientRenderer) HandlePaneHistoryStyled(paneID uint32, lines []proto.S
 	})
 }
 
+// AppendPaneHistoryStyled appends retained server history with frozen cells for
+// a pane during attach bootstrap chunk replay.
+func (cr *ClientRenderer) AppendPaneHistoryStyled(paneID uint32, lines []proto.StyledLine) {
+	history := proto.CloneStyledLines(lines)
+	cr.updateState(func(next *clientSnapshot) clientUIResult {
+		next.baseHistory[paneID] = append(next.baseHistory[paneID], history...)
+		return clientUIResult{}
+	})
+}
+
 func (cr *ClientRenderer) HandlePaneHistoryMessage(paneID uint32, history []string, styledHistory []proto.StyledLine) {
 	if len(styledHistory) > 0 {
 		cr.HandlePaneHistoryStyled(paneID, styledHistory)
 		return
 	}
 	cr.HandlePaneHistory(paneID, history)
+}
+
+func (cr *ClientRenderer) AppendPaneHistoryMessage(paneID uint32, history []string, styledHistory []proto.StyledLine) {
+	if len(styledHistory) > 0 {
+		cr.AppendPaneHistoryStyled(paneID, styledHistory)
+		return
+	}
+	cr.AppendPaneHistory(paneID, history)
 }
 
 func (cr *ClientRenderer) emitUIEvent(name string) {

--- a/internal/server/attach_bootstrap_test.go
+++ b/internal/server/attach_bootstrap_test.go
@@ -503,7 +503,7 @@ func (r *attachReplayState) HandleLayout(layout *proto.LayoutSnapshot) {
 }
 
 func (r *attachReplayState) HandlePaneHistory(paneID uint32, history []string) {
-	r.histories[paneID] = append([]string(nil), history...)
+	r.histories[paneID] = append(r.histories[paneID], history...)
 }
 
 func (r *attachReplayState) HandlePaneOutput(paneID uint32, data []byte) {

--- a/internal/server/pane_history_chunk.go
+++ b/internal/server/pane_history_chunk.go
@@ -1,0 +1,70 @@
+package server
+
+import (
+	"bytes"
+	"encoding/gob"
+	"fmt"
+
+	"github.com/weill-labs/amux/internal/proto"
+)
+
+const paneHistoryChunkThreshold = 4 * 1024 * 1024
+
+func chunkPaneHistoryMessages(paneID uint32, history []proto.StyledLine, maxChunkSize int) ([]*Message, error) {
+	if len(history) == 0 {
+		return nil, nil
+	}
+	if maxChunkSize <= 0 {
+		return nil, fmt.Errorf("invalid pane history chunk size: %d", maxChunkSize)
+	}
+
+	messages := make([]*Message, 0, 1)
+	for start := 0; start < len(history); {
+		end, err := findPaneHistoryChunkEnd(paneID, history, start, maxChunkSize)
+		if err != nil {
+			return nil, err
+		}
+		messages = append(messages, newPaneHistoryMessage(paneID, history[start:end]))
+		start = end
+	}
+	return messages, nil
+}
+
+func findPaneHistoryChunkEnd(paneID uint32, history []proto.StyledLine, start, maxChunkSize int) (int, error) {
+	lo, hi := start+1, len(history)
+	best := start
+	for lo <= hi {
+		mid := lo + (hi-lo)/2
+		size, err := estimatePaneHistoryMessageSize(newPaneHistoryMessage(paneID, history[start:mid]))
+		if err != nil {
+			return 0, err
+		}
+		if size <= maxChunkSize {
+			best = mid
+			lo = mid + 1
+			continue
+		}
+		hi = mid - 1
+	}
+	if best > start {
+		return best, nil
+	}
+	return start + 1, nil
+}
+
+func newPaneHistoryMessage(paneID uint32, history []proto.StyledLine) *Message {
+	return &Message{
+		Type:          MsgTypePaneHistory,
+		PaneID:        paneID,
+		History:       proto.StyledLineText(history),
+		StyledHistory: proto.CloneStyledLines(history),
+	}
+}
+
+func estimatePaneHistoryMessageSize(msg *Message) (int, error) {
+	var buf bytes.Buffer
+	if err := gob.NewEncoder(&buf).Encode(msg); err != nil {
+		return 0, fmt.Errorf("encoding pane history message: %w", err)
+	}
+	return buf.Len(), nil
+}

--- a/internal/server/pane_history_chunk_test.go
+++ b/internal/server/pane_history_chunk_test.go
@@ -1,0 +1,159 @@
+package server
+
+import (
+	"fmt"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/weill-labs/amux/internal/mux"
+)
+
+func TestChunkPaneHistoryMessagesSplitsLargeHistoryUnderThreshold(t *testing.T) {
+	t.Parallel()
+
+	const (
+		lineCount      = 320
+		lineWidth      = 64 * 1024
+		chunkThreshold = 1 << 20
+	)
+
+	pane := newProxyPane(1, mux.PaneMeta{
+		Name:  "pane-1",
+		Host:  mux.DefaultHost,
+		Color: "f5e0dc",
+	}, 80, 2, nil, nil, func(data []byte) (int, error) { return len(data), nil })
+	lines := largeHistoryLines(lineCount, lineWidth)
+	pane.SetRetainedHistory(lines)
+
+	styledHistory, _, _ := pane.StyledHistoryScreenSnapshot()
+	chunks, err := chunkPaneHistoryMessages(pane.ID, styledHistory, chunkThreshold)
+	if err != nil {
+		t.Fatalf("chunkPaneHistoryMessages: %v", err)
+	}
+	if len(chunks) < 2 {
+		t.Fatalf("chunk count = %d, want more than one chunk", len(chunks))
+	}
+
+	var flat []string
+	for i, msg := range chunks {
+		if msg.Type != MsgTypePaneHistory {
+			t.Fatalf("chunk %d type = %v, want pane history", i, msg.Type)
+		}
+		if msg.PaneID != pane.ID {
+			t.Fatalf("chunk %d pane id = %d, want %d", i, msg.PaneID, pane.ID)
+		}
+		size, err := estimatePaneHistoryMessageSize(msg)
+		if err != nil {
+			t.Fatalf("estimate chunk %d size: %v", i, err)
+		}
+		if size > chunkThreshold {
+			t.Fatalf("chunk %d size = %d, want <= %d", i, size, chunkThreshold)
+		}
+		flat = append(flat, msg.History...)
+	}
+
+	if got, want := len(flat), len(lines); got != want {
+		t.Fatalf("history line count after chunking = %d, want %d", got, want)
+	}
+	for i, want := range lines {
+		if got := flat[i]; got != want {
+			t.Fatalf("history line %d = %q, want %q", i, got, want)
+		}
+	}
+}
+
+func TestHandleAttachChunksLargePaneHistoryDuringBootstrap(t *testing.T) {
+	t.Parallel()
+
+	srv, sess, cleanup := newCommandTestSession(t)
+	defer cleanup()
+
+	const (
+		lineCount = 320
+		lineWidth = 64 * 1024
+	)
+
+	pane := newAttachTestPane(sess, 1, "pane-1", 80, 2)
+	lines := largeHistoryLines(lineCount, lineWidth)
+	pane.SetRetainedHistory(lines)
+
+	w := mux.NewWindow(pane, 80, 3)
+	w.ID = 1
+	w.Name = "window-1"
+	if err := setAttachTestLayout(sess, []*mux.Window{w}, w.ID, []*mux.Pane{pane}); err != nil {
+		t.Fatalf("setAttachTestLayout: %v", err)
+	}
+
+	serverConn, peerConn := net.Pipe()
+	defer peerConn.Close()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		srv.handleAttach(newClientConn(serverConn), &Message{
+			Type:    MsgTypeAttach,
+			Session: sess.Name,
+			Cols:    80,
+			Rows:    24,
+		})
+	}()
+
+	msg := readMsgWithTimeoutDuration(t, peerConn, 5*time.Second)
+	if msg.Type != MsgTypeLayout {
+		t.Fatalf("first message type = %v, want layout", msg.Type)
+	}
+	if msg.Layout == nil || len(msg.Layout.Panes) != 1 {
+		t.Fatalf("layout panes = %d, want 1", len(msg.Layout.Panes))
+	}
+
+	var (
+		historyMsgs int
+		gotHistory  []string
+		outputs     int
+	)
+	for outputs < len(msg.Layout.Panes) {
+		msg = readMsgWithTimeoutDuration(t, peerConn, 5*time.Second)
+		switch msg.Type {
+		case MsgTypePaneHistory:
+			historyMsgs++
+			gotHistory = append(gotHistory, msg.History...)
+		case MsgTypePaneOutput:
+			outputs++
+		default:
+			t.Fatalf("unexpected bootstrap message: %+v", msg)
+		}
+	}
+
+	if historyMsgs < 2 {
+		t.Fatalf("history message count = %d, want at least 2 chunks", historyMsgs)
+	}
+	if got, want := len(gotHistory), len(lines); got != want {
+		t.Fatalf("bootstrapped history line count = %d, want %d", got, want)
+	}
+	for i, want := range lines {
+		if got := gotHistory[i]; got != want {
+			t.Fatalf("bootstrapped history line %d = %q, want %q", i, got, want)
+		}
+	}
+
+	if err := writeMsgOnConn(peerConn, &Message{Type: MsgTypeDetach}); err != nil {
+		t.Fatalf("WriteMsg detach: %v", err)
+	}
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("handleAttach did not exit after detach")
+	}
+}
+
+func largeHistoryLines(lineCount, lineWidth int) []string {
+	lines := make([]string, lineCount)
+	for i := range lines {
+		suffix := fmt.Sprintf("-%06d", i)
+		lines[i] = strings.Repeat(string(rune('a'+(i%26))), lineWidth-len(suffix)) + suffix
+	}
+	return lines
+}

--- a/internal/server/pane_history_chunk_test.go
+++ b/internal/server/pane_history_chunk_test.go
@@ -14,9 +14,9 @@ func TestChunkPaneHistoryMessagesSplitsLargeHistoryUnderThreshold(t *testing.T) 
 	t.Parallel()
 
 	const (
-		lineCount      = 320
+		lineCount      = 260
 		lineWidth      = 64 * 1024
-		chunkThreshold = 1 << 20
+		chunkThreshold = paneHistoryChunkThreshold
 	)
 
 	pane := newProxyPane(1, mux.PaneMeta{
@@ -71,7 +71,7 @@ func TestHandleAttachChunksLargePaneHistoryDuringBootstrap(t *testing.T) {
 	defer cleanup()
 
 	const (
-		lineCount = 320
+		lineCount = 260
 		lineWidth = 64 * 1024
 	)
 
@@ -99,7 +99,7 @@ func TestHandleAttachChunksLargePaneHistoryDuringBootstrap(t *testing.T) {
 		})
 	}()
 
-	msg := readMsgWithTimeoutDuration(t, peerConn, 5*time.Second)
+	msg := readMsgWithTimeoutDuration(t, peerConn, 15*time.Second)
 	if msg.Type != MsgTypeLayout {
 		t.Fatalf("first message type = %v, want layout", msg.Type)
 	}
@@ -114,7 +114,7 @@ func TestHandleAttachChunksLargePaneHistoryDuringBootstrap(t *testing.T) {
 		outputs     int
 	)
 	for outputs < paneCount {
-		msg = readMsgWithTimeoutDuration(t, peerConn, 5*time.Second)
+		msg = readMsgWithTimeoutDuration(t, peerConn, 15*time.Second)
 		switch msg.Type {
 		case MsgTypePaneHistory:
 			historyMsgs++

--- a/internal/server/pane_history_chunk_test.go
+++ b/internal/server/pane_history_chunk_test.go
@@ -87,7 +87,6 @@ func TestHandleAttachChunksLargePaneHistoryDuringBootstrap(t *testing.T) {
 	}
 
 	serverConn, peerConn := net.Pipe()
-	defer peerConn.Close()
 
 	done := make(chan struct{})
 	go func() {
@@ -107,13 +106,14 @@ func TestHandleAttachChunksLargePaneHistoryDuringBootstrap(t *testing.T) {
 	if msg.Layout == nil || len(msg.Layout.Panes) != 1 {
 		t.Fatalf("layout panes = %d, want 1", len(msg.Layout.Panes))
 	}
+	paneCount := len(msg.Layout.Panes)
 
 	var (
 		historyMsgs int
 		gotHistory  []string
 		outputs     int
 	)
-	for outputs < len(msg.Layout.Panes) {
+	for outputs < paneCount {
 		msg = readMsgWithTimeoutDuration(t, peerConn, 5*time.Second)
 		switch msg.Type {
 		case MsgTypePaneHistory:
@@ -138,8 +138,8 @@ func TestHandleAttachChunksLargePaneHistoryDuringBootstrap(t *testing.T) {
 		}
 	}
 
-	if err := writeMsgOnConn(peerConn, &Message{Type: MsgTypeDetach}); err != nil {
-		t.Fatalf("WriteMsg detach: %v", err)
+	if err := peerConn.Close(); err != nil {
+		t.Fatalf("Close peer conn: %v", err)
 	}
 
 	select {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -802,12 +802,14 @@ func (s *Server) handleAttach(cc *clientConn, msg *Message) {
 	bootstrapSeqs := make(map[uint32]uint64, len(res.paneSnapshots))
 	for _, ps := range res.paneSnapshots {
 		if len(ps.styledHistory) > 0 {
-			cc.Send(&Message{
-				Type:          MsgTypePaneHistory,
-				PaneID:        ps.paneID,
-				History:       proto.StyledLineText(ps.styledHistory),
-				StyledHistory: proto.CloneStyledLines(ps.styledHistory),
-			})
+			messages, err := chunkPaneHistoryMessages(ps.paneID, ps.styledHistory, paneHistoryChunkThreshold)
+			if err != nil {
+				cc.Close()
+				return
+			}
+			for _, historyMsg := range messages {
+				cc.Send(historyMsg)
+			}
 		}
 		cc.Send(&Message{Type: MsgTypePaneOutput, PaneID: ps.paneID, PaneData: ps.screen})
 		bootstrapSeqs[ps.paneID] = ps.outputSeq

--- a/internal/server/session_broadcast.go
+++ b/internal/server/session_broadcast.go
@@ -101,12 +101,7 @@ func (s *Session) broadcastPaneOutputNow(paneID uint32, data []byte, seq uint64)
 
 func (s *Session) broadcastPaneHistoryNow(paneID uint32, history []proto.StyledLine) {
 	clients := s.ensureClientManager().snapshotClients()
-	msg := &Message{
-		Type:          MsgTypePaneHistory,
-		PaneID:        paneID,
-		History:       proto.StyledLineText(history),
-		StyledHistory: proto.CloneStyledLines(history),
-	}
+	msg := newPaneHistoryMessage(paneID, history)
 	for _, c := range clients {
 		c.sendPaneMessage(msg)
 	}


### PR DESCRIPTION
Motivation
Chunked pane history fixes attach bootstrap for long-running servers without needing to relax the wire limit. A production pane accumulated about 27 MB of retained history, which could exceed the pane-history bootstrap frame size and abort new attaches.

Summary
- Split large attach-bootstrap `MsgTypePaneHistory` payloads into multiple messages using a serialized-size estimate and a 4 MB chunk target.
- Keep live `MsgTypePaneHistory` replacement semantics unchanged, but append chunked history during the bootstrap replay phases on the client and in the attach replay test helper.
- Add coverage for chunk sizing, chunked attach bootstrap replay with >16 MB of retained history, and bootstrap-vs-correction history semantics on the client.

Testing
- `go test ./internal/server ./internal/client -run 'TestChunkPaneHistoryMessagesSplitsLargeHistoryUnderThreshold|TestHandleAttachChunksLargePaneHistoryDuringBootstrap|TestApplyAttachBootstrapReplayMessageAppendsPaneHistoryChunks|TestApplyAttachBootstrapMessageReplacesPaneHistoryDuringCorrection' -count=100`
- `go test ./internal/client -run TestReadAttachBootstrapKeepsPeakHeapUnderBound -v`
- `go test ./internal/client -run TestRenderCoalescedPaneOutputRespectsFrameBudget -v`
- `go test ./internal/mux -run TestAgentStatusTracksBusyAndIdle -count=3 -v` (fails locally in untouched code)
- `go test ./... -timeout 120s` (fails locally on `TestReadAttachBootstrapKeepsPeakHeapUnderBound`, `TestRenderCoalescedPaneOutputRespectsFrameBudget`, and `TestAgentStatusTracksBusyAndIdle` under package-wide runs)

Review focus
- Check that bootstrap chunking only affects attach replay and does not change live `MsgTypePaneHistory` replacement behavior after attach.
- Check the split between bootstrap replay append semantics and correction-window replacement semantics in `internal/client/attach_bootstrap.go`.
- Check the size-estimate chunk search in `internal/server/pane_history_chunk.go`, especially the single-line fallback path.

Closes LAB-1266
