### PR TITLE
Lazy-load hidden pane history during attach bootstrap

### DIFF
--- a/internal/client/attach_session_test.go
+++ b/internal/client/attach_session_test.go
@@ -1,12 +1,14 @@
 package client
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"net"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -643,6 +645,109 @@ func TestReadAttachBootstrapAppliesImmediateReattachResizeCorrectionBeforeReturn
 	lines := strings.Split(cr.renderer.CapturePaneText(1, false), "\n")
 	if len(lines) == 0 || lines[0] != resizedLine {
 		t.Fatalf("pane-1 first line after bootstrap = %q, want %q", lines[0], resizedLine)
+	}
+}
+
+func TestReadAttachBootstrapDefersHiddenPaneHistoryUntilLaterWindowActivation(t *testing.T) {
+	t.Parallel()
+
+	serverConn, clientConn := net.Pipe()
+	done := make(chan struct{})
+	t.Cleanup(func() {
+		_ = serverConn.Close()
+		_ = clientConn.Close()
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+			t.Fatal("attach bootstrap writer did not exit")
+		}
+	})
+
+	root1 := proto.CellSnapshot{
+		X: 0, Y: 0, W: 20, H: 3,
+		IsLeaf: true, Dir: -1, PaneID: 1,
+	}
+	root2 := proto.CellSnapshot{
+		X: 0, Y: 0, W: 20, H: 3,
+		IsLeaf: true, Dir: -1, PaneID: 2,
+	}
+	panes := []proto.PaneSnapshot{
+		{ID: 1, Name: "pane-1", Host: "local", Color: "f5e0dc"},
+		{ID: 2, Name: "pane-2", Host: "local", Color: "f2cdcd"},
+	}
+	layout1 := &proto.LayoutSnapshot{
+		SessionName:  "test",
+		ActivePaneID: 1,
+		Width:        20,
+		Height:       3,
+		Root:         root1,
+		Panes:        panes,
+		Windows: []proto.WindowSnapshot{
+			{ID: 1, Name: "window-1", Index: 1, ActivePaneID: 1, Root: root1, Panes: []proto.PaneSnapshot{panes[0]}},
+			{ID: 2, Name: "window-2", Index: 2, ActivePaneID: 2, Root: root2, Panes: []proto.PaneSnapshot{panes[1]}},
+		},
+		ActiveWindowID: 1,
+	}
+	layout2 := &proto.LayoutSnapshot{
+		SessionName:  "test",
+		ActivePaneID: 2,
+		Width:        20,
+		Height:       3,
+		Root:         root2,
+		Panes:        panes,
+		Windows: []proto.WindowSnapshot{
+			{ID: 1, Name: "window-1", Index: 1, ActivePaneID: 1, Root: root1, Panes: []proto.PaneSnapshot{panes[0]}},
+			{ID: 2, Name: "window-2", Index: 2, ActivePaneID: 2, Root: root2, Panes: []proto.PaneSnapshot{panes[1]}},
+		},
+		ActiveWindowID: 2,
+	}
+
+	const hiddenScreen = "hidden-live"
+
+	go func() {
+		defer close(done)
+		_ = writeProtoMessages(
+			serverConn,
+			&proto.Message{Type: proto.MsgTypeLayout, Layout: layout1},
+			&proto.Message{Type: proto.MsgTypePaneHistory, PaneID: 1, History: []string{"older-visible"}},
+			&proto.Message{Type: proto.MsgTypePaneOutput, PaneID: 1, PaneData: []byte("\033[2J\033[Hvisible-live")},
+			&proto.Message{Type: proto.MsgTypePaneOutput, PaneID: 2, PaneData: []byte("\033[2J\033[H" + hiddenScreen)},
+			&proto.Message{Type: proto.MsgTypeBell},
+		)
+	}()
+
+	cr := NewClientRenderer(20, 4)
+	if err := readAttachBootstrap(clientConn, proto.NewReader(clientConn), cr); err != nil {
+		t.Fatalf("readAttachBootstrap: %v", err)
+	}
+
+	if history := cr.loadState().baseHistory[2]; len(history) != 0 {
+		t.Fatalf("hidden pane bootstrap history = %q, want no history before deferred update", history)
+	}
+
+	cr.HandleLayout(layout2)
+
+	lines := strings.Split(cr.renderer.CapturePaneText(2, false), "\n")
+	if len(lines) == 0 || lines[0] != hiddenScreen {
+		t.Fatalf("hidden pane first line after window activation = %q, want %q", lines[0], hiddenScreen)
+	}
+
+	cr.HandlePaneHistoryMessage(2, []string{"older-hidden"}, nil)
+
+	var capture proto.CaptureJSON
+	out := cr.CaptureJSONWithHistory(nil)
+	if err := json.Unmarshal([]byte(out), &capture); err != nil {
+		t.Fatalf("JSON parse: %v\nraw: %s", err, out)
+	}
+	if len(capture.Panes) != 1 {
+		t.Fatalf("panes = %d, want 1", len(capture.Panes))
+	}
+	got := capture.Panes[0].Content
+	for len(got) > 0 && got[len(got)-1] == "" {
+		got = got[:len(got)-1]
+	}
+	if want := []string{"older-hidden", hiddenScreen}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("content = %#v, want %#v", got, want)
 	}
 }
 

--- a/internal/mux/pane_emulator.go
+++ b/internal/mux/pane_emulator.go
@@ -105,6 +105,16 @@ func (p *Pane) RenderScreen() string {
 	})
 }
 
+// ScreenSnapshot returns the current visible screen plus the latest
+// live-output sequence included in that state.
+func (p *Pane) ScreenSnapshot() (screen string, seq uint64) {
+	p.withActor(func() {
+		screen = RenderWithCursor(p.emulator)
+		seq = p.outputSeq.Load()
+	})
+	return screen, seq
+}
+
 // HistoryScreenSnapshot returns a consistent snapshot of retained scrollback,
 // current screen, and the latest live-output sequence included in that state.
 func (p *Pane) HistoryScreenSnapshot() (history []string, screen string, seq uint64) {
@@ -116,19 +126,31 @@ func (p *Pane) HistoryScreenSnapshot() (history []string, screen string, seq uin
 	return history, screen, seq
 }
 
+func (p *Pane) styledHistorySnapshot() []proto.StyledLine {
+	baseHistory := p.loadBaseHistory()
+	liveHistory := EmulatorScrollbackStyledLines(p.emulator)
+	baseStart, liveStart := trimScrollbackStarts(len(baseHistory), len(liveHistory), effectiveScrollbackLines(p.scrollbackLines))
+
+	history := make([]proto.StyledLine, 0, len(baseHistory)-baseStart+len(liveHistory)-liveStart)
+	for _, line := range baseHistory[baseStart:] {
+		history = append(history, proto.StyledLine{Text: line})
+	}
+	return append(history, proto.CloneStyledLines(liveHistory[liveStart:])...)
+}
+
+// StyledHistorySnapshot returns retained history with frozen cell styles.
+func (p *Pane) StyledHistorySnapshot() (history []proto.StyledLine) {
+	p.withActor(func() {
+		history = p.styledHistorySnapshot()
+	})
+	return history
+}
+
 // StyledHistoryScreenSnapshot returns retained history with frozen cell styles,
 // current screen, and the latest live-output sequence included in that state.
 func (p *Pane) StyledHistoryScreenSnapshot() (history []proto.StyledLine, screen string, seq uint64) {
 	p.withActor(func() {
-		baseHistory := p.loadBaseHistory()
-		liveHistory := EmulatorScrollbackStyledLines(p.emulator)
-		baseStart, liveStart := trimScrollbackStarts(len(baseHistory), len(liveHistory), effectiveScrollbackLines(p.scrollbackLines))
-
-		history = make([]proto.StyledLine, 0, len(baseHistory)-baseStart+len(liveHistory)-liveStart)
-		for _, line := range baseHistory[baseStart:] {
-			history = append(history, proto.StyledLine{Text: line})
-		}
-		history = append(history, proto.CloneStyledLines(liveHistory[liveStart:])...)
+		history = p.styledHistorySnapshot()
 		screen = RenderWithCursor(p.emulator)
 		seq = p.outputSeq.Load()
 	})

--- a/internal/server/session_events_client.go
+++ b/internal/server/session_events_client.go
@@ -378,7 +378,8 @@ func (s *Session) handleAttachEvent(srv *Server, cc *clientConn, cols, rows int)
 	}
 
 	res.snap = s.snapshotLayout(idleSnap)
-	activeWindowPanes := windowPanes(s.activeWindow())
+	activeWindow := s.activeWindow()
+	activeWindowPanes := windowPanes(activeWindow)
 	activePaneIDs := make(map[uint32]struct{}, len(activeWindowPanes))
 	for _, pane := range activeWindowPanes {
 		activePaneIDs[pane.ID] = struct{}{}

--- a/internal/server/session_events_client.go
+++ b/internal/server/session_events_client.go
@@ -378,14 +378,24 @@ func (s *Session) handleAttachEvent(srv *Server, cc *clientConn, cols, rows int)
 	}
 
 	res.snap = s.snapshotLayout(idleSnap)
+	activeWindowPanes := windowPanes(s.activeWindow())
+	activePaneIDs := make(map[uint32]struct{}, len(activeWindowPanes))
+	for _, pane := range activeWindowPanes {
+		activePaneIDs[pane.ID] = struct{}{}
+	}
 	for _, p := range s.Panes {
-		history, screen, seq := p.StyledHistoryScreenSnapshot()
-		res.paneSnapshots = append(res.paneSnapshots, attachPaneSnapshot{
-			paneID:        p.ID,
-			styledHistory: history,
-			screen:        []byte(screen),
-			outputSeq:     seq,
-		})
+		snapshot := attachPaneSnapshot{paneID: p.ID}
+		if _, ok := activePaneIDs[p.ID]; ok {
+			history, screen, seq := p.StyledHistoryScreenSnapshot()
+			snapshot.styledHistory = history
+			snapshot.screen = []byte(screen)
+			snapshot.outputSeq = seq
+		} else {
+			screen, seq := p.ScreenSnapshot()
+			snapshot.screen = []byte(screen)
+			snapshot.outputSeq = seq
+		}
+		res.paneSnapshots = append(res.paneSnapshots, snapshot)
 	}
 
 	return res

--- a/internal/server/session_events_layout.go
+++ b/internal/server/session_events_layout.go
@@ -468,8 +468,9 @@ func (e commandMutationEvent) handle(s *Session) {
 	ctx.commit()
 	s.drainScheduledMutationPanes(ctx)
 	if res.err == nil {
-		deferredHistories := []paneHistoryUpdate(nil)
-		if s.ActiveWindowID != beforeActiveWindowID {
+		activeWindowChanged := s.ActiveWindowID != beforeActiveWindowID
+		var deferredHistories []paneHistoryUpdate
+		if activeWindowChanged {
 			deferredHistories = windowPaneHistories(s.activeWindow())
 		}
 		s.ensureInputRouter().syncPanes(s.Panes)

--- a/internal/server/session_events_layout.go
+++ b/internal/server/session_events_layout.go
@@ -360,6 +360,27 @@ type paneHistoryUpdate struct {
 	history []proto.StyledLine
 }
 
+func windowPaneHistories(w *mux.Window) []paneHistoryUpdate {
+	if w == nil || w.Root == nil {
+		return nil
+	}
+	histories := make([]paneHistoryUpdate, 0, w.PaneCount())
+	w.Root.Walk(func(cell *mux.LayoutCell) {
+		if cell == nil || cell.Pane == nil {
+			return
+		}
+		history := cell.Pane.StyledHistorySnapshot()
+		if len(history) == 0 {
+			return
+		}
+		histories = append(histories, paneHistoryUpdate{
+			paneID:  cell.Pane.ID,
+			history: history,
+		})
+	})
+	return histories
+}
+
 type paneRender struct {
 	paneID uint32
 	data   []byte
@@ -441,11 +462,16 @@ type commandMutationEvent struct {
 }
 
 func (e commandMutationEvent) handle(s *Session) {
+	beforeActiveWindowID := s.ActiveWindowID
 	ctx := newMutationContext(s)
 	res := recoverCommandMutation(e.fn, ctx)
 	ctx.commit()
 	s.drainScheduledMutationPanes(ctx)
 	if res.err == nil {
+		deferredHistories := []paneHistoryUpdate(nil)
+		if s.ActiveWindowID != beforeActiveWindowID {
+			deferredHistories = windowPaneHistories(s.activeWindow())
+		}
 		s.ensureInputRouter().syncPanes(s.Panes)
 		// Keep enqueueCommandMutation callers from observing stale input routing
 		// after focus/window mutations return.
@@ -453,6 +479,9 @@ func (e commandMutationEvent) handle(s *Session) {
 		if res.broadcastLayout {
 			s.broadcastLayoutNow()
 			res.broadcastLayout = false
+		}
+		for _, ph := range deferredHistories {
+			s.broadcastPaneHistoryNow(ph.paneID, ph.history)
 		}
 		for _, ph := range res.paneHistories {
 			s.broadcastPaneHistoryNow(ph.paneID, ph.history)

--- a/internal/server/session_events_test.go
+++ b/internal/server/session_events_test.go
@@ -211,6 +211,90 @@ func TestHandleAttachSendsPaneHistoryBeforePaneOutput(t *testing.T) {
 	}
 }
 
+func TestHandleAttachOnlySendsPaneHistoryForActiveWindowPanes(t *testing.T) {
+	t.Parallel()
+
+	srv, sess, cleanup := newCommandTestSession(t)
+	defer cleanup()
+
+	pane1 := newAttachTestPane(sess, 1, "pane-1", 80, 2)
+	pane1.FeedOutput([]byte("pane-1-a\r\npane-1-b\r\npane-1-c\r\n"))
+
+	pane2 := newAttachTestPane(sess, 2, "pane-2", 80, 2)
+	pane2.FeedOutput([]byte("pane-2-a\r\npane-2-b\r\npane-2-c\r\n"))
+
+	w1 := mux.NewWindow(pane1, 80, 3)
+	w1.ID = 1
+	w1.Name = "window-1"
+
+	w2 := mux.NewWindow(pane2, 80, 3)
+	w2.ID = 2
+	w2.Name = "window-2"
+
+	if err := setAttachTestLayout(sess, []*mux.Window{w1, w2}, w1.ID, []*mux.Pane{pane1, pane2}); err != nil {
+		t.Fatalf("setAttachTestLayout: %v", err)
+	}
+
+	serverConn, peerConn := net.Pipe()
+	defer peerConn.Close()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		srv.handleAttach(newClientConn(serverConn), &Message{
+			Type:    MsgTypeAttach,
+			Session: sess.Name,
+			Cols:    80,
+			Rows:    4,
+		})
+	}()
+
+	if msg := readMsgWithTimeout(t, peerConn); msg.Type != MsgTypeLayout {
+		t.Fatalf("first message type = %v, want layout", msg.Type)
+	}
+
+	msg := readMsgWithTimeout(t, peerConn)
+	if msg.Type != MsgTypePaneHistory {
+		t.Fatalf("second message type = %v, want pane history", msg.Type)
+	}
+	if msg.PaneID != pane1.ID {
+		t.Fatalf("history pane id = %d, want %d", msg.PaneID, pane1.ID)
+	}
+
+	msg = readMsgWithTimeout(t, peerConn)
+	if msg.Type != MsgTypePaneOutput {
+		t.Fatalf("third message type = %v, want pane output", msg.Type)
+	}
+	if msg.PaneID != pane1.ID {
+		t.Fatalf("first pane output id = %d, want %d", msg.PaneID, pane1.ID)
+	}
+
+	msg = readMsgWithTimeout(t, peerConn)
+	if msg.Type != MsgTypePaneOutput {
+		t.Fatalf("fourth message type = %v, want pane output for hidden window pane", msg.Type)
+	}
+	if msg.PaneID != pane2.ID {
+		t.Fatalf("hidden pane output id = %d, want %d", msg.PaneID, pane2.ID)
+	}
+	if !bytes.Contains(msg.PaneData, []byte("pane-2-c")) {
+		t.Fatalf("hidden pane output = %q, want latest hidden pane screen", msg.PaneData)
+	}
+
+	readUntil(t, peerConn, func(msg *Message) bool {
+		return msg.Type == MsgTypeLayout && msg.Layout != nil && msg.Layout.ActiveWindowID == w1.ID
+	})
+
+	if err := writeMsgOnConn(peerConn, &Message{Type: MsgTypeDetach}); err != nil {
+		t.Fatalf("WriteMsg detach: %v", err)
+	}
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("handleAttach did not exit after detach")
+	}
+}
+
 func TestEnqueueLiveInputPaneResolvesFreshSessionPane(t *testing.T) {
 	t.Parallel()
 
@@ -406,6 +490,81 @@ func TestCommandMutationBroadcastsLayoutBeforeQueuedPaneOutput(t *testing.T) {
 	}
 	if second.PaneID != pane.ID || string(second.PaneData) != "queued-output" {
 		t.Fatalf("pane output = pane %d %q, want pane %d queued-output", second.PaneID, string(second.PaneData), pane.ID)
+	}
+}
+
+func TestCommandMutationBroadcastsDeferredHistoryWhenActiveWindowChanges(t *testing.T) {
+	t.Parallel()
+
+	sess := newSession("test-command-deferred-history")
+	t.Cleanup(func() { stopSessionBackgroundLoops(t, sess) })
+
+	pane1 := newProxyPane(1, mux.PaneMeta{
+		Name:  "pane-1",
+		Host:  mux.DefaultHost,
+		Color: "f5e0dc",
+	}, 80, 2, nil, nil, func(data []byte) (int, error) { return len(data), nil })
+	pane1.FeedOutput([]byte("pane-1-a\r\npane-1-b\r\npane-1-c\r\n"))
+
+	pane2 := newProxyPane(2, mux.PaneMeta{
+		Name:  "pane-2",
+		Host:  mux.DefaultHost,
+		Color: "f2cdcd",
+	}, 80, 2, nil, nil, func(data []byte) (int, error) { return len(data), nil })
+	pane2.FeedOutput([]byte("pane-2-a\r\npane-2-b\r\npane-2-c\r\n"))
+
+	w1 := mux.NewWindow(pane1, 80, 3)
+	w1.ID = 1
+	w1.Name = "window-1"
+
+	w2 := mux.NewWindow(pane2, 80, 3)
+	w2.ID = 2
+	w2.Name = "window-2"
+
+	sess.Windows = []*mux.Window{w1, w2}
+	sess.ActiveWindowID = w1.ID
+	sess.Panes = []*mux.Pane{pane1, pane2}
+
+	serverConn, peerConn := net.Pipe()
+	t.Cleanup(func() { _ = peerConn.Close() })
+
+	cc := newClientConn(serverConn)
+	t.Cleanup(cc.Close)
+	sess.ensureClientManager().setClientsForTest(cc)
+
+	res := sess.enqueueCommandMutation(func(mctx *MutationContext) commandMutationResult {
+		mctx.activateWindow(w2)
+		return commandMutationResult{
+			broadcastLayout: true,
+			paneRenders:     activePaneRender(mctx.activeWindow()),
+		}
+	})
+	if res.err != nil {
+		t.Fatalf("enqueueCommandMutation error = %v", res.err)
+	}
+
+	first := readMsgWithTimeout(t, peerConn)
+	if first.Type != MsgTypeLayout {
+		t.Fatalf("first message type = %v, want layout", first.Type)
+	}
+	if first.Layout == nil || first.Layout.ActiveWindowID != w2.ID {
+		t.Fatalf("layout active window = %+v, want window %d", first.Layout, w2.ID)
+	}
+
+	second := readMsgWithTimeout(t, peerConn)
+	if second.Type != MsgTypePaneHistory {
+		t.Fatalf("second message type = %v, want deferred pane history", second.Type)
+	}
+	if second.PaneID != pane2.ID {
+		t.Fatalf("history pane id = %d, want %d", second.PaneID, pane2.ID)
+	}
+
+	third := readMsgWithTimeout(t, peerConn)
+	if third.Type != MsgTypePaneOutput {
+		t.Fatalf("third message type = %v, want pane output", third.Type)
+	}
+	if third.PaneID != pane2.ID {
+		t.Fatalf("pane output id = %d, want %d", third.PaneID, pane2.ID)
 	}
 }
 

--- a/internal/server/session_window.go
+++ b/internal/server/session_window.go
@@ -49,6 +49,20 @@ func (s *Session) findWindowByPaneID(paneID uint32) *mux.Window {
 	return nil
 }
 
+func windowPanes(w *mux.Window) []*mux.Pane {
+	if w == nil || w.Root == nil {
+		return nil
+	}
+	panes := make([]*mux.Pane, 0, w.PaneCount())
+	w.Root.Walk(func(cell *mux.LayoutCell) {
+		if cell == nil || cell.Pane == nil {
+			return
+		}
+		panes = append(panes, cell.Pane)
+	})
+	return panes
+}
+
 // removeWindow removes a window from the list by ID.
 func (s *Session) removeWindow(windowID uint32) {
 	for i, w := range s.Windows {


### PR DESCRIPTION
## Motivation
Attach bootstrap was cloning full styled scrollback for every pane, including panes in hidden windows. On large sessions that made attach dominated by hidden-pane history allocation instead of visible-pane rendering.

## Summary
- send full styled history during attach only for panes in the active window, while still sending screen snapshots for every pane
- broadcast deferred `MsgTypePaneHistory` for the newly active window after command mutations that switch windows
- add regressions for active-window-only attach history, deferred history on window activation, and client handling of late hidden-pane history

## Testing
- `go test ./internal/server -run 'TestHandleAttachOnlySendsPaneHistoryForActiveWindowPanes|TestCommandMutationBroadcastsDeferredHistoryWhenActiveWindowChanges' -count=100`
- `go test ./internal/client -run 'TestReadAttachBootstrapDefersHiddenPaneHistoryUntilLaterWindowActivation' -count=100`
- `go test ./... -timeout 120s`

## Review focus
- `internal/server/session_events_client.go`: active-window vs hidden-window snapshot partitioning during attach
- `internal/server/session_events_layout.go`: deferred history broadcasts when the active window changes
- `internal/mux/pane_emulator.go`: lightweight screen-only and history-only snapshot helpers used by the server

Closes LAB-1299
