### PR TITLE
Preserve detach errors and gate hot-reload reexec

### DIFF
--- a/internal/client/attach.go
+++ b/internal/client/attach.go
@@ -90,6 +90,7 @@ func isConnectionLostError(err error) bool {
 		return false
 	}
 	return errors.Is(err, io.EOF) ||
+		errors.Is(err, io.ErrUnexpectedEOF) ||
 		errors.Is(err, net.ErrClosed) ||
 		strings.Contains(err.Error(), "use of closed network connection") ||
 		strings.Contains(err.Error(), "broken pipe") ||
@@ -126,7 +127,7 @@ func disconnectNoticeForReadError(err error) string {
 	if isConnectionLostError(err) {
 		return "detached: connection lost"
 	}
-	return "detached: protocol error"
+	return fmt.Sprintf("detached: protocol error: %v", err)
 }
 
 func formatDetachNotice(text, fallback string) string {

--- a/internal/client/attach_test.go
+++ b/internal/client/attach_test.go
@@ -274,6 +274,40 @@ func TestFormatAttachError(t *testing.T) {
 	}
 }
 
+func TestDisconnectNoticeForReadError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{name: "nil", err: nil, want: ""},
+		{name: "connection lost eof", err: io.EOF, want: "detached: connection lost"},
+		{
+			name: "connection lost unexpected eof during decode",
+			err:  fmt.Errorf("decoding message: %w", io.ErrUnexpectedEOF),
+			want: "detached: connection lost",
+		},
+		{
+			name: "protocol error includes detail",
+			err:  errors.New("decoding message: unknown wire type 7"),
+			want: "detached: protocol error: decoding message: unknown wire type 7",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := disconnectNoticeForReadError(tt.err); got != tt.want {
+				t.Fatalf("disconnectNoticeForReadError(%v) = %q, want %q", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestHotReloadDetachNotice(t *testing.T) {
 	t.Parallel()
 

--- a/internal/reload/reload.go
+++ b/internal/reload/reload.go
@@ -4,18 +4,12 @@ package reload
 
 import (
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"sync"
 	"time"
 
 	"github.com/fsnotify/fsnotify"
-)
-
-const (
-	reloadDebounceDelay   = 200 * time.Millisecond
-	reloadReadyRetryDelay = 50 * time.Millisecond
 )
 
 // ResolveExecutable returns the absolute invocation path of the running binary.
@@ -143,15 +137,12 @@ func executablePathReady(execPath string) bool {
 	defer f.Close()
 
 	var prefix [4]byte
-	n, err := io.ReadFull(f, prefix[:])
-	if err != nil && err != io.EOF && err != io.ErrUnexpectedEOF {
-		return false
-	}
+	n, _ := f.Read(prefix[:])
 	return executablePrefixLooksValid(prefix[:n])
 }
 
 // WatchBinary watches for changes to the binary at execPath and sends on
-// triggerReload when a change is detected.
+// triggerReload when a change is detected (with 200ms debounce).
 // If ready is non-nil, it is closed after the file watcher is registered.
 func WatchBinary(execPath string, triggerReload chan<- struct{}, ready chan<- struct{}) {
 	watchBinary(execPath, triggerReload, ready, nil)
@@ -201,18 +192,18 @@ func watchBinary(execPath string, triggerReload chan<- struct{}, ready chan<- st
 			if !watchEventMatchesTarget(event, base, matchChmod) {
 				continue
 			}
-			debounce = resetDebounceTimer(debounce, reloadDebounceDelay)
+			debounce = resetDebounceTimer(debounce, 200*time.Millisecond)
 			debounceC = debounce.C
 
 		case <-debounceC:
 			debounceC = nil
 			if drainPendingReloadEvents(watcher.Events, watcher.Errors, base, matchChmod) {
-				debounce = resetDebounceTimer(debounce, reloadDebounceDelay)
+				debounce = resetDebounceTimer(debounce, 200*time.Millisecond)
 				debounceC = debounce.C
 				continue
 			}
 			if !executablePathReady(execPath) {
-				debounce = resetDebounceTimer(debounce, reloadReadyRetryDelay)
+				debounce = resetDebounceTimer(debounce, 50*time.Millisecond)
 				debounceC = debounce.C
 				continue
 			}

--- a/internal/reload/reload.go
+++ b/internal/reload/reload.go
@@ -13,6 +13,11 @@ import (
 	"github.com/fsnotify/fsnotify"
 )
 
+const (
+	reloadDebounceDelay   = 200 * time.Millisecond
+	reloadReadyRetryDelay = 50 * time.Millisecond
+)
+
 // ResolveExecutable returns the absolute invocation path of the running binary.
 func ResolveExecutable() (string, error) {
 	exe, err := os.Executable()
@@ -146,7 +151,7 @@ func executablePathReady(execPath string) bool {
 }
 
 // WatchBinary watches for changes to the binary at execPath and sends on
-// triggerReload when a change is detected (with 200ms debounce).
+// triggerReload when a change is detected.
 // If ready is non-nil, it is closed after the file watcher is registered.
 func WatchBinary(execPath string, triggerReload chan<- struct{}, ready chan<- struct{}) {
 	watchBinary(execPath, triggerReload, ready, nil)
@@ -196,18 +201,18 @@ func watchBinary(execPath string, triggerReload chan<- struct{}, ready chan<- st
 			if !watchEventMatchesTarget(event, base, matchChmod) {
 				continue
 			}
-			debounce = resetDebounceTimer(debounce, 200*time.Millisecond)
+			debounce = resetDebounceTimer(debounce, reloadDebounceDelay)
 			debounceC = debounce.C
 
 		case <-debounceC:
 			debounceC = nil
 			if drainPendingReloadEvents(watcher.Events, watcher.Errors, base, matchChmod) {
-				debounce = resetDebounceTimer(debounce, 200*time.Millisecond)
+				debounce = resetDebounceTimer(debounce, reloadDebounceDelay)
 				debounceC = debounce.C
 				continue
 			}
 			if !executablePathReady(execPath) {
-				debounce = resetDebounceTimer(debounce, 50*time.Millisecond)
+				debounce = resetDebounceTimer(debounce, reloadReadyRetryDelay)
 				debounceC = debounce.C
 				continue
 			}

--- a/internal/reload/reload.go
+++ b/internal/reload/reload.go
@@ -4,6 +4,7 @@ package reload
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"sync"
@@ -89,10 +90,69 @@ func drainPendingReloadEvents(events <-chan fsnotify.Event, errors <-chan error,
 	}
 }
 
+func executablePrefixLooksValid(prefix []byte) bool {
+	if len(prefix) >= 2 && prefix[0] == '#' && prefix[1] == '!' {
+		return true
+	}
+	if len(prefix) < 4 {
+		return false
+	}
+
+	switch {
+	case prefix[0] == 0x7f && prefix[1] == 'E' && prefix[2] == 'L' && prefix[3] == 'F':
+		return true
+	case prefix[0] == 0xfe && prefix[1] == 0xed && prefix[2] == 0xfa && prefix[3] == 0xce:
+		return true
+	case prefix[0] == 0xce && prefix[1] == 0xfa && prefix[2] == 0xed && prefix[3] == 0xfe:
+		return true
+	case prefix[0] == 0xfe && prefix[1] == 0xed && prefix[2] == 0xfa && prefix[3] == 0xcf:
+		return true
+	case prefix[0] == 0xcf && prefix[1] == 0xfa && prefix[2] == 0xed && prefix[3] == 0xfe:
+		return true
+	case prefix[0] == 0xca && prefix[1] == 0xfe && prefix[2] == 0xba && prefix[3] == 0xbe:
+		return true
+	case prefix[0] == 0xbe && prefix[1] == 0xba && prefix[2] == 0xfe && prefix[3] == 0xca:
+		return true
+	case prefix[0] == 0xca && prefix[1] == 0xfe && prefix[2] == 0xba && prefix[3] == 0xbf:
+		return true
+	case prefix[0] == 0xbf && prefix[1] == 0xba && prefix[2] == 0xfe && prefix[3] == 0xca:
+		return true
+	default:
+		return false
+	}
+}
+
+func executablePathReady(execPath string) bool {
+	info, err := os.Stat(execPath)
+	if err != nil {
+		return false
+	}
+	if !info.Mode().IsRegular() || info.Mode().Perm()&0111 == 0 {
+		return false
+	}
+
+	f, err := os.Open(execPath)
+	if err != nil {
+		return false
+	}
+	defer f.Close()
+
+	var prefix [4]byte
+	n, err := io.ReadFull(f, prefix[:])
+	if err != nil && err != io.EOF && err != io.ErrUnexpectedEOF {
+		return false
+	}
+	return executablePrefixLooksValid(prefix[:n])
+}
+
 // WatchBinary watches for changes to the binary at execPath and sends on
 // triggerReload when a change is detected (with 200ms debounce).
 // If ready is non-nil, it is closed after the file watcher is registered.
 func WatchBinary(execPath string, triggerReload chan<- struct{}, ready chan<- struct{}) {
+	watchBinary(execPath, triggerReload, ready, nil)
+}
+
+func watchBinary(execPath string, triggerReload chan<- struct{}, ready chan<- struct{}, stop <-chan struct{}) {
 	dir := filepath.Dir(execPath)
 	base := filepath.Base(execPath)
 	matchChmod := false
@@ -126,6 +186,9 @@ func WatchBinary(execPath string, triggerReload chan<- struct{}, ready chan<- st
 
 	for {
 		select {
+		case <-stop:
+			return
+
 		case event, ok := <-watcher.Events:
 			if !ok {
 				return
@@ -140,6 +203,11 @@ func WatchBinary(execPath string, triggerReload chan<- struct{}, ready chan<- st
 			debounceC = nil
 			if drainPendingReloadEvents(watcher.Events, watcher.Errors, base, matchChmod) {
 				debounce = resetDebounceTimer(debounce, 200*time.Millisecond)
+				debounceC = debounce.C
+				continue
+			}
+			if !executablePathReady(execPath) {
+				debounce = resetDebounceTimer(debounce, 50*time.Millisecond)
 				debounceC = debounce.C
 				continue
 			}

--- a/internal/reload/reload_test.go
+++ b/internal/reload/reload_test.go
@@ -461,6 +461,74 @@ func TestWatchBinaryDeleteAndRecreate(t *testing.T) {
 	}
 }
 
+func TestWatchBinaryWaitsForExecutableReady(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	binPath := filepath.Join(dir, "amux-test")
+	writeFakeVersionedBinary(t, binPath, "v1")
+
+	triggerReload := make(chan struct{}, 1)
+	ready := make(chan struct{})
+	stop := make(chan struct{})
+	t.Cleanup(func() { close(stop) })
+	go watchBinary(binPath, triggerReload, ready, stop)
+	<-ready
+
+	if err := os.WriteFile(binPath, []byte("not an executable"), 0755); err != nil {
+		t.Fatalf("write invalid replacement: %v", err)
+	}
+
+	select {
+	case <-triggerReload:
+		t.Fatal("reload triggered before replacement path became executable")
+	case <-time.After(400 * time.Millisecond):
+	}
+
+	writeFakeVersionedBinary(t, binPath, "v2")
+
+	select {
+	case <-triggerReload:
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected reload trigger after executable replacement became ready")
+	}
+}
+
+func TestExecutablePrefixLooksValid(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		prefix []byte
+		want   bool
+	}{
+		{name: "empty", prefix: nil, want: false},
+		{name: "short shebang", prefix: []byte("#!"), want: true},
+		{name: "short invalid", prefix: []byte("ab"), want: false},
+		{name: "elf", prefix: []byte{0x7f, 'E', 'L', 'F'}, want: true},
+		{name: "mach o 32", prefix: []byte{0xfe, 0xed, 0xfa, 0xce}, want: true},
+		{name: "mach o 32 swapped", prefix: []byte{0xce, 0xfa, 0xed, 0xfe}, want: true},
+		{name: "mach o 64", prefix: []byte{0xfe, 0xed, 0xfa, 0xcf}, want: true},
+		{name: "mach o 64 swapped", prefix: []byte{0xcf, 0xfa, 0xed, 0xfe}, want: true},
+		{name: "fat", prefix: []byte{0xca, 0xfe, 0xba, 0xbe}, want: true},
+		{name: "fat swapped", prefix: []byte{0xbe, 0xba, 0xfe, 0xca}, want: true},
+		{name: "fat64", prefix: []byte{0xca, 0xfe, 0xba, 0xbf}, want: true},
+		{name: "fat64 swapped", prefix: []byte{0xbf, 0xba, 0xfe, 0xca}, want: true},
+		{name: "invalid four byte prefix", prefix: []byte("nope"), want: false},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := executablePrefixLooksValid(tt.prefix); got != tt.want {
+				t.Fatalf("executablePrefixLooksValid(%v) = %v, want %v", tt.prefix, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestExecutablePathReady(t *testing.T) {
 	t.Parallel()
 
@@ -476,6 +544,13 @@ func TestExecutablePathReady(t *testing.T) {
 	if err := os.WriteFile(notExecPath, []byte(fakeVersionedBinaryScript("notexec")), 0644); err != nil {
 		t.Fatalf("write non-executable script: %v", err)
 	}
+	unreadablePath := filepath.Join(dir, "unreadable")
+	if err := os.WriteFile(unreadablePath, []byte(fakeVersionedBinaryScript("unreadable")), 0700); err != nil {
+		t.Fatalf("write unreadable script seed: %v", err)
+	}
+	if err := os.Chmod(unreadablePath, 0111); err != nil {
+		t.Fatalf("chmod unreadable script: %v", err)
+	}
 
 	tests := []struct {
 		name string
@@ -486,6 +561,7 @@ func TestExecutablePathReady(t *testing.T) {
 		{name: "invalid executable bytes", path: invalidPath, want: false},
 		{name: "valid script", path: scriptPath, want: true},
 		{name: "missing execute bit", path: notExecPath, want: false},
+		{name: "missing read bit", path: unreadablePath, want: false},
 	}
 
 	for _, tt := range tests {

--- a/internal/reload/reload_test.go
+++ b/internal/reload/reload_test.go
@@ -423,10 +423,8 @@ func TestWatchBinaryBadDirClosesReady(t *testing.T) {
 	// should still be closed so callers don't block forever.
 	ready := make(chan struct{})
 	triggerReload := make(chan struct{}, 1)
-	stop := make(chan struct{})
-	t.Cleanup(func() { close(stop) })
 
-	go watchBinary("/nonexistent/path/amux-test", triggerReload, ready, stop)
+	go WatchBinary("/nonexistent/path/amux-test", triggerReload, ready)
 
 	select {
 	case <-ready:
@@ -446,9 +444,7 @@ func TestWatchBinaryDeleteAndRecreate(t *testing.T) {
 
 	triggerReload := make(chan struct{}, 1)
 	ready := make(chan struct{})
-	stop := make(chan struct{})
-	t.Cleanup(func() { close(stop) })
-	go watchBinary(binPath, triggerReload, ready, stop)
+	go WatchBinary(binPath, triggerReload, ready)
 	<-ready
 
 	// Delete and recreate (simulates build tools that replace via rename)
@@ -522,9 +518,7 @@ func TestWatchBinaryInstallScriptSequence(t *testing.T) {
 
 	triggerReload := make(chan struct{}, 1)
 	ready := make(chan struct{})
-	stop := make(chan struct{})
-	t.Cleanup(func() { close(stop) })
-	go watchBinary(binPath, triggerReload, ready, stop)
+	go WatchBinary(binPath, triggerReload, ready)
 	<-ready
 
 	toolDir := newInstallScriptToolDir(t, "newbuild")
@@ -572,9 +566,7 @@ func TestWatchBinaryInstallScriptSequenceViaSymlinkPath(t *testing.T) {
 
 	triggerReload := make(chan struct{}, 1)
 	ready := make(chan struct{})
-	stop := make(chan struct{})
-	t.Cleanup(func() { close(stop) })
-	go watchBinary(binPath, triggerReload, ready, stop)
+	go WatchBinary(binPath, triggerReload, ready)
 	<-ready
 
 	toolDir := newInstallScriptToolDir(t, "newbuild")

--- a/internal/reload/reload_test.go
+++ b/internal/reload/reload_test.go
@@ -329,18 +329,18 @@ func TestWatchBinaryDebounce(t *testing.T) {
 	// Create a temp directory with a fake binary
 	dir := t.TempDir()
 	binPath := filepath.Join(dir, "amux-test")
-	if err := os.WriteFile(binPath, []byte("v1"), 0755); err != nil {
-		t.Fatal(err)
-	}
+	writeFakeVersionedBinary(t, binPath, "v1")
 
 	triggerReload := make(chan struct{}, 1)
 	ready := make(chan struct{})
-	go WatchBinary(binPath, triggerReload, ready)
+	stop := make(chan struct{})
+	t.Cleanup(func() { close(stop) })
+	go watchBinary(binPath, triggerReload, ready, stop)
 	<-ready
 
 	// Write to the file multiple times in quick succession (simulates go build)
 	for i := 0; i < 5; i++ {
-		os.WriteFile(binPath, []byte("v2"), 0755)
+		writeFakeVersionedBinary(t, binPath, fmt.Sprintf("v2-%d", i))
 		time.Sleep(20 * time.Millisecond)
 	}
 
@@ -368,13 +368,13 @@ func TestWatchBinaryIgnoresOtherFiles(t *testing.T) {
 	binPath := filepath.Join(dir, "amux-test")
 	otherPath := filepath.Join(dir, "other-file")
 
-	if err := os.WriteFile(binPath, []byte("v1"), 0755); err != nil {
-		t.Fatal(err)
-	}
+	writeFakeVersionedBinary(t, binPath, "v1")
 
 	triggerReload := make(chan struct{}, 1)
 	ready := make(chan struct{})
-	go WatchBinary(binPath, triggerReload, ready)
+	stop := make(chan struct{})
+	t.Cleanup(func() { close(stop) })
+	go watchBinary(binPath, triggerReload, ready, stop)
 	<-ready
 
 	// Write to a different file in the same directory
@@ -396,17 +396,17 @@ func TestWatchBinaryNilReady(t *testing.T) {
 	// Passing nil for the ready channel should not panic.
 	dir := t.TempDir()
 	binPath := filepath.Join(dir, "amux-test")
-	if err := os.WriteFile(binPath, []byte("v1"), 0755); err != nil {
-		t.Fatal(err)
-	}
+	writeFakeVersionedBinary(t, binPath, "v1")
 
 	triggerReload := make(chan struct{}, 1)
-	go WatchBinary(binPath, triggerReload, nil)
+	stop := make(chan struct{})
+	t.Cleanup(func() { close(stop) })
+	go watchBinary(binPath, triggerReload, nil, stop)
 
 	// Inherent race: cannot use ready channel since we're testing nil.
 	// Generous 2s fallback timeout below handles slow CI.
 	<-time.After(200 * time.Millisecond) // let watcher register
-	os.WriteFile(binPath, []byte("v2"), 0755)
+	writeFakeVersionedBinary(t, binPath, "v2")
 
 	select {
 	case <-triggerReload:
@@ -423,8 +423,10 @@ func TestWatchBinaryBadDirClosesReady(t *testing.T) {
 	// should still be closed so callers don't block forever.
 	ready := make(chan struct{})
 	triggerReload := make(chan struct{}, 1)
+	stop := make(chan struct{})
+	t.Cleanup(func() { close(stop) })
 
-	go WatchBinary("/nonexistent/path/amux-test", triggerReload, ready)
+	go watchBinary("/nonexistent/path/amux-test", triggerReload, ready, stop)
 
 	select {
 	case <-ready:
@@ -440,19 +442,19 @@ func TestWatchBinaryDeleteAndRecreate(t *testing.T) {
 	dir := t.TempDir()
 	binPath := filepath.Join(dir, "amux-test")
 
-	if err := os.WriteFile(binPath, []byte("v1"), 0755); err != nil {
-		t.Fatal(err)
-	}
+	writeFakeVersionedBinary(t, binPath, "v1")
 
 	triggerReload := make(chan struct{}, 1)
 	ready := make(chan struct{})
-	go WatchBinary(binPath, triggerReload, ready)
+	stop := make(chan struct{})
+	t.Cleanup(func() { close(stop) })
+	go watchBinary(binPath, triggerReload, ready, stop)
 	<-ready
 
 	// Delete and recreate (simulates build tools that replace via rename)
 	os.Remove(binPath)
 	time.Sleep(50 * time.Millisecond)
-	os.WriteFile(binPath, []byte("v2"), 0755)
+	writeFakeVersionedBinary(t, binPath, "v2")
 
 	// Should trigger reload after debounce
 	select {
@@ -460,6 +462,45 @@ func TestWatchBinaryDeleteAndRecreate(t *testing.T) {
 		// Good
 	case <-time.After(2 * time.Second):
 		t.Fatal("expected reload trigger after delete+create, got none")
+	}
+}
+
+func TestExecutablePathReady(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	missingPath := filepath.Join(dir, "missing")
+	invalidPath := filepath.Join(dir, "invalid")
+	if err := os.WriteFile(invalidPath, []byte("not an executable"), 0755); err != nil {
+		t.Fatalf("write invalid executable: %v", err)
+	}
+	scriptPath := filepath.Join(dir, "script")
+	writeFakeVersionedBinary(t, scriptPath, "ready")
+	notExecPath := filepath.Join(dir, "not-exec")
+	if err := os.WriteFile(notExecPath, []byte(fakeVersionedBinaryScript("notexec")), 0644); err != nil {
+		t.Fatalf("write non-executable script: %v", err)
+	}
+
+	tests := []struct {
+		name string
+		path string
+		want bool
+	}{
+		{name: "missing", path: missingPath, want: false},
+		{name: "invalid executable bytes", path: invalidPath, want: false},
+		{name: "valid script", path: scriptPath, want: true},
+		{name: "missing execute bit", path: notExecPath, want: false},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := executablePathReady(tt.path); got != tt.want {
+				t.Fatalf("executablePathReady(%q) = %v, want %v", tt.path, got, tt.want)
+			}
+		})
 	}
 }
 
@@ -481,7 +522,9 @@ func TestWatchBinaryInstallScriptSequence(t *testing.T) {
 
 	triggerReload := make(chan struct{}, 1)
 	ready := make(chan struct{})
-	go WatchBinary(binPath, triggerReload, ready)
+	stop := make(chan struct{})
+	t.Cleanup(func() { close(stop) })
+	go watchBinary(binPath, triggerReload, ready, stop)
 	<-ready
 
 	toolDir := newInstallScriptToolDir(t, "newbuild")
@@ -529,7 +572,9 @@ func TestWatchBinaryInstallScriptSequenceViaSymlinkPath(t *testing.T) {
 
 	triggerReload := make(chan struct{}, 1)
 	ready := make(chan struct{})
-	go WatchBinary(binPath, triggerReload, ready)
+	stop := make(chan struct{})
+	t.Cleanup(func() { close(stop) })
+	go watchBinary(binPath, triggerReload, ready, stop)
 	<-ready
 
 	toolDir := newInstallScriptToolDir(t, "newbuild")


### PR DESCRIPTION
## Motivation

Client detach notices were collapsing distinct read failures into a generic `detached: protocol error`, which hid the actual cause during hot-reload reconnects and transient server interruptions. The same path also treated mid-message EOFs during server restart as protocol bugs even though they behave like ordinary connection loss.

## Summary

- include the underlying read error in `detached: protocol error` notices so reconnect failures keep the actionable detail
- classify wrapped `io.ErrUnexpectedEOF` read failures as connection loss so server-restart decode interruptions no longer surface as protocol errors
- wait for the watched replacement path to look executable before firing hot-reload, so replace-in-place races do not re-exec into a not-yet-ready binary
- add regression coverage for detach notice formatting, executable readiness detection, install-script reload sequences, and watcher cleanup during repeated runs

## Testing

- `go test ./internal/client -run 'TestDisconnectNoticeForReadError' -count=100`
- `go test ./internal/reload -run 'TestExecutablePathReady' -count=100`
- `go test ./internal/reload -run 'TestWatchBinaryDebounce$' -count=100`
- `go test ./internal/reload -run 'TestWatchBinaryNilReady$' -count=100`
- `go test ./internal/reload -run 'TestWatchBinaryDeleteAndRecreate$' -count=100`
- `go test ./internal/reload -run 'TestWatchBinaryInstallScriptSequence$|TestWatchBinaryInstallScriptSequenceViaSymlinkPath$' -count=1`
- `go test ./... -timeout 120s` (hit unrelated flakes in `TestRespawnPreservesPaneMetadataAndCwdWhileResettingState` and `TestTakeoverAttachFailureLeavesSSHPaneVisible`)
- `go test ./test -run 'TestRespawnPreservesPaneMetadataAndCwdWhileResettingState$' -count=1`
- `go test ./test -run 'TestTakeoverAttachFailureLeavesSSHPaneVisible$' -count=1`

## Review focus

- whether `io.ErrUnexpectedEOF` is the right connection-lost classification for gob decode interruption during reload
- whether the executable readiness gate is strict enough to block transient invalid replacements without delaying normal installs
- whether the test-only stop seam in `watchBinary` is the narrowest acceptable way to prevent fsnotify goroutine leaks under `-count=100`

Closes LAB-1270
