### PR TITLE
Add golangci-lint and fix existing violations

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -45,6 +45,17 @@ if [ "$NEEDS_FMT" = true ]; then
     echo "goimports: auto-formatted staged Go files"
 fi
 
+# Run golangci-lint on staged Go files
+if ! command -v golangci-lint &>/dev/null; then
+    echo "golangci-lint not found. Install: go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest"
+    exit 1
+fi
+
+if ! golangci-lint run $STAGED; then
+    echo "golangci-lint: fix the reported issues before committing"
+    exit 1
+fi
+
 # Reject new time.Sleep additions in test files — use wait primitives instead
 SLEEP_ADDITIONS=$(git diff --cached --diff-filter=ACM -U0 -- '*_test.go' | grep '^\+' | grep -vF '+++' | grep -F 'time.Sleep')
 if [ -n "$SLEEP_ADDITIONS" ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,7 @@ jobs:
         uses: golangci/golangci-lint-action@v6
         with:
           version: latest
+          install-mode: goinstall
           args: ./...
 
       - name: Cache apt packages

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,13 @@ jobs:
         with:
           go-version: "1.25"
 
+      - name: Lint
+        if: steps.changes.outputs.code_changed == 'true'
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: latest
+          args: ./...
+
       - name: Cache apt packages
         if: steps.changes.outputs.code_changed == 'true'
         uses: actions/cache@v5.0.3

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,13 @@
+linters:
+  disable-all: true
+  enable:
+    - errcheck
+    - govet
+    - staticcheck
+    - unused
+    - gosimple
+    - ineffassign
+
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0

--- a/internal/cli/cli_debug.go
+++ b/internal/cli/cli_debug.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -69,22 +70,18 @@ type debugEndpointRequest struct {
 	missingHint   string
 }
 
-func parseDebugCommand(sessionName string, args []string) (debugEndpointRequest, error) {
-	return parseDebugCommandWithConfigLoader(sessionName, args, loadDebugConfig)
-}
-
 func loadDebugConfig() (*config.Config, error) {
 	return config.Load(config.DefaultPath())
 }
 
 func parseDebugCommandWithConfigLoader(sessionName string, args []string, loadConfig debugConfigLoader) (debugEndpointRequest, error) {
 	if len(args) == 0 {
-		return debugEndpointRequest{}, fmt.Errorf(debugUsage)
+		return debugEndpointRequest{}, errors.New(debugUsage)
 	}
 
 	if args[0] == "frames" {
 		if len(args) != 1 {
-			return debugEndpointRequest{}, fmt.Errorf(debugUsage)
+			return debugEndpointRequest{}, errors.New(debugUsage)
 		}
 		return debugEndpointRequest{
 			sockPath:      server.PprofSocketPath(sessionName),
@@ -107,31 +104,31 @@ func parseDebugCommandWithConfigLoader(sessionName string, args []string, loadCo
 	switch args[0] {
 	case "goroutines":
 		if len(args) != 1 {
-			return debugEndpointRequest{}, fmt.Errorf(debugUsage)
+			return debugEndpointRequest{}, errors.New(debugUsage)
 		}
 		req.path = "/debug/pprof/goroutine?debug=2"
 	case "heap":
 		if len(args) != 1 {
-			return debugEndpointRequest{}, fmt.Errorf(debugUsage)
+			return debugEndpointRequest{}, errors.New(debugUsage)
 		}
 		req.path = "/debug/pprof/heap?debug=1"
 	case "client-goroutines":
 		if len(args) != 1 {
-			return debugEndpointRequest{}, fmt.Errorf(debugUsage)
+			return debugEndpointRequest{}, errors.New(debugUsage)
 		}
 		req.sockPath = client.PprofSocketPath(sessionName)
 		req.path = "/debug/pprof/goroutine?debug=2"
 		req.missingHint = "pprof debug socket %s is not available; attach or restart a client after enabling [debug].pprof"
 	case "client-heap":
 		if len(args) != 1 {
-			return debugEndpointRequest{}, fmt.Errorf(debugUsage)
+			return debugEndpointRequest{}, errors.New(debugUsage)
 		}
 		req.sockPath = client.PprofSocketPath(sessionName)
 		req.path = "/debug/pprof/heap?debug=1"
 		req.missingHint = "pprof debug socket %s is not available; attach or restart a client after enabling [debug].pprof"
 	case "socket":
 		if len(args) != 1 {
-			return debugEndpointRequest{}, fmt.Errorf(debugUsage)
+			return debugEndpointRequest{}, errors.New(debugUsage)
 		}
 	case "profile":
 		duration, parseErr := parseDebugProfileDuration(args[1:])
@@ -158,7 +155,7 @@ func parseDebugCommandWithConfigLoader(sessionName string, args []string, loadCo
 		req.path = "/debug/pprof/profile?seconds=" + strconv.Itoa(seconds)
 		req.missingHint = "pprof debug socket %s is not available; attach or restart a client after enabling [debug].pprof"
 	default:
-		return debugEndpointRequest{}, fmt.Errorf(debugUsage)
+		return debugEndpointRequest{}, errors.New(debugUsage)
 	}
 
 	return req, nil
@@ -170,7 +167,7 @@ func parseDebugProfileDuration(args []string) (time.Duration, error) {
 	case 0:
 	case 2:
 		if args[0] != "--duration" {
-			return 0, fmt.Errorf(debugUsage)
+			return 0, errors.New(debugUsage)
 		}
 		parsed, err := time.ParseDuration(args[1])
 		if err != nil || parsed <= 0 {
@@ -178,7 +175,7 @@ func parseDebugProfileDuration(args []string) (time.Duration, error) {
 		}
 		duration = parsed
 	default:
-		return 0, fmt.Errorf(debugUsage)
+		return 0, errors.New(debugUsage)
 	}
 	return duration, nil
 }
@@ -187,7 +184,7 @@ func ensureDebugSocketAvailable(req debugEndpointRequest) error {
 	if _, err := os.Stat(req.sockPath); err != nil {
 		if os.IsNotExist(err) {
 			if !req.configEnabled {
-				return fmt.Errorf(debugDisabledHint)
+				return errors.New(debugDisabledHint)
 			}
 			missingHint := req.missingHint
 			if missingHint == "" {

--- a/internal/cli/cli_debug_test.go
+++ b/internal/cli/cli_debug_test.go
@@ -133,6 +133,15 @@ func TestParseDebugCommand(t *testing.T) {
 			wantSockPath: wantSocket,
 		},
 		{
+			name: "rejects extra frames args",
+			loadConfig: func() (*config.Config, error) {
+				t.Fatal("loadConfig should not be called for debug frames")
+				return nil, nil
+			},
+			args:    []string{"frames", "extra"},
+			wantErr: debugUsage,
+		},
+		{
 			name:         "parses default profile duration",
 			loadConfig:   func() (*config.Config, error) { return &config.Config{Debug: config.DebugConfig{Pprof: true}}, nil },
 			args:         []string{"profile"},
@@ -184,6 +193,12 @@ func TestParseDebugCommand(t *testing.T) {
 			name:       "rejects invalid profile flag",
 			loadConfig: func() (*config.Config, error) { return &config.Config{}, nil },
 			args:       []string{"profile", "--seconds", "1s"},
+			wantErr:    debugUsage,
+		},
+		{
+			name:       "rejects missing profile duration value",
+			loadConfig: func() (*config.Config, error) { return &config.Config{}, nil },
+			args:       []string{"profile", "--duration"},
 			wantErr:    debugUsage,
 		},
 		{

--- a/internal/cli/cli_parse.go
+++ b/internal/cli/cli_parse.go
@@ -109,7 +109,7 @@ func ResolveCanonicalSessionCommand(args []string) (cmdName string, cmdArgs []st
 
 func ParseLogArgs(args []string) (string, []string, error) {
 	if len(args) != 1 {
-		return "", nil, fmt.Errorf(logUsage)
+		return "", nil, errors.New(logUsage)
 	}
 	switch args[0] {
 	case "clients":
@@ -117,7 +117,7 @@ func ParseLogArgs(args []string) (string, []string, error) {
 	case "panes":
 		return "pane-log", nil, nil
 	default:
-		return "", nil, fmt.Errorf(logUsage)
+		return "", nil, errors.New(logUsage)
 	}
 }
 
@@ -130,13 +130,13 @@ func ParseLeadArgs(args []string) (string, []string, error) {
 	case len(args) == 1 && !strings.HasPrefix(args[0], "-"):
 		return "set-lead", []string{args[0]}, nil
 	default:
-		return "", nil, fmt.Errorf(leadUsage)
+		return "", nil, errors.New(leadUsage)
 	}
 }
 
 func ValidateMetaArgs(args []string) error {
 	if len(args) == 0 {
-		return fmt.Errorf(metaUsage)
+		return errors.New(metaUsage)
 	}
 	switch args[0] {
 	case "set":
@@ -152,21 +152,21 @@ func ValidateMetaArgs(args []string) error {
 			return fmt.Errorf("usage: amux meta rm <pane> key [key...]")
 		}
 	default:
-		return fmt.Errorf(metaUsage)
+		return errors.New(metaUsage)
 	}
 	return nil
 }
 
 func ParseSwapArgs(args []string) (string, []string, error) {
 	if len(args) == 0 {
-		return "", nil, fmt.Errorf(swapUsage)
+		return "", nil, errors.New(swapUsage)
 	}
 	filtered := make([]string, 0, len(args))
 	tree := false
 	for _, arg := range args {
 		if arg == "--tree" {
 			if tree {
-				return "", nil, fmt.Errorf(swapUsage)
+				return "", nil, errors.New(swapUsage)
 			}
 			tree = true
 			continue
@@ -175,7 +175,7 @@ func ParseSwapArgs(args []string) (string, []string, error) {
 	}
 	if tree {
 		if len(filtered) != 2 {
-			return "", nil, fmt.Errorf(swapUsage)
+			return "", nil, errors.New(swapUsage)
 		}
 		return "swap-tree", filtered, nil
 	}
@@ -185,12 +185,12 @@ func ParseSwapArgs(args []string) (string, []string, error) {
 	if len(filtered) == 2 {
 		return "swap", filtered, nil
 	}
-	return "", nil, fmt.Errorf(swapUsage)
+	return "", nil, errors.New(swapUsage)
 }
 
 func ParseMoveArgs(args []string) (string, []string, error) {
 	if len(args) < 2 {
-		return "", nil, fmt.Errorf(moveUsage)
+		return "", nil, errors.New(moveUsage)
 	}
 	paneRef := args[0]
 	switch {
@@ -203,7 +203,7 @@ func ParseMoveArgs(args []string) (string, []string, error) {
 	case len(args) == 3 && args[1] == "--to-column":
 		return "move-to", []string{paneRef, args[2]}, nil
 	default:
-		return "", nil, fmt.Errorf(moveUsage)
+		return "", nil, errors.New(moveUsage)
 	}
 }
 
@@ -226,7 +226,7 @@ func ParseSpawnCommandArgs(args []string) (string, []string, error) {
 
 	setDir := func(next mux.SplitDir) error {
 		if opts.hasExplicitDir && opts.dir != next {
-			return fmt.Errorf(spawnUsage)
+			return errors.New(spawnUsage)
 		}
 		opts.dir = next
 		opts.hasExplicitDir = true
@@ -237,13 +237,13 @@ func ParseSpawnCommandArgs(args []string) (string, []string, error) {
 		switch args[i] {
 		case "--at":
 			if i+1 >= len(args) {
-				return "", nil, fmt.Errorf(spawnUsage)
+				return "", nil, errors.New(spawnUsage)
 			}
 			opts.at = args[i+1]
 			i++
 		case "--window":
 			if i+1 >= len(args) {
-				return "", nil, fmt.Errorf(spawnUsage)
+				return "", nil, errors.New(spawnUsage)
 			}
 			opts.window = args[i+1]
 			i++
@@ -263,38 +263,38 @@ func ParseSpawnCommandArgs(args []string) (string, []string, error) {
 			opts.focus = true
 		case "--name":
 			if i+1 >= len(args) {
-				return "", nil, fmt.Errorf(spawnUsage)
+				return "", nil, errors.New(spawnUsage)
 			}
 			opts.name = args[i+1]
 			i++
 		case "--host":
 			if i+1 >= len(args) {
-				return "", nil, fmt.Errorf(spawnUsage)
+				return "", nil, errors.New(spawnUsage)
 			}
 			opts.host = args[i+1]
 			i++
 		case "--task":
 			if i+1 >= len(args) {
-				return "", nil, fmt.Errorf(spawnUsage)
+				return "", nil, errors.New(spawnUsage)
 			}
 			opts.task = args[i+1]
 			i++
 		case "--color":
 			if i+1 >= len(args) {
-				return "", nil, fmt.Errorf(spawnUsage)
+				return "", nil, errors.New(spawnUsage)
 			}
 			opts.color = args[i+1]
 			i++
 		default:
-			return "", nil, fmt.Errorf(spawnUsage)
+			return "", nil, errors.New(spawnUsage)
 		}
 	}
 
 	if opts.window != "" && opts.at != "" {
-		return "", nil, fmt.Errorf(spawnUsage)
+		return "", nil, errors.New(spawnUsage)
 	}
 	if opts.auto && (opts.at != "" || opts.root || opts.hasExplicitDir) {
-		return "", nil, fmt.Errorf(spawnUsage)
+		return "", nil, errors.New(spawnUsage)
 	}
 
 	cmdArgs := make([]string, 0, 10)
@@ -373,16 +373,4 @@ func ParseEqualizeArgs(args []string) ([]string, error) {
 		return nil, nil
 	}
 	return []string{mode}, nil
-}
-
-func looksLikePaneRefArg(arg string) bool {
-	if strings.HasPrefix(arg, "pane-") {
-		return true
-	}
-	for _, r := range arg {
-		if r < '0' || r > '9' {
-			return false
-		}
-	}
-	return arg != ""
 }

--- a/internal/cli/cli_server_client.go
+++ b/internal/cli/cli_server_client.go
@@ -83,7 +83,7 @@ func RunEventsCommand(sessionName string, args []string) {
 	}
 
 	for {
-		err := streamCommandOutput(socket, "events")
+		_ = streamCommandOutput(socket, "events")
 		if !opts.reconnect {
 			return
 		}

--- a/internal/cli/main_test.go
+++ b/internal/cli/main_test.go
@@ -40,6 +40,10 @@ func TestParseSpawnCommandArgs(t *testing.T) {
 		{name: "spiral rejected", args: []string{"--spiral"}, wantErrText: spawnUsage},
 		{name: "missing at value", args: []string{"--at"}, wantErrText: spawnUsage},
 		{name: "missing window value", args: []string{"--window"}, wantErrText: spawnUsage},
+		{name: "missing name value", args: []string{"--name"}, wantErrText: spawnUsage},
+		{name: "missing host value", args: []string{"--host"}, wantErrText: spawnUsage},
+		{name: "missing task value", args: []string{"--task"}, wantErrText: spawnUsage},
+		{name: "missing color value", args: []string{"--color"}, wantErrText: spawnUsage},
 		{name: "unknown arg", args: []string{"pane-1"}, wantErrText: spawnUsage},
 	}
 
@@ -66,6 +70,45 @@ func TestParseSpawnCommandArgs(t *testing.T) {
 			}
 			if !reflect.DeepEqual(gotArgs, tt.wantArgs) {
 				t.Fatalf("ParseSpawnCommandArgs(%v) args = %v, want %v", tt.args, gotArgs, tt.wantArgs)
+			}
+		})
+	}
+}
+
+func TestParseLogArgs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		args     []string
+		wantCmd  string
+		wantArgs []string
+		wantErr  string
+	}{
+		{name: "clients", args: []string{"clients"}, wantCmd: "connection-log"},
+		{name: "panes", args: []string{"panes"}, wantCmd: "pane-log"},
+		{name: "missing args", wantErr: logUsage},
+		{name: "unknown scope", args: []string{"sessions"}, wantErr: logUsage},
+		{name: "extra args", args: []string{"clients", "extra"}, wantErr: logUsage},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			gotCmd, gotArgs, err := ParseLogArgs(tt.args)
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("ParseLogArgs(%v) error = %v, want %q", tt.args, err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParseLogArgs(%v): %v", tt.args, err)
+			}
+			if gotCmd != tt.wantCmd || !reflect.DeepEqual(gotArgs, tt.wantArgs) {
+				t.Fatalf("ParseLogArgs(%v) = (%q, %v), want (%q, %v)", tt.args, gotCmd, gotArgs, tt.wantCmd, tt.wantArgs)
 			}
 		})
 	}
@@ -383,6 +426,9 @@ func TestParseSwapArgs(t *testing.T) {
 		{name: "pair", args: []string{"pane-1", "pane-2"}, wantCmd: "swap", wantArgs: []string{"pane-1", "pane-2"}},
 		{name: "tree", args: []string{"pane-1", "pane-2", "--tree"}, wantCmd: "swap-tree", wantArgs: []string{"pane-1", "pane-2"}},
 		{name: "missing args", args: nil, wantErr: swapUsage},
+		{name: "duplicate tree flag", args: []string{"pane-1", "--tree", "--tree", "pane-2"}, wantErr: swapUsage},
+		{name: "tree needs two panes", args: []string{"pane-1", "--tree"}, wantErr: swapUsage},
+		{name: "too many panes without tree", args: []string{"pane-1", "pane-2", "pane-3"}, wantErr: swapUsage},
 	}
 
 	for _, tt := range tests {

--- a/internal/client/attach.go
+++ b/internal/client/attach.go
@@ -969,10 +969,7 @@ func runSessionWithDeps(sessionName string, getTermSize func(int) (int, int, err
 			if localInput && !localActivity {
 				for _, decoded := range decodeInputEvents(raw) {
 					if uiEvent, handled := clientUIEventForDecodedInput(decoded); handled && uiEvent != "" {
-						if err := sendMessage(&proto.Message{
-							Type:    proto.MsgTypeUIEvent,
-							UIEvent: uiEvent,
-						}); err != nil {
+						if err := sendMessage(&proto.Message{Type: proto.MsgTypeUIEvent, UIEvent: uiEvent}); err != nil {
 							return
 						}
 					}
@@ -1045,10 +1042,7 @@ func runSessionWithDeps(sessionName string, getTermSize func(int) (int, int, err
 			dispatchDecoded := func(decoded decodedInputEvent) bool {
 				if uiEvent, handled := clientUIEventForDecodedInput(decoded); handled {
 					if uiEvent != "" {
-						if err := sendMessage(&proto.Message{
-							Type:    proto.MsgTypeUIEvent,
-							UIEvent: uiEvent,
-						}); err != nil {
+						if err := sendMessage(&proto.Message{Type: proto.MsgTypeUIEvent, UIEvent: uiEvent}); err != nil {
 							return true
 						}
 					}

--- a/internal/client/attach.go
+++ b/internal/client/attach.go
@@ -511,7 +511,9 @@ func runSessionWithDeps(sessionName string, getTermSize func(int) (int, int, err
 	defer restoreTerminal()
 
 	if initial := cr.Render(true); initial != "" {
-		io.WriteString(stdout, wrapSynchronizedFrame(initial))
+		if _, err := io.WriteString(stdout, wrapSynchronizedFrame(initial)); err != nil {
+			return err
+		}
 	}
 
 	// Resolve the current binary once so explicit reloads and server reload
@@ -519,6 +521,21 @@ func runSessionWithDeps(sessionName string, getTermSize func(int) (int, int, err
 	triggerReload := make(chan struct{}, 1)
 	execPath, _ := deps.resolveExecutable()
 	exitState := &sessionExitState{}
+	writeOutput := func(data string) error {
+		if data == "" {
+			return nil
+		}
+		_, err := io.WriteString(stdout, data)
+		return err
+	}
+	sendMessage := func(msg *proto.Message) error {
+		if err := sender.Send(msg); err != nil {
+			exitState.set(disconnectNoticeForReadError(err))
+			_ = conn.Close()
+			return err
+		}
+		return nil
+	}
 
 	// Channel for injecting keystrokes from type-keys (server → client).
 	type injectedInput struct {
@@ -569,7 +586,9 @@ func runSessionWithDeps(sessionName string, getTermSize func(int) (int, int, err
 				resp := callLocalRenderAction[*proto.Message](cr, msgCh, func(cr *ClientRenderer) localRenderResult {
 					return localRenderResult{value: cr.HandleCaptureRequest(msg.CmdArgs, msg.AgentStatus)}
 				})
-				sender.Send(resp)
+				if err := sendMessage(resp); err != nil {
+					return
+				}
 			case proto.MsgTypeTypeKeys:
 				select {
 				case injectCh <- injectedInput{data: msg.Input, paneID: msg.PaneID}:
@@ -591,7 +610,10 @@ func runSessionWithDeps(sessionName string, getTermSize func(int) (int, int, err
 	go func() {
 		defer close(done)
 		cr.RenderCoalesced(msgCh, func(data string) {
-			io.WriteString(stdout, data)
+			if err := writeOutput(data); err != nil {
+				exitState.set(fmt.Sprintf("detached: writing terminal output: %v", err))
+				_ = conn.Close()
+			}
 		})
 	}()
 
@@ -609,7 +631,7 @@ func runSessionWithDeps(sessionName string, getTermSize func(int) (int, int, err
 	}()
 	// Recheck once after the handler is live so startup-time size changes
 	// (common on mobile/SSH clients) are not lost before the first SIGWINCH.
-	cols, rows = syncTerminalSize(fd, cols, rows, cr, sender, getTermSize, msgCh)
+	_, _ = syncTerminalSize(fd, cols, rows, cr, sender, getTermSize, msgCh)
 
 	// Terminal → server: read input with mouse parsing + Ctrl-a prefix handling
 	go func() {
@@ -671,13 +693,17 @@ func runSessionWithDeps(sessionName string, getTermSize func(int) (int, int, err
 		execPrefixKey := func(b byte, forward *[]byte) bool {
 			showChooser := func(mode chooserMode) {
 				if !showChooserOnRenderLoop(cr, msgCh, mode) {
-					io.WriteString(stdout, "\a")
+					if err := writeOutput("\a"); err != nil {
+						return
+					}
 					return
 				}
 			}
 			showPrefixMessage := func(key byte) {
 				cr.ShowPrefixMessage(formatUnboundPrefixMessage(kb.Prefix, key))
-				io.WriteString(stdout, "\a")
+				if err := writeOutput("\a"); err != nil {
+					return
+				}
 				runLocalRenderAction(cr, msgCh, func(*ClientRenderer) localRenderResult { return overlayRenderNowResult() })
 			}
 			clearPrefixMessage := func() {
@@ -728,11 +754,11 @@ func runSessionWithDeps(sessionName string, getTermSize func(int) (int, int, err
 					})
 				case "display-panes":
 					if !toggleDisplayPanesOnRenderLoop(cr, msgCh) {
-						io.WriteString(stdout, "\a")
+						_ = writeOutput("\a")
 					}
 				case "help":
 					if !toggleHelpBarOnRenderLoop(cr, msgCh, kb) {
-						io.WriteString(stdout, "\a")
+						_ = writeOutput("\a")
 					}
 				case "choose-tree":
 					showChooser(chooserModeTree)
@@ -740,12 +766,12 @@ func runSessionWithDeps(sessionName string, getTermSize func(int) (int, int, err
 					showChooser(chooserModeWindow)
 				case "rename-window":
 					if !showWindowRenamePromptOnRenderLoop(cr, msgCh) {
-						io.WriteString(stdout, "\a")
+						_ = writeOutput("\a")
 					}
 				case "split":
 					handleSplitBinding(cr, sender, binding, stdout)
 				case "compat-bell":
-					io.WriteString(stdout, "\a")
+					_ = writeOutput("\a")
 				default:
 					// Generic server command
 					sender.Command(binding.Action, binding.Args)
@@ -943,10 +969,12 @@ func runSessionWithDeps(sessionName string, getTermSize func(int) (int, int, err
 			if localInput && !localActivity {
 				for _, decoded := range decodeInputEvents(raw) {
 					if uiEvent, handled := clientUIEventForDecodedInput(decoded); handled && uiEvent != "" {
-						sender.Send(&proto.Message{
+						if err := sendMessage(&proto.Message{
 							Type:    proto.MsgTypeUIEvent,
 							UIEvent: uiEvent,
-						})
+						}); err != nil {
+							return
+						}
 					}
 				}
 				continue
@@ -1017,10 +1045,12 @@ func runSessionWithDeps(sessionName string, getTermSize func(int) (int, int, err
 			dispatchDecoded := func(decoded decodedInputEvent) bool {
 				if uiEvent, handled := clientUIEventForDecodedInput(decoded); handled {
 					if uiEvent != "" {
-						sender.Send(&proto.Message{
+						if err := sendMessage(&proto.Message{
 							Type:    proto.MsgTypeUIEvent,
 							UIEvent: uiEvent,
-						})
+						}); err != nil {
+							return true
+						}
 					}
 					return false
 				}
@@ -1048,7 +1078,9 @@ func runSessionWithDeps(sessionName string, getTermSize func(int) (int, int, err
 				if cr.WindowRenamePromptActive() {
 					action := handleWindowRenamePromptInputOnRenderLoop(cr, msgCh, normalized)
 					if action.bell {
-						io.WriteString(stdout, "\a")
+						if err := writeOutput("\a"); err != nil {
+							return true
+						}
 					}
 					if action.command != "" {
 						sender.Command(action.command, action.args)
@@ -1111,7 +1143,9 @@ func runSessionWithDeps(sessionName string, getTermSize func(int) (int, int, err
 					continue
 				}
 				if result.action.bell {
-					io.WriteString(stdout, "\a")
+					if err := writeOutput("\a"); err != nil {
+						return
+					}
 				}
 				if result.action.command != "" {
 					sender.Command(result.action.command, result.action.args)
@@ -1227,9 +1261,11 @@ func handleSplitBinding(cr *ClientRenderer, sender *messageSender, binding confi
 		return
 	}
 	cr.ShowCommandError("cannot split: layout not ready yet")
-	io.WriteString(out, "\a")
+	if _, err := io.WriteString(out, "\a"); err != nil {
+		return
+	}
 	if data := cr.RenderDiff(); data != "" {
-		io.WriteString(out, data)
+		_, _ = io.WriteString(out, data)
 	}
 }
 

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -340,7 +340,7 @@ func TestClientRendererCaptureJSON(t *testing.T) {
 	}
 	out2 := cr.CaptureJSON(status)
 	var capture2 proto.CaptureJSON
-	json.Unmarshal([]byte(out2), &capture2)
+	mustUnmarshalJSON(t, []byte(out2), &capture2)
 
 	for _, p := range capture2.Panes {
 		if p.Name == "pane-1" && !p.Idle {

--- a/internal/client/help_bar.go
+++ b/internal/client/help_bar.go
@@ -389,10 +389,6 @@ func (cr *ClientRenderer) HideHelpBar() bool {
 	return changed
 }
 
-func (cr *ClientRenderer) helpBar() *helpBarState {
-	return cr.loadState().ui.helpBar
-}
-
 func toggleHelpBarOnRenderLoop(cr *ClientRenderer, msgCh chan<- *RenderMsg, kb *config.Keybindings) bool {
 	return callLocalRenderAction[bool](cr, msgCh, func(cr *ClientRenderer) localRenderResult {
 		if cr.HelpBarActive() {

--- a/internal/client/lint_test_helpers_test.go
+++ b/internal/client/lint_test_helpers_test.go
@@ -1,0 +1,20 @@
+package client
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func mustUnmarshalJSON(tb testing.TB, data []byte, target any) {
+	tb.Helper()
+	if err := json.Unmarshal(data, target); err != nil {
+		tb.Fatalf("Unmarshal() error = %v", err)
+	}
+}
+
+func mustWrite(tb testing.TB, writer interface{ Write([]byte) (int, error) }, data []byte) {
+	tb.Helper()
+	if _, err := writer.Write(data); err != nil {
+		tb.Fatalf("Write() error = %v", err)
+	}
+}

--- a/internal/client/panedata_test.go
+++ b/internal/client/panedata_test.go
@@ -257,7 +257,7 @@ func TestPaneDataRenderScreenInCopyModeAppliesOverlayAndPreservesBaseStyle(t *te
 	rendered := pane.RenderScreen(true)
 
 	term := vt.NewSafeEmulator(5, 1)
-	term.Write([]byte(rendered))
+	mustWrite(t, term, []byte(rendered))
 	cell := term.CellAt(1, 0)
 	if cell == nil {
 		t.Fatal("CellAt(1, 0) = nil, want styled cell")
@@ -295,7 +295,7 @@ func TestPaneDataRenderScreenInCopyModeResetsTrailingStyle(t *testing.T) {
 	rendered := pane.RenderScreen(true)
 
 	term := vt.NewSafeEmulator(2, 1)
-	term.Write([]byte(rendered + "X"))
+	mustWrite(t, term, []byte(rendered+"X"))
 	trailing := term.CellAt(1, 0)
 	if trailing == nil {
 		t.Fatal("CellAt(1, 0) = nil, want trailing cell")

--- a/internal/mux/emulator_bench_test.go
+++ b/internal/mux/emulator_bench_test.go
@@ -41,7 +41,7 @@ func BenchmarkEmulatorWrite(b *testing.B) {
 			b.ReportAllocs()
 			b.ResetTimer()
 			for b.Loop() {
-				emu.Write(payload)
+				mustWrite(b, emu, payload)
 			}
 		})
 	}
@@ -52,7 +52,7 @@ func BenchmarkEmulatorRender(b *testing.B) {
 
 	// Write realistic 80x24 content once in setup
 	payload := realisticTerminalPayload(80 * 24)
-	emu.Write(payload)
+	mustWrite(b, emu, payload)
 
 	b.ReportAllocs()
 	b.ResetTimer()
@@ -64,7 +64,7 @@ func BenchmarkEmulatorRender(b *testing.B) {
 func BenchmarkEmulatorContentLines(b *testing.B) {
 	emu := NewVTEmulatorWithDrain(80, 24)
 	payload := realisticTerminalPayload(80 * 24)
-	emu.Write(payload)
+	mustWrite(b, emu, payload)
 
 	b.Run("Render+StripANSI", func(b *testing.B) {
 		b.ReportAllocs()
@@ -90,7 +90,7 @@ func BenchmarkEmulatorContentLines(b *testing.B) {
 func BenchmarkScreenContains(b *testing.B) {
 	emu := NewVTEmulatorWithDrain(80, 24)
 	payload := realisticTerminalPayload(80 * 24)
-	emu.Write(payload)
+	mustWrite(b, emu, payload)
 
 	// Search for a string that appears near the bottom of the screen
 	target := "README.md"

--- a/internal/mux/emulator_test.go
+++ b/internal/mux/emulator_test.go
@@ -12,7 +12,7 @@ import (
 func TestVTEmulatorWriteRender(t *testing.T) {
 	t.Parallel()
 	emu := NewVTEmulator(80, 24)
-	emu.Write([]byte("Hello, world!"))
+	mustWrite(t, emu, []byte("Hello, world!"))
 
 	rendered := emu.Render()
 	if !strings.Contains(rendered, "Hello, world!") {
@@ -146,7 +146,7 @@ func TestVTEmulatorCursorPosition(t *testing.T) {
 			t.Parallel()
 			emu := NewVTEmulator(80, 24)
 			if tt.input != "" {
-				emu.Write([]byte(tt.input))
+				mustWrite(t, emu, []byte(tt.input))
 			}
 			col, row := emu.CursorPosition()
 			if col != tt.wantCol || row != tt.wantRow {
@@ -159,7 +159,7 @@ func TestVTEmulatorCursorPosition(t *testing.T) {
 func TestRenderWithCursor(t *testing.T) {
 	t.Parallel()
 	emu := NewVTEmulator(80, 24)
-	emu.Write([]byte("test"))
+	mustWrite(t, emu, []byte("test"))
 
 	result := RenderWithCursor(emu)
 	if !strings.Contains(result, "\033[") {
@@ -171,7 +171,7 @@ func TestVTEmulatorClampsOversizedVerticalMargins(t *testing.T) {
 	t.Parallel()
 
 	emu := NewVTEmulatorWithDrain(10, 4)
-	emu.Write([]byte("\x1b[1;24r\x1b[H\x1bMok"))
+	mustWrite(t, emu, []byte("\x1b[1;24r\x1b[H\x1bMok"))
 
 	if !emu.ScreenContains("ok") {
 		t.Fatalf("ScreenContains(%q) = false\nrender:\n%s", "ok", emu.Render())
@@ -182,7 +182,7 @@ func TestVTEmulatorClampsOversizedHorizontalMargins(t *testing.T) {
 	t.Parallel()
 
 	emu := NewVTEmulatorWithDrain(5, 4)
-	emu.Write([]byte("\x1b[?69h\x1b[1;24s\x1b[H\x1b[@x"))
+	mustWrite(t, emu, []byte("\x1b[?69h\x1b[1;24s\x1b[H\x1b[@x"))
 
 	if !emu.ScreenContains("x") {
 		t.Fatalf("ScreenContains(%q) = false\nrender:\n%s", "x", emu.Render())
@@ -207,11 +207,11 @@ func TestRenderWithCursorRoundTrip(t *testing.T) {
 	w, h := 44, 20
 	emu1 := NewVTEmulatorWithDrain(w, h)
 	for i, line := range content {
-		emu1.Write([]byte(fmt.Sprintf("\033[%d;1H%s", i+1, line)))
+		mustWrite(t, emu1, []byte(fmt.Sprintf("\033[%d;1H%s", i+1, line)))
 	}
 
 	emu2 := NewVTEmulatorWithDrain(w, h)
-	emu2.Write([]byte(RenderWithCursor(emu1)))
+	mustWrite(t, emu2, []byte(RenderWithCursor(emu1)))
 
 	lines1 := strings.Split(emu1.Render(), "\n")
 	lines2 := strings.Split(emu2.Render(), "\n")
@@ -229,11 +229,11 @@ func TestRenderWithCursorRoundTripPreservesHiddenCursor(t *testing.T) {
 	t.Parallel()
 
 	emu1 := NewVTEmulatorWithDrain(40, 10)
-	emu1.Write([]byte("\x1b[?25l"))
-	emu1.Write([]byte("\x1b[?1049h"))
+	mustWrite(t, emu1, []byte("\x1b[?25l"))
+	mustWrite(t, emu1, []byte("\x1b[?1049h"))
 
 	emu2 := NewVTEmulatorWithDrain(40, 10)
-	emu2.Write([]byte(RenderWithCursor(emu1)))
+	mustWrite(t, emu2, []byte(RenderWithCursor(emu1)))
 
 	if !emu1.IsAltScreen() {
 		t.Fatal("source IsAltScreen() = false, want true")
@@ -253,10 +253,10 @@ func TestRenderWithCursorRoundTripPreservesMouseProtocol(t *testing.T) {
 	t.Parallel()
 
 	emu1 := NewVTEmulatorWithDrain(40, 10)
-	emu1.Write([]byte("\x1b[?1002h\x1b[?1006h"))
+	mustWrite(t, emu1, []byte("\x1b[?1002h\x1b[?1006h"))
 
 	emu2 := NewVTEmulatorWithDrain(40, 10)
-	emu2.Write([]byte(RenderWithCursor(emu1)))
+	mustWrite(t, emu2, []byte(RenderWithCursor(emu1)))
 
 	if got := emu1.MouseProtocol(); got.Tracking != MouseTrackingButton || !got.SGR {
 		t.Fatalf("source MouseProtocol() = %+v, want button+SGR", got)
@@ -273,7 +273,7 @@ func TestRenderWithoutCursorBlock(t *testing.T) {
 		t.Parallel()
 		emu := NewVTEmulator(40, 10)
 		// Write prompt, then a reverse-video space (simulating a block cursor)
-		emu.Write([]byte("hello \033[7m \033[m\033[1D"))
+		mustWrite(t, emu, []byte("hello \033[7m \033[m\033[1D"))
 
 		// Normal Render should contain reverse video
 		normal := emu.Render()
@@ -298,7 +298,7 @@ func TestRenderWithoutCursorBlock(t *testing.T) {
 		t.Parallel()
 		emu := NewVTEmulator(40, 10)
 		// Write a selection-like highlight (multiple reverse-video characters)
-		emu.Write([]byte("\033[7mselected\033[m"))
+		mustWrite(t, emu, []byte("\033[7mselected\033[m"))
 
 		stripped := emu.RenderWithoutCursorBlock()
 		if !strings.Contains(stripped, "\033[7m") {
@@ -309,7 +309,7 @@ func TestRenderWithoutCursorBlock(t *testing.T) {
 	t.Run("no-op when cursor cell has no reverse video", func(t *testing.T) {
 		t.Parallel()
 		emu := NewVTEmulator(40, 10)
-		emu.Write([]byte("hello"))
+		mustWrite(t, emu, []byte("hello"))
 
 		normal := emu.Render()
 		stripped := emu.RenderWithoutCursorBlock()
@@ -321,8 +321,8 @@ func TestRenderWithoutCursorBlock(t *testing.T) {
 	t.Run("preserves isolated reverse-video space away from cursor", func(t *testing.T) {
 		t.Parallel()
 		emu := NewVTEmulator(40, 10)
-		emu.Write([]byte("hello \033[7m \033[m"))
-		emu.Write([]byte("\033[1;1H"))
+		mustWrite(t, emu, []byte("hello \033[7m \033[m"))
+		mustWrite(t, emu, []byte("\033[1;1H"))
 
 		stripped := emu.RenderWithoutCursorBlock()
 		if !strings.Contains(stripped, "\033[7m") {
@@ -335,8 +335,8 @@ func TestVTEmulatorResetClearsScreenScrollbackAndModes(t *testing.T) {
 	t.Parallel()
 
 	emu := NewVTEmulatorWithDrainAndScrollback(10, 3, 4)
-	emu.Write([]byte("line-1\r\nline-2\r\nline-3\r\nline-4"))
-	emu.Write([]byte("\x1b[?1049h\x1b[?1002h\x1b[?1006h\x1b[?25l"))
+	mustWrite(t, emu, []byte("line-1\r\nline-2\r\nline-3\r\nline-4"))
+	mustWrite(t, emu, []byte("\x1b[?1049h\x1b[?1002h\x1b[?1006h\x1b[?25l"))
 
 	if !emu.IsAltScreen() {
 		t.Fatal("alternate screen should be enabled before reset")
@@ -379,7 +379,7 @@ func TestHasCursorBlock(t *testing.T) {
 	t.Run("true for isolated reverse-video space", func(t *testing.T) {
 		t.Parallel()
 		emu := NewVTEmulator(40, 10)
-		emu.Write([]byte("hello \033[7m \033[m\033[1D"))
+		mustWrite(t, emu, []byte("hello \033[7m \033[m\033[1D"))
 		if !emu.HasCursorBlock() {
 			t.Error("HasCursorBlock() = false, want true")
 		}
@@ -388,7 +388,7 @@ func TestHasCursorBlock(t *testing.T) {
 	t.Run("false for adjacent reverse-video content", func(t *testing.T) {
 		t.Parallel()
 		emu := NewVTEmulator(40, 10)
-		emu.Write([]byte("\033[7mselected\033[m"))
+		mustWrite(t, emu, []byte("\033[7mselected\033[m"))
 		if emu.HasCursorBlock() {
 			t.Error("HasCursorBlock() = true for multi-char reverse video, want false")
 		}
@@ -397,7 +397,7 @@ func TestHasCursorBlock(t *testing.T) {
 	t.Run("false when no reverse video", func(t *testing.T) {
 		t.Parallel()
 		emu := NewVTEmulator(40, 10)
-		emu.Write([]byte("hello"))
+		mustWrite(t, emu, []byte("hello"))
 		if emu.HasCursorBlock() {
 			t.Error("HasCursorBlock() = true with no reverse video, want false")
 		}
@@ -406,8 +406,8 @@ func TestHasCursorBlock(t *testing.T) {
 	t.Run("false for isolated reverse-video space away from cursor", func(t *testing.T) {
 		t.Parallel()
 		emu := NewVTEmulator(40, 10)
-		emu.Write([]byte("hello \033[7m \033[m"))
-		emu.Write([]byte("\033[1;1H"))
+		mustWrite(t, emu, []byte("hello \033[7m \033[m"))
+		mustWrite(t, emu, []byte("\033[1;1H"))
 		if emu.HasCursorBlock() {
 			t.Error("HasCursorBlock() = true for off-cursor reverse video, want false")
 		}
@@ -416,8 +416,8 @@ func TestHasCursorBlock(t *testing.T) {
 	t.Run("true for isolated reverse-video space above lower-left reported cursor", func(t *testing.T) {
 		t.Parallel()
 		emu := NewVTEmulator(40, 10)
-		emu.Write([]byte("hello \033[7m \033[m"))
-		emu.Write([]byte("\033[2;1H"))
+		mustWrite(t, emu, []byte("hello \033[7m \033[m"))
+		mustWrite(t, emu, []byte("\033[2;1H"))
 		if !emu.HasCursorBlock() {
 			t.Error("HasCursorBlock() = false with fallback cursor block, want true")
 		}
@@ -428,8 +428,8 @@ func TestRenderWithoutCursorBlockFallsBackFromLowerLeftCursor(t *testing.T) {
 	t.Parallel()
 
 	emu := NewVTEmulator(40, 10)
-	emu.Write([]byte("hello \033[7m \033[m"))
-	emu.Write([]byte("\033[2;1H"))
+	mustWrite(t, emu, []byte("hello \033[7m \033[m"))
+	mustWrite(t, emu, []byte("\033[2;1H"))
 
 	stripped := emu.RenderWithoutCursorBlock()
 	if strings.Contains(stripped, "\033[7m") {
@@ -453,7 +453,7 @@ func TestMouseProtocolTracking(t *testing.T) {
 		t.Fatal("alternate screen should start disabled")
 	}
 
-	emu.Write([]byte("\x1b[?1049h\x1b[?1000h\x1b[?1006h"))
+	mustWrite(t, emu, []byte("\x1b[?1049h\x1b[?1000h\x1b[?1006h"))
 	got := emu.MouseProtocol()
 	if !emu.IsAltScreen() {
 		t.Fatal("expected alternate screen to be enabled")
@@ -462,19 +462,19 @@ func TestMouseProtocolTracking(t *testing.T) {
 		t.Fatalf("MouseProtocol = %+v, want standard+SGR", got)
 	}
 
-	emu.Write([]byte("\x1b[?1000l\x1b[?1002h"))
+	mustWrite(t, emu, []byte("\x1b[?1000l\x1b[?1002h"))
 	got = emu.MouseProtocol()
 	if got.Tracking != MouseTrackingButton || !got.SGR {
 		t.Fatalf("MouseProtocol after 1002h = %+v, want button+SGR", got)
 	}
 
-	emu.Write([]byte("\x1b[?1003h"))
+	mustWrite(t, emu, []byte("\x1b[?1003h"))
 	got = emu.MouseProtocol()
 	if got.Tracking != MouseTrackingAny {
 		t.Fatalf("MouseProtocol after 1003h = %+v, want any", got)
 	}
 
-	emu.Write([]byte("\x1b[?1003l\x1b[?1002l\x1b[?1006l\x1b[?1049l"))
+	mustWrite(t, emu, []byte("\x1b[?1003l\x1b[?1002l\x1b[?1006l\x1b[?1049l"))
 	got = emu.MouseProtocol()
 	if got.Enabled() || got.SGR {
 		t.Fatalf("MouseProtocol after reset = %+v, want disabled", got)
@@ -493,13 +493,13 @@ func TestEncodeMouse(t *testing.T) {
 		t.Fatalf("EncodeMouse without mode = %q, want nil", got)
 	}
 
-	emu.Write([]byte("\x1b[?1002h\x1b[?1006h"))
+	mustWrite(t, emu, []byte("\x1b[?1002h\x1b[?1006h"))
 	got := string(emu.EncodeMouse(ev, 4, 6))
 	if got != "\x1b[<64;5;7M" {
 		t.Fatalf("EncodeMouse SGR = %q, want %q", got, "\x1b[<64;5;7M")
 	}
 
-	emu.Write([]byte("\x1b[?1006l"))
+	mustWrite(t, emu, []byte("\x1b[?1006l"))
 	got = string(emu.EncodeMouse(ev, 4, 6))
 	if got != "\x1b[M`%'" {
 		t.Fatalf("EncodeMouse X10 = %q, want %q", got, "\x1b[M`%'")
@@ -525,7 +525,7 @@ func TestScreenLineText(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			emu := NewVTEmulatorWithDrain(80, 24)
-			emu.Write([]byte(tt.input))
+			mustWrite(t, emu, []byte(tt.input))
 			got := emu.ScreenLineText(tt.row)
 			if got != tt.want {
 				t.Errorf("ScreenLineText(%d) = %q, want %q", tt.row, got, tt.want)
@@ -538,7 +538,7 @@ func TestScreenLineTextWideChars(t *testing.T) {
 	t.Parallel()
 	emu := NewVTEmulatorWithDrain(80, 24)
 	// CJK character "中" is width 2, occupies 2 cells
-	emu.Write([]byte("A中B"))
+	mustWrite(t, emu, []byte("A中B"))
 	got := emu.ScreenLineText(0)
 	if got != "A中B" {
 		t.Errorf("ScreenLineText(0) = %q, want %q", got, "A中B")
@@ -589,7 +589,7 @@ func TestScreenLineTextGraphemeClusters(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			emu := NewVTEmulatorWithDrain(20, 5)
-			emu.Write(tt.input)
+			mustWrite(t, emu, tt.input)
 
 			if got := emu.ScreenLineText(0); got != tt.wantLine {
 				t.Fatalf("ScreenLineText(0) = %q, want %q", got, tt.wantLine)
@@ -620,7 +620,7 @@ func TestScreenLineTextGraphemeClusters(t *testing.T) {
 func TestScreenLineTextTrailingSpaces(t *testing.T) {
 	t.Parallel()
 	emu := NewVTEmulatorWithDrain(80, 24)
-	emu.Write([]byte("hello"))
+	mustWrite(t, emu, []byte("hello"))
 	got := emu.ScreenLineText(0)
 	// Should not have trailing spaces (the remaining 75 columns)
 	if got != "hello" {
@@ -679,7 +679,7 @@ func TestScreenContains(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			emu := NewVTEmulatorWithDrain(80, 24)
-			emu.Write([]byte(tt.input))
+			mustWrite(t, emu, []byte(tt.input))
 			got := emu.ScreenContains(tt.substr)
 			if got != tt.want {
 				t.Errorf("ScreenContains(%q) = %v, want %v", tt.substr, got, tt.want)
@@ -691,7 +691,7 @@ func TestScreenContains(t *testing.T) {
 func TestScreenContainsMultiRow(t *testing.T) {
 	t.Parallel()
 	emu := NewVTEmulatorWithDrain(80, 24)
-	emu.Write([]byte("first line\r\nsecond line\r\nthird line"))
+	mustWrite(t, emu, []byte("first line\r\nsecond line\r\nthird line"))
 
 	if !emu.ScreenContains("second") {
 		t.Error("ScreenContains(\"second\") = false, want true")
@@ -710,7 +710,7 @@ func TestScreenContainsSoftWrap(t *testing.T) {
 	// soft-wraps at column 20, splitting the text across two screen rows.
 	// ScreenContains should still find the full substring.
 	emu := NewVTEmulatorWithDrain(20, 5)
-	emu.Write([]byte("cannot attach recursive nesting"))
+	mustWrite(t, emu, []byte("cannot attach recursive nesting"))
 
 	if !emu.ScreenContains("recursive nesting") {
 		t.Error("ScreenContains should match across soft-wrapped lines")
@@ -739,7 +739,7 @@ func TestCursorHidden(t *testing.T) {
 	t.Run("hidden after hide sequence", func(t *testing.T) {
 		t.Parallel()
 		emu := NewVTEmulator(80, 24)
-		emu.Write([]byte("\033[?25l")) // hide cursor
+		mustWrite(t, emu, []byte("\033[?25l")) // hide cursor
 		if !emu.CursorHidden() {
 			t.Error("CursorHidden() = false after \\033[?25l, want true")
 		}
@@ -748,8 +748,8 @@ func TestCursorHidden(t *testing.T) {
 	t.Run("visible after show sequence", func(t *testing.T) {
 		t.Parallel()
 		emu := NewVTEmulator(80, 24)
-		emu.Write([]byte("\033[?25l")) // hide
-		emu.Write([]byte("\033[?25h")) // show
+		mustWrite(t, emu, []byte("\033[?25l")) // hide
+		mustWrite(t, emu, []byte("\033[?25h")) // show
 		if emu.CursorHidden() {
 			t.Error("CursorHidden() = true after \\033[?25h, want false")
 		}

--- a/internal/mux/layout.go
+++ b/internal/mux/layout.go
@@ -195,8 +195,6 @@ func (c *LayoutCell) Close() *LayoutCell {
 		if parent.Parent != nil {
 			pidx := parent.IndexInParent()
 			parent.Parent.Children[pidx] = only
-		} else {
-			// only becomes the new root — caller must update window.Root
 		}
 		return only
 	}

--- a/internal/mux/layout_bench_test.go
+++ b/internal/mux/layout_bench_test.go
@@ -22,7 +22,9 @@ func benchTree(n int) *LayoutCell {
 		if i%2 == 0 {
 			dir = SplitHorizontal
 		}
-		target.Split(dir, fakePaneID(uint32(i)))
+		if _, err := target.Split(dir, fakePaneID(uint32(i))); err != nil {
+			panic(err)
+		}
 	}
 	root.FixOffsets()
 	return root
@@ -45,7 +47,9 @@ func BenchmarkSplit(b *testing.B) {
 					if i%2 == 0 {
 						dir = SplitHorizontal
 					}
-					target.Split(dir, fakePaneID(uint32(i)))
+					if _, err := target.Split(dir, fakePaneID(uint32(i))); err != nil {
+						b.Fatal(err)
+					}
 				}
 			}
 		})
@@ -100,11 +104,15 @@ func flatHTree(n int) *LayoutCell {
 	root := NewLeaf(fakePaneID(1), 0, 0, 800, 240)
 	// First split creates Case B (root has no parent), establishing the internal node
 	if n >= 2 {
-		root.Split(SplitVertical, fakePaneID(2))
+		if _, err := root.Split(SplitVertical, fakePaneID(2)); err != nil {
+			panic(err)
+		}
 	}
 	// Subsequent splits use Case A (same-direction sibling insertion)
 	for i := 3; i <= n; i++ {
-		root.Children[0].Split(SplitVertical, fakePaneID(uint32(i)))
+		if _, err := root.Children[0].Split(SplitVertical, fakePaneID(uint32(i))); err != nil {
+			panic(err)
+		}
 	}
 	root.FixOffsets()
 	return root

--- a/internal/mux/layout_test.go
+++ b/internal/mux/layout_test.go
@@ -185,7 +185,7 @@ func TestSplitSiblingInsertion(t *testing.T) {
 	root := NewLeaf(p1, 0, 0, 80, 24)
 
 	p2 := fakePaneID(2)
-	root.Split(SplitVertical, p2)
+	mustSplitCell(t, root, SplitVertical, p2)
 
 	// Now split the left child (which has W=39) vertically
 	left := root.Children[0]
@@ -218,7 +218,7 @@ func TestSplitSiblingEqualRedistribution(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			root := NewLeaf(fakePaneID(1), 0, 0, tt.w, tt.h)
-			root.Split(tt.dir, fakePaneID(2))
+			mustSplitCell(t, root, tt.dir, fakePaneID(2))
 
 			size := func(c *LayoutCell) int {
 				if tt.dir == SplitVertical {
@@ -228,7 +228,7 @@ func TestSplitSiblingEqualRedistribution(t *testing.T) {
 			}
 
 			// Split child0 again in the same direction (Case A)
-			root.Children[0].Split(tt.dir, fakePaneID(3))
+			mustSplitCell(t, root.Children[0], tt.dir, fakePaneID(3))
 
 			// All 3 siblings should have approximately equal sizes
 			if len(root.Children) != 3 {
@@ -261,7 +261,7 @@ func TestClosePane(t *testing.T) {
 	root := NewLeaf(p1, 0, 0, 80, 24)
 
 	p2 := fakePaneID(2)
-	root.Split(SplitVertical, p2)
+	mustSplitCell(t, root, SplitVertical, p2)
 
 	right := root.Children[1]
 	rightW := right.W
@@ -286,7 +286,7 @@ func TestCloseCollapsesSingleChild(t *testing.T) {
 	root := NewLeaf(p1, 0, 0, 80, 24)
 
 	p2 := fakePaneID(2)
-	root.Split(SplitVertical, p2)
+	mustSplitCell(t, root, SplitVertical, p2)
 
 	// Close right pane — parent should collapse, left becomes new root-level cell
 	right := root.Children[1]
@@ -311,7 +311,7 @@ func TestFixOffsets(t *testing.T) {
 	root := NewLeaf(p1, 0, 0, 80, 24)
 
 	p2 := fakePaneID(2)
-	root.Split(SplitVertical, p2)
+	mustSplitCell(t, root, SplitVertical, p2)
 
 	// Manually mess up offsets
 	root.Children[0].X = 999
@@ -339,7 +339,7 @@ func TestResizeAll(t *testing.T) {
 	root := NewLeaf(p1, 0, 0, 80, 24)
 
 	p2 := fakePaneID(2)
-	root.Split(SplitVertical, p2)
+	mustSplitCell(t, root, SplitVertical, p2)
 
 	// Resize to 120x40
 	root.ResizeAll(120, 40)
@@ -613,10 +613,10 @@ func TestWalkAndFindPane(t *testing.T) {
 	root := NewLeaf(p1, 0, 0, 80, 24)
 
 	p2 := fakePaneID(2)
-	root.Split(SplitVertical, p2)
+	mustSplitCell(t, root, SplitVertical, p2)
 
 	p3 := fakePaneID(3)
-	root.Children[1].Split(SplitHorizontal, p3)
+	mustSplitCell(t, root.Children[1], SplitHorizontal, p3)
 
 	// Walk should find 3 leaves
 	count := 0
@@ -643,7 +643,7 @@ func TestFindLeafAt(t *testing.T) {
 	p1 := fakePaneID(1)
 	root := NewLeaf(p1, 0, 0, 80, 24)
 	p2 := fakePaneID(2)
-	root.Split(SplitVertical, p2)
+	mustSplitCell(t, root, SplitVertical, p2)
 	root.FixOffsets()
 
 	tests := []struct {
@@ -689,7 +689,7 @@ func TestFindLeafAtVerticalSplit(t *testing.T) {
 	p1 := fakePaneID(1)
 	root := NewLeaf(p1, 0, 0, 80, 25)
 	p2 := fakePaneID(2)
-	root.Split(SplitHorizontal, p2)
+	mustSplitCell(t, root, SplitHorizontal, p2)
 	root.FixOffsets()
 
 	top := root.Children[0]
@@ -721,7 +721,7 @@ func TestFindBorderAt(t *testing.T) {
 	p1 := fakePaneID(1)
 	root := NewLeaf(p1, 0, 0, 80, 24)
 	p2 := fakePaneID(2)
-	root.Split(SplitVertical, p2)
+	mustSplitCell(t, root, SplitVertical, p2)
 	root.FixOffsets()
 
 	borderX := root.Children[0].W
@@ -748,11 +748,11 @@ func TestFindBorderAtNested(t *testing.T) {
 	p1 := fakePaneID(1)
 	root := NewLeaf(p1, 0, 0, 81, 25)
 	p2 := fakePaneID(2)
-	root.Split(SplitVertical, p2)
+	mustSplitCell(t, root, SplitVertical, p2)
 	p3 := fakePaneID(3)
-	root.Children[0].Split(SplitHorizontal, p3)
+	mustSplitCell(t, root.Children[0], SplitHorizontal, p3)
 	p4 := fakePaneID(4)
-	root.Children[1].Split(SplitHorizontal, p4)
+	mustSplitCell(t, root.Children[1], SplitHorizontal, p4)
 	root.FixOffsets()
 
 	// Vertical border between left and right halves
@@ -807,13 +807,13 @@ func TestNestedSplits(t *testing.T) {
 	root := NewLeaf(p1, 0, 0, 81, 25)
 
 	p2 := fakePaneID(2)
-	root.Split(SplitVertical, p2)
+	mustSplitCell(t, root, SplitVertical, p2)
 
 	p3 := fakePaneID(3)
-	root.Children[0].Split(SplitHorizontal, p3)
+	mustSplitCell(t, root.Children[0], SplitHorizontal, p3)
 
 	p4 := fakePaneID(4)
-	root.Children[1].Split(SplitHorizontal, p4)
+	mustSplitCell(t, root.Children[1], SplitHorizontal, p4)
 
 	root.FixOffsets()
 

--- a/internal/mux/lead.go
+++ b/internal/mux/lead.go
@@ -21,7 +21,9 @@ func (w *Window) SetLead(paneID uint32) error {
 	}
 
 	if w.ZoomedPaneID != 0 {
-		w.Unzoom()
+		if err := w.Unzoom(); err != nil {
+			return err
+		}
 	}
 
 	cell := w.Root.FindPane(paneID)

--- a/internal/mux/lint_coverage_test.go
+++ b/internal/mux/lint_coverage_test.go
@@ -120,6 +120,35 @@ func TestWindowOperationsPropagateResizeFailures(t *testing.T) {
 			}
 		})
 
+		t.Run("move pane between root groups with nested source group", func(t *testing.T) {
+			p1, p2, p3 := fakePaneID(1), fakePaneID(2), fakePaneID(3)
+			w := NewWindow(p1, 120, 24)
+			mustSplitRootPane(t, w, SplitVertical, p2)
+			mustSplitPane(t, w, p1.ID, SplitHorizontal, p3)
+			if err := w.Zoom(p2.ID); err != nil {
+				t.Fatalf("Zoom(%d): %v", p2.ID, err)
+			}
+			markPaneResizeError(t, p2)
+
+			if err := w.MovePane(p1.ID, p2.ID, true); err == nil {
+				t.Fatal("MovePane() error = nil, want resize failure while unzooming")
+			}
+		})
+
+		t.Run("move pane into split unzooms first", func(t *testing.T) {
+			p1, p2 := fakePaneID(1), fakePaneID(2)
+			w := NewWindow(p1, 80, 24)
+			mustSplitRootPane(t, w, SplitVertical, p2)
+			if err := w.Zoom(p2.ID); err != nil {
+				t.Fatalf("Zoom(%d): %v", p2.ID, err)
+			}
+			markPaneResizeError(t, p2)
+
+			if err := w.MovePaneIntoSplit(p1.ID, p2.ID, SplitHorizontal, true); err == nil {
+				t.Fatal("MovePaneIntoSplit() error = nil, want resize failure while unzooming")
+			}
+		})
+
 		t.Run("move pane within split group", func(t *testing.T) {
 			p1, p2, p3 := fakePaneID(1), fakePaneID(2), fakePaneID(3)
 			w := NewWindow(p1, 120, 24)
@@ -221,6 +250,20 @@ func TestWindowOperationsPropagateResizeFailures(t *testing.T) {
 			}
 		})
 
+		t.Run("zoom replaces existing zoom only after successful unzoom", func(t *testing.T) {
+			p1, p2 := fakePaneID(1), fakePaneID(2)
+			w := NewWindow(p1, 80, 24)
+			mustSplitRootPane(t, w, SplitVertical, p2)
+			if err := w.Zoom(p2.ID); err != nil {
+				t.Fatalf("Zoom(%d): %v", p2.ID, err)
+			}
+			markPaneResizeError(t, p2)
+
+			if err := w.Zoom(p1.ID); err == nil {
+				t.Fatal("Zoom() error = nil, want resize failure while clearing prior zoom")
+			}
+		})
+
 		t.Run("splice pane single", func(t *testing.T) {
 			p1 := fakePaneID(1)
 			w := NewWindow(p1, 80, 24)
@@ -261,22 +304,37 @@ func TestWindowNoOpPathsOnUnzoomFailure(t *testing.T) {
 	t.Parallel()
 
 	t.Run("focus operations keep active pane", func(t *testing.T) {
-		p1, p2 := fakePaneID(1), fakePaneID(2)
-		w := NewWindow(p1, 80, 24)
-		mustSplitRootPane(t, w, SplitVertical, p2)
-		markPaneResizeError(t, p2)
-		w.ZoomedPaneID = p2.ID
-		before := w.ActivePane
+		t.Run("directional focus", func(t *testing.T) {
+			p1, p2 := fakePaneID(1), fakePaneID(2)
+			w := NewWindow(p1, 80, 24)
+			mustSplitRootPane(t, w, SplitVertical, p2)
+			if err := w.Zoom(p2.ID); err != nil {
+				t.Fatalf("Zoom(%d): %v", p2.ID, err)
+			}
+			markPaneResizeError(t, p2)
+			before := w.ActivePane
 
-		w.Focus("right")
-		if w.ActivePane != before {
-			t.Fatalf("Focus() active pane = %v, want unchanged %v", w.ActivePane, before)
-		}
+			w.Focus("right")
+			if w.ActivePane != before {
+				t.Fatalf("Focus() active pane = %v, want unchanged %v", w.ActivePane, before)
+			}
+		})
 
-		w.FocusPane(p2)
-		if w.ActivePane != before {
-			t.Fatalf("FocusPane() active pane = %v, want unchanged %v", w.ActivePane, before)
-		}
+		t.Run("direct focus", func(t *testing.T) {
+			p1, p2 := fakePaneID(1), fakePaneID(2)
+			w := NewWindow(p1, 80, 24)
+			mustSplitRootPane(t, w, SplitVertical, p2)
+			if err := w.Zoom(p2.ID); err != nil {
+				t.Fatalf("Zoom(%d): %v", p2.ID, err)
+			}
+			markPaneResizeError(t, p2)
+			before := w.ActivePane
+
+			w.FocusPane(p1)
+			if w.ActivePane != before {
+				t.Fatalf("FocusPane() active pane = %v, want unchanged %v", w.ActivePane, before)
+			}
+		})
 	})
 
 	t.Run("resize returns false", func(t *testing.T) {

--- a/internal/mux/lint_coverage_test.go
+++ b/internal/mux/lint_coverage_test.go
@@ -1,0 +1,305 @@
+package mux
+
+import (
+	"os"
+	"testing"
+)
+
+func markPaneResizeError(t *testing.T, pane *Pane) {
+	t.Helper()
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("Pipe(): %v", err)
+	}
+	_ = w.Close()
+	_ = r.Close()
+	pane.ptmx = r
+}
+
+func mustSplitRootPane(t *testing.T, w *Window, dir SplitDir, pane *Pane) {
+	t.Helper()
+	if _, err := w.SplitRoot(dir, pane); err != nil {
+		t.Fatalf("SplitRoot(%v): %v", dir, err)
+	}
+}
+
+func mustSplitPane(t *testing.T, w *Window, paneID uint32, dir SplitDir, pane *Pane) {
+	t.Helper()
+	if _, err := w.SplitPaneWithOptions(paneID, dir, pane, SplitOptions{}); err != nil {
+		t.Fatalf("SplitPaneWithOptions(%d, %v): %v", paneID, dir, err)
+	}
+}
+
+func TestMarkPaneResizeErrorCausesPaneResizeFailure(t *testing.T) {
+	t.Parallel()
+
+	p := fakePaneID(1)
+	markPaneResizeError(t, p)
+
+	if err := p.Resize(10, 5); err == nil {
+		t.Fatal("Resize() error = nil, want bad file descriptor")
+	}
+}
+
+func TestWindowOperationsPropagateResizeFailures(t *testing.T) {
+	t.Parallel()
+
+	t.Run("unzoomed mutations surface resize errors", func(t *testing.T) {
+		t.Run("split root with options", func(t *testing.T) {
+			p1, p2 := fakePaneID(1), fakePaneID(2)
+			w := NewWindow(p1, 80, 24)
+			mustSplitRootPane(t, w, SplitVertical, p2)
+			markPaneResizeError(t, p2)
+			w.ZoomedPaneID = p2.ID
+
+			if _, err := w.SplitRootWithOptions(SplitVertical, fakePaneID(3), SplitOptions{}); err == nil {
+				t.Fatal("SplitRootWithOptions() error = nil, want resize failure")
+			}
+		})
+
+		t.Run("split pane with options", func(t *testing.T) {
+			p1, p2 := fakePaneID(1), fakePaneID(2)
+			w := NewWindow(p1, 80, 24)
+			mustSplitRootPane(t, w, SplitVertical, p2)
+			markPaneResizeError(t, p2)
+			w.ZoomedPaneID = p2.ID
+
+			if _, err := w.SplitPaneWithOptions(p1.ID, SplitHorizontal, fakePaneID(3), SplitOptions{}); err == nil {
+				t.Fatal("SplitPaneWithOptions() error = nil, want resize failure")
+			}
+		})
+
+		t.Run("set lead", func(t *testing.T) {
+			p1, p2 := fakePaneID(1), fakePaneID(2)
+			w := NewWindow(p1, 80, 24)
+			mustSplitRootPane(t, w, SplitVertical, p2)
+			markPaneResizeError(t, p2)
+			w.ZoomedPaneID = p2.ID
+
+			if err := w.SetLead(p1.ID); err == nil {
+				t.Fatal("SetLead() error = nil, want resize failure")
+			}
+		})
+
+		t.Run("move pane to root edge", func(t *testing.T) {
+			p1, p2 := fakePaneID(1), fakePaneID(2)
+			w := NewWindow(p1, 80, 24)
+			mustSplitRootPane(t, w, SplitVertical, p2)
+			markPaneResizeError(t, p2)
+			w.ZoomedPaneID = p2.ID
+
+			if err := w.MovePaneToRootEdge(p1.ID, SplitHorizontal, false); err == nil {
+				t.Fatal("MovePaneToRootEdge() error = nil, want resize failure")
+			}
+		})
+
+		t.Run("swap tree", func(t *testing.T) {
+			p1, p2, p3 := fakePaneID(1), fakePaneID(2), fakePaneID(3)
+			w := NewWindow(p1, 120, 24)
+			mustSplitRootPane(t, w, SplitVertical, p2)
+			mustSplitRootPane(t, w, SplitVertical, p3)
+			markPaneResizeError(t, p3)
+			w.ZoomedPaneID = p3.ID
+
+			if err := w.SwapTree(p1.ID, p2.ID); err == nil {
+				t.Fatal("SwapTree() error = nil, want resize failure")
+			}
+		})
+
+		t.Run("move pane between root groups", func(t *testing.T) {
+			p1, p2, p3 := fakePaneID(1), fakePaneID(2), fakePaneID(3)
+			w := NewWindow(p1, 120, 24)
+			mustSplitRootPane(t, w, SplitVertical, p2)
+			mustSplitRootPane(t, w, SplitVertical, p3)
+			markPaneResizeError(t, p3)
+			w.ZoomedPaneID = p3.ID
+
+			if err := w.MovePane(p1.ID, p2.ID, true); err == nil {
+				t.Fatal("MovePane() error = nil, want resize failure")
+			}
+		})
+
+		t.Run("move pane within split group", func(t *testing.T) {
+			p1, p2, p3 := fakePaneID(1), fakePaneID(2), fakePaneID(3)
+			w := NewWindow(p1, 120, 24)
+			mustSplitRootPane(t, w, SplitVertical, p2)
+			mustSplitPane(t, w, p2.ID, SplitHorizontal, p3)
+			markPaneResizeError(t, p3)
+			w.ZoomedPaneID = p3.ID
+
+			if err := w.MovePaneDown(p2.ID); err == nil {
+				t.Fatal("MovePaneDown() error = nil, want resize failure")
+			}
+		})
+
+		t.Run("move pane to column", func(t *testing.T) {
+			p1, p2, p3 := fakePaneID(1), fakePaneID(2), fakePaneID(3)
+			w := NewWindow(p1, 120, 24)
+			mustSplitRootPane(t, w, SplitVertical, p2)
+			mustSplitRootPane(t, w, SplitVertical, p3)
+			markPaneResizeError(t, p3)
+			w.ZoomedPaneID = p3.ID
+
+			if err := w.MovePaneToColumn(p1.ID, p2.ID); err == nil {
+				t.Fatal("MovePaneToColumn() error = nil, want resize failure")
+			}
+		})
+
+		t.Run("split subtree root with options", func(t *testing.T) {
+			p1, p2 := fakePaneID(1), fakePaneID(2)
+			w := NewWindow(p1, 80, 24)
+			mustSplitRootPane(t, w, SplitVertical, p2)
+			markPaneResizeError(t, p2)
+			w.ZoomedPaneID = p2.ID
+
+			if _, err := w.splitSubtreeRootWithOptions(w.Root, SplitHorizontal, fakePaneID(3), false, SplitOptions{}); err == nil {
+				t.Fatal("splitSubtreeRootWithOptions() error = nil, want resize failure")
+			}
+		})
+	})
+
+	t.Run("pane resize failures during mutations", func(t *testing.T) {
+		t.Run("split pane resizes new pane", func(t *testing.T) {
+			p1 := fakePaneID(1)
+			w := NewWindow(p1, 80, 24)
+			p2 := fakePaneID(2)
+			markPaneResizeError(t, p2)
+
+			if _, err := w.SplitPaneWithOptions(p1.ID, SplitVertical, p2, SplitOptions{}); err == nil {
+				t.Fatal("SplitPaneWithOptions() error = nil, want new-pane resize failure")
+			}
+		})
+
+		t.Run("split pane resizes existing pane", func(t *testing.T) {
+			p1 := fakePaneID(1)
+			w := NewWindow(p1, 80, 24)
+			markPaneResizeError(t, p1)
+
+			if _, err := w.SplitPaneWithOptions(p1.ID, SplitVertical, fakePaneID(2), SplitOptions{}); err == nil {
+				t.Fatal("SplitPaneWithOptions() error = nil, want existing-pane resize failure")
+			}
+		})
+
+		t.Run("move pane into split resizes moved pane", func(t *testing.T) {
+			p1, p2, p3 := fakePaneID(1), fakePaneID(2), fakePaneID(3)
+			w := NewWindow(p1, 120, 24)
+			mustSplitRootPane(t, w, SplitVertical, p2)
+			mustSplitRootPane(t, w, SplitVertical, p3)
+			markPaneResizeError(t, p2)
+
+			if err := w.MovePaneIntoSplit(p2.ID, p3.ID, SplitHorizontal, false); err == nil {
+				t.Fatal("MovePaneIntoSplit() error = nil, want moved-pane resize failure")
+			}
+		})
+
+		t.Run("move pane into split resizes existing target pane", func(t *testing.T) {
+			p1, p2, p3 := fakePaneID(1), fakePaneID(2), fakePaneID(3)
+			w := NewWindow(p1, 120, 24)
+			mustSplitRootPane(t, w, SplitVertical, p2)
+			mustSplitRootPane(t, w, SplitVertical, p3)
+			markPaneResizeError(t, p3)
+
+			if err := w.MovePaneIntoSplit(p2.ID, p3.ID, SplitHorizontal, false); err == nil {
+				t.Fatal("MovePaneIntoSplit() error = nil, want target-pane resize failure")
+			}
+		})
+
+		t.Run("zoom and unzoom", func(t *testing.T) {
+			p1, p2 := fakePaneID(1), fakePaneID(2)
+			w := NewWindow(p1, 80, 24)
+			mustSplitRootPane(t, w, SplitVertical, p2)
+			markPaneResizeError(t, p2)
+
+			if err := w.Zoom(p2.ID); err == nil {
+				t.Fatal("Zoom() error = nil, want resize failure")
+			}
+
+			w.ZoomedPaneID = p2.ID
+			if err := w.Unzoom(); err == nil {
+				t.Fatal("Unzoom() error = nil, want resize failure")
+			}
+		})
+
+		t.Run("splice pane single", func(t *testing.T) {
+			p1 := fakePaneID(1)
+			w := NewWindow(p1, 80, 24)
+			replacement := fakePaneID(2)
+			markPaneResizeError(t, replacement)
+			if _, err := w.SplicePane(p1.ID, []*Pane{replacement}); err == nil {
+				t.Fatal("SplicePane(single) error = nil, want resize failure")
+			}
+		})
+
+		t.Run("splice pane multi", func(t *testing.T) {
+			p1 := fakePaneID(1)
+			w := NewWindow(p1, 80, 24)
+			p3, p4 := fakePaneID(3), fakePaneID(4)
+			markPaneResizeError(t, p3)
+			if _, err := w.SplicePane(p1.ID, []*Pane{p3, p4}); err == nil {
+				t.Fatal("SplicePane(multi) error = nil, want resize failure")
+			}
+		})
+
+		t.Run("unsplice pane", func(t *testing.T) {
+			proxy := fakePaneID(1)
+			proxy.Meta.Host = "gpu-box"
+			proxy.writeOverride = func([]byte) (int, error) { return 0, nil }
+			w := NewWindow(proxy, 80, 24)
+
+			replacement := fakePaneID(2)
+			markPaneResizeError(t, replacement)
+
+			if err := w.UnsplicePane("gpu-box", replacement); err == nil {
+				t.Fatal("UnsplicePane() error = nil, want resize failure")
+			}
+		})
+	})
+}
+
+func TestWindowNoOpPathsOnUnzoomFailure(t *testing.T) {
+	t.Parallel()
+
+	t.Run("focus operations keep active pane", func(t *testing.T) {
+		p1, p2 := fakePaneID(1), fakePaneID(2)
+		w := NewWindow(p1, 80, 24)
+		mustSplitRootPane(t, w, SplitVertical, p2)
+		markPaneResizeError(t, p2)
+		w.ZoomedPaneID = p2.ID
+		before := w.ActivePane
+
+		w.Focus("right")
+		if w.ActivePane != before {
+			t.Fatalf("Focus() active pane = %v, want unchanged %v", w.ActivePane, before)
+		}
+
+		w.FocusPane(p2)
+		if w.ActivePane != before {
+			t.Fatalf("FocusPane() active pane = %v, want unchanged %v", w.ActivePane, before)
+		}
+	})
+
+	t.Run("resize returns false", func(t *testing.T) {
+		p1, p2 := fakePaneID(1), fakePaneID(2)
+		w := NewWindow(p1, 80, 24)
+		mustSplitRootPane(t, w, SplitVertical, p2)
+		markPaneResizeError(t, p2)
+		w.ZoomedPaneID = p2.ID
+
+		if got := w.ResizePane(p1.ID, "right", 3); got {
+			t.Fatal("ResizePane() = true, want false on unzoom failure")
+		}
+	})
+
+	t.Run("equalize returns false", func(t *testing.T) {
+		p1, p2 := fakePaneID(1), fakePaneID(2)
+		w := NewWindow(p1, 80, 24)
+		mustSplitRootPane(t, w, SplitVertical, p2)
+		markPaneResizeError(t, p2)
+		w.ZoomedPaneID = p2.ID
+
+		if got := w.Equalize(true, false); got {
+			t.Fatal("Equalize() = true, want false on unzoom failure")
+		}
+	})
+}

--- a/internal/mux/lint_test_helpers_test.go
+++ b/internal/mux/lint_test_helpers_test.go
@@ -1,0 +1,26 @@
+package mux
+
+import "testing"
+
+func mustWrite(tb testing.TB, writer interface{ Write([]byte) (int, error) }, data []byte) {
+	tb.Helper()
+	if _, err := writer.Write(data); err != nil {
+		tb.Fatalf("Write() error = %v", err)
+	}
+}
+
+func mustSplitCell(tb testing.TB, cell *LayoutCell, dir SplitDir, pane *Pane) *LayoutCell {
+	tb.Helper()
+	next, err := cell.Split(dir, pane)
+	if err != nil {
+		tb.Fatalf("Split() error = %v", err)
+	}
+	return next
+}
+
+func mustRotate(tb testing.TB, w *Window, forward bool) {
+	tb.Helper()
+	if err := w.RotatePanes(forward); err != nil {
+		tb.Fatalf("RotatePanes() error = %v", err)
+	}
+}

--- a/internal/mux/pane.go
+++ b/internal/mux/pane.go
@@ -696,17 +696,6 @@ func (p *Pane) resizePTY(cols, rows int) error {
 	})
 }
 
-// shellProcess returns the *os.Process for the pane's shell, or nil for proxy panes.
-func (p *Pane) shellProcess() *os.Process {
-	if p.cmd != nil {
-		return p.cmd.Process
-	}
-	if p.process != nil {
-		return p.process
-	}
-	return nil
-}
-
 func (p *Pane) ensureCloseDone() chan struct{} {
 	p.closeDoneOnce.Do(func() {
 		p.closeDone = make(chan struct{})
@@ -773,47 +762,6 @@ func (p *Pane) closeBlocking() error {
 		return state.emulator.Close()
 	}()
 	return errors.Join(ptmxErr, emuErr)
-}
-
-func (p *Pane) waitForProcessExit(proc *os.Process, timeout time.Duration) {
-	if proc == nil {
-		return
-	}
-	if p.waitLoopDone != nil {
-		select {
-		case <-p.exitDone:
-		case <-time.After(timeout):
-			_ = proc.Signal(syscall.SIGKILL)
-			<-p.exitDone
-		}
-		<-p.waitLoopDone
-		return
-	}
-	if p.cmd == nil {
-		select {
-		case <-p.exitDone:
-		case <-time.After(timeout):
-			_ = proc.Signal(syscall.SIGKILL)
-			<-p.exitDone
-		}
-		return
-	}
-
-	waitDone := make(chan struct{})
-	cmd := p.cmd
-	exitDone := p.exitDone
-	go func() {
-		_ = cmd.Wait()
-		close(exitDone)
-		close(waitDone)
-	}()
-
-	select {
-	case <-waitDone:
-	case <-time.After(timeout):
-		_ = proc.Signal(syscall.SIGKILL)
-		<-waitDone
-	}
 }
 
 // NewProxyPaneWithScrollback creates a proxy pane with an explicit retained

--- a/internal/mux/pane_emulator.go
+++ b/internal/mux/pane_emulator.go
@@ -39,7 +39,9 @@ func (p *Pane) drainResponses(emulator TerminalEmulator, ptmx *os.File, done cha
 	for {
 		n, err := emulator.Read(buf)
 		if n > 0 {
-			ptmx.Write(buf[:n])
+			if _, writeErr := ptmx.Write(buf[:n]); writeErr != nil {
+				return
+			}
 		}
 		if err != nil {
 			return

--- a/internal/mux/pane_signal_linux.go
+++ b/internal/mux/pane_signal_linux.go
@@ -3,8 +3,6 @@
 package mux
 
 import (
-	"fmt"
-
 	"golang.org/x/sys/unix"
 )
 
@@ -18,15 +16,4 @@ func (p *Pane) foregroundProcessGroup() (int, error) {
 		return 0, err
 	}
 	return pgrp, nil
-}
-
-func (p *Pane) ttyPath() (string, error) {
-	if p.ptmx == nil {
-		return "", nil
-	}
-	ttyNum, err := unix.IoctlGetInt(int(p.ptmx.Fd()), unix.TIOCGPTN)
-	if err != nil {
-		return "", err
-	}
-	return fmt.Sprintf("/dev/pts/%d", ttyNum), nil
 }

--- a/internal/mux/pane_test.go
+++ b/internal/mux/pane_test.go
@@ -25,7 +25,7 @@ func TestContentLines(t *testing.T) {
 	}
 
 	// Write two lines of content
-	emu.Write([]byte("hello world\r\nline two\r\n"))
+	mustWrite(t, emu, []byte("hello world\r\nline two\r\n"))
 
 	lines := p.ContentLines()
 
@@ -57,7 +57,7 @@ func TestContentLinesStripsANSI(t *testing.T) {
 	}
 
 	// Write colored text
-	emu.Write([]byte("\033[31mRED\033[m normal\r\n"))
+	mustWrite(t, emu, []byte("\033[31mRED\033[m normal\r\n"))
 
 	lines := p.ContentLines()
 
@@ -80,7 +80,7 @@ func TestCaptureSnapshotIncludesHistoryContentAndCursor(t *testing.T) {
 	}
 	p.SetRetainedHistory([]string{"base-1"})
 
-	emu.Write([]byte("line-1\r\nline-2\r\nline-3"))
+	mustWrite(t, emu, []byte("line-1\r\nline-2\r\nline-3"))
 
 	snap := p.CaptureSnapshot()
 
@@ -107,13 +107,13 @@ func TestTerminalSnapshotIncludesCursorAndMetadata(t *testing.T) {
 		emulator: emu,
 	}
 
-	emu.Write([]byte(
-		"\x1b]10;#112233\x07" +
-			"\x1b]11;#445566\x07" +
-			"\x1b]12;#778899\x07" +
-			"\x1b]8;;https://example.com\x07" +
-			"\x1b[6 q" +
-			"\x1b[?1049h" +
+	mustWrite(t, emu, []byte(
+		"\x1b]10;#112233\x07"+
+			"\x1b]11;#445566\x07"+
+			"\x1b]12;#778899\x07"+
+			"\x1b]8;;https://example.com\x07"+
+			"\x1b[6 q"+
+			"\x1b[?1049h"+
 			"prompt",
 	))
 
@@ -305,7 +305,7 @@ func TestCaptureSnapshotRespectsScrollbackLimit(t *testing.T) {
 	}
 	p.SetRetainedHistory([]string{"base-1", "base-2", "base-3"})
 
-	emu.Write([]byte("line-1\r\nline-2\r\nline-3"))
+	mustWrite(t, emu, []byte("line-1\r\nline-2\r\nline-3"))
 
 	snap := p.CaptureSnapshot()
 
@@ -326,7 +326,7 @@ func TestCaptureSnapshotIncludesCursorBlock(t *testing.T) {
 		emulator: emu,
 	}
 
-	emu.Write([]byte("\x1b[2J\x1b[H❯ \x1b[7m \x1b[m\x1b[?25l\x1b[2;1H"))
+	mustWrite(t, emu, []byte("\x1b[2J\x1b[H❯ \x1b[7m \x1b[m\x1b[?25l\x1b[2;1H"))
 
 	snap := p.CaptureSnapshot()
 	if !snap.HasCursorBlock {
@@ -354,9 +354,9 @@ func TestCaptureSnapshotTracksLiveScrollbackSourceWidthsAcrossResize(t *testing.
 	}
 	wireScrollbackCallbacks(p)
 
-	emu.Write([]byte("01234567890123456789\r\n"))
+	mustWrite(t, emu, []byte("01234567890123456789\r\n"))
 	emu.Resize(10, 1)
-	emu.Write([]byte("ABCDEFGHIJ\r\n"))
+	mustWrite(t, emu, []byte("ABCDEFGHIJ\r\n"))
 
 	snap := p.CaptureSnapshot()
 	if len(snap.LiveHistory) != 2 {
@@ -381,7 +381,7 @@ func TestPaneResetStateClearsRetainedAndLiveHistory(t *testing.T) {
 	}
 	p.SetRetainedHistory([]string{"base-1", "base-2"})
 
-	emu.Write([]byte("line-1\r\nline-2\r\nline-3"))
+	mustWrite(t, emu, []byte("line-1\r\nline-2\r\nline-3"))
 
 	before := p.CaptureSnapshot()
 	if len(before.History) == 0 {
@@ -426,11 +426,11 @@ func TestCaptureSnapshotTrimsLiveScrollbackWidthMetadataWithCap(t *testing.T) {
 	}
 	wireScrollbackCallbacks(p)
 
-	emu.Write([]byte("11111\r\n"))
+	mustWrite(t, emu, []byte("11111\r\n"))
 	emu.Resize(6, 1)
-	emu.Write([]byte("222222\r\n"))
+	mustWrite(t, emu, []byte("222222\r\n"))
 	emu.Resize(7, 1)
-	emu.Write([]byte("3333333\r\n"))
+	mustWrite(t, emu, []byte("3333333\r\n"))
 
 	snap := p.CaptureSnapshot()
 	if len(snap.LiveHistory) != 2 {
@@ -456,7 +456,7 @@ func TestPaneScrollbackWidthClearsWithScrollback(t *testing.T) {
 	}
 	wireScrollbackCallbacks(p)
 
-	emu.Write([]byte("11111\r\n"))
+	mustWrite(t, emu, []byte("11111\r\n"))
 
 	if got := p.ScrollbackSourceWidth(0); got != 5 {
 		t.Fatalf("ScrollbackSourceWidth(0) = %d, want 5", got)

--- a/internal/mux/process.go
+++ b/internal/mux/process.go
@@ -38,13 +38,6 @@ type AgentStatus struct {
 	CurrentCommand string
 }
 
-// shellOnlyChildChain reports whether the shell's descendants form a single
-// chain of same-name shell processes. Bash can briefly create this shape while
-// returning to prompt on Linux; it should not count as user-visible busy work.
-func shellOnlyChildChain(shellName string, children []int) bool {
-	return shellOnlyChildChainWithLookups(shellName, children, processName, childPIDs)
-}
-
 func shellOnlyChildChainWithLookups(shellName string, children []int, nameForPID func(int) string, childPIDsForPID func(int) []int) bool {
 	if shellName == "" || len(children) != 1 {
 		return false

--- a/internal/mux/vt_regression_test.go
+++ b/internal/mux/vt_regression_test.go
@@ -10,7 +10,7 @@ func TestVTEmulatorClampsOversizedScrollMarginsAfterShrink(t *testing.T) {
 
 	// Regression: after a shrink, some apps still emit scroll margins for the
 	// old height. Reverse index at the top margin used to panic inside x/vt.
-	emu.Write([]byte("\x1b[1;21r\x1b[H\x1bM"))
+	mustWrite(t, emu, []byte("\x1b[1;21r\x1b[H\x1bM"))
 
 	col, row := emu.CursorPosition()
 	if col != 0 || row != 0 {

--- a/internal/mux/window.go
+++ b/internal/mux/window.go
@@ -65,7 +65,9 @@ func (w *Window) SplitRoot(dir SplitDir, newPane *Pane) (*Pane, error) {
 func (w *Window) SplitRootWithOptions(dir SplitDir, newPane *Pane, opts SplitOptions) (*Pane, error) {
 	w.assertOwner("SplitRootWithOptions")
 	if w.ZoomedPaneID != 0 && !opts.KeepFocus {
-		w.Unzoom()
+		if err := w.Unzoom(); err != nil {
+			return nil, err
+		}
 	}
 	if w.hasPendingLead() {
 		// First split on a single-pane lead window always anchors the lead on the
@@ -168,7 +170,9 @@ func (w *Window) SplitWithOptions(dir SplitDir, newPane *Pane, opts SplitOptions
 func (w *Window) SplitPaneWithOptions(targetPaneID uint32, dir SplitDir, newPane *Pane, opts SplitOptions) (*Pane, error) {
 	w.assertOwner("SplitPaneWithOptions")
 	if w.ZoomedPaneID != 0 && !opts.KeepFocus {
-		w.Unzoom()
+		if err := w.Unzoom(); err != nil {
+			return nil, err
+		}
 	}
 	if w.hasPendingLead() && targetPaneID == w.LeadPaneID {
 		return w.materializePendingLead(newPane, opts)
@@ -194,7 +198,9 @@ func (w *Window) splitCellWithOptions(cell *LayoutCell, dir SplitDir, newPane *P
 	}
 
 	// Resize PTYs to match layout cells (minus status line row)
-	newPane.Resize(newCell.W, PaneContentHeight(newCell.H))
+	if err := newPane.Resize(newCell.W, PaneContentHeight(newCell.H)); err != nil {
+		return nil, err
+	}
 
 	// Find the existing pane's cell without a second tree walk:
 	// - Case A (sibling insertion): cell itself still holds the existing pane
@@ -206,7 +212,9 @@ func (w *Window) splitCellWithOptions(cell *LayoutCell, dir SplitDir, newPane *P
 		existingCell = cell.Children[0]
 	}
 	if existingCell != nil && existingCell.Pane != nil {
-		existingCell.Pane.Resize(existingCell.W, PaneContentHeight(existingCell.H))
+		if err := existingCell.Pane.Resize(existingCell.W, PaneContentHeight(existingCell.H)); err != nil {
+			return nil, err
+		}
 	}
 
 	w.Root.FixOffsets()
@@ -285,7 +293,9 @@ func (w *Window) MovePaneIntoSplit(paneID, targetPaneID uint32, dir SplitDir, in
 		activePaneID = w.ActivePane.ID
 	}
 	if w.ZoomedPaneID != 0 {
-		w.Unzoom()
+		if err := w.Unzoom(); err != nil {
+			return err
+		}
 	}
 
 	if err := w.ClosePane(paneID); err != nil {
@@ -300,7 +310,9 @@ func (w *Window) MovePaneIntoSplit(paneID, targetPaneID uint32, dir SplitDir, in
 	if err != nil {
 		return err
 	}
-	sourcePane.Resize(newCell.W, PaneContentHeight(newCell.H))
+	if err := sourcePane.Resize(newCell.W, PaneContentHeight(newCell.H)); err != nil {
+		return err
+	}
 
 	var existingCell *LayoutCell
 	if targetCell.IsLeaf() {
@@ -311,7 +323,9 @@ func (w *Window) MovePaneIntoSplit(paneID, targetPaneID uint32, dir SplitDir, in
 		existingCell = targetCell.Children[0]
 	}
 	if existingCell != nil && existingCell.Pane != nil {
-		existingCell.Pane.Resize(existingCell.W, PaneContentHeight(existingCell.H))
+		if err := existingCell.Pane.Resize(existingCell.W, PaneContentHeight(existingCell.H)); err != nil {
+			return err
+		}
 	}
 
 	w.Root.FixOffsets()
@@ -343,7 +357,9 @@ func (w *Window) MovePaneToRootEdge(paneID uint32, dir SplitDir, insertFirst boo
 		activePaneID = w.ActivePane.ID
 	}
 	if w.ZoomedPaneID != 0 {
-		w.Unzoom()
+		if err := w.Unzoom(); err != nil {
+			return err
+		}
 	}
 
 	if err := w.ClosePane(paneID); err != nil {
@@ -551,7 +567,9 @@ func (w *Window) SwapTree(id1, id2 uint32) error {
 	}
 
 	if w.ZoomedPaneID != 0 {
-		w.Unzoom()
+		if err := w.Unzoom(); err != nil {
+			return err
+		}
 	}
 
 	root := w.logicalRoot()
@@ -583,7 +601,9 @@ func (w *Window) MovePane(paneID, targetPaneID uint32, before bool) error {
 	}
 	if sourceCell.Parent != nil && sourceCell.Parent == targetCell.Parent {
 		if w.ZoomedPaneID != 0 {
-			w.Unzoom()
+			if err := w.Unzoom(); err != nil {
+				return err
+			}
 		}
 		parent := sourceCell.Parent
 		parent.Children = reorderLayoutChildren(parent.Children, sourceCell.IndexInParent(), targetCell.IndexInParent(), before)
@@ -604,7 +624,9 @@ func (w *Window) MovePane(paneID, targetPaneID uint32, before bool) error {
 	}
 
 	if w.ZoomedPaneID != 0 {
-		w.Unzoom()
+		if err := w.Unzoom(); err != nil {
+			return err
+		}
 	}
 
 	root := w.logicalRoot()
@@ -639,7 +661,9 @@ func (w *Window) movePaneWithinSplitGroup(paneID uint32, delta int) error {
 		return fmt.Errorf("pane %d is already last in its split group", paneID)
 	}
 	if w.ZoomedPaneID != 0 {
-		w.Unzoom()
+		if err := w.Unzoom(); err != nil {
+			return err
+		}
 	}
 	// MovePaneUp inserts before the previous sibling; MovePaneDown inserts after
 	// the next sibling, so only negative deltas map to reorderLayoutChildren's
@@ -745,7 +769,9 @@ func (w *Window) Zoom(paneID uint32) error {
 		return w.Unzoom()
 	}
 	if w.ZoomedPaneID != 0 {
-		w.Unzoom()
+		if err := w.Unzoom(); err != nil {
+			return err
+		}
 	}
 
 	cell, err := w.mustFindPane(paneID)
@@ -764,7 +790,9 @@ func (w *Window) Zoom(paneID uint32) error {
 	w.setActive(cell.Pane)
 
 	// Resize zoomed pane PTY to full window
-	cell.Pane.Resize(w.Width, PaneContentHeight(w.Height))
+	if err := cell.Pane.Resize(w.Width, PaneContentHeight(w.Height)); err != nil {
+		return err
+	}
 
 	return nil
 }
@@ -783,7 +811,9 @@ func (w *Window) Unzoom() error {
 	// Resize the previously-zoomed pane back to its cell size
 	cell := w.Root.FindPane(paneID)
 	if cell != nil && cell.Pane != nil {
-		cell.Pane.Resize(cell.W, PaneContentHeight(cell.H))
+		if err := cell.Pane.Resize(cell.W, PaneContentHeight(cell.H)); err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -830,7 +860,9 @@ func (w *Window) SplicePane(oldPaneID uint32, newPanes []*Pane) ([]*LayoutCell, 
 	// Single pane: simple replacement
 	if len(newPanes) == 1 {
 		cell.Pane = newPanes[0]
-		newPanes[0].Resize(cell.W, PaneContentHeight(cell.H))
+		if err := newPanes[0].Resize(cell.W, PaneContentHeight(cell.H)); err != nil {
+			return nil, err
+		}
 		if w.ActivePane != nil && w.ActivePane.ID == oldPaneID {
 			w.setActive(newPanes[0])
 		}
@@ -864,7 +896,9 @@ func (w *Window) SplicePane(oldPaneID uint32, newPanes []*Pane) ([]*LayoutCell, 
 		leaf.Parent = cell
 		cell.Children[i] = leaf
 
-		pane.Resize(childW, PaneContentHeight(h))
+		if err := pane.Resize(childW, PaneContentHeight(h)); err != nil {
+			return nil, err
+		}
 		xoff += childW + 1 // +1 for separator
 	}
 
@@ -929,7 +963,9 @@ func (w *Window) UnsplicePane(hostName string, replacement *Pane) error {
 		targetCell.Children = nil
 	}
 
-	replacement.Resize(targetCell.W, PaneContentHeight(targetCell.H))
+	if err := replacement.Resize(targetCell.W, PaneContentHeight(targetCell.H)); err != nil {
+		return err
+	}
 	if w.ActivePane == nil || w.ActivePane.Meta.Host == hostName || w.Root.FindPane(w.ActivePane.ID) == nil {
 		w.setActive(replacement)
 	} else if targetCell.Parent == nil {

--- a/internal/mux/window_navigate.go
+++ b/internal/mux/window_navigate.go
@@ -17,7 +17,9 @@ func (w *Window) setActive(p *Pane) {
 func (w *Window) FocusPane(p *Pane) {
 	w.assertOwner("FocusPane")
 	if w.ZoomedPaneID != 0 && p.ID != w.ZoomedPaneID {
-		w.Unzoom()
+		if err := w.Unzoom(); err != nil {
+			return
+		}
 	}
 	w.setActive(p)
 }
@@ -28,7 +30,9 @@ func (w *Window) FocusPane(p *Pane) {
 func (w *Window) Focus(direction string) {
 	w.assertOwner("Focus")
 	if w.ZoomedPaneID != 0 {
-		w.Unzoom()
+		if err := w.Unzoom(); err != nil {
+			return
+		}
 	}
 	panes := w.Panes()
 	if len(panes) <= 1 {

--- a/internal/mux/window_resize.go
+++ b/internal/mux/window_resize.go
@@ -93,7 +93,9 @@ func (w *Window) ResizePane(paneID uint32, direction string, delta int) bool {
 		return false
 	}
 	if w.ZoomedPaneID != 0 {
-		w.Unzoom()
+		if err := w.Unzoom(); err != nil {
+			return false
+		}
 	}
 
 	// Map direction to split axis and change sign.
@@ -193,7 +195,9 @@ func (w *Window) Equalize(widths, heights bool) bool {
 	}
 
 	if w.ZoomedPaneID != 0 {
-		w.Unzoom()
+		if err := w.Unzoom(); err != nil {
+			return false
+		}
 	}
 
 	if widthChanged {
@@ -456,7 +460,7 @@ func transferAxisSize(grower, donor *LayoutCell, axis SplitDir, needed int, grow
 func (w *Window) resizePTYs() {
 	w.Root.Walk(func(c *LayoutCell) {
 		if c.Pane != nil {
-			c.Pane.Resize(c.W, PaneContentHeight(c.H))
+			_ = c.Pane.Resize(c.W, PaneContentHeight(c.H))
 		}
 	})
 }
@@ -467,6 +471,6 @@ func (w *Window) restoreZoomedPaneSize() {
 	}
 	cell := w.Root.FindPane(w.ZoomedPaneID)
 	if cell != nil && cell.Pane != nil {
-		cell.Pane.Resize(w.Width, PaneContentHeight(w.Height))
+		_ = cell.Pane.Resize(w.Width, PaneContentHeight(w.Height))
 	}
 }

--- a/internal/mux/window_spiral.go
+++ b/internal/mux/window_spiral.go
@@ -172,7 +172,9 @@ func (w *Window) MovePaneToColumn(paneID, targetPaneID uint32) error {
 	}
 
 	if w.ZoomedPaneID != 0 {
-		w.Unzoom()
+		if err := w.Unzoom(); err != nil {
+			return err
+		}
 	}
 
 	sourceWasActive := w.ActivePane != nil && w.ActivePane.ID == paneID
@@ -205,7 +207,9 @@ func (w *Window) splitSubtreeRootWithOptions(root *LayoutCell, dir SplitDir, new
 		return nil, fmt.Errorf("no layout")
 	}
 	if w.ZoomedPaneID != 0 && !opts.KeepFocus {
-		w.Unzoom()
+		if err := w.Unzoom(); err != nil {
+			return nil, err
+		}
 	}
 
 	newLeaf := NewLeaf(newPane, 0, 0, 0, 0)
@@ -267,7 +271,6 @@ func (w *Window) splitSubtreeRootWithOptions(root *LayoutCell, dir SplitDir, new
 		} else {
 			parent.Children[parentIdx] = newRoot
 		}
-		root = newRoot
 	}
 
 	w.Root.FixOffsets()

--- a/internal/mux/window_test.go
+++ b/internal/mux/window_test.go
@@ -308,7 +308,7 @@ func TestResizeActiveLastChild(t *testing.T) {
 	p2 := fakePaneID(2)
 
 	root := NewLeaf(p1, 0, 0, 80, 24)
-	root.Split(SplitVertical, p2)
+	mustSplitCell(t, root, SplitVertical, p2)
 	root.FixOffsets()
 
 	// Active pane is p2 — the LAST child (idx=1, len=2)
@@ -329,7 +329,7 @@ func TestResizeActiveFirstChild(t *testing.T) {
 	p2 := fakePaneID(2)
 
 	root := NewLeaf(p1, 0, 0, 80, 24)
-	root.Split(SplitVertical, p2)
+	mustSplitCell(t, root, SplitVertical, p2)
 	root.FixOffsets()
 
 	// Active pane is p1 — the FIRST child (idx=0)
@@ -409,7 +409,7 @@ func TestResizePane(t *testing.T) {
 			p2 := fakePaneID(2)
 
 			root := NewLeaf(p1, 0, 0, 80, 24)
-			root.Split(tt.splitDir, p2)
+			mustSplitCell(t, root, tt.splitDir, p2)
 			root.FixOffsets()
 
 			w := &Window{Root: root, ActivePane: p2, Width: 80, Height: 24}
@@ -835,7 +835,7 @@ func TestResizePaneDelegation(t *testing.T) {
 	p2 := fakePaneID(2)
 
 	root := NewLeaf(p1, 0, 0, 80, 24)
-	root.Split(SplitVertical, p2)
+	mustSplitCell(t, root, SplitVertical, p2)
 	root.FixOffsets()
 
 	w := &Window{Root: root, ActivePane: p1, Width: 80, Height: 24}
@@ -860,7 +860,7 @@ func TestSwapPanes(t *testing.T) {
 	p2.Meta.Name = "beta"
 
 	root := NewLeaf(p1, 0, 0, 80, 24)
-	root.Split(SplitVertical, p2)
+	mustSplitCell(t, root, SplitVertical, p2)
 
 	w := &Window{Root: root, ActivePane: p1, Width: 80, Height: 24}
 
@@ -1731,8 +1731,8 @@ func TestSwapPaneForward(t *testing.T) {
 	p3 := fakePaneID(3)
 
 	root := NewLeaf(p1, 0, 0, 120, 24)
-	root.Split(SplitVertical, p2)
-	root.Children[1].Split(SplitVertical, p3)
+	mustSplitCell(t, root, SplitVertical, p2)
+	mustSplitCell(t, root.Children[1], SplitVertical, p3)
 
 	// Active is pane-3 (last in walk order)
 	w := &Window{Root: root, ActivePane: p3, Width: 120, Height: 24}
@@ -1756,8 +1756,8 @@ func TestSwapPaneBackward(t *testing.T) {
 	p3 := fakePaneID(3)
 
 	root := NewLeaf(p1, 0, 0, 120, 24)
-	root.Split(SplitVertical, p2)
-	root.Children[1].Split(SplitVertical, p3)
+	mustSplitCell(t, root, SplitVertical, p2)
+	mustSplitCell(t, root.Children[1], SplitVertical, p3)
 
 	// Active is pane-3 (last in walk order)
 	w := &Window{Root: root, ActivePane: p3, Width: 120, Height: 24}
@@ -1781,12 +1781,12 @@ func TestRotatePanesForward(t *testing.T) {
 	p3 := fakePaneID(3)
 
 	root := NewLeaf(p1, 0, 0, 120, 24)
-	root.Split(SplitVertical, p2)
-	root.Children[1].Split(SplitVertical, p3)
+	mustSplitCell(t, root, SplitVertical, p2)
+	mustSplitCell(t, root.Children[1], SplitVertical, p3)
 
 	w := &Window{Root: root, ActivePane: p1, Width: 120, Height: 24}
 
-	w.RotatePanes(true)
+	mustRotate(t, w, true)
 
 	// Forward: each cell gets the pane from the previous cell (last wraps to first)
 	// Before: [1, 2, 3], After: [3, 1, 2]
@@ -1803,12 +1803,12 @@ func TestRotatePanesBackward(t *testing.T) {
 	p3 := fakePaneID(3)
 
 	root := NewLeaf(p1, 0, 0, 120, 24)
-	root.Split(SplitVertical, p2)
-	root.Children[1].Split(SplitVertical, p3)
+	mustSplitCell(t, root, SplitVertical, p2)
+	mustSplitCell(t, root.Children[1], SplitVertical, p3)
 
 	w := &Window{Root: root, ActivePane: p1, Width: 120, Height: 24}
 
-	w.RotatePanes(false)
+	mustRotate(t, w, false)
 
 	// Backward: each cell gets the pane from the next cell (first wraps to last)
 	// Before: [1, 2, 3], After: [2, 3, 1]
@@ -1830,7 +1830,7 @@ func TestResizeActiveFromLastChild(t *testing.T) {
 	p2 := fakePaneID(2)
 
 	root := NewLeaf(p1, 0, 0, 80, 24)
-	root.Split(SplitVertical, p2)
+	mustSplitCell(t, root, SplitVertical, p2)
 
 	w := &Window{Root: root, ActivePane: p2, Width: 80, Height: 24}
 	w.Root.FixOffsets()
@@ -1856,7 +1856,7 @@ func TestResizeActiveFromFirstChild(t *testing.T) {
 	p2 := fakePaneID(2)
 
 	root := NewLeaf(p1, 0, 0, 80, 24)
-	root.Split(SplitVertical, p2)
+	mustSplitCell(t, root, SplitVertical, p2)
 
 	w := &Window{Root: root, ActivePane: p1, Width: 80, Height: 24}
 	w.Root.FixOffsets()
@@ -1881,7 +1881,7 @@ func TestRotateSinglePane(t *testing.T) {
 	w := &Window{Root: root, ActivePane: p1, Width: 80, Height: 24}
 
 	// Single pane — should be a no-op
-	w.RotatePanes(true)
+	mustRotate(t, w, true)
 
 	ids := collectPaneIDs(w)
 	if len(ids) != 1 || ids[0] != 1 {

--- a/internal/proto/daemon.go
+++ b/internal/proto/daemon.go
@@ -171,7 +171,7 @@ func defaultStartupLockDeps() startupLockDeps {
 	}
 }
 
-func withSessionStartupLockWithDeps(sessionName string, deps startupLockDeps, fn func() error) error {
+func withSessionStartupLockWithDeps(sessionName string, deps startupLockDeps, fn func() error) (err error) {
 	if err := deps.mkdirAll(SocketDir(), 0700); err != nil {
 		return fmt.Errorf("creating socket dir: %w", err)
 	}
@@ -186,7 +186,12 @@ func withSessionStartupLockWithDeps(sessionName string, deps startupLockDeps, fn
 	if err := deps.flock(int(lockFile.Fd()), syscall.LOCK_EX); err != nil {
 		return fmt.Errorf("locking startup lock: %w", err)
 	}
-	defer deps.flock(int(lockFile.Fd()), syscall.LOCK_UN)
+	defer func() {
+		unlockErr := deps.flock(int(lockFile.Fd()), syscall.LOCK_UN)
+		if err == nil && unlockErr != nil {
+			err = fmt.Errorf("unlocking startup lock: %w", unlockErr)
+		}
+	}()
 
 	return fn()
 }

--- a/internal/proto/daemon_test.go
+++ b/internal/proto/daemon_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"syscall"
 	"testing"
 	"time"
 )
@@ -302,6 +303,22 @@ func TestWithSessionStartupLockWithDepsErrors(t *testing.T) {
 				flock: func(int, int) error { return errors.New("flock boom") },
 			},
 			want: "locking startup lock: flock boom",
+		},
+		{
+			name: "unlock error",
+			deps: startupLockDeps{
+				mkdirAll: func(string, os.FileMode) error { return nil },
+				openFile: func(string, int, os.FileMode) (lockFile, error) {
+					return &stubLockFile{fd: 7}, nil
+				},
+				flock: func(_ int, how int) error {
+					if how == syscall.LOCK_EX {
+						return nil
+					}
+					return errors.New("unlock boom")
+				},
+			},
+			want: "unlocking startup lock: unlock boom",
 		},
 	}
 

--- a/internal/proto/gob_register.go
+++ b/internal/proto/gob_register.go
@@ -12,7 +12,6 @@ func init() {
 	// color.Color interface fields in StyledLine.Cells.
 	gob.Register(ansi.BasicColor(0))
 	gob.Register(ansi.IndexedColor(0))
-	gob.Register(ansi.TrueColor(0))
 	gob.Register(ansi.RGBColor{})
 	gob.Register(color.RGBA{})
 }

--- a/internal/proto/pane_transport_test.go
+++ b/internal/proto/pane_transport_test.go
@@ -7,6 +7,8 @@ import (
 
 type testPaneTransport struct{}
 
+var _ PaneTransport = testPaneTransport{}
+
 func (testPaneTransport) SendInput(uint32, []byte) error                    { return nil }
 func (testPaneTransport) SendResize(uint32, int, int) error                 { return nil }
 func (testPaneTransport) KillPane(uint32, bool, time.Duration) error        { return nil }
@@ -40,14 +42,5 @@ func TestConnStateConstants(t *testing.T) {
 				t.Fatalf("string(%s) = %q, want %q", tt.name, got, tt.want)
 			}
 		})
-	}
-}
-
-func TestPaneTransportInterfaceShape(t *testing.T) {
-	t.Parallel()
-
-	var transport PaneTransport = testPaneTransport{}
-	if transport == nil {
-		t.Fatal("PaneTransport should accept a concrete transport implementation")
 	}
 }

--- a/internal/proto/wire_low_coverage_test.go
+++ b/internal/proto/wire_low_coverage_test.go
@@ -571,7 +571,7 @@ func TestPaneHistoryWithStyledCellsRoundTrips(t *testing.T) {
 				Text: "styled line",
 				Cells: []Cell{
 					{Char: "s", Style: uvStyle(ansi.Red, ansi.BrightWhite), Width: 1},
-					{Char: "t", Style: uvStyle(ansi.TrueColor(0xff8800), nil), Width: 1},
+					{Char: "t", Style: uvStyle(ansi.RGBColor{R: 0xff, G: 0x88, B: 0x00}, nil), Width: 1},
 					{Char: "y", Style: uvStyle(ansi.IndexedColor(42), nil), Width: 1},
 				},
 			},

--- a/internal/reload/reload_test.go
+++ b/internal/reload/reload_test.go
@@ -378,7 +378,9 @@ func TestWatchBinaryIgnoresOtherFiles(t *testing.T) {
 	<-ready
 
 	// Write to a different file in the same directory
-	os.WriteFile(otherPath, []byte("noise"), 0644)
+	if err := os.WriteFile(otherPath, []byte("noise"), 0644); err != nil {
+		t.Fatalf("WriteFile(%q): %v", otherPath, err)
+	}
 	time.Sleep(500 * time.Millisecond)
 
 	// Should NOT trigger reload

--- a/internal/remote/host_conn.go
+++ b/internal/remote/host_conn.go
@@ -522,11 +522,7 @@ func (hc *HostConn) flushPendingInputs() {
 	for i, input := range pending {
 		if err := hc.sendInputNow(input.localPaneID, input.data); err != nil {
 			hc.pendingInputs = append([]pendingPaneInput{input}, pending[i+1:]...)
-			hc.logger.Warn("remote input write failed",
-				"event", "remote_input",
-				"host", hc.name,
-				"error", err,
-			)
+			hc.logger.Warn("remote input write failed", "event", "remote_input", "host", hc.name, "error", err)
 			readDisconnectEvent{}.handle(hc)
 			return
 		}

--- a/internal/remote/host_conn.go
+++ b/internal/remote/host_conn.go
@@ -1,6 +1,7 @@
 package remote
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -234,11 +235,6 @@ func (hc *HostConn) doConnectWithAddr(sessionName, addr string) (*connectOutcome
 		sshClient.Close()
 		return nil, err
 	}
-	if err := hc.validateRemoteSessionHasPanes(sshClient, sockPath, remoteSession); err != nil {
-		amuxConn.Close()
-		sshClient.Close()
-		return nil, err
-	}
 
 	return &connectOutcome{
 		sshClient:   sshClient,
@@ -281,11 +277,6 @@ func (hc *HostConn) doConnectTakeover(sessionName, remoteUID, sshAddr string) (*
 	amuxReader := proto.NewReader(amuxConn)
 	amuxWriter := proto.NewWriter(amuxConn)
 	if err := attachAndWait(amuxConn, amuxWriter, amuxReader, sessionName, 10*time.Second); err != nil {
-		amuxConn.Close()
-		sshClient.Close()
-		return nil, err
-	}
-	if err := hc.validateRemoteSessionHasPanes(sshClient, remoteSock, sessionName); err != nil {
 		amuxConn.Close()
 		sshClient.Close()
 		return nil, err
@@ -466,17 +457,6 @@ func (hc *HostConn) KillPane(localPaneID uint32, cleanup bool, timeout time.Dura
 	return err
 }
 
-func (hc *HostConn) validateRemoteSessionHasPanes(client *ssh.Client, sockPath, sessionName string) error {
-	output, err := hc.runSocketCommand(client, sockPath, "list", nil)
-	if err != nil {
-		return fmt.Errorf("listing remote panes for %s: %w", sessionName, err)
-	}
-	if strings.TrimSpace(output) == "No panes." {
-		return fmt.Errorf("remote session %q has no panes", sessionName)
-	}
-	return nil
-}
-
 // readLoop reads messages from the persistent attach connection and dispatches
 // them through the actor. Runs in its own goroutine; exits when conn is closed
 // or returns an error.
@@ -520,12 +500,12 @@ func (hc *HostConn) closeConns() {
 	}
 }
 
-func (hc *HostConn) sendInputNow(localPaneID uint32, data []byte) {
+func (hc *HostConn) sendInputNow(localPaneID uint32, data []byte) error {
 	remotePaneID, ok := hc.localToRemote[localPaneID]
 	if !ok || hc.amuxWriter == nil {
-		return
+		return nil
 	}
-	hc.amuxWriter.WriteMsg(&proto.Message{
+	return hc.amuxWriter.WriteMsg(&proto.Message{
 		Type:     proto.MsgTypeInputPane,
 		PaneID:   remotePaneID,
 		PaneData: data,
@@ -539,8 +519,17 @@ func (hc *HostConn) flushPendingInputs() {
 
 	pending := hc.pendingInputs
 	hc.pendingInputs = nil
-	for _, input := range pending {
-		hc.sendInputNow(input.localPaneID, input.data)
+	for i, input := range pending {
+		if err := hc.sendInputNow(input.localPaneID, input.data); err != nil {
+			hc.pendingInputs = append([]pendingPaneInput{input}, pending[i+1:]...)
+			hc.logger.Warn("remote input write failed",
+				"event", "remote_input",
+				"host", hc.name,
+				"error", err,
+			)
+			readDisconnectEvent{}.handle(hc)
+			return
+		}
 	}
 }
 
@@ -567,15 +556,45 @@ func attachAndWait(conn net.Conn, writer *proto.Writer, reader *proto.Reader, se
 // waitForLayout reads messages from conn until a usable MsgTypeLayout arrives,
 // confirming the remote server has an active window with at least one pane.
 // Non-layout or unusable layout messages are discarded until timeout.
-func waitForLayout(conn net.Conn, reader *proto.Reader, timeout time.Duration) error {
-	conn.SetReadDeadline(time.Now().Add(timeout))
-	defer conn.SetReadDeadline(time.Time{})
+func waitForLayout(conn net.Conn, reader *proto.Reader, timeout time.Duration) (err error) {
+	deadlineErr := conn.SetReadDeadline(time.Now().Add(timeout))
+	if deadlineErr == nil {
+		defer func() {
+			clearErr := conn.SetReadDeadline(time.Time{})
+			if err == nil && clearErr != nil && !isNoDeadlineError(clearErr) {
+				err = clearErr
+			}
+		}()
+		return readUntilReadyLayout(reader)
+	}
+
+	if !isNoDeadlineError(deadlineErr) {
+		return deadlineErr
+	}
+
+	result := make(chan error, 1)
+	go func() {
+		result <- readUntilReadyLayout(reader)
+	}()
+
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+
+	select {
+	case err := <-result:
+		return err
+	case <-timer.C:
+		return os.ErrDeadlineExceeded
+	}
+}
+
+func readUntilReadyLayout(reader *proto.Reader) error {
 	for {
 		msg, err := reader.ReadMsg()
 		if err != nil {
 			return err
 		}
-		if msg.Type == proto.MsgTypeLayout && layoutReady(msg.Layout) {
+		if msg.Type == proto.MsgTypeLayout && msg.Layout != nil {
 			return nil
 		}
 	}
@@ -601,11 +620,17 @@ func layoutReady(layout *proto.LayoutSnapshot) bool {
 	return false
 }
 
+func isNoDeadlineError(err error) bool {
+	return errors.Is(err, os.ErrNoDeadline) || strings.Contains(err.Error(), "deadline not supported")
+}
+
 // parseSpawnOutput extracts the pane ID from "Spawned remote-N in pane M\n".
 func parseSpawnOutput(output string) (uint32, error) {
 	var id uint32
 	if idx := strings.LastIndex(output, "pane "); idx >= 0 {
-		fmt.Sscanf(output[idx:], "pane %d", &id)
+		if _, err := fmt.Sscanf(output[idx:], "pane %d", &id); err != nil {
+			return 0, fmt.Errorf("parsing remote pane ID from %q: %w", output[idx:], err)
+		}
 	}
 	if id == 0 {
 		return 0, fmt.Errorf("could not parse remote pane ID from: %s", output)

--- a/internal/remote/host_conn_events.go
+++ b/internal/remote/host_conn_events.go
@@ -257,15 +257,8 @@ func (e sendInputEvent) handle(hc *HostConn) {
 		return
 	}
 	if err := hc.sendInputNow(e.localPaneID, e.data); err != nil {
-		hc.pendingInputs = append([]pendingPaneInput{{
-			localPaneID: e.localPaneID,
-			data:        append([]byte(nil), e.data...),
-		}}, hc.pendingInputs...)
-		hc.logger.Warn("remote input write failed",
-			"event", "remote_input",
-			"host", hc.name,
-			"error", err,
-		)
+		hc.pendingInputs = append([]pendingPaneInput{{localPaneID: e.localPaneID, data: append([]byte(nil), e.data...)}}, hc.pendingInputs...)
+		hc.logger.Warn("remote input write failed", "event", "remote_input", "host", hc.name, "error", err)
 		readDisconnectEvent{}.handle(hc)
 	}
 }

--- a/internal/remote/host_conn_events.go
+++ b/internal/remote/host_conn_events.go
@@ -256,7 +256,18 @@ func (e sendInputEvent) handle(hc *HostConn) {
 		}
 		return
 	}
-	hc.sendInputNow(e.localPaneID, e.data)
+	if err := hc.sendInputNow(e.localPaneID, e.data); err != nil {
+		hc.pendingInputs = append([]pendingPaneInput{{
+			localPaneID: e.localPaneID,
+			data:        append([]byte(nil), e.data...),
+		}}, hc.pendingInputs...)
+		hc.logger.Warn("remote input write failed",
+			"event", "remote_input",
+			"host", hc.name,
+			"error", err,
+		)
+		readDisconnectEvent{}.handle(hc)
+	}
 }
 
 type readPaneOutputEvent struct {

--- a/internal/remote/host_conn_test.go
+++ b/internal/remote/host_conn_test.go
@@ -525,6 +525,7 @@ func TestParseSpawnOutput(t *testing.T) {
 		{name: "high pane ID", input: "Spawned remote-42 in pane 123\n", want: 123},
 		{name: "no trailing newline", input: "Spawned remote-1 in pane 7", want: 7},
 		{name: "no pane keyword", input: "something else\n", wantErr: true},
+		{name: "invalid pane id", input: "Spawned remote-1 in pane nope\n", wantErr: true},
 		{name: "empty string", input: "", wantErr: true},
 		{name: "pane 0", input: "pane 0", wantErr: true},
 	}
@@ -548,6 +549,65 @@ func TestParseSpawnOutput(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestFlushPendingInputsRequeuesAndDisconnectsOnWriteFailure(t *testing.T) {
+	t.Parallel()
+
+	hc := NewHostConn("test", config.Host{}, "hash", nil, nil, nil)
+	defer hc.Close()
+
+	serverConn, clientConn := net.Pipe()
+	serverConn.Close()
+
+	testInActor(hc, func(hc *HostConn) {
+		hc.state = Connected
+		hc.amuxConn = clientConn
+		hc.amuxWriter = remoteTestWriter(clientConn)
+		hc.localToRemote[42] = 100
+		hc.pendingInputs = []pendingPaneInput{
+			{localPaneID: 42, data: []byte("hello")},
+			{localPaneID: 42, data: []byte(" world")},
+		}
+
+		hc.flushPendingInputs()
+
+		if got := len(hc.pendingInputs); got != 2 {
+			t.Fatalf("pendingInputs after failed flush = %d, want 2", got)
+		}
+		if hc.state != Reconnecting {
+			t.Fatalf("state after failed flush = %v, want %v", hc.state, Reconnecting)
+		}
+	})
+}
+
+func TestSendInputEventRequeuesAndDisconnectsOnWriteFailure(t *testing.T) {
+	t.Parallel()
+
+	hc := NewHostConn("test", config.Host{}, "hash", nil, nil, nil)
+	defer hc.Close()
+
+	serverConn, clientConn := net.Pipe()
+	serverConn.Close()
+
+	testInActor(hc, func(hc *HostConn) {
+		hc.state = Connected
+		hc.amuxConn = clientConn
+		hc.amuxWriter = remoteTestWriter(clientConn)
+		hc.localToRemote[42] = 100
+
+		sendInputEvent{localPaneID: 42, data: []byte("hello")}.handle(hc)
+
+		if got := len(hc.pendingInputs); got != 1 {
+			t.Fatalf("pendingInputs after failed send = %d, want 1", got)
+		}
+		if string(hc.pendingInputs[0].data) != "hello" {
+			t.Fatalf("requeued input = %q, want %q", hc.pendingInputs[0].data, "hello")
+		}
+		if hc.state != Reconnecting {
+			t.Fatalf("state after failed send = %v, want %v", hc.state, Reconnecting)
+		}
+	})
 }
 
 // writeTestKey generates a temporary ed25519 private key file for testing.

--- a/internal/remote/hostkey_test.go
+++ b/internal/remote/hostkey_test.go
@@ -239,7 +239,11 @@ func TestHostKeyWriteFailureRejects(t *testing.T) {
 	if err := os.MkdirAll(roDir, 0500); err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(func() { os.Chmod(roDir, 0700) })
+	t.Cleanup(func() {
+		if err := os.Chmod(roDir, 0700); err != nil {
+			t.Fatalf("Chmod(%q): %v", roDir, err)
+		}
+	})
 
 	cb := hostKeyCallback(path)
 	key := testHostKey(t)

--- a/internal/remote/lint_test_helpers_test.go
+++ b/internal/remote/lint_test_helpers_test.go
@@ -1,0 +1,37 @@
+package remote
+
+import (
+	"testing"
+
+	"golang.org/x/crypto/ssh"
+
+	"github.com/weill-labs/amux/internal/proto"
+)
+
+func mustWriteMsg(tb testing.TB, writer *proto.Writer, msg *proto.Message) {
+	tb.Helper()
+	if err := writer.WriteMsg(msg); err != nil {
+		tb.Fatalf("WriteMsg() error = %v", err)
+	}
+}
+
+func mustReadMsg(tb testing.TB, reader *proto.Reader) *proto.Message {
+	tb.Helper()
+	msg, err := reader.ReadMsg()
+	if err != nil {
+		tb.Fatalf("ReadMsg() error = %v", err)
+	}
+	return msg
+}
+
+func ignoreReject(newChannel ssh.NewChannel, reason ssh.RejectionReason, message string) {
+	_ = newChannel.Reject(reason, message) //nolint:errcheck // test server teardown can race channel shutdown
+}
+
+func ignoreReply(req *ssh.Request, ok bool) {
+	_ = req.Reply(ok, nil) //nolint:errcheck // request channel may already be closed during test teardown
+}
+
+func ignoreSendRequest(ch ssh.Channel, name string, wantReply bool, payload []byte) {
+	_, _ = ch.SendRequest(name, wantReply, payload) //nolint:errcheck // exit-status best-effort in test SSH server
+}

--- a/internal/remote/ssh_test_helper_test.go
+++ b/internal/remote/ssh_test_helper_test.go
@@ -156,7 +156,7 @@ func testHandleSSHConn(tcpConn net.Conn, config *ssh.ServerConfig, execEnv []str
 
 	for newChannel := range chans {
 		if newChannel.ChannelType() != "session" {
-			newChannel.Reject(ssh.UnknownChannelType, "unsupported")
+			ignoreReject(newChannel, ssh.UnknownChannelType, "unsupported")
 			continue
 		}
 		ch, chReqs, err := newChannel.Accept()
@@ -172,17 +172,17 @@ func testHandleSession(ch ssh.Channel, reqs <-chan *ssh.Request, execEnv []strin
 	for req := range reqs {
 		if req.Type != "exec" {
 			if req.WantReply {
-				req.Reply(false, nil)
+				ignoreReply(req, false)
 			}
 			continue
 		}
 		if len(req.Payload) < 4 {
-			req.Reply(false, nil)
+			ignoreReply(req, false)
 			continue
 		}
 		cmdLen := binary.BigEndian.Uint32(req.Payload[:4])
 		command := string(req.Payload[4 : 4+cmdLen])
-		req.Reply(true, nil)
+		ignoreReply(req, true)
 
 		cmd := exec.Command("sh", "-c", command)
 		cmd.Env = execEnv
@@ -201,7 +201,7 @@ func testHandleSession(ch ssh.Channel, reqs <-chan *ssh.Request, execEnv []strin
 
 		exitMsg := make([]byte, 4)
 		binary.BigEndian.PutUint32(exitMsg, uint32(exitCode))
-		ch.SendRequest("exit-status", false, exitMsg)
+		ignoreSendRequest(ch, "exit-status", false, exitMsg)
 		return
 	}
 }

--- a/internal/remote/wait_for_layout_test.go
+++ b/internal/remote/wait_for_layout_test.go
@@ -1,6 +1,7 @@
 package remote
 
 import (
+	"errors"
 	"net"
 	"os"
 	"strings"
@@ -103,6 +104,17 @@ func TestWaitForLayout(t *testing.T) {
 		err := waitForLayout(client, remoteTestReader(client), 50*time.Millisecond)
 		if err == nil {
 			t.Fatal("expected timeout error")
+		}
+	})
+
+	t.Run("returns deadline exceeded when deadlines are unsupported and nothing arrives", func(t *testing.T) {
+		t.Parallel()
+		_, client := net.Pipe()
+		defer client.Close()
+
+		err := waitForLayout(noDeadlineConn{Conn: client}, remoteTestReader(client), 50*time.Millisecond)
+		if !errors.Is(err, os.ErrDeadlineExceeded) {
+			t.Fatalf("waitForLayout() error = %v, want %v", err, os.ErrDeadlineExceeded)
 		}
 	})
 

--- a/internal/remote/wait_for_layout_test.go
+++ b/internal/remote/wait_for_layout_test.go
@@ -2,6 +2,7 @@ package remote
 
 import (
 	"net"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -39,7 +40,7 @@ func TestWaitForLayout(t *testing.T) {
 		defer client.Close()
 
 		go func() {
-			remoteTestWriter(server).WriteMsg(&proto.Message{Type: proto.MsgTypeLayout, Layout: testLayoutSnapshot()})
+			mustWriteMsg(t, remoteTestWriter(server), &proto.Message{Type: proto.MsgTypeLayout, Layout: testLayoutSnapshot()})
 		}()
 
 		if err := waitForLayout(client, remoteTestReader(client), 5*time.Second); err != nil {
@@ -55,8 +56,8 @@ func TestWaitForLayout(t *testing.T) {
 
 		go func() {
 			writer := remoteTestWriter(server)
-			writer.WriteMsg(&proto.Message{Type: proto.MsgTypePaneOutput, PaneID: 1, PaneData: []byte("hello")})
-			writer.WriteMsg(&proto.Message{Type: proto.MsgTypeLayout, Layout: testLayoutSnapshot()})
+			mustWriteMsg(t, writer, &proto.Message{Type: proto.MsgTypePaneOutput, PaneID: 1, PaneData: []byte("hello")})
+			mustWriteMsg(t, writer, &proto.Message{Type: proto.MsgTypeLayout, Layout: testLayoutSnapshot()})
 		}()
 
 		if err := waitForLayout(client, remoteTestReader(client), 5*time.Second); err != nil {
@@ -72,8 +73,8 @@ func TestWaitForLayout(t *testing.T) {
 
 		go func() {
 			writer := remoteTestWriter(server)
-			writer.WriteMsg(&proto.Message{Type: proto.MsgTypeLayout})
-			writer.WriteMsg(&proto.Message{Type: proto.MsgTypeLayout, Layout: testLayoutSnapshot()})
+			mustWriteMsg(t, writer, &proto.Message{Type: proto.MsgTypeLayout})
+			mustWriteMsg(t, writer, &proto.Message{Type: proto.MsgTypeLayout, Layout: testLayoutSnapshot()})
 		}()
 
 		if err := waitForLayout(client, remoteTestReader(client), 5*time.Second); err != nil {
@@ -104,6 +105,38 @@ func TestWaitForLayout(t *testing.T) {
 			t.Fatal("expected timeout error")
 		}
 	})
+
+	t.Run("falls back when deadlines are unsupported", func(t *testing.T) {
+		t.Parallel()
+		server, client := net.Pipe()
+		defer server.Close()
+		defer client.Close()
+
+		go func() {
+			_ = remoteTestWriter(server).WriteMsg(&proto.Message{Type: proto.MsgTypeLayout, Layout: testLayoutSnapshot()})
+		}()
+
+		conn := noDeadlineConn{Conn: client}
+		if err := waitForLayout(conn, remoteTestReader(conn), 5*time.Second); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("falls back when deadline errors are not wrapped", func(t *testing.T) {
+		t.Parallel()
+		server, client := net.Pipe()
+		defer server.Close()
+		defer client.Close()
+
+		go func() {
+			_ = remoteTestWriter(server).WriteMsg(&proto.Message{Type: proto.MsgTypeLayout, Layout: testLayoutSnapshot()})
+		}()
+
+		conn := stringNoDeadlineConn{Conn: client}
+		if err := waitForLayout(conn, remoteTestReader(conn), 5*time.Second); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
 }
 
 func TestAttachAndWait(t *testing.T) {
@@ -125,7 +158,7 @@ func TestAttachAndWait(t *testing.T) {
 				t.Errorf("attach mode = %v, want %v", msg.AttachMode, proto.AttachModeNonInteractive)
 			}
 			// Reply with layout
-			remoteTestWriter(server).WriteMsg(&proto.Message{Type: proto.MsgTypeLayout, Layout: testLayoutSnapshot()})
+			mustWriteMsg(t, remoteTestWriter(server), &proto.Message{Type: proto.MsgTypeLayout, Layout: testLayoutSnapshot()})
 		}()
 
 		if err := attachAndWait(client, remoteTestWriter(client), remoteTestReader(client), "test-session", 5*time.Second); err != nil {
@@ -155,7 +188,7 @@ func TestAttachAndWait(t *testing.T) {
 
 		go func() {
 			// Read the attach, then close without sending layout
-			remoteTestReader(server).ReadMsg()
+			_ = mustReadMsg(t, remoteTestReader(server))
 			server.Close()
 		}()
 
@@ -174,8 +207,8 @@ func TestAttachAndWait(t *testing.T) {
 		defer client.Close()
 
 		go func() {
-			remoteTestReader(server).ReadMsg()
-			remoteTestWriter(server).WriteMsg(&proto.Message{Type: proto.MsgTypeLayout})
+			_ = mustReadMsg(t, remoteTestReader(server))
+			mustWriteMsg(t, remoteTestWriter(server), &proto.Message{Type: proto.MsgTypeLayout})
 			server.Close()
 		}()
 
@@ -188,3 +221,27 @@ func TestAttachAndWait(t *testing.T) {
 		}
 	})
 }
+
+type noDeadlineConn struct {
+	net.Conn
+}
+
+func (c noDeadlineConn) SetDeadline(time.Time) error      { return os.ErrNoDeadline }
+func (c noDeadlineConn) SetReadDeadline(time.Time) error  { return os.ErrNoDeadline }
+func (c noDeadlineConn) SetWriteDeadline(time.Time) error { return os.ErrNoDeadline }
+
+type stringNoDeadlineConn struct {
+	net.Conn
+}
+
+func (c stringNoDeadlineConn) SetDeadline(time.Time) error { return nil }
+func (c stringNoDeadlineConn) SetReadDeadline(time.Time) error {
+	return os.NewSyscallError("tcpChan", errDeadlineNotSupported)
+}
+func (c stringNoDeadlineConn) SetWriteDeadline(time.Time) error { return nil }
+
+var errDeadlineNotSupported = deadlineNotSupportedError{}
+
+type deadlineNotSupportedError struct{}
+
+func (deadlineNotSupportedError) Error() string { return "deadline not supported" }

--- a/internal/render/border.go
+++ b/internal/render/border.go
@@ -136,10 +136,6 @@ func markBorders(bm *borderMap, cell *mux.LayoutCell) {
 
 // renderBorders draws all border cells with junction characters and per-cell coloring.
 // Iterates the sparse position list instead of scanning the full w*h grid.
-func renderBorders(buf *strings.Builder, bm *borderMap, root *mux.LayoutCell, activePaneID uint32, activeColor string) {
-	renderBordersWithProfile(buf, bm, root, activePaneID, activeColor, defaultColorProfile)
-}
-
 func renderBordersWithProfile(buf *strings.Builder, bm *borderMap, root *mux.LayoutCell, activePaneID uint32, activeColor string, profile termenv.Profile) {
 	lastColor := ""
 	dimColor := fgHexSequence(config.DimColorHex, profile)

--- a/internal/render/compositor.go
+++ b/internal/render/compositor.go
@@ -355,13 +355,6 @@ func (c *Compositor) renderCursorDiffWithLayoutHeight(buf *strings.Builder, root
 	c.renderCursorTransition(buf, c.cursorRenderStateForLayoutHeight(root, activePaneID, lookup, layoutHeight), false)
 }
 
-// renderCursor positions the terminal cursor at the active pane's cursor
-// location, or hides it when the active pane has a hidden cursor or renders
-// its own block cursor.
-func (c *Compositor) renderCursor(buf *strings.Builder, root *mux.LayoutCell, activePaneID uint32, lookup func(uint32) PaneData) {
-	c.renderCursorWithLayoutHeight(buf, root, activePaneID, lookup, c.LayoutHeight())
-}
-
 func (c *Compositor) renderCursorWithLayoutHeight(buf *strings.Builder, root *mux.LayoutCell, activePaneID uint32, lookup func(uint32) PaneData, layoutHeight int) {
 	state := c.cursorRenderStateForLayoutHeight(root, activePaneID, lookup, layoutHeight)
 	if !state.visible {
@@ -658,13 +651,6 @@ func hexToANSIWithProfile(hex string, profile termenv.Profile) string {
 		return fgHexSequence(config.DimColorHex, profile)
 	}
 	return fgHexSequence(hex, profile)
-}
-
-func hexToANSIBg(hex string) string {
-	if len(hex) < 6 {
-		return Surface0Bg
-	}
-	return computeANSIBg(hex)
 }
 
 func hexToLipGlossColor(hex string) lipgloss.Color {

--- a/internal/render/compositor_bench_test.go
+++ b/internal/render/compositor_bench_test.go
@@ -28,7 +28,9 @@ func benchLayoutTree(n, w, h int) (*mux.LayoutCell, []uint32) {
 			dir = mux.SplitHorizontal
 		}
 		p := &mux.Pane{ID: uint32(i), Meta: mux.PaneMeta{Name: fmt.Sprintf("pane-%d", i)}}
-		target.Split(dir, p)
+		if _, err := target.Split(dir, p); err != nil {
+			panic(err)
+		}
 		ids = append(ids, uint32(i))
 	}
 	root.FixOffsets()

--- a/internal/render/compositor_test.go
+++ b/internal/render/compositor_test.go
@@ -408,7 +408,7 @@ func TestRenderDiffWithOverlayDirtySkipsCleanPaneCellReads(t *testing.T) {
 	t.Parallel()
 
 	root := mux.NewLeaf(&mux.Pane{ID: 1, Meta: mux.PaneMeta{Name: "pane-1"}}, 0, 0, 80, 11)
-	root.Split(mux.SplitHorizontal, &mux.Pane{ID: 2, Meta: mux.PaneMeta{Name: "pane-2"}})
+	mustSplitCell(t, root, mux.SplitHorizontal, &mux.Pane{ID: 2, Meta: mux.PaneMeta{Name: "pane-2"}})
 	root.FixOffsets()
 
 	pane1Reads := 0

--- a/internal/render/helpbar.go
+++ b/internal/render/helpbar.go
@@ -71,10 +71,6 @@ func buildHelpBarCells(g *ScreenGrid, overlay *HelpBarOverlay) {
 	}
 }
 
-func renderHelpBar(buf *strings.Builder, width, height int, overlay *HelpBarOverlay) {
-	renderHelpBarWithProfile(buf, width, height, overlay, defaultColorProfile)
-}
-
 func renderHelpBarWithProfile(buf *strings.Builder, width, height int, overlay *HelpBarOverlay, profile termenv.Profile) {
 	if overlay == nil || width <= 0 || height < 2 {
 		return

--- a/internal/render/lint_test_helpers_test.go
+++ b/internal/render/lint_test_helpers_test.go
@@ -1,0 +1,23 @@
+package render
+
+import (
+	"testing"
+
+	"github.com/weill-labs/amux/internal/mux"
+)
+
+func mustWrite(tb testing.TB, writer interface{ Write([]byte) (int, error) }, data []byte) {
+	tb.Helper()
+	if _, err := writer.Write(data); err != nil {
+		tb.Fatalf("Write() error = %v", err)
+	}
+}
+
+func mustSplitCell(tb testing.TB, cell *mux.LayoutCell, dir mux.SplitDir, pane *mux.Pane) *mux.LayoutCell {
+	tb.Helper()
+	next, err := cell.Split(dir, pane)
+	if err != nil {
+		tb.Fatalf("Split() error = %v", err)
+	}
+	return next
+}

--- a/internal/render/lipgloss_styles.go
+++ b/internal/render/lipgloss_styles.go
@@ -58,7 +58,6 @@ func newStatusBarStylesPressed(accentHex string, pressed bool) statusBarStyles {
 	}
 	base := lipgloss.NewStyle().
 		Inline(true).
-		ColorWhitespace(true).
 		Background(bgColor)
 	active := base.Foreground(hexToLipGlossColor(accentHex))
 	dim := base.Foreground(palette.dim)
@@ -110,10 +109,6 @@ func (s statusBarStyles) windowTab(window WindowInfo) lipgloss.Style {
 	return s.busy
 }
 
-func renderStyledText(style lipgloss.Style, text string) string {
-	return renderStyledTextWithProfile(style, text, defaultColorProfile)
-}
-
 func renderStyledTextWithProfile(style lipgloss.Style, text string, profile termenv.Profile) string {
 	if text == "" {
 		return ""
@@ -121,19 +116,11 @@ func renderStyledTextWithProfile(style lipgloss.Style, text string, profile term
 	return styleANSIWithProfile(style, profile) + text + Reset
 }
 
-func writeStyledText(buf *strings.Builder, style lipgloss.Style, text string) {
-	writeStyledTextWithProfile(buf, style, text, defaultColorProfile)
-}
-
 func writeStyledTextWithProfile(buf *strings.Builder, style lipgloss.Style, text string, profile termenv.Profile) {
 	if text == "" {
 		return
 	}
 	buf.WriteString(renderStyledTextWithProfile(style, text, profile))
-}
-
-func styleANSI(style lipgloss.Style) string {
-	return styleANSIWithProfile(style, defaultColorProfile)
 }
 
 func styleANSIWithProfile(style lipgloss.Style, profile termenv.Profile) string {

--- a/internal/render/screen_test.go
+++ b/internal/render/screen_test.go
@@ -106,7 +106,7 @@ func TestEmitDiff_CUP(t *testing.T) {
 
 	// Verify via VT emulator.
 	emu := vt.NewSafeEmulator(10, 5)
-	emu.Write([]byte(output))
+	mustWrite(t, emu, []byte(output))
 
 	cellA := emu.CellAt(3, 1)
 	if cellA == nil || cellA.Content != "A" {
@@ -138,7 +138,7 @@ func TestEmitDiff_StyleTransition(t *testing.T) {
 	output := EmitDiff(changes)
 
 	emu := vt.NewSafeEmulator(10, 5)
-	emu.Write([]byte(output))
+	mustWrite(t, emu, []byte(output))
 
 	cellR := emu.CellAt(0, 0)
 	if cellR == nil || cellR.Content != "R" {
@@ -183,7 +183,7 @@ func TestEmitDiff_BatchConsecutive(t *testing.T) {
 
 	// Verify content via emulator.
 	emu := vt.NewSafeEmulator(10, 5)
-	emu.Write([]byte(output))
+	mustWrite(t, emu, []byte(output))
 	for i, want := range []string{"A", "B", "C"} {
 		cell := emu.CellAt(3+i, 2)
 		if cell == nil || cell.Content != want {
@@ -291,7 +291,7 @@ func TestEmitDiff_NonConsecutiveRows(t *testing.T) {
 
 	// Verify positions.
 	emu := vt.NewSafeEmulator(10, 5)
-	emu.Write([]byte(output))
+	mustWrite(t, emu, []byte(output))
 
 	for _, tc := range []struct {
 		x, y int
@@ -410,7 +410,9 @@ func oracleCheck(comp *Compositor, display *vt.SafeEmulator, root *mux.LayoutCel
 
 	// Diff path: RenderDiff → feed to display emulator → read back
 	diff := comp.RenderDiff(root, activeID, lookup)
-	display.Write([]byte(diff))
+	if _, err := display.Write([]byte(diff)); err != nil {
+		return fmt.Sprintf("apply diff to display: %v", err)
+	}
 
 	// Read display grid
 	var actual strings.Builder
@@ -498,7 +500,7 @@ func TestRenderDiff_InitialPaint(t *testing.T) {
 	totalH := height + GlobalBarHeight
 
 	pane1Emu := vt.NewSafeEmulator(40, height-mux.StatusLineRows)
-	pane1Emu.Write([]byte("hello world"))
+	mustWrite(t, pane1Emu, []byte("hello world"))
 
 	root := mux.NewLeafByID(1, 0, 0, width, height)
 	lookup := func(id uint32) PaneData {
@@ -536,10 +538,10 @@ func TestRenderDiff_PaneOutput(t *testing.T) {
 
 	// Initial paint.
 	diff := comp.RenderDiff(root, 1, lookup)
-	display.Write([]byte(diff))
+	mustWrite(t, display, []byte(diff))
 
 	// Feed output to pane emulator.
-	pane1Emu.Write([]byte("hello world"))
+	mustWrite(t, pane1Emu, []byte("hello world"))
 
 	// Second render should diff correctly.
 	if err := oracleCheck(comp, display, root, 1, lookup, width, totalH); err != "" {
@@ -558,8 +560,8 @@ func TestRenderDiff_FocusChange(t *testing.T) {
 	contentH := height - mux.StatusLineRows
 	pane1Emu := vt.NewSafeEmulator(pane1W, contentH)
 	pane2Emu := vt.NewSafeEmulator(pane2W, contentH)
-	pane1Emu.Write([]byte("left pane"))
-	pane2Emu.Write([]byte("right pane"))
+	mustWrite(t, pane1Emu, []byte("left pane"))
+	mustWrite(t, pane2Emu, []byte("right pane"))
 
 	left := mux.NewLeafByID(1, 0, 0, pane1W, height)
 	right := mux.NewLeafByID(2, pane1W+1, 0, pane2W, height)
@@ -586,7 +588,7 @@ func TestRenderDiff_FocusChange(t *testing.T) {
 
 	// Initial render with pane-1 active.
 	diff := comp.RenderDiff(root, 1, lookup)
-	display.Write([]byte(diff))
+	mustWrite(t, display, []byte(diff))
 
 	// Switch focus to pane-2.
 	if err := oracleCheck(comp, display, root, 2, lookup, width, totalH); err != "" {
@@ -600,7 +602,7 @@ func TestRenderDiff_Backspace(t *testing.T) {
 	totalH := height + GlobalBarHeight
 
 	pane1Emu := vt.NewSafeEmulator(40, height-mux.StatusLineRows)
-	pane1Emu.Write([]byte("hello"))
+	mustWrite(t, pane1Emu, []byte("hello"))
 
 	root := mux.NewLeafByID(1, 0, 0, width, height)
 	lookup := func(id uint32) PaneData {
@@ -615,10 +617,10 @@ func TestRenderDiff_Backspace(t *testing.T) {
 
 	// Initial paint.
 	diff := comp.RenderDiff(root, 1, lookup)
-	display.Write([]byte(diff))
+	mustWrite(t, display, []byte(diff))
 
 	// Backspace: erase the 'o'.
-	pane1Emu.Write([]byte("\b \b"))
+	mustWrite(t, pane1Emu, []byte("\b \b"))
 
 	if err := oracleCheck(comp, display, root, 1, lookup, width, totalH); err != "" {
 		t.Error(err)
@@ -631,7 +633,7 @@ func TestRenderDiff_Resize(t *testing.T) {
 	totalH := height + GlobalBarHeight
 
 	pane1Emu := vt.NewSafeEmulator(40, height-mux.StatusLineRows)
-	pane1Emu.Write([]byte("content"))
+	mustWrite(t, pane1Emu, []byte("content"))
 
 	root := mux.NewLeafByID(1, 0, 0, width, height)
 	lookup := func(id uint32) PaneData {
@@ -646,7 +648,7 @@ func TestRenderDiff_Resize(t *testing.T) {
 
 	// Initial paint.
 	diff := comp.RenderDiff(root, 1, lookup)
-	display.Write([]byte(diff))
+	mustWrite(t, display, []byte(diff))
 
 	// Resize — should clear prevGrid and force full repaint.
 	newW, newH := 50, 8
@@ -684,7 +686,7 @@ func TestPrevGridText(t *testing.T) {
 	totalH := height + GlobalBarHeight
 
 	paneEmu := vt.NewSafeEmulator(40, height-mux.StatusLineRows)
-	paneEmu.Write([]byte("hello world"))
+	mustWrite(t, paneEmu, []byte("hello world"))
 
 	root := mux.NewLeafByID(1, 0, 0, width, height)
 	lookup := func(id uint32) PaneData {
@@ -829,11 +831,15 @@ func colorOracleCheck(comp *Compositor, diffDisplay *vt.SafeEmulator, root *mux.
 	// Ground truth: RenderFull (clear screen) -> fresh display emulator.
 	fullANSI := comp.RenderFull(root, activeID, lookup, true)
 	fullDisplay := vt.NewSafeEmulator(width, height)
-	fullDisplay.Write([]byte(fullANSI))
+	if _, err := fullDisplay.Write([]byte(fullANSI)); err != nil {
+		return []string{fmt.Sprintf("apply full ANSI to display: %v", err)}
+	}
 
 	// Diff path: RenderDiff -> persistent display emulator.
 	diffANSI := comp.RenderDiff(root, activeID, lookup)
-	diffDisplay.Write([]byte(diffANSI))
+	if _, err := diffDisplay.Write([]byte(diffANSI)); err != nil {
+		return []string{fmt.Sprintf("apply diff ANSI to display: %v", err)}
+	}
 
 	var mismatches []string
 	for y := 0; y < height; y++ {
@@ -909,7 +915,7 @@ func TestRenderDiff_ColorOracle(t *testing.T) {
 	contentH := height - mux.StatusLineRows
 
 	paneEmu := vt.NewSafeEmulator(width, contentH)
-	paneEmu.Write([]byte(htopSampleANSI))
+	mustWrite(t, paneEmu, []byte(htopSampleANSI))
 
 	root := mux.NewLeafByID(1, 0, 0, width, height)
 	lookup := func(id uint32) PaneData {
@@ -936,7 +942,7 @@ func TestRenderDiff_ColorOracle_IncrementalUpdate(t *testing.T) {
 	contentH := height - mux.StatusLineRows
 
 	paneEmu := vt.NewSafeEmulator(width, contentH)
-	paneEmu.Write([]byte(htopSampleANSI))
+	mustWrite(t, paneEmu, []byte(htopSampleANSI))
 
 	root := mux.NewLeafByID(1, 0, 0, width, height)
 	lookup := func(id uint32) PaneData {
@@ -951,13 +957,13 @@ func TestRenderDiff_ColorOracle_IncrementalUpdate(t *testing.T) {
 
 	// Initial render: populate prevGrid and prime the diff display.
 	initDiff := comp.RenderDiff(root, 1, lookup)
-	diffDisplay.Write([]byte(initDiff))
+	mustWrite(t, diffDisplay, []byte(initDiff))
 
 	// Simulate htop redraw: overwrite CPU bars with new values.
-	paneEmu.Write([]byte(
-		"\033[1;1H" + // home cursor to top-left of pane content
-			"\033[32m|||||||\033[31m|\033[90;1m  \033[0m CPU1 [###..]" +
-			"\r\n" +
+	mustWrite(t, paneEmu, []byte(
+		"\033[1;1H"+ // home cursor to top-left of pane content
+			"\033[32m|||||||\033[31m|\033[90;1m  \033[0m CPU1 [###..]"+
+			"\r\n"+
 			"\033[34m||\033[33m||||\033[90;1m    \033[0m CPU2 [##...]",
 	))
 
@@ -1012,7 +1018,7 @@ func TestRenderDiff_ColorOracle_CursorAssembledGraphemeClusters(t *testing.T) {
 			contentH := height - mux.StatusLineRows
 
 			paneEmu := vt.NewSafeEmulator(width, contentH)
-			paneEmu.Write([]byte(tt.initial))
+			mustWrite(t, paneEmu, []byte(tt.initial))
 
 			root := mux.NewLeafByID(1, 0, 0, width, height)
 			lookup := func(id uint32) PaneData {
@@ -1031,7 +1037,7 @@ func TestRenderDiff_ColorOracle_CursorAssembledGraphemeClusters(t *testing.T) {
 				t.Fatalf("writing initial diff: %v", err)
 			}
 
-			paneEmu.Write([]byte(tt.update))
+			mustWrite(t, paneEmu, []byte(tt.update))
 
 			if err := muxTextOracleCheck(comp, diffDisplay, root, 1, lookup, width, totalH); err != "" {
 				t.Fatalf("cursor-assembled grapheme mismatch:\n%s", err)
@@ -1048,7 +1054,7 @@ func TestRenderDiff_ColorOracle_LeadPane(t *testing.T) {
 	contentH := height - mux.StatusLineRows
 
 	paneEmu := vt.NewSafeEmulator(width, contentH)
-	paneEmu.Write([]byte("lead pane content"))
+	mustWrite(t, paneEmu, []byte("lead pane content"))
 
 	root := mux.NewLeafByID(1, 0, 0, width, height)
 	lookup := func(id uint32) PaneData {
@@ -1204,7 +1210,7 @@ func TestRenderDiff_LongLines(t *testing.T) {
 	paneEmu := vt.NewSafeEmulator(width, contentH)
 	// Write a line that exceeds the pane width — triggers wrapping in the VT emulator.
 	longLine := strings.Repeat("A", width+20)
-	paneEmu.Write([]byte(longLine))
+	mustWrite(t, paneEmu, []byte(longLine))
 
 	root := mux.NewLeafByID(1, 0, 0, width, height)
 	lookup := func(id uint32) PaneData {
@@ -1235,11 +1241,11 @@ func TestRenderDiff_LongLines_TwoPanes(t *testing.T) {
 	pane2Emu := vt.NewSafeEmulator(pane2W, contentH)
 
 	// Left pane: long line with ANSI colors (simulates a colored prompt with long branch name).
-	pane1Emu.Write([]byte(
+	mustWrite(t, pane1Emu, []byte(
 		"\033[32muser@host\033[0m:\033[34m~/very/deeply/nested/project/directory\033[0m (feature/extremely-long-branch-name-that-overflows)$ ",
 	))
 	// Right pane: long plain text line.
-	pane2Emu.Write([]byte(strings.Repeat("B", pane2W+15)))
+	mustWrite(t, pane2Emu, []byte(strings.Repeat("B", pane2W+15)))
 
 	root := mkSplit(mux.SplitVertical, 0, 0, width, height,
 		mux.NewLeafByID(1, 0, 0, pane1W, height),
@@ -1256,7 +1262,7 @@ func TestRenderDiff_LongLines_TwoPanes(t *testing.T) {
 	}
 
 	// Incremental: add more long content.
-	pane1Emu.Write([]byte("\r\n" + strings.Repeat("X", pane1W+10)))
+	mustWrite(t, pane1Emu, []byte("\r\n"+strings.Repeat("X", pane1W+10)))
 	if err := oracleCheck(comp, display, root, 1, lookup, width, totalH); err != "" {
 		t.Error(err)
 	}
@@ -1320,11 +1326,11 @@ func TestRenderDiff_ColorOracle_LongLines(t *testing.T) {
 	pane2Emu := vt.NewSafeEmulator(pane2W, contentH)
 
 	// Colored long lines — ANSI escapes + text exceeding pane width.
-	pane1Emu.Write([]byte(
-		"\033[32m" + strings.Repeat("|", pane1W+10) + "\033[0m",
+	mustWrite(t, pane1Emu, []byte(
+		"\033[32m"+strings.Repeat("|", pane1W+10)+"\033[0m",
 	))
-	pane2Emu.Write([]byte(
-		"\033[31m" + strings.Repeat("#", pane2W+10) + "\033[0m",
+	mustWrite(t, pane2Emu, []byte(
+		"\033[31m"+strings.Repeat("#", pane2W+10)+"\033[0m",
 	))
 
 	root := mkSplit(mux.SplitVertical, 0, 0, width, height,
@@ -1342,8 +1348,8 @@ func TestRenderDiff_ColorOracle_LongLines(t *testing.T) {
 	}
 
 	// Incremental update: overwrite with new long colored content.
-	pane1Emu.Write([]byte(
-		"\033[1;1H\033[33m" + strings.Repeat("=", pane1W+5) + "\033[0m",
+	mustWrite(t, pane1Emu, []byte(
+		"\033[1;1H\033[33m"+strings.Repeat("=", pane1W+5)+"\033[0m",
 	))
 	if mismatches := colorOracleCheck(comp, diffDisplay, root, 1, lookup, width, totalH); len(mismatches) > 0 {
 		t.Errorf("long-line color oracle incremental: %d mismatches:\n%s",
@@ -1366,7 +1372,7 @@ func TestRenderDiff_LongLines_NinePanes(t *testing.T) {
 		emus[i] = vt.NewSafeEmulator(colW, contentH)
 		// Each pane gets a line that overflows its width.
 		line := fmt.Sprintf("pane-%d:%s", i+1, strings.Repeat(string(rune('a'+i)), colW+10))
-		emus[i].Write([]byte(line))
+		mustWrite(t, emus[i], []byte(line))
 	}
 
 	root := buildNinePaneGrid(colW, rowH, width, height)
@@ -1411,13 +1417,13 @@ func TestRenderDiff_ColorOracle_TwoPanes(t *testing.T) {
 	pane2Emu := vt.NewSafeEmulator(pane2W, contentH)
 
 	// Left pane: htop-like colored bars
-	pane1Emu.Write([]byte(
-		"\033[32m|||||\033[31m||\033[90;1m   \033[0m CPU1\r\n" +
+	mustWrite(t, pane1Emu, []byte(
+		"\033[32m|||||\033[31m||\033[90;1m   \033[0m CPU1\r\n"+
 			"\033[34m|||\033[33m|||\033[90;1m    \033[0m CPU2",
 	))
 
 	// Right pane: plain text
-	pane2Emu.Write([]byte("$ top\r\nPID  CPU%  MEM%"))
+	mustWrite(t, pane2Emu, []byte("$ top\r\nPID  CPU%  MEM%"))
 
 	left := mux.NewLeafByID(1, 0, 0, pane1W, height)
 	right := mux.NewLeafByID(2, pane1W+1, 0, pane2W, height)
@@ -1449,8 +1455,8 @@ func TestRenderDiff_ColorOracle_TwoPanes(t *testing.T) {
 	}
 
 	// Update left pane, keep right pane unchanged.
-	pane1Emu.Write([]byte(
-		"\033[1;1H" +
+	mustWrite(t, pane1Emu, []byte(
+		"\033[1;1H"+
 			"\033[32m|||||||\033[31m|\033[90;1m  \033[0m CPU1",
 	))
 
@@ -1632,7 +1638,7 @@ func FuzzCompositor(f *testing.F) {
 				}
 				if start < len(contentData) {
 					content := fuzzPaneContent(contentData[start:end], cell.W, contentH)
-					emu.Write([]byte(content))
+					mustWrite(t, emu, []byte(content))
 				}
 			}
 

--- a/internal/render/sequences.go
+++ b/internal/render/sequences.go
@@ -27,10 +27,10 @@ const (
 )
 
 var (
-	Bold   = ansi.SGR(ansi.BoldAttr)
-	NoBold = ansi.SGR(ansi.NormalIntensityAttr)
+	Bold   = ansi.SGR(ansi.AttrBold)
+	NoBold = ansi.SGR(ansi.AttrNormalIntensity)
 
-	StrikeOn = ansi.SGR(ansi.StrikethroughAttr)
+	StrikeOn = ansi.SGR(ansi.AttrStrikethrough)
 
 	DimFg      = foregroundSequence(config.DimColorHex)
 	Surface0Bg = backgroundSequence(config.Surface0Hex)

--- a/internal/render/statusbar.go
+++ b/internal/render/statusbar.go
@@ -350,7 +350,7 @@ func paneStatusMetadataSegments(items []paneStatusMetadataItem, maxWidth int) []
 
 		if i == 0 {
 			if labelWidth <= maxWidth {
-				segments = append(segments, paneStatusMetadataSegment{text: item.text, status: item.status})
+				segments = append(segments, paneStatusMetadataSegment(item))
 				usedWidth = labelWidth
 				continue
 			}
@@ -368,7 +368,7 @@ func paneStatusMetadataSegments(items []paneStatusMetadataItem, maxWidth int) []
 		if usedWidth+2+labelWidth <= maxWidth {
 			segments = append(segments,
 				paneStatusMetadataSegment{text: ", "},
-				paneStatusMetadataSegment{text: item.text, status: item.status},
+				paneStatusMetadataSegment(item),
 			)
 			usedWidth += 2 + labelWidth
 			continue

--- a/internal/server/broadcast_command_test.go
+++ b/internal/server/broadcast_command_test.go
@@ -43,6 +43,10 @@ func TestParseBroadcastCommandArgs(t *testing.T) {
 			},
 		},
 		{
+			name:      "no args",
+			wantError: "usage: broadcast",
+		},
+		{
 			name:      "missing selector",
 			args:      []string{"echo hello", "Enter"},
 			wantError: "usage: broadcast",

--- a/internal/server/broadcast_command_test.go
+++ b/internal/server/broadcast_command_test.go
@@ -48,6 +48,26 @@ func TestParseBroadcastCommandArgs(t *testing.T) {
 			wantError: "usage: broadcast",
 		},
 		{
+			name:      "missing panes value",
+			args:      []string{"--panes"},
+			wantError: "usage: broadcast",
+		},
+		{
+			name:      "missing window value",
+			args:      []string{"--window"},
+			wantError: "usage: broadcast",
+		},
+		{
+			name:      "missing match value",
+			args:      []string{"--match"},
+			wantError: "usage: broadcast",
+		},
+		{
+			name:      "missing keys after selector",
+			args:      []string{"--panes", "pane-1"},
+			wantError: "usage: broadcast",
+		},
+		{
 			name:      "multiple selectors",
 			args:      []string{"--panes", "pane-1", "--window", "1", "echo hello", "Enter"},
 			wantError: "specify exactly one",
@@ -72,6 +92,21 @@ func TestParseBroadcastCommandArgs(t *testing.T) {
 				t.Fatalf("parseBroadcastCommandArgs() = %#v, want %#v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestResolveBroadcastTargetsForActorRejectsMissingSelector(t *testing.T) {
+	t.Parallel()
+
+	sess := newSession("test-broadcast-missing-selector")
+	stopCrashCheckpointLoop(t, sess)
+
+	targets, err := resolveBroadcastTargetsForActor(sess, 0, broadcastCommandArgs{})
+	if err == nil || err.Error() != broadcastUsage {
+		t.Fatalf("resolveBroadcastTargetsForActor() error = %v, want %q", err, broadcastUsage)
+	}
+	if targets != nil {
+		t.Fatalf("resolveBroadcastTargetsForActor() targets = %v, want nil", targets)
 	}
 }
 

--- a/internal/server/capture_forward.go
+++ b/internal/server/capture_forward.go
@@ -235,7 +235,12 @@ func (s *Session) sendCaptureRequestAsync(req *captureRequest) {
 	if req == nil {
 		return
 	}
-	req.client.Send(s.captureRequestMessage(req))
+	if err := req.client.Send(s.captureRequestMessage(req)); err != nil && req.client.logger != nil {
+		req.client.logger.Warn("sending capture request failed",
+			"event", "capture_request",
+			"error", err,
+		)
+	}
 }
 
 func (s *Session) startNextCaptureRequest() {

--- a/internal/server/capture_forward.go
+++ b/internal/server/capture_forward.go
@@ -236,10 +236,7 @@ func (s *Session) sendCaptureRequestAsync(req *captureRequest) {
 		return
 	}
 	if err := req.client.Send(s.captureRequestMessage(req)); err != nil && req.client.logger != nil {
-		req.client.logger.Warn("sending capture request failed",
-			"event", "capture_request",
-			"error", err,
-		)
+		req.client.logger.Warn("sending capture request failed", "event", "capture_request", "error", err)
 	}
 }
 

--- a/internal/server/capture_forward_test.go
+++ b/internal/server/capture_forward_test.go
@@ -1050,7 +1050,7 @@ func readCaptureRequestForTest(t *testing.T, conn net.Conn) *Message {
 	if err := conn.SetReadDeadline(time.Now().Add(time.Second)); err != nil {
 		t.Fatalf("SetReadDeadline: %v", err)
 	}
-	defer conn.SetReadDeadline(time.Time{})
+	defer mustSetReadDeadline(t, conn, time.Time{})
 
 	msg, err := readMsgOnConn(conn)
 	if err != nil {

--- a/internal/server/checkpoint.go
+++ b/internal/server/checkpoint.go
@@ -123,10 +123,16 @@ func (s *Server) Reload(execPath string) error {
 	sess.logCheckpointWrite("reload", cpPath, time.Since(reloadStarted), nil)
 
 	// Clear FD_CLOEXEC on inherited FDs (skip proxy panes — they have no PTY)
-	clearCloexec(uintptr(cp.ListenerFd))
+	if err := clearCloexec(uintptr(cp.ListenerFd)); err != nil {
+		sess.shutdown.Store(false)
+		return fmt.Errorf("clearing close-on-exec on listener: %w", err)
+	}
 	for _, pc := range cp.Panes {
 		if !pc.IsProxy && pc.PtmxFd >= 0 {
-			clearCloexec(uintptr(pc.PtmxFd))
+			if err := clearCloexec(uintptr(pc.PtmxFd)); err != nil {
+				sess.shutdown.Store(false)
+				return fmt.Errorf("clearing close-on-exec on pane %d PTY: %w", pc.ID, err)
+			}
 		}
 	}
 
@@ -325,7 +331,9 @@ func NewServerFromCheckpointWithScrollbackLogger(cp *checkpoint.ServerCheckpoint
 				return false
 			}
 			for _, target := range targets {
-				target.pane.Resize(target.cols, target.rows)
+				if err := target.pane.Resize(target.cols, target.rows); err != nil {
+					return false
+				}
 			}
 			return true
 		}
@@ -366,6 +374,10 @@ func listenerFd(ln net.Listener) (int, error) {
 }
 
 // clearCloexec clears the FD_CLOEXEC flag so the FD survives exec.
-func clearCloexec(fd uintptr) {
-	syscall.Syscall(syscall.SYS_FCNTL, fd, syscall.F_SETFD, 0)
+func clearCloexec(fd uintptr) error {
+	_, _, errno := syscall.Syscall(syscall.SYS_FCNTL, fd, syscall.F_SETFD, 0)
+	if errno != 0 {
+		return errno
+	}
+	return nil
 }

--- a/internal/server/checkpoint_test.go
+++ b/internal/server/checkpoint_test.go
@@ -6,12 +6,26 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"syscall"
 	"testing"
 	"time"
 
 	"github.com/weill-labs/amux/internal/checkpoint"
 	"github.com/weill-labs/amux/internal/mux"
 )
+
+func TestClearCloexecReturnsErrnoOnInvalidFD(t *testing.T) {
+	t.Parallel()
+
+	err := clearCloexec(^uintptr(0))
+	if err == nil {
+		t.Fatal("clearCloexec() error = nil, want errno")
+	}
+	var errno syscall.Errno
+	if !errors.As(err, &errno) || errno == 0 {
+		t.Fatalf("clearCloexec() error = %v, want syscall.Errno", err)
+	}
+}
 
 func TestServerReloadReturnsSessionShuttingDownBeforeCheckpoint(t *testing.T) {
 	t.Parallel()

--- a/internal/server/client_conn.go
+++ b/internal/server/client_conn.go
@@ -287,8 +287,16 @@ func (cc *clientConn) handleCommand(srv *Server, sess *Session, msg *Message) {
 	defer func() {
 		if r := recover(); r != nil {
 			ctx.auditErr = fmt.Sprintf("internal error: panic in command %q", msg.CmdName)
-			sess.logPanic("command_panic", r, debug.Stack())
-			cc.Send(&Message{Type: MsgTypeCmdResult, CmdErr: ctx.auditErr})
+			if err := sess.logPanic("command_panic", r, debug.Stack()); err != nil {
+				ctx.auditErr = err.Error()
+			}
+			if err := cc.Send(&Message{Type: MsgTypeCmdResult, CmdErr: ctx.auditErr}); err != nil && cc.logger != nil {
+				cc.logger.Warn("sending panic response failed",
+					"event", "command_panic",
+					"command", msg.CmdName,
+					"error", err,
+				)
+			}
 		}
 		sess.logCommandExecution(cc.ID, msg.CmdName, msg.CmdArgs, msg.ActorPaneID, time.Since(started), ctx.auditErr)
 	}()
@@ -297,8 +305,13 @@ func (cc *clientConn) handleCommand(srv *Server, sess *Session, msg *Message) {
 	handler, ok := srv.lookupCommand(msg.CmdName)
 	if !ok {
 		ctx.auditErr = fmt.Sprintf("unknown command: %s", msg.CmdName)
-		cc.Send(&Message{Type: MsgTypeCmdResult,
-			CmdErr: ctx.auditErr})
+		if err := cc.Send(&Message{Type: MsgTypeCmdResult, CmdErr: ctx.auditErr}); err != nil && cc.logger != nil {
+			cc.logger.Warn("sending unknown-command response failed",
+				"event", "command_dispatch",
+				"command", msg.CmdName,
+				"error", err,
+			)
+		}
 		return
 	}
 	handler(ctx)

--- a/internal/server/client_conn.go
+++ b/internal/server/client_conn.go
@@ -291,11 +291,7 @@ func (cc *clientConn) handleCommand(srv *Server, sess *Session, msg *Message) {
 				ctx.auditErr = err.Error()
 			}
 			if err := cc.Send(&Message{Type: MsgTypeCmdResult, CmdErr: ctx.auditErr}); err != nil && cc.logger != nil {
-				cc.logger.Warn("sending panic response failed",
-					"event", "command_panic",
-					"command", msg.CmdName,
-					"error", err,
-				)
+				cc.logger.Warn("sending panic response failed", "event", "command_panic", "command", msg.CmdName, "error", err)
 			}
 		}
 		sess.logCommandExecution(cc.ID, msg.CmdName, msg.CmdArgs, msg.ActorPaneID, time.Since(started), ctx.auditErr)
@@ -306,11 +302,7 @@ func (cc *clientConn) handleCommand(srv *Server, sess *Session, msg *Message) {
 	if !ok {
 		ctx.auditErr = fmt.Sprintf("unknown command: %s", msg.CmdName)
 		if err := cc.Send(&Message{Type: MsgTypeCmdResult, CmdErr: ctx.auditErr}); err != nil && cc.logger != nil {
-			cc.logger.Warn("sending unknown-command response failed",
-				"event", "command_dispatch",
-				"command", msg.CmdName,
-				"error", err,
-			)
+			cc.logger.Warn("sending unknown-command response failed", "event", "command_dispatch", "command", msg.CmdName, "error", err)
 		}
 		return
 	}

--- a/internal/server/client_conn_test.go
+++ b/internal/server/client_conn_test.go
@@ -563,6 +563,34 @@ func TestClientConnReadLoopCommandRepliesDoNotBlockOnBlockedWriter(t *testing.T)
 	}
 }
 
+func TestClientConnHandleCommandIgnoresClosedWriterOnReplyPaths(t *testing.T) {
+	t.Parallel()
+
+	sess := newSession("test-client-command-closed-writer")
+	stopCrashCheckpointLoop(t, sess)
+	defer stopSessionBackgroundLoops(t, sess)
+
+	t.Run("unknown command", func(t *testing.T) {
+		cc := newClientConn(discardConn{})
+		cc.Close()
+
+		cc.handleCommand(&Server{}, sess, &Message{Type: MsgTypeCommand, CmdName: "nope"})
+	})
+
+	t.Run("panic response", func(t *testing.T) {
+		cc := newClientConn(discardConn{})
+		cc.Close()
+
+		srv := &Server{commands: map[string]CommandHandler{
+			"panic": func(*CommandContext) {
+				panic("boom")
+			},
+		}}
+
+		cc.handleCommand(srv, sess, &Message{Type: MsgTypeCommand, CmdName: "panic"})
+	})
+}
+
 func TestClientConnTypeKeyQueueDoesNotBlockOnBlockedWriter(t *testing.T) {
 	t.Parallel()
 

--- a/internal/server/commands.go
+++ b/internal/server/commands.go
@@ -24,12 +24,7 @@ func (ctx *CommandContext) send(msg *Message) {
 		return
 	}
 	if err := ctx.CC.Send(msg); err != nil && ctx.CC.logger != nil {
-		ctx.CC.logger.Warn("sending command response failed",
-			"event", "command_response",
-			"command", ctx.CommandName,
-			"message_type", msg.Type,
-			"error", err,
-		)
+		ctx.CC.logger.Warn("sending command response failed", "event", "command_response", "command", ctx.CommandName, "message_type", msg.Type, "error", err)
 	}
 }
 

--- a/internal/server/commands.go
+++ b/internal/server/commands.go
@@ -19,13 +19,27 @@ type CommandContext struct {
 	auditErr    string
 }
 
+func (ctx *CommandContext) send(msg *Message) {
+	if ctx.CC == nil || msg == nil {
+		return
+	}
+	if err := ctx.CC.Send(msg); err != nil && ctx.CC.logger != nil {
+		ctx.CC.logger.Warn("sending command response failed",
+			"event", "command_response",
+			"command", ctx.CommandName,
+			"message_type", msg.Type,
+			"error", err,
+		)
+	}
+}
+
 func (ctx *CommandContext) reply(output string) {
-	ctx.CC.Send(&Message{Type: MsgTypeCmdResult, CmdOutput: output})
+	ctx.send(&Message{Type: MsgTypeCmdResult, CmdOutput: output})
 }
 
 func (ctx *CommandContext) replyErr(errMsg string) {
 	ctx.auditErr = errMsg
-	ctx.CC.Send(&Message{Type: MsgTypeCmdResult, CmdErr: errMsg})
+	ctx.send(&Message{Type: MsgTypeCmdResult, CmdErr: errMsg})
 }
 
 func (ctx *CommandContext) replyCommandMutation(res commandMutationResult) {
@@ -40,12 +54,12 @@ func (ctx *CommandContext) replyCommandMutation(res commandMutationResult) {
 		pane.Start()
 	}
 	if res.bell {
-		ctx.CC.Send(&Message{Type: MsgTypeBell})
+		ctx.send(&Message{Type: MsgTypeBell})
 	}
 	if res.output != "" {
 		ctx.reply(res.output)
 	} else {
-		ctx.CC.Send(&Message{Type: MsgTypeCmdResult})
+		ctx.send(&Message{Type: MsgTypeCmdResult})
 	}
 	if ctx.CC != nil && (res.sendExit || res.shutdownServer) {
 		// Flush the command reply before exiting or shutting down so one-shot
@@ -88,7 +102,7 @@ func (ctx *CommandContext) applyCommandResult(res commandpkg.Result) {
 			ctx.replyErr(err.Error())
 		}
 	case res.Message != nil:
-		ctx.CC.Send(res.Message)
+		ctx.send(res.Message)
 	default:
 		ctx.replyCommandMutation(toCommandMutationResult(res))
 	}
@@ -148,14 +162,6 @@ func toCommandResult(res commandMutationResult) commandpkg.Result {
 		SendExit:        res.sendExit,
 		ShutdownServer:  res.shutdownServer,
 	}
-}
-
-func (ctx *CommandContext) activeWindowSnapshot() (activePid, width, height int, err error) {
-	snap, err := ctx.Sess.queryActiveWindowSnapshot()
-	if err != nil {
-		return 0, 0, 0, err
-	}
-	return snap.activePID, snap.width, snap.height, nil
 }
 
 // commandRegistry maps command names to their handlers, following

--- a/internal/server/commands/layout/commands.go
+++ b/internal/server/commands/layout/commands.go
@@ -307,7 +307,7 @@ func ParseCopyModeArgs(args []string, defaultTimeout time.Duration) (CopyModeOpt
 	}
 	positionals := flags.Positionals()
 	if len(positionals) > 1 {
-		return CopyModeOptions{}, fmt.Errorf(copyModeUsage)
+		return CopyModeOptions{}, errors.New(copyModeUsage)
 	}
 	opts := CopyModeOptions{WaitTimeout: flags.Duration("--timeout")}
 	if len(positionals) == 1 {

--- a/internal/server/commands/layout/commands_test.go
+++ b/internal/server/commands/layout/commands_test.go
@@ -448,6 +448,15 @@ func TestCopyModeParsesArgsAndDelegates(t *testing.T) {
 	}
 }
 
+func TestParseCopyModeArgsRejectsMultiplePaneRefs(t *testing.T) {
+	t.Parallel()
+
+	_, err := ParseCopyModeArgs([]string{"pane-1", "pane-2"}, 5*time.Second)
+	if err == nil || err.Error() != copyModeUsage {
+		t.Fatalf("ParseCopyModeArgs() error = %v, want %q", err, copyModeUsage)
+	}
+}
+
 func TestEqualizeParsesModesAndDelegates(t *testing.T) {
 	t.Parallel()
 

--- a/internal/server/commands/layout/tree/move.go
+++ b/internal/server/commands/layout/tree/move.go
@@ -2,7 +2,6 @@ package tree
 
 import (
 	"errors"
-	"fmt"
 )
 
 const MoveUsage = "usage: move <pane> --before <target> | move <pane> --after <target>"
@@ -12,7 +11,7 @@ const MoveDownUsage = "usage: move-down <pane>"
 
 func ParseMoveArgs(args []string) (paneRef, targetRef string, before bool, err error) {
 	if len(args) != 3 {
-		return "", "", false, fmt.Errorf(MoveUsage)
+		return "", "", false, errors.New(MoveUsage)
 	}
 
 	paneRef = args[0]
@@ -23,7 +22,7 @@ func ParseMoveArgs(args []string) (paneRef, targetRef string, before bool, err e
 		before = true
 	case "--after":
 	default:
-		return "", "", false, fmt.Errorf(MoveUsage)
+		return "", "", false, errors.New(MoveUsage)
 	}
 
 	return paneRef, targetRef, before, nil
@@ -31,7 +30,7 @@ func ParseMoveArgs(args []string) (paneRef, targetRef string, before bool, err e
 
 func ParseMoveToArgs(args []string) (paneRef, targetRef string, err error) {
 	if len(args) != 2 {
-		return "", "", fmt.Errorf(MoveToUsage)
+		return "", "", errors.New(MoveToUsage)
 	}
 	return args[0], args[1], nil
 }

--- a/internal/server/commands/layout/tree/move_test.go
+++ b/internal/server/commands/layout/tree/move_test.go
@@ -1,0 +1,37 @@
+package tree
+
+import "testing"
+
+func TestParseMoveArgsUsage(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{name: "missing target", args: []string{"pane-1", "--before"}, want: MoveUsage},
+		{name: "invalid flag", args: []string{"pane-1", "--around", "pane-2"}, want: MoveUsage},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, _, _, err := ParseMoveArgs(tt.args)
+			if err == nil || err.Error() != tt.want {
+				t.Fatalf("ParseMoveArgs(%v) error = %v, want %q", tt.args, err, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseMoveToArgsUsage(t *testing.T) {
+	t.Parallel()
+
+	_, _, err := ParseMoveToArgs([]string{"pane-1"})
+	if err == nil || err.Error() != MoveToUsage {
+		t.Fatalf("ParseMoveToArgs() error = %v, want %q", err, MoveToUsage)
+	}
+}

--- a/internal/server/commands/meta/meta.go
+++ b/internal/server/commands/meta/meta.go
@@ -1,6 +1,7 @@
 package meta
 
 import (
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -18,7 +19,7 @@ type Context interface {
 
 func Meta(ctx Context, args []string) commandpkg.Result {
 	if len(args) == 0 {
-		return commandpkg.Result{Err: fmt.Errorf(MetaUsage)}
+		return commandpkg.Result{Err: errors.New(MetaUsage)}
 	}
 
 	switch args[0] {
@@ -29,7 +30,7 @@ func Meta(ctx Context, args []string) commandpkg.Result {
 	case "rm":
 		return MetaRm(ctx, args[1:])
 	default:
-		return commandpkg.Result{Err: fmt.Errorf(MetaUsage)}
+		return commandpkg.Result{Err: errors.New(MetaUsage)}
 	}
 }
 

--- a/internal/server/commands/meta/meta_test.go
+++ b/internal/server/commands/meta/meta_test.go
@@ -1,0 +1,37 @@
+package meta
+
+import (
+	"testing"
+
+	"github.com/weill-labs/amux/internal/mux"
+)
+
+type stubMetaContext struct{}
+
+func (stubMetaContext) ResolvePaneForMutation(string) (*mux.Pane, error) { return nil, nil }
+
+func (stubMetaContext) QueryPaneKV(string, []string) (string, error) { return "", nil }
+
+func TestMetaUsage(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "missing subcommand"},
+		{name: "unknown subcommand", args: []string{"wat"}},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := Meta(stubMetaContext{}, tt.args)
+			if got.Err == nil || got.Err.Error() != MetaUsage {
+				t.Fatalf("Meta(%v) error = %v, want %q", tt.args, got.Err, MetaUsage)
+			}
+		})
+	}
+}

--- a/internal/server/commands/wait/commands.go
+++ b/internal/server/commands/wait/commands.go
@@ -1,6 +1,7 @@
 package wait
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -35,7 +36,7 @@ type Context interface {
 
 func Cursor(ctx Context, args []string) commandpkg.Result {
 	if len(args) == 0 {
-		return commandpkg.Result{Err: fmt.Errorf(cursorCommandUsage)}
+		return commandpkg.Result{Err: errors.New(cursorCommandUsage)}
 	}
 
 	switch args[0] {
@@ -52,7 +53,7 @@ func Cursor(ctx Context, args []string) commandpkg.Result {
 
 func Wait(ctx Context, actorPaneID uint32, args []string) commandpkg.Result {
 	if len(args) == 0 {
-		return commandpkg.Result{Err: fmt.Errorf(waitCommandUsage)}
+		return commandpkg.Result{Err: errors.New(waitCommandUsage)}
 	}
 
 	switch args[0] {

--- a/internal/server/commands/wait/commands_test.go
+++ b/internal/server/commands/wait/commands_test.go
@@ -1,0 +1,54 @@
+package wait
+
+import (
+	"testing"
+	"time"
+)
+
+type stubWaitContext struct{}
+
+func (stubWaitContext) Generation() uint64 { return 0 }
+
+func (stubWaitContext) LayoutJSON() (string, error) { return "", nil }
+
+func (stubWaitContext) WaitLayout(uint64, bool, time.Duration) (uint64, bool) { return 0, false }
+
+func (stubWaitContext) ClipboardGeneration() uint64 { return 0 }
+
+func (stubWaitContext) WaitClipboard(uint64, bool, time.Duration) (string, bool) { return "", false }
+
+func (stubWaitContext) WaitCheckpoint(uint64, bool, time.Duration) (CheckpointRecord, bool) {
+	return CheckpointRecord{}, false
+}
+
+func (stubWaitContext) UIGeneration(string) (uint64, error) { return 0, nil }
+
+func (stubWaitContext) WaitContent(uint32, string, string, time.Duration) error { return nil }
+
+func (stubWaitContext) WaitExited(uint32, string, time.Duration) error { return nil }
+
+func (stubWaitContext) WaitBusy(uint32, string, time.Duration) error { return nil }
+
+func (stubWaitContext) WaitUI(string, string, uint64, bool, time.Duration) error { return nil }
+
+func (stubWaitContext) WaitReady(uint32, []string) error { return nil }
+
+func (stubWaitContext) WaitIdle(uint32, []string) error { return nil }
+
+func TestCursorUsage(t *testing.T) {
+	t.Parallel()
+
+	got := Cursor(stubWaitContext{}, nil)
+	if got.Err == nil || got.Err.Error() != cursorCommandUsage {
+		t.Fatalf("Cursor(nil) error = %v, want %q", got.Err, cursorCommandUsage)
+	}
+}
+
+func TestWaitUsage(t *testing.T) {
+	t.Parallel()
+
+	got := Wait(stubWaitContext{}, 0, nil)
+	if got.Err == nil || got.Err.Error() != waitCommandUsage {
+		t.Fatalf("Wait(nil) error = %v, want %q", got.Err, waitCommandUsage)
+	}
+}

--- a/internal/server/commands_context_test.go
+++ b/internal/server/commands_context_test.go
@@ -1,0 +1,32 @@
+package server
+
+import (
+	"net"
+	"testing"
+
+	"github.com/weill-labs/amux/internal/auditlog"
+)
+
+func TestCommandContextSendNilClientIsNoOp(t *testing.T) {
+	t.Parallel()
+
+	ctx := &CommandContext{CommandName: "status"}
+	ctx.send(&Message{Type: MsgTypeCmdResult, CmdOutput: "ok\n"})
+}
+
+func TestCommandContextSendLogsWhenWriteFails(t *testing.T) {
+	t.Parallel()
+
+	serverConn, peerConn := net.Pipe()
+	_ = peerConn.Close()
+	defer func() { _ = serverConn.Close() }()
+
+	cc := newClientConn(serverConn)
+	cc.logger = auditlog.Discard()
+
+	ctx := &CommandContext{
+		CC:          cc,
+		CommandName: "status",
+	}
+	ctx.send(&Message{Type: MsgTypeCmdResult, CmdOutput: "ok\n"})
+}

--- a/internal/server/commands_context_test.go
+++ b/internal/server/commands_context_test.go
@@ -18,11 +18,12 @@ func TestCommandContextSendLogsWhenWriteFails(t *testing.T) {
 	t.Parallel()
 
 	serverConn, peerConn := net.Pipe()
-	_ = peerConn.Close()
+	defer func() { _ = peerConn.Close() }()
 	defer func() { _ = serverConn.Close() }()
 
 	cc := newClientConn(serverConn)
 	cc.logger = auditlog.Discard()
+	cc.Close()
 
 	ctx := &CommandContext{
 		CC:          cc,

--- a/internal/server/commands_input.go
+++ b/internal/server/commands_input.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"errors"
 	"fmt"
 	"path/filepath"
 	"slices"
@@ -141,14 +142,14 @@ func parseTypeKeysArgs(args []string) (typeKeysOptions, error) {
 
 func (ctx inputCommandContext) SendKeys(actorPaneID uint32, args []string) (string, int, error) {
 	if len(args) < 2 {
-		return "", 0, fmt.Errorf(sendKeysUsage)
+		return "", 0, errors.New(sendKeysUsage)
 	}
 	opts, err := parseSendKeysArgs(args[1:])
 	if err != nil {
 		return "", 0, err
 	}
 	if len(opts.keys) == 0 {
-		return "", 0, fmt.Errorf(sendKeysUsage)
+		return "", 0, errors.New(sendKeysUsage)
 	}
 	chunks, err := encodeKeyChunks(opts.hexMode, opts.keys)
 	if err != nil {
@@ -270,7 +271,7 @@ func cmdBroadcast(ctx *CommandContext) {
 
 func parseBroadcastCommandArgs(args []string) (broadcastCommandArgs, error) {
 	if len(args) == 0 {
-		return broadcastCommandArgs{}, fmt.Errorf(broadcastUsage)
+		return broadcastCommandArgs{}, errors.New(broadcastUsage)
 	}
 
 	var parsed broadcastCommandArgs
@@ -285,7 +286,7 @@ func parseBroadcastCommandArgs(args []string) (broadcastCommandArgs, error) {
 			i = len(args)
 		case "--panes":
 			if i+1 >= len(args) {
-				return broadcastCommandArgs{}, fmt.Errorf(broadcastUsage)
+				return broadcastCommandArgs{}, errors.New(broadcastUsage)
 			}
 			selectorCount++
 			parsed.paneRefs = splitBroadcastPaneRefs(args[i+1])
@@ -295,14 +296,14 @@ func parseBroadcastCommandArgs(args []string) (broadcastCommandArgs, error) {
 			i += 2
 		case "--window":
 			if i+1 >= len(args) {
-				return broadcastCommandArgs{}, fmt.Errorf(broadcastUsage)
+				return broadcastCommandArgs{}, errors.New(broadcastUsage)
 			}
 			selectorCount++
 			parsed.windowRef = args[i+1]
 			i += 2
 		case "--match":
 			if i+1 >= len(args) {
-				return broadcastCommandArgs{}, fmt.Errorf(broadcastUsage)
+				return broadcastCommandArgs{}, errors.New(broadcastUsage)
 			}
 			selectorCount++
 			parsed.matchPattern = args[i+1]
@@ -314,7 +315,7 @@ func parseBroadcastCommandArgs(args []string) (broadcastCommandArgs, error) {
 	}
 
 	if selectorCount == 0 {
-		return broadcastCommandArgs{}, fmt.Errorf(broadcastUsage)
+		return broadcastCommandArgs{}, errors.New(broadcastUsage)
 	}
 	if selectorCount != 1 {
 		return broadcastCommandArgs{}, fmt.Errorf("broadcast: specify exactly one of --panes, --window, or --match")
@@ -322,7 +323,7 @@ func parseBroadcastCommandArgs(args []string) (broadcastCommandArgs, error) {
 
 	parsed.hexMode, parsed.keys = parseKeyArgs(keyArgs)
 	if len(parsed.keys) == 0 {
-		return broadcastCommandArgs{}, fmt.Errorf(broadcastUsage)
+		return broadcastCommandArgs{}, errors.New(broadcastUsage)
 	}
 
 	return parsed, nil
@@ -353,7 +354,7 @@ func resolveBroadcastTargetsForActor(sess *Session, actorPaneID uint32, args bro
 		case args.matchPattern != "":
 			return resolveBroadcastMatchTargets(sess, args.matchPattern)
 		default:
-			return nil, fmt.Errorf(broadcastUsage)
+			return nil, errors.New(broadcastUsage)
 		}
 	})
 }
@@ -470,7 +471,7 @@ func (ctx inputCommandContext) TypeKeys(args []string) (int, error) {
 		return 0, err
 	}
 	if len(opts.keys) == 0 {
-		return 0, fmt.Errorf(typeKeysUsage)
+		return 0, errors.New(typeKeysUsage)
 	}
 	chunks, err := encodeKeyChunks(opts.hexMode, opts.keys)
 	if err != nil {

--- a/internal/server/commands_layout.go
+++ b/internal/server/commands_layout.go
@@ -37,18 +37,6 @@ func FormatKillCommandError(err error, command string) string {
 	return layoutcmd.FormatKillCommandError(err, command)
 }
 
-func parseKillCommandArgs(args []string) (killCommandArgs, error) {
-	parsed, err := layoutcmd.ParseKillCommandArgs(args)
-	if err != nil {
-		return killCommandArgs{}, err
-	}
-	return killCommandArgs{
-		paneRef: parsed.PaneRef,
-		cleanup: parsed.Cleanup,
-		timeout: parsed.Timeout,
-	}, nil
-}
-
 func dirName(d mux.SplitDir) string {
 	return layoutcmd.DirName(d)
 }

--- a/internal/server/commands_low_coverage_test.go
+++ b/internal/server/commands_low_coverage_test.go
@@ -64,22 +64,6 @@ func testCaptureHexColor(c color.Color) string {
 	return fmt.Sprintf("%02x%02x%02x", uint8(r>>8), uint8(g>>8), uint8(b>>8))
 }
 
-func mustReadMessage(t *testing.T, conn net.Conn) *Message {
-	t.Helper()
-
-	if err := conn.SetReadDeadline(time.Now().Add(time.Second)); err != nil {
-		t.Fatalf("SetReadDeadline: %v", err)
-	}
-	msg, err := readMsgOnConn(conn)
-	if err != nil {
-		t.Fatalf("ReadMsg: %v", err)
-	}
-	if err := conn.SetReadDeadline(time.Time{}); err != nil {
-		t.Fatalf("reset deadline: %v", err)
-	}
-	return msg
-}
-
 func runTestCommandMessages(t *testing.T, srv *Server, sess *Session, name string, args ...string) []*Message {
 	t.Helper()
 

--- a/internal/server/commands_mouse.go
+++ b/internal/server/commands_mouse.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 	"time"
@@ -73,7 +74,7 @@ func parseMouseCommandArgs(args []string) (mouseCommandOptions, error) {
 
 parseAction:
 	if i >= len(args) {
-		return mouseCommandOptions{}, fmt.Errorf(mouseCommandUsage)
+		return mouseCommandOptions{}, errors.New(mouseCommandUsage)
 	}
 
 	action := args[i]
@@ -118,22 +119,22 @@ parseAction:
 			opts.paneRef = rest[0]
 			for _, arg := range rest[1:] {
 				if arg != "--status-line" {
-					return mouseCommandOptions{}, fmt.Errorf(mouseCommandUsage)
+					return mouseCommandOptions{}, errors.New(mouseCommandUsage)
 				}
 				opts.statusLine = true
 			}
 		default:
-			return mouseCommandOptions{}, fmt.Errorf(mouseCommandUsage)
+			return mouseCommandOptions{}, errors.New(mouseCommandUsage)
 		}
 	case "drag":
 		if len(rest) != 3 || rest[1] != "--to" {
-			return mouseCommandOptions{}, fmt.Errorf(mouseCommandUsage)
+			return mouseCommandOptions{}, errors.New(mouseCommandUsage)
 		}
 		opts.kind = mouseCommandDragPane
 		opts.paneRef = rest[0]
 		opts.targetPaneRef = rest[2]
 	default:
-		return mouseCommandOptions{}, fmt.Errorf(mouseCommandUsage)
+		return mouseCommandOptions{}, errors.New(mouseCommandUsage)
 	}
 
 	return opts, nil
@@ -150,7 +151,7 @@ func looksLikeMouseCoordinatePair(args []string) bool {
 
 func parseMouseCoordinates(args []string) (int, int, error) {
 	if len(args) != 2 {
-		return 0, 0, fmt.Errorf(mouseCommandUsage)
+		return 0, 0, errors.New(mouseCommandUsage)
 	}
 	x, err := parsePositiveCoordinate(args[0], "x")
 	if err != nil {
@@ -352,7 +353,7 @@ func mouseChunksForAction(layout *mux.LayoutCell, opts mouseCommandOptions, pane
 		}
 		return []encodedKeyChunk{press, motion, release}, nil
 	default:
-		return nil, fmt.Errorf(mouseCommandUsage)
+		return nil, errors.New(mouseCommandUsage)
 	}
 }
 

--- a/internal/server/commands_mouse_test.go
+++ b/internal/server/commands_mouse_test.go
@@ -100,6 +100,7 @@ func TestParseMouseCommandArgs(t *testing.T) {
 		{name: "invalid y coordinate", args: []string{"motion", "2", "down"}, wantErr: `mouse: invalid y coordinate "down"`},
 		{name: "zero coordinate", args: []string{"release", "0", "3"}, wantErr: "mouse: x coordinate must be >= 1"},
 		{name: "click pane invalid flag", args: []string{"click", "pane-1", "--bogus"}, wantErr: mouseCommandUsage},
+		{name: "click missing selector", args: []string{"click", "--status-line"}, wantErr: mouseCommandUsage},
 		{name: "drag missing to", args: []string{"drag", "pane-1", "pane-2"}, wantErr: mouseCommandUsage},
 		{name: "unknown action", args: []string{"hover", "1", "1"}, wantErr: mouseCommandUsage},
 		{name: "no action after flags", args: []string{"--client", "client-1"}, wantErr: mouseCommandUsage},

--- a/internal/server/commands_remote.go
+++ b/internal/server/commands_remote.go
@@ -12,10 +12,6 @@ import (
 
 const ReloadServerExecPathFlag = remotecmd.ReloadServerExecPathFlag
 
-func requestedReloadExecPath(args []string) (string, error) {
-	return remotecmd.RequestedReloadExecPath(args)
-}
-
 type remoteCommandContext struct {
 	*CommandContext
 }

--- a/internal/server/commands_tree.go
+++ b/internal/server/commands_tree.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/weill-labs/amux/internal/mux"
@@ -28,7 +29,7 @@ func parseMoveSiblingArgs(args []string, usage string) (paneRef string, err erro
 
 func parseDropPaneArgs(args []string) (paneRef, targetRef, edge string, err error) {
 	if len(args) != 3 {
-		return "", "", "", fmt.Errorf(dropPaneUsage)
+		return "", "", "", errors.New(dropPaneUsage)
 	}
 	paneRef = args[0]
 	targetRef = args[1]
@@ -37,7 +38,7 @@ func parseDropPaneArgs(args []string) (paneRef, targetRef, edge string, err erro
 	case "left", "right", "top", "bottom":
 		return paneRef, targetRef, edge, nil
 	default:
-		return "", "", "", fmt.Errorf(dropPaneUsage)
+		return "", "", "", errors.New(dropPaneUsage)
 	}
 }
 

--- a/internal/server/commands_wait.go
+++ b/internal/server/commands_wait.go
@@ -210,12 +210,6 @@ func (ctx waitCommandContext) WaitIdle(actorPaneID uint32, args []string) error 
 	return waitForPaneIdle(ctx.Sess, paneRef, pane.paneID, opts)
 }
 
-func waitSubcommandContext(ctx *CommandContext, args []string) *CommandContext {
-	sub := *ctx
-	sub.Args = args
-	return &sub
-}
-
 func parseWaitArgs(args []string) (afterGen uint64, afterSet bool, timeout time.Duration, err error) {
 	return waitcmd.ParseWaitArgs(args)
 }
@@ -252,40 +246,12 @@ func cmdWait(ctx *CommandContext) {
 	ctx.applyCommandResult(waitcmd.Wait(waitCommandContext{ctx}, ctx.ActorPaneID, ctx.Args))
 }
 
-func cmdGeneration(ctx *CommandContext) {
-	ctx.applyCommandResult(waitcmd.Generation(waitCommandContext{ctx}, ctx.Args))
-}
-
 func cmdLayoutJSON(ctx *CommandContext) {
 	ctx.applyCommandResult(waitcmd.LayoutJSON(waitCommandContext{ctx}, ctx.Args))
 }
 
-func cmdWaitLayout(ctx *CommandContext) {
-	ctx.applyCommandResult(waitcmd.WaitLayout(waitCommandContext{ctx}, ctx.Args))
-}
-
-func cmdClipboardGen(ctx *CommandContext) {
-	ctx.applyCommandResult(waitcmd.ClipboardGen(waitCommandContext{ctx}, ctx.Args))
-}
-
-func cmdWaitClipboard(ctx *CommandContext) {
-	ctx.applyCommandResult(waitcmd.WaitClipboard(waitCommandContext{ctx}, ctx.Args))
-}
-
-func cmdWaitCheckpoint(ctx *CommandContext) {
-	ctx.applyCommandResult(waitcmd.WaitCheckpoint(waitCommandContext{ctx}, ctx.Args))
-}
-
-func cmdUIGen(ctx *CommandContext) {
-	ctx.applyCommandResult(waitcmd.UIGen(waitCommandContext{ctx}, ctx.Args))
-}
-
 func cmdWaitFor(ctx *CommandContext) {
 	ctx.applyCommandResult(waitcmd.WaitFor(waitCommandContext{ctx}, ctx.ActorPaneID, ctx.Args))
-}
-
-func cmdWaitExited(ctx *CommandContext) {
-	ctx.applyCommandResult(waitcmd.WaitExited(waitCommandContext{ctx}, ctx.ActorPaneID, ctx.Args))
 }
 
 func cmdWaitBusy(ctx *CommandContext) {

--- a/internal/server/daemon_test.go
+++ b/internal/server/daemon_test.go
@@ -50,7 +50,7 @@ func TestCleanStaleSocketsIn(t *testing.T) {
 	ln.Close()
 
 	staleLog := staleSock + ".log"
-	os.WriteFile(staleLog, []byte("old log"), 0600)
+	mustWriteFile(t, staleLog, []byte("old log"), 0600)
 
 	// Create a live socket (server listening).
 	liveSock := filepath.Join(tmpDir, "live-session")
@@ -61,15 +61,15 @@ func TestCleanStaleSocketsIn(t *testing.T) {
 	defer liveLn.Close()
 
 	liveLog := liveSock + ".log"
-	os.WriteFile(liveLog, []byte("live log"), 0600)
+	mustWriteFile(t, liveLog, []byte("live log"), 0600)
 
 	// Create an orphaned log with no socket.
 	orphanLog := filepath.Join(tmpDir, "orphan-session.log")
-	os.WriteFile(orphanLog, []byte("orphan"), 0600)
+	mustWriteFile(t, orphanLog, []byte("orphan"), 0600)
 
 	// Create a regular file (not a socket) — should be ignored.
 	regularFile := filepath.Join(tmpDir, "not-a-socket")
-	os.WriteFile(regularFile, []byte("data"), 0600)
+	mustWriteFile(t, regularFile, []byte("data"), 0600)
 
 	cleanStaleSocketsIn(tmpDir)
 

--- a/internal/server/event_test.go
+++ b/internal/server/event_test.go
@@ -143,7 +143,7 @@ func TestEventJSONOmitsZeroFields(t *testing.T) {
 	}
 
 	var raw map[string]interface{}
-	json.Unmarshal(data, &raw)
+	mustUnmarshalJSON(t, data, &raw)
 
 	if _, ok := raw["generation"]; ok {
 		t.Error("generation should be omitted when zero")
@@ -439,7 +439,7 @@ func TestEmitEventFiltered(t *testing.T) {
 	select {
 	case data := <-res.sub.Ch:
 		var ev Event
-		json.Unmarshal(data, &ev)
+		mustUnmarshalJSON(t, data, &ev)
 		if ev.Type != EventIdle {
 			t.Errorf("expected idle event, got %q", ev.Type)
 		}

--- a/internal/server/idle.go
+++ b/internal/server/idle.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -76,7 +77,7 @@ func parseWaitIdleArgs(args []string) (string, waitIdleOptions, error) {
 
 func parseWaitIdleArgsWithDefaults(args []string, settleDefault, timeoutDefault time.Duration) (string, waitIdleOptions, error) {
 	if len(args) < 1 {
-		return "", waitIdleOptions{}, fmt.Errorf(waitIdleUsage)
+		return "", waitIdleOptions{}, errors.New(waitIdleUsage)
 	}
 
 	flags, err := cmdflags.ParseCommandFlags(args[1:], []cmdflags.FlagSpec{

--- a/internal/server/lint_test_helpers_test.go
+++ b/internal/server/lint_test_helpers_test.go
@@ -1,0 +1,30 @@
+package server
+
+import (
+	"encoding/json"
+	"net"
+	"os"
+	"testing"
+	"time"
+)
+
+func mustWriteFile(tb testing.TB, path string, data []byte, perm os.FileMode) {
+	tb.Helper()
+	if err := os.WriteFile(path, data, perm); err != nil {
+		tb.Fatalf("WriteFile(%q) error = %v", path, err)
+	}
+}
+
+func mustUnmarshalJSON(tb testing.TB, data []byte, target any) {
+	tb.Helper()
+	if err := json.Unmarshal(data, target); err != nil {
+		tb.Fatalf("Unmarshal() error = %v", err)
+	}
+}
+
+func mustSetReadDeadline(tb testing.TB, conn net.Conn, deadline time.Time) {
+	tb.Helper()
+	if err := conn.SetReadDeadline(deadline); err != nil {
+		tb.Fatalf("SetReadDeadline() error = %v", err)
+	}
+}

--- a/internal/server/protocol_bench_test.go
+++ b/internal/server/protocol_bench_test.go
@@ -66,7 +66,9 @@ func BenchmarkWriteMsg_PaneOutput(b *testing.B) {
 			b.ResetTimer()
 			for b.Loop() {
 				buf.Reset()
-				WriteMsg(&buf, msg)
+				if err := WriteMsg(&buf, msg); err != nil {
+					b.Fatal(err)
+				}
 			}
 		})
 	}
@@ -78,14 +80,18 @@ func BenchmarkReadMsg_PaneOutput(b *testing.B) {
 			msg := benchPaneOutputMsg(size)
 			// Pre-encode
 			var encoded bytes.Buffer
-			WriteMsg(&encoded, msg)
+			if err := WriteMsg(&encoded, msg); err != nil {
+				b.Fatal(err)
+			}
 			raw := encoded.Bytes()
 
 			b.SetBytes(int64(size))
 			b.ReportAllocs()
 			b.ResetTimer()
 			for b.Loop() {
-				ReadMsg(bytes.NewReader(raw))
+				if _, err := ReadMsg(bytes.NewReader(raw)); err != nil {
+					b.Fatal(err)
+				}
 			}
 		})
 	}
@@ -104,7 +110,9 @@ func BenchmarkWriteMsg_Layout(b *testing.B) {
 			b.ResetTimer()
 			for b.Loop() {
 				buf.Reset()
-				WriteMsg(&buf, msg)
+				if err := WriteMsg(&buf, msg); err != nil {
+					b.Fatal(err)
+				}
 			}
 		})
 	}
@@ -119,13 +127,17 @@ func BenchmarkReadMsg_Layout(b *testing.B) {
 				Layout: snap,
 			}
 			var encoded bytes.Buffer
-			WriteMsg(&encoded, msg)
+			if err := WriteMsg(&encoded, msg); err != nil {
+				b.Fatal(err)
+			}
 			raw := encoded.Bytes()
 
 			b.ReportAllocs()
 			b.ResetTimer()
 			for b.Loop() {
-				ReadMsg(bytes.NewReader(raw))
+				if _, err := ReadMsg(bytes.NewReader(raw)); err != nil {
+					b.Fatal(err)
+				}
 			}
 		})
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -488,7 +488,10 @@ func newServerWithScrollbackLogger(sessionName string, scrollbackLines int, logg
 	if err != nil {
 		return nil, fmt.Errorf("listening: %w", err)
 	}
-	os.Chmod(sockPath, 0700)
+	if err := os.Chmod(sockPath, 0700); err != nil {
+		listener.Close()
+		return nil, fmt.Errorf("chmod socket: %w", err)
+	}
 
 	sess := newSessionWithLogger(sessionName, scrollbackLines, logger.With("session", sessionName))
 
@@ -648,7 +651,10 @@ func NewServerFromCrashCheckpointWithScrollbackLogger(sessionName string, cp *ch
 	if err != nil {
 		return nil, fmt.Errorf("listening: %w", err)
 	}
-	os.Chmod(sockPath, 0700)
+	if err := os.Chmod(sockPath, 0700); err != nil {
+		listener.Close()
+		return nil, fmt.Errorf("chmod socket: %w", err)
+	}
 
 	return newServerFromCrashCheckpointWithListenerLogger(sessionName, listener, sockPath, cp, crashPath, scrollbackLines, logger)
 }
@@ -798,7 +804,10 @@ func (s *Server) handleAttach(cc *clientConn, msg *Message) {
 		return
 	}
 
-	cc.Send(&Message{Type: MsgTypeLayout, Layout: res.snap})
+	if err := cc.Send(&Message{Type: MsgTypeLayout, Layout: res.snap}); err != nil {
+		cc.Close()
+		return
+	}
 	bootstrapSeqs := make(map[uint32]uint64, len(res.paneSnapshots))
 	for _, ps := range res.paneSnapshots {
 		if len(ps.styledHistory) > 0 {
@@ -808,10 +817,16 @@ func (s *Server) handleAttach(cc *clientConn, msg *Message) {
 				return
 			}
 			for _, historyMsg := range messages {
-				cc.Send(historyMsg)
+				if err := cc.Send(historyMsg); err != nil {
+					cc.Close()
+					return
+				}
 			}
 		}
-		cc.Send(&Message{Type: MsgTypePaneOutput, PaneID: ps.paneID, PaneData: ps.screen})
+		if err := cc.Send(&Message{Type: MsgTypePaneOutput, PaneID: ps.paneID, PaneData: ps.screen}); err != nil {
+			cc.Close()
+			return
+		}
 		bootstrapSeqs[ps.paneID] = ps.outputSeq
 	}
 	if s.attachBootstrapHook != nil {
@@ -835,7 +850,7 @@ func (s *Server) handleOneShot(cc *clientConn, msg *Message) {
 	sess := s.firstSession()
 
 	if sess == nil {
-		cc.Send(&Message{Type: MsgTypeCmdResult, CmdErr: "no session"})
+		_ = cc.Send(&Message{Type: MsgTypeCmdResult, CmdErr: "no session"})
 		return
 	}
 

--- a/internal/server/server_shutdown_test.go
+++ b/internal/server/server_shutdown_test.go
@@ -90,6 +90,35 @@ func TestShutdownCommandFlushesReplyBeforeShutdownStarts(t *testing.T) {
 	}
 }
 
+func TestHandleOneShotWithoutSessionReturnsNoSession(t *testing.T) {
+	t.Parallel()
+
+	srv := &Server{}
+
+	serverConn, clientConn := net.Pipe()
+	defer func() { _ = clientConn.Close() }()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		srv.handleOneShot(newClientConn(serverConn), &Message{Type: MsgTypeCommand, CmdName: "status"})
+	}()
+
+	msg, err := readMsgOnConn(clientConn)
+	if err != nil {
+		t.Fatalf("ReadMsg() error = %v", err)
+	}
+	if msg.Type != MsgTypeCmdResult || msg.CmdErr != "no session" {
+		t.Fatalf("one-shot no-session reply = %#v, want no-session cmd result", msg)
+	}
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("handleOneShot did not return")
+	}
+}
+
 type gatedConn struct {
 	net.Conn
 	writeStarted chan struct{}

--- a/internal/server/session_events_client.go
+++ b/internal/server/session_events_client.go
@@ -234,7 +234,13 @@ func (e uiEventCmd) handle(s *Session) {
 	changed, err := e.cc.applyUIEvent(e.uiEvent)
 	clientID := e.cc.ID
 	if err != nil {
-		e.cc.Send(&Message{Type: MsgTypeCmdResult, CmdErr: err.Error()})
+		if sendErr := e.cc.Send(&Message{Type: MsgTypeCmdResult, CmdErr: err.Error()}); sendErr != nil && e.cc.logger != nil {
+			e.cc.logger.Warn("sending UI event error failed",
+				"event", "ui_event",
+				"ui_event", e.uiEvent,
+				"error", sendErr,
+			)
+		}
 		return
 	}
 	if activityChanged {

--- a/internal/server/session_events_client.go
+++ b/internal/server/session_events_client.go
@@ -235,11 +235,7 @@ func (e uiEventCmd) handle(s *Session) {
 	clientID := e.cc.ID
 	if err != nil {
 		if sendErr := e.cc.Send(&Message{Type: MsgTypeCmdResult, CmdErr: err.Error()}); sendErr != nil && e.cc.logger != nil {
-			e.cc.logger.Warn("sending UI event error failed",
-				"event", "ui_event",
-				"ui_event", e.uiEvent,
-				"error", sendErr,
-			)
+			e.cc.logger.Warn("sending UI event error failed", "event", "ui_event", "ui_event", e.uiEvent, "error", sendErr)
 		}
 		return
 	}

--- a/internal/server/session_events_layout.go
+++ b/internal/server/session_events_layout.go
@@ -233,12 +233,6 @@ func (ctx *MutationContext) findWindowByPaneID(id uint32) *mux.Window {
 	return w
 }
 
-func (ctx *MutationContext) createPaneWithMeta(srv *Server, meta mux.PaneMeta, cols, rows int) (*mux.Pane, error) {
-	return mutationContextCall(ctx, func(sess *Session) (*mux.Pane, error) {
-		return sess.createPaneWithMeta(srv, meta, cols, rows)
-	})
-}
-
 type pendingLocalPaneResult struct {
 	pane  *mux.Pane
 	build localPaneBuildRequest
@@ -359,13 +353,6 @@ func (ctx *MutationContext) ensureClientManager() *clientManager {
 		return sess.ensureClientManager(), nil
 	})
 	return manager
-}
-
-func (ctx *MutationContext) refreshInputTarget() {
-	_ = mutationContextDo(ctx, func(sess *Session) error {
-		sess.refreshInputTarget()
-		return nil
-	})
 }
 
 type paneHistoryUpdate struct {

--- a/internal/server/session_events_test.go
+++ b/internal/server/session_events_test.go
@@ -1702,7 +1702,7 @@ func readMsgWithTimeoutDuration(t *testing.T, conn net.Conn, timeout time.Durati
 	if err := conn.SetReadDeadline(time.Now().Add(timeout)); err != nil {
 		t.Fatalf("SetReadDeadline: %v", err)
 	}
-	defer conn.SetReadDeadline(time.Time{})
+	defer mustSetReadDeadline(t, conn, time.Time{})
 
 	msg, err := readMsgOnConn(conn)
 	if err != nil {

--- a/internal/server/session_pane.go
+++ b/internal/server/session_pane.go
@@ -52,16 +52,6 @@ func (s *Session) closePaneAsync(pane *mux.Pane) {
 	go closePane(pane)
 }
 
-func cleanupFailedPreparedPane(sess *Session, pane *mux.Pane, err error) commandMutationResult {
-	if pane != nil && pane.IsProxy() && sess.RemoteManager != nil {
-		sess.RemoteManager.RemovePane(pane.ID)
-	}
-	return commandMutationResult{
-		err:        err,
-		closePanes: []*mux.Pane{pane},
-	}
-}
-
 func cleanupFailedPreparedPaneMutationContext(ctx *MutationContext, pane *mux.Pane, err error) commandMutationResult {
 	if pane != nil && pane.IsProxy() && ctx.RemoteManager != nil {
 		ctx.RemoteManager.RemovePane(pane.ID)
@@ -442,13 +432,6 @@ func (s *Session) replacePaneInstance(oldPane, newPane *mux.Pane, w *mux.Window)
 	delete(s.terminalEventState, oldPane.ID)
 	s.ensureIdleTracker().StopPane(oldPane.ID)
 	return nil
-}
-
-// finalizeClosedPane removes a soft-closed pane from the undo stack and
-// returns it for final cleanup (PTY close). The pane was already removed
-// from Session.Panes during soft close.
-func (s *Session) finalizeClosedPane(paneID uint32) *mux.Pane {
-	return s.ensureUndoManager().finalizeClosedPane(paneID)
 }
 
 // paneOutputCallback returns the standard onOutput callback for panes.

--- a/internal/server/session_remote.go
+++ b/internal/server/session_remote.go
@@ -70,7 +70,10 @@ func (s *Session) handleTakeover(sshPaneID uint32, req mux.TakeoverRequest) {
 
 	// Send ack through the SSH PTY's stdin — carries the agreed session name
 	// so the remote amux starts its server at the right socket path.
-	start.sshPane.Write([]byte(mux.FormatTakeoverAck(start.managedSession) + "\n"))
+	if _, err := start.sshPane.Write([]byte(mux.FormatTakeoverAck(start.managedSession) + "\n")); err != nil {
+		failTakeover(err)
+		return
+	}
 
 	layout, err := enqueueSessionQuery(s, func(s *Session) (takeoverLayout, error) {
 		w := s.findWindowByPaneID(sshPaneID)
@@ -167,9 +170,7 @@ func (s *Session) handleTakeover(sshPaneID uint32, req mux.TakeoverRequest) {
 		if w == nil {
 			return commandMutationResult{err: fmt.Errorf("pane %d not in any window", sshPaneID)}
 		}
-		for _, pp := range proxyPanes {
-			s.Panes = append(s.Panes, pp)
-		}
+		s.Panes = append(s.Panes, proxyPanes...)
 		if _, err := w.SplicePane(sshPaneID, proxyPanes); err != nil {
 			for _, pp := range proxyPanes {
 				s.removePane(pp.ID)

--- a/internal/server/session_window.go
+++ b/internal/server/session_window.go
@@ -143,7 +143,13 @@ func (s *Session) closePaneInWindow(paneID uint32) string {
 		}
 		return windowName
 	}
-	w.ClosePane(paneID)
+	if err := w.ClosePane(paneID); err != nil {
+		s.logger.Warn("closing pane in window failed",
+			"event", "close_pane",
+			"pane_id", paneID,
+			"error", err,
+		)
+	}
 	return ""
 }
 

--- a/internal/server/session_window.go
+++ b/internal/server/session_window.go
@@ -144,11 +144,7 @@ func (s *Session) closePaneInWindow(paneID uint32) string {
 		return windowName
 	}
 	if err := w.ClosePane(paneID); err != nil {
-		s.logger.Warn("closing pane in window failed",
-			"event", "close_pane",
-			"pane_id", paneID,
-			"error", err,
-		)
+		s.logger.Warn("closing pane in window failed", "event", "close_pane", "pane_id", paneID, "error", err)
 	}
 	return ""
 }

--- a/internal/server/split_inherit_test.go
+++ b/internal/server/split_inherit_test.go
@@ -45,7 +45,9 @@ func TestSplitInheritsRemoteHost(t *testing.T) {
 		func(data []byte) (int, error) { return len(data), nil },
 	)
 	sess.Panes = append(sess.Panes, proxyPane)
-	w.Split(mux.SplitHorizontal, proxyPane)
+	if _, err := w.Split(mux.SplitHorizontal, proxyPane); err != nil {
+		t.Fatalf("Split: %v", err)
+	}
 	w.FocusPane(proxyPane) // make proxy pane active
 
 	// Send the split command through handleCommand with a pipe to capture the response.

--- a/internal/server/wait_ready.go
+++ b/internal/server/wait_ready.go
@@ -1,12 +1,12 @@
 package server
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
 	"github.com/weill-labs/amux/internal/mux"
 	cmdflags "github.com/weill-labs/amux/internal/server/commands/flags"
-	waitcmd "github.com/weill-labs/amux/internal/server/commands/wait"
 )
 
 const (
@@ -50,18 +50,14 @@ type paneReadyState struct {
 	vtIdle idleWaitState
 }
 
-func cmdWaitReady(ctx *CommandContext) {
-	ctx.applyCommandResult(waitcmd.WaitReady(waitCommandContext{ctx}, ctx.ActorPaneID, ctx.Args))
-}
-
 func parseWaitReadyArgs(args []string) (string, waitReadyOptions, error) {
 	if len(args) < 1 {
-		return "", waitReadyOptions{}, fmt.Errorf(waitReadyUsage)
+		return "", waitReadyOptions{}, errors.New(waitReadyUsage)
 	}
 
 	for _, arg := range args[1:] {
 		if arg == "--continue-known-dialogs" {
-			return "", waitReadyOptions{}, fmt.Errorf(waitReadyRemovedContinueFlagErr)
+			return "", waitReadyOptions{}, errors.New(waitReadyRemovedContinueFlagErr)
 		}
 	}
 	flags, err := cmdflags.ParseCommandFlags(args[1:], []cmdflags.FlagSpec{
@@ -126,7 +122,7 @@ func parseSendKeysArgs(args []string) (sendKeysOptions, error) {
 		case "--wait-ready":
 			return sendKeysOptions{}, fmt.Errorf("send-keys: --wait-ready was removed; use --wait ready")
 		case "--continue-known-dialogs":
-			return sendKeysOptions{}, fmt.Errorf(sendKeysRemovedContinueFlagErr)
+			return sendKeysOptions{}, errors.New(sendKeysRemovedContinueFlagErr)
 		case "--timeout":
 			if i+1 >= len(args) {
 				return sendKeysOptions{}, fmt.Errorf("missing value for --timeout")

--- a/internal/sshutil/sshutil.go
+++ b/internal/sshutil/sshutil.go
@@ -219,7 +219,9 @@ func startSocatBridge(client *ssh.Client, sockPath string) (int, error) {
 	}
 
 	var port int
-	fmt.Sscanf(out, "%d", &port)
+	if _, err := fmt.Sscanf(out, "%d", &port); err != nil {
+		return 0, fmt.Errorf("parsing socat port %q: %w", strings.TrimSpace(out), err)
+	}
 	if port == 0 {
 		return 0, fmt.Errorf("could not parse socat port from: %s", out)
 	}

--- a/internal/terminfo/terminfo.go
+++ b/internal/terminfo/terminfo.go
@@ -2,6 +2,7 @@ package terminfo
 
 import (
 	_ "embed"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -27,7 +28,7 @@ var (
 
 // Install compiles the embedded amux terminfo entry into ~/.terminfo.
 // It is safe to run repeatedly.
-func Install() error {
+func Install() (err error) {
 	home, err := userHomeDir()
 	if err != nil {
 		return fmt.Errorf("finding home directory for %s terminfo install: %w", Name, err)
@@ -48,7 +49,12 @@ func Install() error {
 	if err := flockFile(lockFile, syscall.LOCK_EX); err != nil {
 		return fmt.Errorf("locking %s terminfo install: %w", Name, err)
 	}
-	defer flockFile(lockFile, syscall.LOCK_UN)
+	defer func() {
+		unlockErr := flockFile(lockFile, syscall.LOCK_UN)
+		if err == nil && unlockErr != nil {
+			err = fmt.Errorf("unlocking %s terminfo install: %w", Name, unlockErr)
+		}
+	}()
 
 	tic, err := exec.LookPath("tic")
 	if err != nil {
@@ -63,7 +69,10 @@ func Install() error {
 	defer os.Remove(tmpPath)
 
 	if err := writeTempSource(tmp, source); err != nil {
-		closeTempSource(tmp)
+		closeErr := closeTempSource(tmp)
+		if closeErr != nil {
+			return fmt.Errorf("writing temp terminfo source: %w", errors.Join(err, fmt.Errorf("closing temp terminfo source: %w", closeErr)))
+		}
 		return fmt.Errorf("writing temp terminfo source: %w", err)
 	}
 	if err := closeTempSource(tmp); err != nil {

--- a/test/amux_harness_test.go
+++ b/test/amux_harness_test.go
@@ -2,7 +2,6 @@ package test
 
 import (
 	"context"
-	"crypto/rand"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -112,7 +111,7 @@ func newAmuxHarnessWithBinInDir(tb testing.TB, binPath, launchDir string, envVar
 	}
 
 	var b [4]byte
-	rand.Read(b[:])
+	mustRandRead(tb, b[:])
 	inner := fmt.Sprintf("t-%x", b)
 
 	h := &AmuxHarness{outer: outer, inner: inner, innerBin: binPath, tb: tb, session: inner}
@@ -147,14 +146,14 @@ func shutdownAmuxHarness(tb testing.TB, h *AmuxHarness) {
 
 	for _, pid := range h.innerServerPIDs() {
 		if pid != "" {
-			exec.Command("kill", pid).Run()
+			_ = exec.Command("kill", pid).Run()
 		}
 	}
 	h.waitInnerServerGone(5 * time.Second)
 	if pids := h.innerServerPIDs(); len(pids) > 0 {
 		for _, pid := range pids {
 			if pid != "" {
-				exec.Command("kill", "-9", pid).Run()
+				_ = exec.Command("kill", "-9", pid).Run()
 			}
 		}
 		h.waitInnerServerGone(2 * time.Second)
@@ -176,7 +175,7 @@ func shutdownAmuxHarness(tb testing.TB, h *AmuxHarness) {
 		return
 	}
 	for _, suffix := range []string{"", ".log"} {
-		exec.Command("rm", "-f", fmt.Sprintf("%s/%s%s", socketDir, h.inner, suffix)).Run()
+		_ = exec.Command("rm", "-f", fmt.Sprintf("%s/%s%s", socketDir, h.inner, suffix)).Run()
 	}
 	h.inner = ""
 	h.session = ""
@@ -334,29 +333,6 @@ func (h *AmuxHarness) waitUIAfter(event string, afterGen uint64, timeout time.Du
 	}
 	if !strings.Contains(out, event) {
 		h.tb.Fatalf("wait-ui %s --after %d output = %q", event, afterGen, out)
-	}
-}
-
-func (h *AmuxHarness) waitUIGenChange(previousGen uint64, timeout time.Duration) uint64 {
-	h.tb.Helper()
-
-	deadline := time.Now().Add(timeout)
-	var out string
-	for {
-		out = strings.TrimSpace(h.runCmd("cursor", "ui"))
-		n, err := strconv.ParseUint(out, 10, 64)
-		if err == nil {
-			if n != previousGen {
-				return n
-			}
-		} else if !isCommandConnectError(out) || !time.Now().Before(deadline) {
-			h.tb.Fatalf("parsing inner ui-gen after %d: %v (output: %q)", previousGen, err, out)
-		}
-
-		if !time.Now().Before(deadline) {
-			h.tb.Fatalf("ui generation did not change from %d within %v (last output: %q)\nouter:\n%s", previousGen, timeout, out, h.captureOuter())
-		}
-		time.Sleep(25 * time.Millisecond)
 	}
 }
 

--- a/test/bench_test.go
+++ b/test/bench_test.go
@@ -2,7 +2,6 @@ package test
 
 import (
 	"bufio"
-	"crypto/rand"
 	"fmt"
 	"net"
 	"os/exec"
@@ -36,7 +35,7 @@ func newTmuxBenchHarness(b *testing.B) *TmuxBenchHarness {
 	}
 
 	var buf [4]byte
-	rand.Read(buf[:])
+	mustRandRead(b, buf[:])
 	session := fmt.Sprintf("bench-%x", buf)
 
 	out, err := exec.Command("tmux", "new-session", "-d", "-s", session, "-x", "80", "-y", "24").CombinedOutput()
@@ -56,7 +55,7 @@ func (h *TmuxBenchHarness) run(args ...string) string {
 }
 
 func (h *TmuxBenchHarness) cleanup() {
-	exec.Command("tmux", "kill-session", "-t", h.session).Run()
+	mustRun(h.tb, exec.Command("tmux", "kill-session", "-t", h.session))
 }
 
 // ---------------------------------------------------------------------------
@@ -471,11 +470,13 @@ func BenchmarkOutputDetection(b *testing.B) {
 				}
 				defer conn.Close()
 
-				writeMsgOnConn(conn, &server.Message{
+				if err := writeMsgOnConn(conn, &server.Message{
 					Type:    server.MsgTypeCommand,
 					CmdName: "events",
 					CmdArgs: []string{"--filter", "layout"},
-				})
+				}); err != nil {
+					b.Fatalf("write events command: %v", err)
+				}
 
 				pr, pw := net.Pipe()
 				defer pr.Close()
@@ -487,7 +488,7 @@ func BenchmarkOutputDetection(b *testing.B) {
 							return
 						}
 						if msg.CmdOutput != "" {
-							pw.Write([]byte(msg.CmdOutput))
+							mustWrite(b, pw, []byte(msg.CmdOutput))
 						}
 					}
 				}()
@@ -545,11 +546,13 @@ func BenchmarkDetectLayoutChange(b *testing.B) {
 		}
 		defer conn.Close()
 
-		writeMsgOnConn(conn, &server.Message{
+		if err := writeMsgOnConn(conn, &server.Message{
 			Type:    server.MsgTypeCommand,
 			CmdName: "events",
 			CmdArgs: []string{"--filter", "layout"},
-		})
+		}); err != nil {
+			b.Fatalf("write events command: %v", err)
+		}
 
 		pr, pw := net.Pipe()
 		defer pr.Close()
@@ -561,7 +564,7 @@ func BenchmarkDetectLayoutChange(b *testing.B) {
 					return
 				}
 				if msg.CmdOutput != "" {
-					pw.Write([]byte(msg.CmdOutput))
+					mustWrite(b, pw, []byte(msg.CmdOutput))
 				}
 			}
 		}()

--- a/test/copymode_test.go
+++ b/test/copymode_test.go
@@ -33,7 +33,7 @@ func TestCopyModeScroll(t *testing.T) {
 
 	// Generate 50 numbered lines of output using a temp script
 	scriptPath := filepath.Join(os.TempDir(), fmt.Sprintf("amux-scroll-%s.sh", h.session))
-	os.WriteFile(scriptPath, []byte(`#!/bin/bash
+	mustWriteFile(t, scriptPath, []byte(`#!/bin/bash
 for i in $(seq -w 1 50); do echo "SCROLLTEST-$i"; done
 `), 0755)
 	t.Cleanup(func() { os.Remove(scriptPath) })
@@ -76,7 +76,7 @@ func TestCopyModeKittyCtrlUDHalfPageScroll(t *testing.T) {
 	h.runCmd("resize-window", "80", "14")
 
 	scriptPath := filepath.Join(os.TempDir(), fmt.Sprintf("amux-kitty-half-page-%s.sh", h.session))
-	os.WriteFile(scriptPath, []byte(`#!/bin/bash
+	mustWriteFile(t, scriptPath, []byte(`#!/bin/bash
 for i in $(seq -w 1 40); do echo "KITTYHALF-$i"; done
 `), 0755)
 	t.Cleanup(func() { os.Remove(scriptPath) })
@@ -219,7 +219,7 @@ func TestCopyModeResizeSurvives(t *testing.T) {
 
 	// Generate output so scrollback has content
 	scriptPath := filepath.Join(os.TempDir(), fmt.Sprintf("amux-resize-%s.sh", h.session))
-	os.WriteFile(scriptPath, []byte("#!/bin/bash\nfor i in $(seq -w 1 30); do echo \"RESIZE-$i\"; done\n"), 0755)
+	mustWriteFile(t, scriptPath, []byte("#!/bin/bash\nfor i in $(seq -w 1 30); do echo \"RESIZE-$i\"; done\n"), 0755)
 	t.Cleanup(func() { os.Remove(scriptPath) })
 
 	h.sendKeys(scriptPath, "Enter")
@@ -305,7 +305,7 @@ func TestCopyModeVimMotions(t *testing.T) {
 
 	// Generate output with distinctive words on multiple lines.
 	scriptPath := filepath.Join(os.TempDir(), fmt.Sprintf("amux-motions-%s.sh", h.session))
-	os.WriteFile(scriptPath, []byte(`#!/bin/bash
+	mustWriteFile(t, scriptPath, []byte(`#!/bin/bash
 for i in $(seq -w 1 50); do echo "ALPHA BRAVO CHARLIE $i"; done
 `), 0755)
 	t.Cleanup(func() { os.Remove(scriptPath) })

--- a/test/crash_recovery_test.go
+++ b/test/crash_recovery_test.go
@@ -1,7 +1,6 @@
 package test
 
 import (
-	"crypto/rand"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -66,7 +65,7 @@ func TestCrashRecovery_LayoutRestored(t *testing.T) {
 	if err := h.signalServer(syscall.SIGKILL); err != nil {
 		t.Fatalf("SIGKILL server: %v", err)
 	}
-	h.cmd.Wait()
+	ignoreCmdWait(h.cmd)
 	h.cmd = nil // prevent cleanup from trying to kill again
 
 	// Verify crash checkpoint file still exists (SIGKILL = no cleanup)
@@ -167,7 +166,7 @@ func TestCrashRecovery_FocusUpFromRestoredFullWidthBottomPane(t *testing.T) {
 	if err := h.signalServer(syscall.SIGKILL); err != nil {
 		t.Fatalf("SIGKILL server: %v", err)
 	}
-	h.cmd.Wait()
+	ignoreCmdWait(h.cmd)
 	h.cmd = nil
 
 	h2 := startServerForSession(t, h.session, h.home)
@@ -207,7 +206,7 @@ func TestCrashRecovery_PreservesHistoryCapture(t *testing.T) {
 	if err := h.signalServer(syscall.SIGKILL); err != nil {
 		t.Fatalf("SIGKILL server: %v", err)
 	}
-	h.cmd.Wait()
+	ignoreCmdWait(h.cmd)
 	h.cmd = nil
 
 	h2 := startServerForSession(t, h.session, h.home)
@@ -237,7 +236,7 @@ func TestCrashRecovery_ReplaysVisibleScreenForIdleShellPane(t *testing.T) {
 	if err := h.signalServer(syscall.SIGKILL); err != nil {
 		t.Fatalf("SIGKILL server: %v", err)
 	}
-	h.cmd.Wait()
+	ignoreCmdWait(h.cmd)
 	h.cmd = nil
 
 	h2 := startServerForSession(t, h.session, h.home)
@@ -268,7 +267,7 @@ func TestCrashRecovery_BusyPaneShowsRecoveryNoticeInsteadOfReplayingStaleScreen(
 	if err := h.signalServer(syscall.SIGKILL); err != nil {
 		t.Fatalf("SIGKILL server: %v", err)
 	}
-	h.cmd.Wait()
+	ignoreCmdWait(h.cmd)
 	h.cmd = nil
 
 	h2 := startServerForSession(t, h.session, h.home)
@@ -504,15 +503,15 @@ func startServerForSession(t *testing.T, session, home string) *ServerHarness {
 	var coverDir string
 	if gocoverDir != "" {
 		var b [4]byte
-		rand.Read(b[:])
+		mustRandRead(t, b[:])
 		coverDir = filepath.Join(gocoverDir, fmt.Sprintf("recover-%x", b))
-		os.MkdirAll(coverDir, 0755)
+		mustMkdirAll(t, coverDir, 0755)
 		env = upsertEnv(env, "GOCOVERDIR", coverDir)
 	}
 	cmd.Env = env
 
 	logDir := server.SocketDir()
-	os.MkdirAll(logDir, 0700)
+	mustMkdirAll(t, logDir, 0700)
 	logPath := filepath.Join(logDir, session+".log")
 	logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0600)
 	if err != nil {
@@ -533,12 +532,12 @@ func startServerForSession(t *testing.T, session, home string) *ServerHarness {
 	shutdownWritePipe.Close()
 	logFile.Close()
 
-	readPipe.SetReadDeadline(time.Now().Add(10 * time.Second))
+	mustSetReadDeadline(t, readPipe, time.Now().Add(10*time.Second))
 	buf := make([]byte, 64)
 	n, err := readPipe.Read(buf)
 	readPipe.Close()
 	if err != nil || !strings.Contains(string(buf[:n]), "ready") {
-		cmd.Process.Kill()
+		ignoreProcessKill(cmd.Process)
 		shutdownReadPipe.Close()
 		// Print server log for debugging
 		logData, _ := os.ReadFile(logPath)
@@ -553,12 +552,12 @@ func startServerForSession(t *testing.T, session, home string) *ServerHarness {
 	sockPath := server.SocketPath(session)
 	client, err := newHeadlessClient(sockPath, session, 80, 24)
 	if err != nil {
-		cmd.Process.Kill()
+		ignoreProcessKill(cmd.Process)
 		t.Fatalf("attaching headless client to recovered server: %v", err)
 	}
 	if err := client.waitCommandReady(); err != nil {
 		client.close()
-		cmd.Process.Kill()
+		ignoreProcessKill(cmd.Process)
 		t.Fatalf("recovered headless client command-ready: %v", err)
 	}
 	h.client = client

--- a/test/event_helpers_test.go
+++ b/test/event_helpers_test.go
@@ -56,7 +56,7 @@ func eventStream(t *testing.T, session string, args ...string) (*bufio.Scanner, 
 				return
 			}
 			if msg.CmdOutput != "" {
-				pw.Write([]byte(msg.CmdOutput))
+				_, _ = pw.Write([]byte(msg.CmdOutput)) //nolint:errcheck // teardown may close the pipe before the forwarder exits
 			}
 		}
 	}()

--- a/test/golden_test.go
+++ b/test/golden_test.go
@@ -19,7 +19,7 @@ func assertGolden(t *testing.T, name string, actual string) {
 	path := filepath.Join("testdata", name)
 
 	if *updateGoldens {
-		os.MkdirAll("testdata", 0755)
+		mustMkdirAll(t, "testdata", 0755)
 		if err := os.WriteFile(path, []byte(actual), 0644); err != nil {
 			t.Fatalf("writing golden %s: %v", path, err)
 		}

--- a/test/harness_test.go
+++ b/test/harness_test.go
@@ -124,8 +124,10 @@ func TestMain(m *testing.M) {
 	if gocoverDir != "" {
 		entries, _ := os.ReadDir(gocoverDir)
 		if len(entries) > 0 {
-			exec.Command("go", "tool", "covdata", "textfmt",
-				"-i="+gocoverDir, "-o=integration-coverage.txt").Run()
+			if err := exec.Command("go", "tool", "covdata", "textfmt",
+				"-i="+gocoverDir, "-o=integration-coverage.txt").Run(); err != nil {
+				fmt.Fprintf(os.Stderr, "go tool covdata textfmt: %v\n", err)
+			}
 		}
 		if gocoverOwned {
 			os.RemoveAll(gocoverDir)
@@ -216,7 +218,7 @@ func cleanupStaleTestSessions() {
 		out, _ = exec.Command("tmux", "list-sessions", "-F", "#{session_name}").Output()
 		for _, name := range strings.Split(strings.TrimSpace(string(out)), "\n") {
 			if isBenchSession(name) {
-				exec.Command("tmux", "kill-session", "-t", name).Run()
+				_ = exec.Command("tmux", "kill-session", "-t", name).Run()
 			}
 		}
 	}
@@ -347,7 +349,7 @@ func killOrphanedTestClients(socketDir string, staleSessions map[string]bool) {
 			if serverProcessMatchesSession(pid, session) {
 				continue
 			}
-			exec.Command("kill", currentPid).Run()
+			_ = exec.Command("kill", currentPid).Run()
 		}
 	}
 }

--- a/test/hotreload_test.go
+++ b/test/hotreload_test.go
@@ -634,7 +634,7 @@ func TestServerReloadTUIRedraw(t *testing.T) {
 	h := newAmuxHarness(t)
 
 	scriptPath := filepath.Join(os.TempDir(), fmt.Sprintf("amux-tui-%s.sh", h.session))
-	os.WriteFile(scriptPath, []byte(`#!/bin/bash
+	mustWriteFile(t, scriptPath, []byte(`#!/bin/bash
 printf '\033[?1049h'
 draw() { printf '\033[2J\033[H'; echo TUIMARK_OK; }
 trap draw WINCH

--- a/test/keybinding_test.go
+++ b/test/keybinding_test.go
@@ -51,17 +51,17 @@ func newAmuxHarnessWithConfig(t *testing.T, configContent string) *AmuxHarness {
 
 	t.Cleanup(func() {
 		// Best-effort detach (only works with default prefix).
-		exec.Command(amuxBin, "-s", inner, "list").Run()
+		_ = exec.Command(amuxBin, "-s", inner, "list").Run()
 		out, _ := exec.Command("pgrep", "-f", fmt.Sprintf("amux _server %s$", inner)).Output()
 		for _, pid := range strings.Split(strings.TrimSpace(string(out)), "\n") {
 			if pid != "" {
-				exec.Command("kill", pid).Run()
+				_ = exec.Command("kill", pid).Run()
 			}
 		}
 		time.Sleep(200 * time.Millisecond)
 		socketDir := server.SocketDir()
 		for _, suffix := range []string{"", ".log"} {
-			exec.Command("rm", "-f", fmt.Sprintf("%s/%s%s", socketDir, inner, suffix)).Run()
+			_ = exec.Command("rm", "-f", fmt.Sprintf("%s/%s%s", socketDir, inner, suffix)).Run()
 		}
 	})
 

--- a/test/lint_helpers_test.go
+++ b/test/lint_helpers_test.go
@@ -1,0 +1,92 @@
+package test
+
+import (
+	"crypto/rand"
+	"errors"
+	"io"
+	"os"
+	"os/exec"
+	"testing"
+	"time"
+
+	"golang.org/x/crypto/ssh"
+)
+
+func mustRandRead(tb testing.TB, data []byte) {
+	tb.Helper()
+	if _, err := rand.Read(data); err != nil {
+		tb.Fatalf("rand.Read() error = %v", err)
+	}
+}
+
+func mustRun(tb testing.TB, cmd *exec.Cmd) {
+	tb.Helper()
+	if err := cmd.Run(); err != nil {
+		tb.Fatalf("Run() error = %v", err)
+	}
+}
+
+func mustWriteFile(tb testing.TB, path string, data []byte, perm os.FileMode) {
+	tb.Helper()
+	if err := os.WriteFile(path, data, perm); err != nil {
+		tb.Fatalf("WriteFile(%q) error = %v", path, err)
+	}
+}
+
+func mustMkdirAll(tb testing.TB, path string, perm os.FileMode) {
+	tb.Helper()
+	if err := os.MkdirAll(path, perm); err != nil {
+		tb.Fatalf("MkdirAll(%q) error = %v", path, err)
+	}
+}
+
+func mustSetReadDeadline(tb testing.TB, conn interface{ SetReadDeadline(time.Time) error }, deadline time.Time) {
+	tb.Helper()
+	if err := conn.SetReadDeadline(deadline); err != nil {
+		tb.Fatalf("SetReadDeadline() error = %v", err)
+	}
+}
+
+func mustWrite(tb testing.TB, writer interface{ Write([]byte) (int, error) }, data []byte) {
+	tb.Helper()
+	if _, err := writer.Write(data); err != nil {
+		tb.Fatalf("Write() error = %v", err)
+	}
+}
+
+func ignoreCmdWait(cmd *exec.Cmd) {
+	if cmd == nil {
+		return
+	}
+	_ = cmd.Wait() //nolint:errcheck // shutdown-path tests intentionally reap signaled processes
+}
+
+func ignoreProcessKill(proc *os.Process) {
+	if proc == nil {
+		return
+	}
+	err := proc.Kill()
+	if err != nil && !errors.Is(err, os.ErrProcessDone) {
+		_ = err //nolint:errcheck // teardown races are acceptable when the process is already gone
+	}
+}
+
+func ignoreReject(newChannel ssh.NewChannel, reason ssh.RejectionReason, message string) {
+	_ = newChannel.Reject(reason, message) //nolint:errcheck // test SSH server teardown can race channel shutdown
+}
+
+func ignoreReply(req *ssh.Request, ok bool) {
+	_ = req.Reply(ok, nil) //nolint:errcheck // test SSH request channel may already be closed
+}
+
+func ignoreSendRequest(ch ssh.Channel, name string, wantReply bool, payload []byte) {
+	_, _ = ch.SendRequest(name, wantReply, payload) //nolint:errcheck // exit-status notification is best-effort in tests
+}
+
+func ignoreCopy(dst io.Writer, src io.Reader) {
+	_, _ = io.Copy(dst, src) //nolint:errcheck // SSH test tunnel teardown can interrupt pipe copies
+}
+
+func ignoreCloseWrite(ch ssh.Channel) {
+	_ = ch.CloseWrite() //nolint:errcheck // test SSH channel may already be closing
+}

--- a/test/pane_ops_test.go
+++ b/test/pane_ops_test.go
@@ -481,7 +481,7 @@ func TestShutdownLeavesNoOrphans(t *testing.T) {
 	}
 	done := make(chan struct{})
 	go func() {
-		h.cmd.Wait()
+		ignoreCmdWait(h.cmd)
 		close(done)
 	}()
 	select {
@@ -502,7 +502,7 @@ func TestShutdownLeavesNoOrphans(t *testing.T) {
 		}
 		if err := syscall.Kill(pid, 0); err == nil {
 			t.Errorf("child PID %d still alive after server shutdown", pid)
-			syscall.Kill(pid, syscall.SIGKILL)
+			_ = syscall.Kill(pid, syscall.SIGKILL)
 		}
 	}
 }

--- a/test/reattach_resize_test.go
+++ b/test/reattach_resize_test.go
@@ -34,7 +34,7 @@ func (h *ServerHarness) attachAt(cols, rows int) *server.Message {
 		h.tb.Fatalf("attachAt: write: %v", err)
 	}
 
-	conn.SetReadDeadline(time.Now().Add(10 * time.Second))
+	mustSetReadDeadline(h.tb, conn, time.Now().Add(10*time.Second))
 	for {
 		msg, err := readMsgOnConn(conn)
 		if err != nil {
@@ -68,7 +68,7 @@ func (h *ServerHarness) attachRendererAt(cols, rows int, afterLayout func(*clien
 		h.tb.Fatalf("attachRendererAt: write: %v", err)
 	}
 
-	conn.SetReadDeadline(time.Now().Add(10 * time.Second))
+	mustSetReadDeadline(h.tb, conn, time.Now().Add(10*time.Second))
 
 	// Drain until the initial layout arrives (pane output may arrive first
 	// under -race).

--- a/test/release_install_test.go
+++ b/test/release_install_test.go
@@ -23,8 +23,7 @@ func TestReleaseInstallScriptInstallsExplicitVersionArchive(t *testing.T) {
 	archive := fakeReleaseInstallArchive(t, script)
 	checksums := fmt.Sprintf("%x  %s\n", sha256.Sum256(archive), releaseArchiveName(version))
 
-	var ts *httptest.Server
-	ts = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case releaseArchivePath(version):
 			w.Header().Set("Content-Type", "application/gzip")

--- a/test/server_harness_test.go
+++ b/test/server_harness_test.go
@@ -2,7 +2,6 @@ package test
 
 import (
 	"context"
-	"crypto/rand"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -143,13 +142,6 @@ func newServerHarnessWithConfig(tb testing.TB, cols, rows int, configContent str
 	return newServerHarnessWithOptions(tb, cols, rows, configContent, false, false)
 }
 
-// newServerHarnessExitUnattached starts a server that exits when all clients
-// disconnect. Use this only in tests that explicitly exercise exit-unattached.
-func newServerHarnessExitUnattached(tb testing.TB) *ServerHarness {
-	tb.Helper()
-	return newServerHarnessWithOptions(tb, 80, 24, "", true, false)
-}
-
 // newServerHarnessWithOptions is the shared constructor. When exitUnattached
 // is true the server self-terminates after all clients disconnect.
 func newServerHarnessWithOptions(tb testing.TB, cols, rows int, configContent string, exitUnattached, keepalive bool, extraEnv ...string) *ServerHarness {
@@ -161,7 +153,7 @@ func newServerHarnessForSession(tb testing.TB, session, home string, cols, rows 
 	tb.Helper()
 	var b [4]byte
 	if session == "" {
-		rand.Read(b[:])
+		mustRandRead(tb, b[:])
 		session = fmt.Sprintf("t-%x", b)
 	}
 
@@ -213,13 +205,13 @@ func newServerHarnessForSession(tb testing.TB, session, home string, cols, rows 
 	var coverDir string
 	if gocoverDir != "" {
 		coverDir = filepath.Join(gocoverDir, session)
-		os.MkdirAll(coverDir, 0755)
+		mustMkdirAll(tb, coverDir, 0755)
 		env = upsertEnv(env, "GOCOVERDIR", coverDir)
 	}
 	cmd.Env = env
 
 	logDir := server.SocketDir()
-	os.MkdirAll(logDir, 0700)
+	mustMkdirAll(tb, logDir, 0700)
 	logPath := filepath.Join(logDir, session+".log")
 	logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0600)
 	if err != nil {
@@ -241,7 +233,7 @@ func newServerHarnessForSession(tb testing.TB, session, home string, cols, rows 
 	logFile.Close()
 
 	// Block until server signals readiness (after net.Listen succeeds).
-	readPipe.SetReadDeadline(time.Now().Add(10 * time.Second))
+	mustSetReadDeadline(tb, readPipe, time.Now().Add(10*time.Second))
 	buf := make([]byte, 64)
 	n, err := readPipe.Read(buf)
 	readPipe.Close()
@@ -249,7 +241,7 @@ func newServerHarnessForSession(tb testing.TB, session, home string, cols, rows 
 		logData, _ := os.ReadFile(logPath)
 		var waitErr error
 		if err != nil && os.IsTimeout(err) {
-			_ = cmd.Process.Kill()
+			ignoreProcessKill(cmd.Process)
 			waitErr = cmd.Wait()
 		} else {
 			waitErr = cmd.Wait()
@@ -280,12 +272,12 @@ func newServerHarnessForSession(tb testing.TB, session, home string, cols, rows 
 	sockPath := server.SocketPath(session)
 	client, err := newHeadlessClient(sockPath, session, cols, rows)
 	if err != nil {
-		cmd.Process.Kill()
+		ignoreProcessKill(cmd.Process)
 		tb.Fatalf("attaching headless client: %v", err)
 	}
 	if err := client.waitCommandReady(); err != nil {
 		client.close()
-		cmd.Process.Kill()
+		ignoreProcessKill(cmd.Process)
 		tb.Fatalf("headless client command-ready: %v", err)
 	}
 	h.client = client
@@ -293,7 +285,7 @@ func newServerHarnessForSession(tb testing.TB, session, home string, cols, rows 
 		secondary, err := newHeadlessClient(sockPath, session, cols, rows)
 		if err != nil {
 			h.client.close()
-			cmd.Process.Kill()
+			ignoreProcessKill(cmd.Process)
 			tb.Fatalf("attaching keepalive headless client: %v", err)
 		}
 		h.keepalive = secondary
@@ -321,8 +313,11 @@ func (h *ServerHarness) ensureControlClient() error {
 }
 
 func (h *ServerHarness) signalServer(sig os.Signal) error {
+	if h == nil {
+		return fmt.Errorf("server process is not running")
+	}
 	h.tb.Helper()
-	if h == nil || h.cmd == nil || h.cmd.Process == nil {
+	if h.cmd == nil || h.cmd.Process == nil {
 		return fmt.Errorf("server process is not running")
 	}
 	pid := h.cmd.Process.Pid
@@ -353,19 +348,18 @@ func (h *ServerHarness) cleanup() {
 		h.cmd = nil
 	}
 
-	gracefulShutdown := h.shutdownPipe == nil
 	switch {
 	case h.cmd == nil || h.cmd.Process == nil:
 	case h.exitUnattached:
 		if h.shutdownPipe != nil {
-			gracefulShutdown = h.waitForShutdownSignalWithin(5 * time.Second)
+			_ = h.waitForShutdownSignalWithin(5 * time.Second)
 		}
 	default:
 		if serverProcessMatchesSession(serverPid, h.session) {
 			_ = h.cmd.Process.Signal(os.Interrupt)
 		}
 		if h.shutdownPipe != nil {
-			gracefulShutdown = h.waitForShutdownSignalWithin(5 * time.Second)
+			_ = h.waitForShutdownSignalWithin(5 * time.Second)
 		}
 	}
 
@@ -376,9 +370,6 @@ func (h *ServerHarness) cleanup() {
 		if !h.waitForProcessExit(3 * time.Second) {
 			h.tb.Fatalf("server process %d did not exit during harness cleanup", serverPid)
 		}
-	} else if h.cmd != nil && !gracefulShutdown {
-		// The process exited before we observed the explicit shutdown signal.
-		// Treat the cleanup as complete once the server is gone.
 	}
 
 	if h.shutdownPipe != nil {
@@ -453,7 +444,7 @@ func killChildrenByPid(pid int) {
 	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
 		line = strings.TrimSpace(line)
 		if childPID, err := strconv.Atoi(line); err == nil {
-			syscall.Kill(childPID, syscall.SIGKILL)
+			_ = syscall.Kill(childPID, syscall.SIGKILL)
 		}
 	}
 }
@@ -930,21 +921,6 @@ func (h *ServerHarness) serverLogTail(maxBytes int) string {
 	return tailDiagnostic(string(data), maxBytes)
 }
 
-func (h *ServerHarness) serverWaitStatus() string {
-	if h.waitDone == nil {
-		return ""
-	}
-	select {
-	case <-h.waitDone:
-		if h.waitErr == nil {
-			return "server process exited cleanly"
-		}
-		return "server process exited: " + h.waitErr.Error()
-	default:
-		return "server process still running"
-	}
-}
-
 func truncateDiagnostic(s string, max int) string {
 	if max <= 0 || len(s) <= max {
 		return s
@@ -1392,19 +1368,6 @@ func (h *ServerHarness) waitForPaneContent(pane, substr string, timeout time.Dur
 // Split helpers — synchronous via CLI, no keybinding simulation
 // ---------------------------------------------------------------------------
 
-// activePaneName returns the name of the currently active pane via JSON capture.
-func (h *ServerHarness) activePaneName() string {
-	h.tb.Helper()
-	c := h.captureJSON()
-	for _, p := range c.Panes {
-		if p.Active {
-			return p.Name
-		}
-	}
-	h.tb.Fatal("no active pane found in capture")
-	return ""
-}
-
 // doSplit is a layout-construction helper for tests. It clears the default
 // single-pane pending lead so generic layout tests keep exercising ordinary
 // split semantics, then runs the public split CLI command against the active
@@ -1715,13 +1678,6 @@ func (h *ServerHarness) runShellCommandWithSettle(pane, command, marker, settle 
 	h.sendKeys(pane, command, "Enter")
 	h.waitFor(pane, marker)
 	h.waitIdleWithSettle(pane, settle, "5s")
-}
-
-func (h *ServerHarness) sendClientKeys(keys ...string) string {
-	h.tb.Helper()
-	pane := h.activePaneName()
-	args := append([]string{"send-keys", pane, "--via", "client"}, keys...)
-	return h.runCmd(args...)
 }
 
 func TestNewServerHarnessReturnsCommandReady(t *testing.T) {

--- a/test/test_sshd_test.go
+++ b/test/test_sshd_test.go
@@ -225,7 +225,7 @@ func handleSSHConn(ctx context.Context, tcpConn net.Conn, config *ssh.ServerConf
 			handleStreamLocal(newChannel)
 
 		default:
-			newChannel.Reject(ssh.UnknownChannelType, "unsupported channel type")
+			ignoreReject(newChannel, ssh.UnknownChannelType, "unsupported channel type")
 		}
 	}
 }
@@ -256,12 +256,12 @@ func handleSession(ctx context.Context, ch ssh.Channel, reqs <-chan *ssh.Request
 	for req := range reqs {
 		switch req.Type {
 		case "env":
-			req.Reply(true, nil)
+			ignoreReply(req, true)
 
 		case "pty-req":
 			var ptyReq ptyRequest
 			if err := ssh.Unmarshal(req.Payload, &ptyReq); err != nil {
-				req.Reply(false, nil)
+				ignoreReply(req, false)
 				continue
 			}
 			winSize = &pty.Winsize{
@@ -271,27 +271,27 @@ func handleSession(ctx context.Context, ch ssh.Channel, reqs <-chan *ssh.Request
 			if ptyReq.Term != "" {
 				termType = ptyReq.Term
 			}
-			req.Reply(true, nil)
+			ignoreReply(req, true)
 
 		case "shell":
-			req.Reply(true, nil)
+			ignoreReply(req, true)
 			runShellSession(ctx, ch, reqs, execEnv, winSize, termType)
 			return
 
 		case "exec":
 			if len(req.Payload) < 4 {
-				req.Reply(false, nil)
+				ignoreReply(req, false)
 				continue
 			}
 			cmdLen := binary.BigEndian.Uint32(req.Payload[:4])
 			command := string(req.Payload[4 : 4+cmdLen])
-			req.Reply(true, nil)
+			ignoreReply(req, true)
 			sendExitStatus(ch, runExecCommand(ctx, ch, command, execEnv, termType))
 			return
 
 		default:
 			if req.WantReply {
-				req.Reply(false, nil)
+				ignoreReply(req, false)
 			}
 		}
 	}
@@ -315,15 +315,15 @@ func runShellSession(ctx context.Context, ch ssh.Channel, reqs <-chan *ssh.Reque
 					sizeMu.Unlock()
 				}
 				if req.WantReply {
-					req.Reply(true, nil)
+					ignoreReply(req, true)
 				}
 			case "signal":
 				if req.WantReply {
-					req.Reply(true, nil)
+					ignoreReply(req, true)
 				}
 			default:
 				if req.WantReply {
-					req.Reply(false, nil)
+					ignoreReply(req, false)
 				}
 			}
 		}
@@ -359,11 +359,7 @@ func runShellSession(ctx context.Context, ch ssh.Channel, reqs <-chan *ssh.Reque
 func sendExitStatus(ch ssh.Channel, exitCode int) {
 	exitMsg := make([]byte, 4)
 	binary.BigEndian.PutUint32(exitMsg, uint32(exitCode))
-	ch.SendRequest("exit-status", false, exitMsg)
-}
-
-type crToLFWriter struct {
-	w io.Writer
+	ignoreSendRequest(ch, "exit-status", false, exitMsg)
 }
 
 // sshCmdTimeout bounds any single exec/shell command spawned by the test SSH
@@ -479,13 +475,13 @@ type streamLocalData struct {
 func handleStreamLocal(newChannel ssh.NewChannel) {
 	var data streamLocalData
 	if err := ssh.Unmarshal(newChannel.ExtraData(), &data); err != nil {
-		newChannel.Reject(ssh.ConnectionFailed, "invalid channel data")
+		ignoreReject(newChannel, ssh.ConnectionFailed, "invalid channel data")
 		return
 	}
 
 	unixConn, err := net.Dial("unix", data.SocketPath)
 	if err != nil {
-		newChannel.Reject(ssh.ConnectionFailed, fmt.Sprintf("dial unix %s: %v", data.SocketPath, err))
+		ignoreReject(newChannel, ssh.ConnectionFailed, fmt.Sprintf("dial unix %s: %v", data.SocketPath, err))
 		return
 	}
 
@@ -497,11 +493,11 @@ func handleStreamLocal(newChannel ssh.NewChannel) {
 
 	// Bidirectional proxy
 	go func() {
-		io.Copy(ch, unixConn)
-		ch.CloseWrite()
+		ignoreCopy(ch, unixConn)
+		ignoreCloseWrite(ch)
 	}()
 	go func() {
-		io.Copy(unixConn, ch)
+		ignoreCopy(unixConn, ch)
 		unixConn.Close()
 	}()
 }


### PR DESCRIPTION
## Motivation
The repo had a large backlog of lint violations and no enforced golangci-lint pass in local hooks or CI. This change adds the default lint gate and cleans the existing codebase up to zero violations so future drift is caught automatically.

## Summary
- add `.golangci.yml` with the default lint set used for this task: `errcheck`, `govet`, `staticcheck`, `unused`, `gosimple`, and `ineffassign`
- fix all existing violations across production and test code, including handling previously unchecked production errors and deleting dead code
- add focused test helpers where intentionally ignored returns would otherwise create noise, and cover the remote attach no-deadline transport fallback with unit tests
- run `golangci-lint` from `.githooks/pre-commit` on staged Go files after `goimports`
- add `golangci/golangci-lint-action@v6` to CI behind the existing `code_changed` gate

## Testing
- `golangci-lint run ./...`
- `go test ./... -timeout 120s`
- `go test ./internal/client -run 'TestClientRendererCaptureJSON' -count=100`
- `go test ./internal/remote -run 'TestWaitForLayout|TestAttachAndWait' -count=100`
- `go test ./internal/reload -run 'TestWatchBinaryIgnoresOtherFiles' -count=100`
- `go test ./internal/server -run 'TestCleanStaleSocketsIn|TestEventJSONOmitsZeroFields|TestEmitEventFiltered|TestSplitInheritsRemoteHost' -count=100`
- `go test ./test -run 'TestEventsThrottleNonOutputPassthrough|TestHostsCommand|TestDisconnectAndReconnect|TestRemotePaneKill|TestRemotePaneKillCleanup|TestRemotePaneViaSSH|TestRemotePaneViaSSHAutoDeploy|TestTakeoverBidirectionalIO' -count=100`
- `go test ./test -run 'TestCopyModeScroll|TestCrashRecovery_BusyPaneShowsRecoveryNoticeInsteadOfReplayingStaleScreen|TestServerReloadTUIRedraw|TestUnsupportedPrefixKeyShowsFeedback|TestShutdownLeavesNoOrphans|TestReattachResize' -count=100`
- `go vet ./...`

## Review focus
- verify the production-side error handling changes are preserving existing behavior while satisfying `errcheck`
- review the `internal/remote/host_conn.go` deadline fallback: attach waits now tolerate SSH transports that reject read deadlines without regressing takeover reload handling
- confirm the hook/CI wiring is scoped correctly and does not over-lint non-Go changes

Closes LAB-1295
