### PR TITLE
Avoid double-cloning styled pane history

### DIFF
--- a/internal/server/pane_history_chunk.go
+++ b/internal/server/pane_history_chunk.go
@@ -57,7 +57,7 @@ func newPaneHistoryMessage(paneID uint32, history []proto.StyledLine) *Message {
 		Type:          MsgTypePaneHistory,
 		PaneID:        paneID,
 		History:       proto.StyledLineText(history),
-		StyledHistory: proto.CloneStyledLines(history),
+		StyledHistory: append([]proto.StyledLine(nil), history...),
 	}
 }
 

--- a/internal/server/pane_history_chunk_test.go
+++ b/internal/server/pane_history_chunk_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/weill-labs/amux/internal/mux"
+	"github.com/weill-labs/amux/internal/proto"
 )
 
 func TestChunkPaneHistoryMessagesSplitsLargeHistoryUnderThreshold(t *testing.T) {
@@ -61,6 +62,47 @@ func TestChunkPaneHistoryMessagesSplitsLargeHistoryUnderThreshold(t *testing.T) 
 		if got := flat[i]; got != want {
 			t.Fatalf("history line %d = %q, want %q", i, got, want)
 		}
+	}
+}
+
+func TestNewPaneHistoryMessageCopiesStyledLineHeaders(t *testing.T) {
+	t.Parallel()
+
+	history := []proto.StyledLine{
+		{
+			Text: "line-0",
+			Cells: []proto.Cell{
+				{Char: "a", Width: 1},
+				{Char: "b", Width: 1},
+			},
+		},
+	}
+
+	msg := newPaneHistoryMessage(7, history)
+
+	if got, want := len(msg.StyledHistory), len(history); got != want {
+		t.Fatalf("styled history len = %d, want %d", got, want)
+	}
+	if got, want := msg.History, []string{"line-0"}; len(got) != len(want) || got[0] != want[0] {
+		t.Fatalf("history text = %v, want %v", got, want)
+	}
+	if &msg.StyledHistory[0] == &history[0] {
+		t.Fatal("styled history reused caller slice header")
+	}
+	if len(msg.StyledHistory[0].Cells) != len(history[0].Cells) {
+		t.Fatalf("styled history cell count = %d, want %d", len(msg.StyledHistory[0].Cells), len(history[0].Cells))
+	}
+	if &msg.StyledHistory[0].Cells[0] != &history[0].Cells[0] {
+		t.Fatal("styled history cells were deep-cloned, want shared backing cells")
+	}
+
+	history[0].Text = "mutated"
+	history[0].Cells = nil
+	if got, want := msg.StyledHistory[0].Text, "line-0"; got != want {
+		t.Fatalf("styled history text = %q, want %q", got, want)
+	}
+	if got, want := len(msg.StyledHistory[0].Cells), 2; got != want {
+		t.Fatalf("styled history cells len after caller mutation = %d, want %d", got, want)
 	}
 }
 
@@ -154,6 +196,42 @@ func largeHistoryLines(lineCount, lineWidth int) []string {
 	for i := range lines {
 		suffix := fmt.Sprintf("-%06d", i)
 		lines[i] = strings.Repeat(string(rune('a'+(i%26))), lineWidth-len(suffix)) + suffix
+	}
+	return lines
+}
+
+func BenchmarkNewPaneHistoryMessage(b *testing.B) {
+	history := largeStyledHistoryLines(256, 256)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	var msg *Message
+	for b.Loop() {
+		msg = newPaneHistoryMessage(1, history)
+	}
+	if msg == nil {
+		b.Fatal("newPaneHistoryMessage returned nil")
+	}
+}
+
+func largeStyledHistoryLines(lineCount, lineWidth int) []proto.StyledLine {
+	lines := make([]proto.StyledLine, lineCount)
+	for i := range lines {
+		text := largeHistoryLines(1, lineWidth)[0]
+		text = text[:len(text)-7] + fmt.Sprintf("-%06d", i)
+
+		cells := make([]proto.Cell, 0, len(text))
+		for _, r := range text {
+			cells = append(cells, proto.Cell{
+				Char:  string(r),
+				Width: 1,
+			})
+		}
+		lines[i] = proto.StyledLine{
+			Text:  text,
+			Cells: cells,
+		}
 	}
 	return lines
 }

--- a/internal/server/pane_history_chunk_test.go
+++ b/internal/server/pane_history_chunk_test.go
@@ -194,8 +194,7 @@ func TestHandleAttachChunksLargePaneHistoryDuringBootstrap(t *testing.T) {
 func largeHistoryLines(lineCount, lineWidth int) []string {
 	lines := make([]string, lineCount)
 	for i := range lines {
-		suffix := fmt.Sprintf("-%06d", i)
-		lines[i] = strings.Repeat(string(rune('a'+(i%26))), lineWidth-len(suffix)) + suffix
+		lines[i] = largeHistoryLine(i, lineWidth)
 	}
 	return lines
 }
@@ -218,8 +217,7 @@ func BenchmarkNewPaneHistoryMessage(b *testing.B) {
 func largeStyledHistoryLines(lineCount, lineWidth int) []proto.StyledLine {
 	lines := make([]proto.StyledLine, lineCount)
 	for i := range lines {
-		text := largeHistoryLines(1, lineWidth)[0]
-		text = text[:len(text)-7] + fmt.Sprintf("-%06d", i)
+		text := largeHistoryLine(i, lineWidth)
 
 		cells := make([]proto.Cell, 0, len(text))
 		for _, r := range text {
@@ -234,4 +232,9 @@ func largeStyledHistoryLines(lineCount, lineWidth int) []proto.StyledLine {
 		}
 	}
 	return lines
+}
+
+func largeHistoryLine(i, lineWidth int) string {
+	suffix := fmt.Sprintf("-%06d", i)
+	return strings.Repeat(string(rune('a'+(i%26))), lineWidth-len(suffix)) + suffix
 }


### PR DESCRIPTION
## Motivation
Attach bootstrap cloned styled pane history twice: once when building the retained snapshot and again when chunking pane history messages. The second clone adds unnecessary work and allocation pressure on large scrollback restores.

## Summary
- copy only the `[]proto.StyledLine` slice elements in `newPaneHistoryMessage` instead of deep-cloning cell slices again
- add a regression test that locks in the shallow-copy ownership contract for pane history messages
- add a benchmark for pane history message construction and share the test line builder between the existing large-history helpers

## Testing
- `go test ./internal/server -run TestNewPaneHistoryMessageCopiesStyledLineHeaders -count=100`
- `go test ./internal/server -run '^$' -bench BenchmarkNewPaneHistoryMessage -benchmem`
- `go test ./... -timeout 120s`

## Review focus
Confirm that `newPaneHistoryMessage` only ever receives caller-owned styled history snapshots that will not mutate after chunking, since the function now reuses the already-cloned cell backing slices.

## Baseline numbers
| Benchmark | Hardware | Result |
| --- | --- | --- |
| `BenchmarkNewPaneHistoryMessage` | `Linux x86_64, AMD EPYC-Milan Processor` | `2862 ns/op`, `16096 B/op`, `3 allocs/op` |

Closes LAB-1300
