### PR TITLE
Encode pane history with compact binary frames

### DIFF
--- a/internal/client/attach_bootstrap_memory_test.go
+++ b/internal/client/attach_bootstrap_memory_test.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"os"
+	"os/exec"
 	"runtime"
 	"strings"
 	"testing"
@@ -13,16 +15,32 @@ import (
 	"github.com/weill-labs/amux/internal/proto"
 )
 
+const attachBootstrapPeakHeapSubprocessEnv = "AMUX_TEST_ATTACH_BOOTSTRAP_PEAK_HEAP"
+
 func TestReadAttachBootstrapKeepsPeakHeapUnderBound(t *testing.T) {
 	t.Parallel()
 
+	if os.Getenv(attachBootstrapPeakHeapSubprocessEnv) == "1" {
+		runReadAttachBootstrapPeakHeapTest(t)
+		return
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=^TestReadAttachBootstrapKeepsPeakHeapUnderBound$", "-test.parallel=1")
+	cmd.Env = append(os.Environ(), attachBootstrapPeakHeapSubprocessEnv+"=1")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("peak-heap subprocess failed: %v\n%s", err, output)
+	}
+}
+
+func runReadAttachBootstrapPeakHeapTest(t *testing.T) {
 	const (
-		paneCount      = 32
-		historyLines   = 128
-		lineWidth      = 120
-		layoutHeight   = 24
-		peakHeapLimit  = 256 << 20
-		sessionName    = "bootstrap-memory"
+		paneCount     = 32
+		historyLines  = 128
+		lineWidth     = 120
+		layoutHeight  = 24
+		peakHeapLimit = 256 << 20
+		sessionName   = "bootstrap-memory"
 	)
 
 	stream := buildAttachBootstrapReplay(t, sessionName, paneCount, historyLines, lineWidth, layoutHeight)
@@ -59,6 +77,7 @@ func buildAttachBootstrapReplay(t *testing.T, sessionName string, paneCount, his
 
 	var buf bytes.Buffer
 	writer := proto.NewWriter(&buf)
+	writer.SetBinaryPaneHistory(true)
 	if err := writer.WriteMsg(&proto.Message{Type: proto.MsgTypeLayout, Layout: layout}); err != nil {
 		t.Fatalf("write layout: %v", err)
 	}

--- a/internal/client/attach_session_test.go
+++ b/internal/client/attach_session_test.go
@@ -1543,7 +1543,7 @@ func TestAdvertisedAttachCapabilitiesUsesEnvironment(t *testing.T) {
 	if caps == nil {
 		t.Fatal("advertisedAttachCapabilities() = nil, want capabilities")
 	}
-	if !caps.KittyKeyboard || !caps.Hyperlinks || !caps.CursorMetadata || !caps.GraphicsPlaceholder {
+	if !caps.KittyKeyboard || !caps.Hyperlinks || !caps.CursorMetadata || !caps.GraphicsPlaceholder || !caps.BinaryPaneHistory {
 		t.Fatalf("advertised capabilities = %+v, want iTerm defaults plus override", *caps)
 	}
 }

--- a/internal/client/capabilities.go
+++ b/internal/client/capabilities.go
@@ -21,7 +21,11 @@ const (
 // capability registry. This is intentionally conservative: if a feature cannot
 // be inferred reliably from the client environment, we leave it disabled.
 func advertisedAttachCapabilities() *proto.ClientCapabilities {
-	caps := detectAttachCapabilitiesFromEnv(os.LookupEnv)
+	caps := detectedAttachCapabilities(detectTerminalFlavor(os.LookupEnv))
+	caps.BinaryPaneHistory = true
+	if raw, ok := os.LookupEnv("AMUX_CLIENT_CAPABILITIES"); ok {
+		caps = applyCapabilityOverride(caps, raw)
+	}
 	return &caps
 }
 
@@ -115,6 +119,8 @@ func setCapability(caps *proto.ClientCapabilities, name string, enabled bool) bo
 		caps.PromptMarkers = enabled
 	case "graphics_placeholder":
 		caps.GraphicsPlaceholder = enabled
+	case "binary_pane_history":
+		caps.BinaryPaneHistory = enabled
 	default:
 		return false
 	}

--- a/internal/client/capabilities_test.go
+++ b/internal/client/capabilities_test.go
@@ -135,11 +135,12 @@ func TestDetectAttachCapabilitiesFromEnvOverride(t *testing.T) {
 				"AMUX_CLIENT_CAPABILITIES": "all,-graphics_placeholder",
 			},
 			want: proto.ClientCapabilities{
-				KittyKeyboard:  true,
-				Hyperlinks:     true,
-				RichUnderline:  true,
-				CursorMetadata: true,
-				PromptMarkers:  true,
+				KittyKeyboard:     true,
+				Hyperlinks:        true,
+				RichUnderline:     true,
+				CursorMetadata:    true,
+				PromptMarkers:     true,
+				BinaryPaneHistory: true,
 			},
 		},
 		{

--- a/internal/client/helpers_extra_test.go
+++ b/internal/client/helpers_extra_test.go
@@ -17,11 +17,12 @@ func TestAdvertisedAttachCapabilitiesUsesProcessEnv(t *testing.T) {
 
 	got := advertisedAttachCapabilities()
 	want := &proto.ClientCapabilities{
-		KittyKeyboard:  true,
-		Hyperlinks:     true,
-		RichUnderline:  true,
-		PromptMarkers:  true,
-		CursorMetadata: false,
+		KittyKeyboard:     true,
+		Hyperlinks:        true,
+		RichUnderline:     true,
+		PromptMarkers:     true,
+		CursorMetadata:    false,
+		BinaryPaneHistory: true,
 	}
 
 	if got == nil {
@@ -31,6 +32,7 @@ func TestAdvertisedAttachCapabilitiesUsesProcessEnv(t *testing.T) {
 		got.Hyperlinks != want.Hyperlinks ||
 		got.RichUnderline != want.RichUnderline ||
 		got.PromptMarkers != want.PromptMarkers ||
+		got.BinaryPaneHistory != want.BinaryPaneHistory ||
 		got.GraphicsPlaceholder != want.GraphicsPlaceholder {
 		t.Fatalf("advertisedAttachCapabilities() = %+v, want %+v", *got, *want)
 	}

--- a/internal/proto/capabilities.go
+++ b/internal/proto/capabilities.go
@@ -54,7 +54,7 @@ func (c ClientCapabilities) Intersect(other ClientCapabilities) ClientCapabiliti
 
 // EnabledNames returns enabled capability names in stable display order.
 func (c ClientCapabilities) EnabledNames() []string {
-	names := make([]string, 0, 6)
+	names := make([]string, 0, 7)
 	if c.KittyKeyboard {
 		names = append(names, "kitty_keyboard")
 	}

--- a/internal/proto/capabilities.go
+++ b/internal/proto/capabilities.go
@@ -12,6 +12,7 @@ type ClientCapabilities struct {
 	CursorMetadata      bool `json:"cursor_metadata,omitempty"`
 	PromptMarkers       bool `json:"prompt_markers,omitempty"`
 	GraphicsPlaceholder bool `json:"graphics_placeholder,omitempty"`
+	BinaryPaneHistory   bool `json:"binary_pane_history,omitempty"`
 }
 
 // KnownClientCapabilities returns the capability set understood by this build.
@@ -24,6 +25,7 @@ func KnownClientCapabilities() ClientCapabilities {
 		CursorMetadata:      true,
 		PromptMarkers:       true,
 		GraphicsPlaceholder: true,
+		BinaryPaneHistory:   true,
 	}
 }
 
@@ -46,6 +48,7 @@ func (c ClientCapabilities) Intersect(other ClientCapabilities) ClientCapabiliti
 		CursorMetadata:      c.CursorMetadata && other.CursorMetadata,
 		PromptMarkers:       c.PromptMarkers && other.PromptMarkers,
 		GraphicsPlaceholder: c.GraphicsPlaceholder && other.GraphicsPlaceholder,
+		BinaryPaneHistory:   c.BinaryPaneHistory && other.BinaryPaneHistory,
 	}
 }
 
@@ -69,6 +72,9 @@ func (c ClientCapabilities) EnabledNames() []string {
 	}
 	if c.GraphicsPlaceholder {
 		names = append(names, "graphics_placeholder")
+	}
+	if c.BinaryPaneHistory {
+		names = append(names, "binary_pane_history")
 	}
 	return names
 }

--- a/internal/proto/wire.go
+++ b/internal/proto/wire.go
@@ -11,9 +11,10 @@ import (
 // Writer caches gob encoder state for one connection. It is safe for sequential
 // use only; callers serialize writes at a higher level.
 type Writer struct {
-	dst    io.Writer
-	gobBuf bytes.Buffer
-	gobEnc *gob.Encoder
+	dst               io.Writer
+	gobBuf            bytes.Buffer
+	gobEnc            *gob.Encoder
+	binaryPaneHistory bool
 }
 
 // NewWriter binds a stateful gob encoder to one output stream.
@@ -34,6 +35,9 @@ func (w *Writer) WriteMsg(msg *Message) error {
 	}
 	if msg.Type == MsgTypePaneOutput {
 		return writePaneOutputBinary(w.dst, msg)
+	}
+	if msg.Type == MsgTypePaneHistory && w.binaryPaneHistory {
+		return writePaneHistoryBinary(w.dst, msg)
 	}
 	w.gobBuf.Reset()
 	if err := w.gobEnc.Encode(msg); err != nil {
@@ -73,6 +77,9 @@ func (r *Reader) ReadMsg() (*Message, error) {
 
 	if disc[0] == wireFormatBinary {
 		return readPaneOutputBinary(r.src)
+	}
+	if disc[0] == wireFormatPaneHistory {
+		return readPaneHistoryBinary(r.src)
 	}
 	return r.readMsgGob()
 }
@@ -249,6 +256,9 @@ func ReadMsg(r io.Reader) (*Message, error) {
 
 	if disc[0] == wireFormatBinary {
 		return readPaneOutputBinary(r)
+	}
+	if disc[0] == wireFormatPaneHistory {
+		return readPaneHistoryBinary(r)
 	}
 	return readMsgGob(r)
 }

--- a/internal/proto/wire.go
+++ b/internal/proto/wire.go
@@ -8,8 +8,9 @@ import (
 	"io"
 )
 
-// Writer caches gob encoder state for one connection. It is safe for sequential
-// use only; callers serialize writes at a higher level.
+// Writer caches gob encoder state for one connection and can opt specific
+// high-volume message types into compact binary frames. It is safe for
+// sequential use only; callers serialize writes at a higher level.
 type Writer struct {
 	dst               io.Writer
 	gobBuf            bytes.Buffer
@@ -185,8 +186,9 @@ const maxMessageSize = 16 * 1024 * 1024 // 16 MB
 
 // Wire format discriminators. The first byte on the wire identifies the
 // encoding used for the rest of the message:
-//   - wireFormatGob:    [0x00][length:4 BE][gob payload]
-//   - wireFormatBinary: [0x01][paneID:4 BE][length:4 BE][pane data]
+//   - wireFormatGob:         [0x00][length:4 BE][gob payload]
+//   - wireFormatBinary:      [0x01][paneID:4 BE][length:4 BE][pane data]
+//   - wireFormatPaneHistory: [0x02][paneID:4 BE][length:4 BE][pane history payload]
 const (
 	wireFormatGob    byte = 0x00
 	wireFormatBinary byte = 0x01
@@ -194,8 +196,9 @@ const (
 
 // WriteMsg encodes and writes a message to w.
 //
-// MsgTypePaneOutput uses a compact binary encoding (no gob overhead).
-// All other message types use the original length-prefixed gob encoding.
+// The stateless helper only uses the always-on compact PaneOutput frame.
+// Connection-scoped writers can also opt PaneHistory into compact binary via
+// SetBinaryPaneHistory when both peers negotiated support.
 func WriteMsg(w io.Writer, msg *Message) error {
 	if msg.Type == MsgTypePaneOutput {
 		return writePaneOutputBinary(w, msg)

--- a/internal/proto/wire_low_coverage_test.go
+++ b/internal/proto/wire_low_coverage_test.go
@@ -465,6 +465,7 @@ func TestClientCapabilitiesEnabledNamesCoversAllFlags(t *testing.T) {
 		PromptMarkers:       true,
 		CursorMetadata:      true,
 		GraphicsPlaceholder: true,
+		BinaryPaneHistory:   true,
 	}
 
 	got := caps.EnabledNames()
@@ -474,6 +475,7 @@ func TestClientCapabilitiesEnabledNamesCoversAllFlags(t *testing.T) {
 		"cursor_metadata",
 		"prompt_markers",
 		"graphics_placeholder",
+		"binary_pane_history",
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("EnabledNames() = %v, want %v", got, want)

--- a/internal/proto/wire_pane_history.go
+++ b/internal/proto/wire_pane_history.go
@@ -1,0 +1,598 @@
+package proto
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"image/color"
+	"io"
+	"strings"
+
+	uv "github.com/charmbracelet/ultraviolet"
+	"github.com/charmbracelet/x/ansi"
+)
+
+const wireFormatPaneHistory byte = 0x02
+
+const (
+	paneHistoryFlagHistoryFromStyledText byte = 1 << iota
+)
+
+const (
+	paneHistoryLineFlagTextFromCells byte = 1 << iota
+	paneHistoryLineFlagHasCells
+)
+
+const (
+	paneHistoryColorNil byte = iota
+	paneHistoryColorBasic
+	paneHistoryColorIndexed
+	paneHistoryColorRGB
+	paneHistoryColorRGBA
+	paneHistoryColorRGBA64
+)
+
+type paneHistoryCellRun struct {
+	count int
+	cell  Cell
+}
+
+type paneHistoryColorKey struct {
+	kind byte
+	data [8]byte
+}
+
+type paneHistoryStyleKey struct {
+	fg             paneHistoryColorKey
+	bg             paneHistoryColorKey
+	underlineColor paneHistoryColorKey
+	underline      byte
+	attrs          uint8
+}
+
+type paneHistoryReader struct {
+	br *bufio.Reader
+	lr *io.LimitedReader
+}
+
+func newPaneHistoryReader(r io.Reader, limit int64) *paneHistoryReader {
+	lr := &io.LimitedReader{R: r, N: limit}
+	return &paneHistoryReader{
+		br: bufio.NewReader(lr),
+		lr: lr,
+	}
+}
+
+func (r *paneHistoryReader) Read(p []byte) (int, error) {
+	return r.br.Read(p)
+}
+
+func (r *paneHistoryReader) ReadByte() (byte, error) {
+	return r.br.ReadByte()
+}
+
+func (r *paneHistoryReader) remaining() int64 {
+	return int64(r.br.Buffered()) + r.lr.N
+}
+
+// SetBinaryPaneHistory toggles compact binary encoding for MsgTypePaneHistory.
+// Callers should configure this before they begin writing on the stream.
+func (w *Writer) SetBinaryPaneHistory(enabled bool) {
+	if w == nil {
+		return
+	}
+	w.binaryPaneHistory = enabled
+}
+
+func writePaneHistoryBinary(w io.Writer, msg *Message) error {
+	payload, err := encodePaneHistoryPayload(msg)
+	if err != nil {
+		return fmt.Errorf("encoding pane history payload: %w", err)
+	}
+
+	var hdr [9]byte
+	hdr[0] = wireFormatPaneHistory
+	binary.BigEndian.PutUint32(hdr[1:5], msg.PaneID)
+	binary.BigEndian.PutUint32(hdr[5:9], uint32(len(payload)))
+	if _, err := w.Write(hdr[:]); err != nil {
+		return fmt.Errorf("writing pane history header: %w", err)
+	}
+	if len(payload) > 0 {
+		if _, err := w.Write(payload); err != nil {
+			return fmt.Errorf("writing pane history payload: %w", err)
+		}
+	}
+	return nil
+}
+
+func readPaneHistoryBinary(r io.Reader) (*Message, error) {
+	var hdr [8]byte
+	if _, err := io.ReadFull(r, hdr[:]); err != nil {
+		return nil, err
+	}
+
+	paneID := binary.BigEndian.Uint32(hdr[0:4])
+	payloadLen := binary.BigEndian.Uint32(hdr[4:8])
+	if payloadLen > maxMessageSize {
+		return nil, fmt.Errorf("message too large: %d bytes", payloadLen)
+	}
+
+	pr := newPaneHistoryReader(r, int64(payloadLen))
+	msg, err := decodePaneHistoryPayload(paneID, pr, int(payloadLen))
+	if err != nil {
+		return nil, err
+	}
+	if pr.remaining() != 0 {
+		remaining := pr.remaining()
+		if _, err := io.Copy(io.Discard, pr); err != nil {
+			return nil, fmt.Errorf("discarding pane history payload tail: %w", err)
+		}
+		return nil, fmt.Errorf("pane history payload has %d trailing bytes", remaining)
+	}
+	return msg, nil
+}
+
+func encodePaneHistoryPayload(msg *Message) ([]byte, error) {
+	if msg == nil {
+		return nil, fmt.Errorf("nil message")
+	}
+
+	var payload bytes.Buffer
+	flags := byte(0)
+	if paneHistoryMatchesStyledText(msg.History, msg.StyledHistory) {
+		flags |= paneHistoryFlagHistoryFromStyledText
+	}
+	payload.WriteByte(flags)
+	writePaneHistoryUvarint(&payload, uint64(len(msg.History)))
+	writePaneHistoryUvarint(&payload, uint64(len(msg.StyledHistory)))
+
+	if flags&paneHistoryFlagHistoryFromStyledText == 0 {
+		for _, line := range msg.History {
+			writePaneHistoryString(&payload, line)
+		}
+	}
+
+	styles, styleIndex := paneHistoryStyleTable(msg.StyledHistory)
+	writePaneHistoryUvarint(&payload, uint64(len(styles)))
+	for _, style := range styles {
+		if err := writePaneHistoryStyle(&payload, style); err != nil {
+			return nil, err
+		}
+	}
+
+	for _, line := range msg.StyledHistory {
+		lineFlags := byte(0)
+		if len(line.Cells) > 0 {
+			lineFlags |= paneHistoryLineFlagHasCells
+			if paneHistoryCellsTextEqual(line.Text, line.Cells) {
+				lineFlags |= paneHistoryLineFlagTextFromCells
+			}
+		}
+		payload.WriteByte(lineFlags)
+
+		if lineFlags&paneHistoryLineFlagTextFromCells == 0 {
+			writePaneHistoryString(&payload, line.Text)
+		}
+		if lineFlags&paneHistoryLineFlagHasCells == 0 {
+			continue
+		}
+
+		runs := paneHistoryCellRuns(line.Cells)
+		writePaneHistoryUvarint(&payload, uint64(len(runs)))
+		for _, run := range runs {
+			writePaneHistoryUvarint(&payload, uint64(run.count))
+			writePaneHistoryString(&payload, run.cell.Char)
+			if run.cell.Width < 0 {
+				return nil, fmt.Errorf("negative cell width: %d", run.cell.Width)
+			}
+			writePaneHistoryUvarint(&payload, uint64(run.cell.Width))
+			writePaneHistoryUvarint(&payload, uint64(styleIndex[paneHistoryComparableStyle(run.cell.Style)]))
+		}
+	}
+
+	return payload.Bytes(), nil
+}
+
+func decodePaneHistoryPayload(paneID uint32, r *paneHistoryReader, payloadLen int) (*Message, error) {
+	flags, err := r.ReadByte()
+	if err != nil {
+		return nil, fmt.Errorf("reading pane history flags: %w", err)
+	}
+
+	historyCount, err := readPaneHistoryCount(r, payloadLen, "history count")
+	if err != nil {
+		return nil, err
+	}
+	styledCount, err := readPaneHistoryCount(r, payloadLen, "styled history count")
+	if err != nil {
+		return nil, err
+	}
+
+	history := make([]string, historyCount)
+	if flags&paneHistoryFlagHistoryFromStyledText == 0 {
+		for i := 0; i < historyCount; i++ {
+			history[i], err = readPaneHistoryString(r)
+			if err != nil {
+				return nil, fmt.Errorf("reading history line %d: %w", i, err)
+			}
+		}
+	} else if historyCount != styledCount {
+		return nil, fmt.Errorf("history/styled history count mismatch: %d != %d", historyCount, styledCount)
+	}
+
+	styleCount, err := readPaneHistoryCount(r, payloadLen, "style count")
+	if err != nil {
+		return nil, err
+	}
+	styles := make([]uv.Style, styleCount)
+	for i := 0; i < styleCount; i++ {
+		styles[i], err = readPaneHistoryStyle(r)
+		if err != nil {
+			return nil, fmt.Errorf("reading style %d: %w", i, err)
+		}
+	}
+
+	styledHistory := make([]StyledLine, styledCount)
+	for i := 0; i < styledCount; i++ {
+		lineFlags, err := r.ReadByte()
+		if err != nil {
+			return nil, fmt.Errorf("reading styled line %d flags: %w", i, err)
+		}
+
+		line := StyledLine{}
+		if lineFlags&paneHistoryLineFlagTextFromCells == 0 {
+			line.Text, err = readPaneHistoryString(r)
+			if err != nil {
+				return nil, fmt.Errorf("reading styled line %d text: %w", i, err)
+			}
+		}
+		if lineFlags&paneHistoryLineFlagHasCells != 0 {
+			runCount, err := readPaneHistoryCount(r, payloadLen, "cell run count")
+			if err != nil {
+				return nil, fmt.Errorf("reading styled line %d run count: %w", i, err)
+			}
+			line.Cells = make([]Cell, 0, runCount)
+			for runIndex := 0; runIndex < runCount; runIndex++ {
+				runLen, err := readPaneHistoryCount(r, payloadLen, "cell run length")
+				if err != nil {
+					return nil, fmt.Errorf("reading styled line %d run %d length: %w", i, runIndex, err)
+				}
+				char, err := readPaneHistoryString(r)
+				if err != nil {
+					return nil, fmt.Errorf("reading styled line %d run %d char: %w", i, runIndex, err)
+				}
+				width, err := readPaneHistoryCount(r, payloadLen, "cell width")
+				if err != nil {
+					return nil, fmt.Errorf("reading styled line %d run %d width: %w", i, runIndex, err)
+				}
+				styleIndex, err := readPaneHistoryCount(r, payloadLen, "style index")
+				if err != nil {
+					return nil, fmt.Errorf("reading styled line %d run %d style index: %w", i, runIndex, err)
+				}
+				if styleIndex >= len(styles) {
+					return nil, fmt.Errorf("style index %d out of range %d", styleIndex, len(styles))
+				}
+				cell := Cell{
+					Char:  char,
+					Width: width,
+					Style: styles[styleIndex],
+				}
+				for j := 0; j < runLen; j++ {
+					line.Cells = append(line.Cells, cell)
+				}
+			}
+			if lineFlags&paneHistoryLineFlagTextFromCells != 0 {
+				line.Text = paneHistoryCellsText(line.Cells)
+			}
+		}
+		styledHistory[i] = line
+	}
+
+	if flags&paneHistoryFlagHistoryFromStyledText != 0 {
+		history = StyledLineText(styledHistory)
+	}
+
+	return &Message{
+		Type:          MsgTypePaneHistory,
+		PaneID:        paneID,
+		History:       history,
+		StyledHistory: styledHistory,
+	}, nil
+}
+
+func paneHistoryMatchesStyledText(history []string, styled []StyledLine) bool {
+	if len(history) == 0 || len(history) != len(styled) {
+		return false
+	}
+	for i, line := range styled {
+		if history[i] != line.Text {
+			return false
+		}
+	}
+	return true
+}
+
+func paneHistoryStyleTable(lines []StyledLine) ([]uv.Style, map[paneHistoryStyleKey]int) {
+	styles := make([]uv.Style, 0)
+	index := make(map[paneHistoryStyleKey]int)
+	for _, line := range lines {
+		for _, cell := range line.Cells {
+			key := paneHistoryComparableStyle(cell.Style)
+			if _, ok := index[key]; ok {
+				continue
+			}
+			index[key] = len(styles)
+			styles = append(styles, cell.Style)
+		}
+	}
+	return styles, index
+}
+
+func paneHistoryComparableStyle(style uv.Style) paneHistoryStyleKey {
+	return paneHistoryStyleKey{
+		fg:             paneHistoryComparableColor(style.Fg),
+		bg:             paneHistoryComparableColor(style.Bg),
+		underlineColor: paneHistoryComparableColor(style.UnderlineColor),
+		underline:      byte(style.Underline),
+		attrs:          style.Attrs,
+	}
+}
+
+func paneHistoryComparableColor(c color.Color) paneHistoryColorKey {
+	switch v := c.(type) {
+	case nil:
+		return paneHistoryColorKey{kind: paneHistoryColorNil}
+	case ansi.BasicColor:
+		var key paneHistoryColorKey
+		key.kind = paneHistoryColorBasic
+		key.data[0] = byte(v)
+		return key
+	case ansi.IndexedColor:
+		var key paneHistoryColorKey
+		key.kind = paneHistoryColorIndexed
+		key.data[0] = byte(v)
+		return key
+	case ansi.RGBColor:
+		var key paneHistoryColorKey
+		key.kind = paneHistoryColorRGB
+		key.data[0] = v.R
+		key.data[1] = v.G
+		key.data[2] = v.B
+		return key
+	case color.RGBA:
+		var key paneHistoryColorKey
+		key.kind = paneHistoryColorRGBA
+		key.data[0] = v.R
+		key.data[1] = v.G
+		key.data[2] = v.B
+		key.data[3] = v.A
+		return key
+	case color.RGBA64:
+		return paneHistoryComparableRGBA64(v.R, v.G, v.B, v.A)
+	default:
+		r, g, b, a := v.RGBA()
+		return paneHistoryComparableRGBA64(uint16(r), uint16(g), uint16(b), uint16(a))
+	}
+}
+
+func paneHistoryCellRuns(cells []Cell) []paneHistoryCellRun {
+	if len(cells) == 0 {
+		return nil
+	}
+	runs := make([]paneHistoryCellRun, 0, len(cells))
+	current := paneHistoryCellRun{count: 1, cell: cells[0]}
+	currentStyleKey := paneHistoryComparableStyle(cells[0].Style)
+	for _, cell := range cells[1:] {
+		cellStyleKey := paneHistoryComparableStyle(cell.Style)
+		if cell.Char == current.cell.Char && cell.Width == current.cell.Width && cellStyleKey == currentStyleKey {
+			current.count++
+			continue
+		}
+		runs = append(runs, current)
+		current = paneHistoryCellRun{count: 1, cell: cell}
+		currentStyleKey = cellStyleKey
+	}
+	runs = append(runs, current)
+	return runs
+}
+
+func paneHistoryCellsTextEqual(text string, cells []Cell) bool {
+	offset := 0
+	for _, cell := range cells {
+		if offset > len(text) {
+			return false
+		}
+		if !strings.HasPrefix(text[offset:], cell.Char) {
+			return false
+		}
+		offset += len(cell.Char)
+	}
+	return offset == len(text)
+}
+
+func paneHistoryCellsText(cells []Cell) string {
+	var b strings.Builder
+	for _, cell := range cells {
+		b.WriteString(cell.Char)
+	}
+	return b.String()
+}
+
+func writePaneHistoryStyle(dst *bytes.Buffer, style uv.Style) error {
+	if err := writePaneHistoryColor(dst, style.Fg); err != nil {
+		return err
+	}
+	if err := writePaneHistoryColor(dst, style.Bg); err != nil {
+		return err
+	}
+	if err := writePaneHistoryColor(dst, style.UnderlineColor); err != nil {
+		return err
+	}
+	dst.WriteByte(byte(style.Underline))
+	dst.WriteByte(style.Attrs)
+	return nil
+}
+
+func readPaneHistoryStyle(r *paneHistoryReader) (uv.Style, error) {
+	fg, err := readPaneHistoryColor(r)
+	if err != nil {
+		return uv.Style{}, err
+	}
+	bg, err := readPaneHistoryColor(r)
+	if err != nil {
+		return uv.Style{}, err
+	}
+	underlineColor, err := readPaneHistoryColor(r)
+	if err != nil {
+		return uv.Style{}, err
+	}
+	underline, err := r.ReadByte()
+	if err != nil {
+		return uv.Style{}, err
+	}
+	attrs, err := r.ReadByte()
+	if err != nil {
+		return uv.Style{}, err
+	}
+	return uv.Style{
+		Fg:             fg,
+		Bg:             bg,
+		UnderlineColor: underlineColor,
+		Underline:      uv.Underline(underline),
+		Attrs:          attrs,
+	}, nil
+}
+
+func writePaneHistoryColor(dst *bytes.Buffer, c color.Color) error {
+	switch v := c.(type) {
+	case nil:
+		dst.WriteByte(paneHistoryColorNil)
+	case ansi.BasicColor:
+		dst.WriteByte(paneHistoryColorBasic)
+		dst.WriteByte(byte(v))
+	case ansi.IndexedColor:
+		dst.WriteByte(paneHistoryColorIndexed)
+		dst.WriteByte(byte(v))
+	case ansi.RGBColor:
+		dst.WriteByte(paneHistoryColorRGB)
+		dst.WriteByte(v.R)
+		dst.WriteByte(v.G)
+		dst.WriteByte(v.B)
+	case color.RGBA:
+		dst.WriteByte(paneHistoryColorRGBA)
+		dst.WriteByte(v.R)
+		dst.WriteByte(v.G)
+		dst.WriteByte(v.B)
+		dst.WriteByte(v.A)
+	case color.RGBA64:
+		dst.WriteByte(paneHistoryColorRGBA64)
+		writePaneHistoryUint16(dst, v.R)
+		writePaneHistoryUint16(dst, v.G)
+		writePaneHistoryUint16(dst, v.B)
+		writePaneHistoryUint16(dst, v.A)
+	default:
+		r, g, b, a := v.RGBA()
+		dst.WriteByte(paneHistoryColorRGBA64)
+		writePaneHistoryUint16(dst, uint16(r))
+		writePaneHistoryUint16(dst, uint16(g))
+		writePaneHistoryUint16(dst, uint16(b))
+		writePaneHistoryUint16(dst, uint16(a))
+	}
+	return nil
+}
+
+func readPaneHistoryColor(r *paneHistoryReader) (color.Color, error) {
+	kind, err := r.ReadByte()
+	if err != nil {
+		return nil, err
+	}
+	switch kind {
+	case paneHistoryColorNil:
+		return nil, nil
+	case paneHistoryColorBasic:
+		v, err := r.ReadByte()
+		return ansi.BasicColor(v), err
+	case paneHistoryColorIndexed:
+		v, err := r.ReadByte()
+		return ansi.IndexedColor(v), err
+	case paneHistoryColorRGB:
+		var buf [3]byte
+		if _, err := io.ReadFull(r, buf[:]); err != nil {
+			return nil, err
+		}
+		return ansi.RGBColor{R: buf[0], G: buf[1], B: buf[2]}, nil
+	case paneHistoryColorRGBA:
+		var buf [4]byte
+		if _, err := io.ReadFull(r, buf[:]); err != nil {
+			return nil, err
+		}
+		return color.RGBA{R: buf[0], G: buf[1], B: buf[2], A: buf[3]}, nil
+	case paneHistoryColorRGBA64:
+		var buf [8]byte
+		if _, err := io.ReadFull(r, buf[:]); err != nil {
+			return nil, err
+		}
+		return color.RGBA64{
+			R: binary.BigEndian.Uint16(buf[0:2]),
+			G: binary.BigEndian.Uint16(buf[2:4]),
+			B: binary.BigEndian.Uint16(buf[4:6]),
+			A: binary.BigEndian.Uint16(buf[6:8]),
+		}, nil
+	default:
+		return nil, fmt.Errorf("unknown color encoding: %d", kind)
+	}
+}
+
+func readPaneHistoryCount(r *paneHistoryReader, payloadLen int, name string) (int, error) {
+	n, err := binary.ReadUvarint(r)
+	if err != nil {
+		return 0, fmt.Errorf("reading %s: %w", name, err)
+	}
+	if n > uint64(payloadLen) {
+		return 0, fmt.Errorf("%s too large: %d", name, n)
+	}
+	return int(n), nil
+}
+
+func readPaneHistoryString(r *paneHistoryReader) (string, error) {
+	n, err := binary.ReadUvarint(r)
+	if err != nil {
+		return "", err
+	}
+	if n > uint64(r.remaining()) {
+		return "", io.ErrUnexpectedEOF
+	}
+	data := make([]byte, n)
+	if _, err := io.ReadFull(r, data); err != nil {
+		return "", err
+	}
+	return string(data), nil
+}
+
+func paneHistoryComparableRGBA64(r, g, b, a uint16) paneHistoryColorKey {
+	var key paneHistoryColorKey
+	key.kind = paneHistoryColorRGBA64
+	binary.BigEndian.PutUint16(key.data[0:2], r)
+	binary.BigEndian.PutUint16(key.data[2:4], g)
+	binary.BigEndian.PutUint16(key.data[4:6], b)
+	binary.BigEndian.PutUint16(key.data[6:8], a)
+	return key
+}
+
+func writePaneHistoryUint16(dst *bytes.Buffer, v uint16) {
+	var buf [2]byte
+	binary.BigEndian.PutUint16(buf[:], v)
+	dst.Write(buf[:])
+}
+
+func writePaneHistoryString(dst *bytes.Buffer, s string) {
+	writePaneHistoryUvarint(dst, uint64(len(s)))
+	dst.WriteString(s)
+}
+
+func writePaneHistoryUvarint(dst *bytes.Buffer, v uint64) {
+	var buf [binary.MaxVarintLen64]byte
+	n := binary.PutUvarint(buf[:], v)
+	dst.Write(buf[:n])
+}

--- a/internal/proto/wire_pane_history_test.go
+++ b/internal/proto/wire_pane_history_test.go
@@ -3,33 +3,15 @@ package proto
 import (
 	"bytes"
 	"encoding/binary"
+	"errors"
 	"image/color"
+	"io"
 	"reflect"
 	"strings"
 	"testing"
 
 	uv "github.com/charmbracelet/ultraviolet"
 	"github.com/charmbracelet/x/ansi"
-)
-
-const testWireFormatPaneHistory byte = 0x02
-
-const (
-	testPaneHistoryFlagHistoryFromStyledText byte = 1 << iota
-)
-
-const (
-	testPaneHistoryLineFlagTextFromCells byte = 1 << iota
-	testPaneHistoryLineFlagHasCells
-)
-
-const (
-	testPaneHistoryColorNil byte = iota
-	testPaneHistoryColorBasic
-	testPaneHistoryColorIndexed
-	testPaneHistoryColorRGB
-	testPaneHistoryColorRGBA
-	testPaneHistoryColorRGBA64
 )
 
 func TestReadMsgPaneHistoryBinaryFrameWithStyledCells(t *testing.T) {
@@ -60,7 +42,7 @@ func TestReadMsgPaneHistoryBinaryFrameWithStyledCells(t *testing.T) {
 		t.Fatalf("ReadMsg: %v", err)
 	}
 
-	if !reflect.DeepEqual(got, msg) {
+	if !equalMessages(got, msg) {
 		t.Fatalf("round-trip mismatch:\n got: %#v\nwant: %#v", got, msg)
 	}
 }
@@ -114,9 +96,41 @@ func TestReaderReadMsgMixedStreamWithPaneHistoryBinaryFrame(t *testing.T) {
 		if err != nil {
 			t.Fatalf("ReadMsg(%d): %v", i, err)
 		}
-		if !reflect.DeepEqual(got, want) {
+		if !equalMessages(got, want) {
 			t.Fatalf("message %d mismatch:\n got: %#v\nwant: %#v", i, got, want)
 		}
+	}
+}
+
+func TestReadMsgPaneHistoryBinaryFrameWithExplicitHistory(t *testing.T) {
+	t.Parallel()
+
+	msg := &Message{
+		Type:   MsgTypePaneHistory,
+		PaneID: 19,
+		History: []string{
+			"plain one",
+			"plain two",
+		},
+		StyledHistory: []StyledLine{
+			{
+				Text: "styled one",
+				Cells: []Cell{
+					{Char: "s", Width: 1, Style: uv.Style{Fg: ansi.BasicColor(2)}},
+					{Char: "1", Width: 1, Style: uv.Style{Fg: ansi.BasicColor(2)}},
+				},
+			},
+			{Text: "styled two"},
+		},
+	}
+
+	got, err := ReadMsg(bytes.NewReader(encodeTestPaneHistoryFrame(t, msg)))
+	if err != nil {
+		t.Fatalf("ReadMsg: %v", err)
+	}
+
+	if !equalMessages(got, msg) {
+		t.Fatalf("round-trip mismatch:\n got: %#v\nwant: %#v", got, msg)
 	}
 }
 
@@ -147,17 +161,289 @@ func TestWriterWriteMsgPaneHistoryUsesBinaryFrameWhenEnabled(t *testing.T) {
 	if len(raw) < 9 {
 		t.Fatalf("encoded length = %d, want at least 9", len(raw))
 	}
-	if raw[0] != testWireFormatPaneHistory {
-		t.Fatalf("discriminator = %#x, want %#x", raw[0], testWireFormatPaneHistory)
+	if raw[0] != wireFormatPaneHistory {
+		t.Fatalf("discriminator = %#x, want %#x", raw[0], wireFormatPaneHistory)
 	}
 
 	got, err := ReadMsg(bytes.NewReader(raw))
 	if err != nil {
 		t.Fatalf("ReadMsg: %v", err)
 	}
-	if !reflect.DeepEqual(got, msg) {
+	if !equalMessages(got, msg) {
 		t.Fatalf("round-trip mismatch:\n got: %#v\nwant: %#v", got, msg)
 	}
+}
+
+func TestPaneHistoryCodecHelpers(t *testing.T) {
+	t.Parallel()
+
+	t.Run("matches styled text", func(t *testing.T) {
+		t.Parallel()
+
+		styled := []StyledLine{{Text: "one"}, {Text: "two"}}
+		if paneHistoryMatchesStyledText(nil, styled) {
+			t.Fatal("paneHistoryMatchesStyledText(nil, styled) = true, want false")
+		}
+		if paneHistoryMatchesStyledText([]string{"one"}, styled) {
+			t.Fatal("paneHistoryMatchesStyledText(len mismatch) = true, want false")
+		}
+		if paneHistoryMatchesStyledText([]string{"one", "mismatch"}, styled) {
+			t.Fatal("paneHistoryMatchesStyledText(text mismatch) = true, want false")
+		}
+		if !paneHistoryMatchesStyledText([]string{"one", "two"}, styled) {
+			t.Fatal("paneHistoryMatchesStyledText(match) = false, want true")
+		}
+	})
+
+	t.Run("style table and cell runs normalize equivalent colors", func(t *testing.T) {
+		t.Parallel()
+
+		base := uv.Style{
+			Fg:             color.RGBA64{R: 0x0102, G: 0x0304, B: 0x0506, A: 0x0708},
+			Bg:             ansi.BasicColor(4),
+			UnderlineColor: color.RGBA{R: 0x11, G: 0x22, B: 0x33, A: 0x44},
+			Underline:      uv.Underline(2),
+			Attrs:          uv.AttrBold,
+		}
+		equivalent := uv.Style{
+			Fg:             testCustomColor{r: 0x0102, g: 0x0304, b: 0x0506, a: 0x0708},
+			Bg:             ansi.BasicColor(4),
+			UnderlineColor: color.RGBA{R: 0x11, G: 0x22, B: 0x33, A: 0x44},
+			Underline:      uv.Underline(2),
+			Attrs:          uv.AttrBold,
+		}
+		other := uv.Style{Fg: ansi.IndexedColor(9)}
+
+		keyBase := paneHistoryComparableStyle(base)
+		if keyBase != paneHistoryComparableStyle(equivalent) {
+			t.Fatal("paneHistoryComparableStyle should normalize equivalent colors")
+		}
+		if keyBase == paneHistoryComparableStyle(other) {
+			t.Fatal("paneHistoryComparableStyle collapsed distinct styles")
+		}
+
+		line := StyledLine{
+			Text: "xxy",
+			Cells: []Cell{
+				{Char: "x", Width: 1, Style: base},
+				{Char: "x", Width: 1, Style: equivalent},
+				{Char: "y", Width: 1, Style: other},
+			},
+		}
+		styles, index := paneHistoryStyleTable([]StyledLine{line})
+		if len(styles) != 2 {
+			t.Fatalf("style table length = %d, want 2", len(styles))
+		}
+		if index[keyBase] != index[paneHistoryComparableStyle(equivalent)] {
+			t.Fatal("equivalent styles should share one style index")
+		}
+
+		runs := paneHistoryCellRuns(line.Cells)
+		if len(runs) != 2 {
+			t.Fatalf("run count = %d, want 2", len(runs))
+		}
+		if runs[0].count != 2 || runs[0].cell.Char != "x" {
+			t.Fatalf("first run = %+v, want x repeated twice", runs[0])
+		}
+		if runs[1].count != 1 || runs[1].cell.Char != "y" {
+			t.Fatalf("second run = %+v, want single y", runs[1])
+		}
+	})
+
+	t.Run("cells text helpers", func(t *testing.T) {
+		t.Parallel()
+
+		cells := []Cell{
+			{Char: "a", Width: 1},
+			{Char: "bc", Width: 1},
+		}
+		if got := paneHistoryCellsText(cells); got != "abc" {
+			t.Fatalf("paneHistoryCellsText() = %q, want abc", got)
+		}
+		if !paneHistoryCellsTextEqual("abc", cells) {
+			t.Fatal("paneHistoryCellsTextEqual(match) = false, want true")
+		}
+		if paneHistoryCellsTextEqual("ab", cells) {
+			t.Fatal("paneHistoryCellsTextEqual(short text) = true, want false")
+		}
+		if paneHistoryCellsTextEqual("axc", cells) {
+			t.Fatal("paneHistoryCellsTextEqual(prefix mismatch) = true, want false")
+		}
+		if got := paneHistoryCellRuns(nil); got != nil {
+			t.Fatalf("paneHistoryCellRuns(nil) = %#v, want nil", got)
+		}
+	})
+}
+
+func TestPaneHistoryStyleRoundTripCoversColorKinds(t *testing.T) {
+	t.Parallel()
+
+	styles := []uv.Style{
+		{},
+		{
+			Fg:             ansi.BasicColor(3),
+			Bg:             ansi.IndexedColor(42),
+			UnderlineColor: ansi.RGBColor{R: 0xaa, G: 0xbb, B: 0xcc},
+			Underline:      uv.Underline(1),
+			Attrs:          uv.AttrBold,
+		},
+		{
+			Fg:             color.RGBA{R: 0x11, G: 0x22, B: 0x33, A: 0x44},
+			Bg:             color.RGBA64{R: 0x0102, G: 0x0304, B: 0x0506, A: 0x0708},
+			UnderlineColor: testCustomColor{r: 0x1111, g: 0x2222, b: 0x3333, a: 0x4444},
+			Underline:      uv.Underline(2),
+			Attrs:          uv.AttrItalic,
+		},
+	}
+
+	for i, want := range styles {
+		var buf bytes.Buffer
+		if err := writePaneHistoryStyle(&buf, want); err != nil {
+			t.Fatalf("writePaneHistoryStyle(%d): %v", i, err)
+		}
+		reader := newPaneHistoryReader(bytes.NewReader(buf.Bytes()), int64(buf.Len()))
+		got, err := readPaneHistoryStyle(reader)
+		if err != nil {
+			t.Fatalf("readPaneHistoryStyle(%d): %v", i, err)
+		}
+		if !equalStylesByRGBA(got, want) {
+			t.Fatalf("style %d mismatch:\n got: %#v\nwant: %#v", i, got, want)
+		}
+	}
+}
+
+func TestPaneHistoryBinaryErrorPaths(t *testing.T) {
+	t.Parallel()
+
+	t.Run("encode rejects nil message", func(t *testing.T) {
+		t.Parallel()
+
+		if _, err := encodePaneHistoryPayload(nil); err == nil || !strings.Contains(err.Error(), "nil message") {
+			t.Fatalf("encodePaneHistoryPayload(nil) error = %v, want nil message", err)
+		}
+	})
+
+	t.Run("encode rejects negative cell width", func(t *testing.T) {
+		t.Parallel()
+
+		msg := &Message{
+			Type:          MsgTypePaneHistory,
+			PaneID:        1,
+			History:       []string{"x"},
+			StyledHistory: []StyledLine{{Text: "x", Cells: []Cell{{Char: "x", Width: -1}}}},
+		}
+		if _, err := encodePaneHistoryPayload(msg); err == nil || !strings.Contains(err.Error(), "negative cell width") {
+			t.Fatalf("encodePaneHistoryPayload(negative width) error = %v, want negative cell width", err)
+		}
+	})
+
+	t.Run("writer surfaces header and payload write errors", func(t *testing.T) {
+		t.Parallel()
+
+		msg := &Message{
+			Type:          MsgTypePaneHistory,
+			PaneID:        1,
+			History:       []string{"x"},
+			StyledHistory: []StyledLine{{Text: "x"}},
+		}
+		if err := writePaneHistoryBinary(&testFailWriter{failOnCall: 1}, msg); err == nil || !strings.Contains(err.Error(), "writing pane history header") {
+			t.Fatalf("header write error = %v, want header failure", err)
+		}
+		if err := writePaneHistoryBinary(&testFailWriter{failOnCall: 2}, msg); err == nil || !strings.Contains(err.Error(), "writing pane history payload") {
+			t.Fatalf("payload write error = %v, want payload failure", err)
+		}
+	})
+
+	t.Run("binary reader rejects invalid payloads", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []struct {
+			name string
+			raw  []byte
+			want string
+		}{
+			{
+				name: "oversized payload",
+				raw:  appendPaneHistoryHeader(nil, 1, maxMessageSize+1),
+				want: "message too large",
+			},
+			{
+				name: "trailing bytes",
+				raw: func() []byte {
+					payload := append(encodeTestPaneHistoryPayload(t, &Message{
+						Type:          MsgTypePaneHistory,
+						PaneID:        2,
+						History:       []string{"x"},
+						StyledHistory: []StyledLine{{Text: "x"}},
+					}), 0xff)
+					return appendPaneHistoryHeader(payload, 2, uint32(len(payload)))
+				}(),
+				want: "trailing bytes",
+			},
+		}
+
+		for _, tt := range tests {
+			tt := tt
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
+				if _, err := readPaneHistoryBinary(bytes.NewReader(tt.raw)); err == nil || !strings.Contains(err.Error(), tt.want) {
+					t.Fatalf("readPaneHistoryBinary() error = %v, want substring %q", err, tt.want)
+				}
+			})
+		}
+	})
+
+	t.Run("decoder validates history and style references", func(t *testing.T) {
+		t.Parallel()
+
+		var mismatch bytes.Buffer
+		mismatch.WriteByte(paneHistoryFlagHistoryFromStyledText)
+		writePaneHistoryUvarint(&mismatch, 1)
+		writePaneHistoryUvarint(&mismatch, 0)
+		writePaneHistoryUvarint(&mismatch, 0)
+		if _, err := decodePaneHistoryPayload(1, newPaneHistoryReader(bytes.NewReader(mismatch.Bytes()), int64(mismatch.Len())), mismatch.Len()); err == nil || !strings.Contains(err.Error(), "count mismatch") {
+			t.Fatalf("decodePaneHistoryPayload(history mismatch) error = %v, want count mismatch", err)
+		}
+
+		var badStyleIndex bytes.Buffer
+		badStyleIndex.WriteByte(0)
+		writePaneHistoryUvarint(&badStyleIndex, 1)
+		writePaneHistoryUvarint(&badStyleIndex, 1)
+		writePaneHistoryString(&badStyleIndex, "plain")
+		writePaneHistoryUvarint(&badStyleIndex, 0)
+		badStyleIndex.WriteByte(paneHistoryLineFlagHasCells)
+		writePaneHistoryString(&badStyleIndex, "styled")
+		writePaneHistoryUvarint(&badStyleIndex, 1)
+		writePaneHistoryUvarint(&badStyleIndex, 1)
+		writePaneHistoryString(&badStyleIndex, "x")
+		writePaneHistoryUvarint(&badStyleIndex, 1)
+		writePaneHistoryUvarint(&badStyleIndex, 0)
+		if _, err := decodePaneHistoryPayload(1, newPaneHistoryReader(bytes.NewReader(badStyleIndex.Bytes()), int64(badStyleIndex.Len())), badStyleIndex.Len()); err == nil || !strings.Contains(err.Error(), "out of range") {
+			t.Fatalf("decodePaneHistoryPayload(style index) error = %v, want out of range", err)
+		}
+	})
+
+	t.Run("low level readers reject invalid encodings", func(t *testing.T) {
+		t.Parallel()
+
+		if _, err := readPaneHistoryColor(newPaneHistoryReader(bytes.NewReader([]byte{0xff}), 1)); err == nil || !strings.Contains(err.Error(), "unknown color encoding") {
+			t.Fatalf("readPaneHistoryColor() error = %v, want unknown color encoding", err)
+		}
+
+		var countBuf bytes.Buffer
+		writePaneHistoryUvarint(&countBuf, 5)
+		if _, err := readPaneHistoryCount(newPaneHistoryReader(bytes.NewReader(countBuf.Bytes()), int64(countBuf.Len())), 4, "test count"); err == nil || !strings.Contains(err.Error(), "too large") {
+			t.Fatalf("readPaneHistoryCount() error = %v, want too large", err)
+		}
+
+		var stringBuf bytes.Buffer
+		writePaneHistoryUvarint(&stringBuf, 5)
+		stringBuf.WriteByte('x')
+		if _, err := readPaneHistoryString(newPaneHistoryReader(bytes.NewReader(stringBuf.Bytes()), int64(stringBuf.Len()))); !errors.Is(err, io.ErrUnexpectedEOF) {
+			t.Fatalf("readPaneHistoryString() error = %v, want unexpected EOF", err)
+		}
+	})
 }
 
 func enableWriterPaneHistoryBinary(t *testing.T, writer *Writer) {
@@ -174,7 +460,7 @@ func encodeTestPaneHistoryFrame(t *testing.T, msg *Message) []byte {
 
 	payload := encodeTestPaneHistoryPayload(t, msg)
 	var hdr [9]byte
-	hdr[0] = testWireFormatPaneHistory
+	hdr[0] = wireFormatPaneHistory
 	binary.BigEndian.PutUint32(hdr[1:5], msg.PaneID)
 	binary.BigEndian.PutUint32(hdr[5:9], uint32(len(payload)))
 
@@ -190,13 +476,13 @@ func encodeTestPaneHistoryPayload(t *testing.T, msg *Message) []byte {
 	var payload bytes.Buffer
 	flags := byte(0)
 	if testHistoryMatchesStyledText(msg.History, msg.StyledHistory) {
-		flags |= testPaneHistoryFlagHistoryFromStyledText
+		flags |= paneHistoryFlagHistoryFromStyledText
 	}
 	payload.WriteByte(flags)
 	writeTestUvarint(&payload, uint64(len(msg.History)))
 	writeTestUvarint(&payload, uint64(len(msg.StyledHistory)))
 
-	if flags&testPaneHistoryFlagHistoryFromStyledText == 0 {
+	if flags&paneHistoryFlagHistoryFromStyledText == 0 {
 		for _, line := range msg.History {
 			writeTestString(&payload, line)
 		}
@@ -211,16 +497,16 @@ func encodeTestPaneHistoryPayload(t *testing.T, msg *Message) []byte {
 	for _, line := range msg.StyledHistory {
 		lineFlags := byte(0)
 		if len(line.Cells) > 0 {
-			lineFlags |= testPaneHistoryLineFlagHasCells
+			lineFlags |= paneHistoryLineFlagHasCells
 			if testCellsText(line.Cells) == line.Text {
-				lineFlags |= testPaneHistoryLineFlagTextFromCells
+				lineFlags |= paneHistoryLineFlagTextFromCells
 			}
 		}
 		payload.WriteByte(lineFlags)
-		if lineFlags&testPaneHistoryLineFlagTextFromCells == 0 {
+		if lineFlags&paneHistoryLineFlagTextFromCells == 0 {
 			writeTestString(&payload, line.Text)
 		}
-		if lineFlags&testPaneHistoryLineFlagHasCells == 0 {
+		if lineFlags&paneHistoryLineFlagHasCells == 0 {
 			continue
 		}
 
@@ -230,7 +516,7 @@ func encodeTestPaneHistoryPayload(t *testing.T, msg *Message) []byte {
 			writeTestUvarint(&payload, uint64(run.count))
 			writeTestString(&payload, run.cell.Char)
 			writeTestUvarint(&payload, uint64(run.cell.Width))
-			writeTestUvarint(&payload, uint64(styleIndex[testStyleKey(run.cell.Style)]))
+			writeTestUvarint(&payload, uint64(styleIndex[paneHistoryComparableStyle(run.cell.Style)]))
 		}
 	}
 
@@ -252,33 +538,33 @@ func writeTestColor(t *testing.T, dst *bytes.Buffer, c color.Color) {
 
 	switch v := c.(type) {
 	case nil:
-		dst.WriteByte(testPaneHistoryColorNil)
+		dst.WriteByte(paneHistoryColorNil)
 	case ansi.BasicColor:
-		dst.WriteByte(testPaneHistoryColorBasic)
+		dst.WriteByte(paneHistoryColorBasic)
 		dst.WriteByte(byte(v))
 	case ansi.IndexedColor:
-		dst.WriteByte(testPaneHistoryColorIndexed)
+		dst.WriteByte(paneHistoryColorIndexed)
 		dst.WriteByte(byte(v))
 	case ansi.RGBColor:
-		dst.WriteByte(testPaneHistoryColorRGB)
+		dst.WriteByte(paneHistoryColorRGB)
 		dst.WriteByte(v.R)
 		dst.WriteByte(v.G)
 		dst.WriteByte(v.B)
 	case color.RGBA:
-		dst.WriteByte(testPaneHistoryColorRGBA)
+		dst.WriteByte(paneHistoryColorRGBA)
 		dst.WriteByte(v.R)
 		dst.WriteByte(v.G)
 		dst.WriteByte(v.B)
 		dst.WriteByte(v.A)
 	case color.RGBA64:
-		dst.WriteByte(testPaneHistoryColorRGBA64)
+		dst.WriteByte(paneHistoryColorRGBA64)
 		writeTestUint16(dst, v.R)
 		writeTestUint16(dst, v.G)
 		writeTestUint16(dst, v.B)
 		writeTestUint16(dst, v.A)
 	default:
 		r, g, b, a := v.RGBA()
-		dst.WriteByte(testPaneHistoryColorRGBA64)
+		dst.WriteByte(paneHistoryColorRGBA64)
 		writeTestUint16(dst, uint16(r))
 		writeTestUint16(dst, uint16(g))
 		writeTestUint16(dst, uint16(b))
@@ -315,24 +601,27 @@ func testCellRuns(cells []Cell) []testCellRun {
 
 	runs := make([]testCellRun, 0, len(cells))
 	current := testCellRun{count: 1, cell: cells[0]}
+	currentStyleKey := paneHistoryComparableStyle(cells[0].Style)
 	for _, cell := range cells[1:] {
-		if reflect.DeepEqual(cell, current.cell) {
+		cellStyleKey := paneHistoryComparableStyle(cell.Style)
+		if cell.Char == current.cell.Char && cell.Width == current.cell.Width && cellStyleKey == currentStyleKey {
 			current.count++
 			continue
 		}
 		runs = append(runs, current)
 		current = testCellRun{count: 1, cell: cell}
+		currentStyleKey = cellStyleKey
 	}
 	runs = append(runs, current)
 	return runs
 }
 
-func buildTestStyleTable(lines []StyledLine) ([]uv.Style, map[string]int) {
+func buildTestStyleTable(lines []StyledLine) ([]uv.Style, map[paneHistoryStyleKey]int) {
 	styles := make([]uv.Style, 0)
-	index := make(map[string]int)
+	index := make(map[paneHistoryStyleKey]int)
 	for _, line := range lines {
 		for _, cell := range line.Cells {
-			key := testStyleKey(cell.Style)
+			key := paneHistoryComparableStyle(cell.Style)
 			if _, ok := index[key]; ok {
 				continue
 			}
@@ -341,50 +630,6 @@ func buildTestStyleTable(lines []StyledLine) ([]uv.Style, map[string]int) {
 		}
 	}
 	return styles, index
-}
-
-func testStyleKey(style uv.Style) string {
-	var b strings.Builder
-	b.WriteString(testColorKey(style.Fg))
-	b.WriteByte('|')
-	b.WriteString(testColorKey(style.Bg))
-	b.WriteByte('|')
-	b.WriteString(testColorKey(style.UnderlineColor))
-	b.WriteByte('|')
-	b.WriteByte(byte(style.Underline))
-	b.WriteByte('|')
-	b.WriteByte(style.Attrs)
-	return b.String()
-}
-
-func testColorKey(c color.Color) string {
-	switch v := c.(type) {
-	case nil:
-		return "nil"
-	case ansi.BasicColor:
-		return "basic:" + string([]byte{byte(v)})
-	case ansi.IndexedColor:
-		return "indexed:" + string([]byte{byte(v)})
-	case ansi.RGBColor:
-		return "rgb:" + string([]byte{v.R, v.G, v.B})
-	case color.RGBA:
-		return "rgba:" + string([]byte{v.R, v.G, v.B, v.A})
-	case color.RGBA64:
-		var buf [8]byte
-		binary.BigEndian.PutUint16(buf[0:2], v.R)
-		binary.BigEndian.PutUint16(buf[2:4], v.G)
-		binary.BigEndian.PutUint16(buf[4:6], v.B)
-		binary.BigEndian.PutUint16(buf[6:8], v.A)
-		return "rgba64:" + string(buf[:])
-	default:
-		r, g, b, a := v.RGBA()
-		var buf [8]byte
-		binary.BigEndian.PutUint16(buf[0:2], uint16(r))
-		binary.BigEndian.PutUint16(buf[2:4], uint16(g))
-		binary.BigEndian.PutUint16(buf[4:6], uint16(b))
-		binary.BigEndian.PutUint16(buf[6:8], uint16(a))
-		return "generic:" + string(buf[:])
-	}
 }
 
 func testHistoryMatchesStyledText(history []string, styled []StyledLine) bool {
@@ -508,4 +753,104 @@ func benchmarkPaneHistoryMessage(lineCount, width int) *Message {
 		History:       history,
 		StyledHistory: styled,
 	}
+}
+
+type testCustomColor struct {
+	r uint16
+	g uint16
+	b uint16
+	a uint16
+}
+
+func (c testCustomColor) RGBA() (uint32, uint32, uint32, uint32) {
+	return uint32(c.r), uint32(c.g), uint32(c.b), uint32(c.a)
+}
+
+type testFailWriter struct {
+	failOnCall int
+	calls      int
+}
+
+func (w *testFailWriter) Write(p []byte) (int, error) {
+	w.calls++
+	if w.calls == w.failOnCall {
+		return 0, errors.New("boom")
+	}
+	return len(p), nil
+}
+
+func appendPaneHistoryHeader(payload []byte, paneID uint32, payloadLen uint32) []byte {
+	var hdr [8]byte
+	binary.BigEndian.PutUint32(hdr[0:4], paneID)
+	binary.BigEndian.PutUint32(hdr[4:8], payloadLen)
+	return append(hdr[:], payload...)
+}
+
+func equalPaneHistoryMessage(got, want *Message) bool {
+	if got == nil || want == nil {
+		return got == want
+	}
+	if got.Type != want.Type || got.PaneID != want.PaneID || !equalStringSlices(got.History, want.History) {
+		return false
+	}
+	if len(got.StyledHistory) != len(want.StyledHistory) {
+		return false
+	}
+	for i := range got.StyledHistory {
+		if got.StyledHistory[i].Text != want.StyledHistory[i].Text || !equalCells(got.StyledHistory[i].Cells, want.StyledHistory[i].Cells) {
+			return false
+		}
+	}
+	return true
+}
+
+func equalMessages(got, want *Message) bool {
+	if got == nil || want == nil {
+		return got == want
+	}
+	if got.Type != MsgTypePaneHistory || want.Type != MsgTypePaneHistory {
+		return reflect.DeepEqual(got, want)
+	}
+	return equalPaneHistoryMessage(got, want)
+}
+
+func equalStringSlices(got, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func equalCells(got, want []Cell) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for i := range got {
+		if got[i].Char != want[i].Char || got[i].Width != want[i].Width || !equalStylesByRGBA(got[i].Style, want[i].Style) {
+			return false
+		}
+	}
+	return true
+}
+
+func equalStylesByRGBA(got, want uv.Style) bool {
+	return equalColorsByRGBA(got.Fg, want.Fg) &&
+		equalColorsByRGBA(got.Bg, want.Bg) &&
+		equalColorsByRGBA(got.UnderlineColor, want.UnderlineColor) &&
+		got.Underline == want.Underline &&
+		got.Attrs == want.Attrs
+}
+
+func equalColorsByRGBA(got, want color.Color) bool {
+	if got == nil || want == nil {
+		return got == nil && want == nil
+	}
+	gr, gg, gb, ga := got.RGBA()
+	wr, wg, wb, wa := want.RGBA()
+	return gr == wr && gg == wg && gb == wb && ga == wa
 }

--- a/internal/proto/wire_pane_history_test.go
+++ b/internal/proto/wire_pane_history_test.go
@@ -97,13 +97,14 @@ func TestReaderReadMsgMixedStreamWithPaneHistoryBinaryFrame(t *testing.T) {
 	}
 
 	var wire bytes.Buffer
-	if err := WriteMsg(&wire, msgs[0]); err != nil {
+	writer := NewWriter(&wire)
+	if err := writer.WriteMsg(msgs[0]); err != nil {
 		t.Fatalf("WriteMsg layout: %v", err)
 	}
 	if _, err := wire.Write(encodeTestPaneHistoryFrame(t, msgs[1])); err != nil {
 		t.Fatalf("write pane history frame: %v", err)
 	}
-	if err := WriteMsg(&wire, msgs[2]); err != nil {
+	if err := writer.WriteMsg(msgs[2]); err != nil {
 		t.Fatalf("WriteMsg command: %v", err)
 	}
 
@@ -162,14 +163,10 @@ func TestWriterWriteMsgPaneHistoryUsesBinaryFrameWhenEnabled(t *testing.T) {
 func enableWriterPaneHistoryBinary(t *testing.T, writer *Writer) {
 	t.Helper()
 
-	field := reflect.ValueOf(writer).Elem().FieldByName("binaryPaneHistory")
-	if !field.IsValid() {
-		t.Fatal("Writer.binaryPaneHistory field not found")
+	if writer == nil {
+		t.Fatal("writer is nil")
 	}
-	if !field.CanSet() || field.Kind() != reflect.Bool {
-		t.Fatal("Writer.binaryPaneHistory field is not a settable bool")
-	}
-	field.SetBool(true)
+	writer.SetBinaryPaneHistory(true)
 }
 
 func encodeTestPaneHistoryFrame(t *testing.T, msg *Message) []byte {
@@ -408,4 +405,107 @@ func testCellsText(cells []Cell) string {
 		b.WriteString(cell.Char)
 	}
 	return b.String()
+}
+
+func BenchmarkPaneHistoryMessageWire(b *testing.B) {
+	msg := benchmarkPaneHistoryMessage(1024, 120)
+
+	b.Run("write/gob", func(b *testing.B) {
+		var wire bytes.Buffer
+		b.ReportAllocs()
+		for b.Loop() {
+			wire.Reset()
+			if err := WriteMsg(&wire, msg); err != nil {
+				b.Fatalf("WriteMsg: %v", err)
+			}
+		}
+	})
+
+	b.Run("write/binary", func(b *testing.B) {
+		var wire bytes.Buffer
+		writer := NewWriter(&wire)
+		writer.SetBinaryPaneHistory(true)
+		b.ReportAllocs()
+		for b.Loop() {
+			wire.Reset()
+			if err := writer.WriteMsg(msg); err != nil {
+				b.Fatalf("WriteMsg: %v", err)
+			}
+		}
+	})
+
+	b.Run("read/gob", func(b *testing.B) {
+		var wire bytes.Buffer
+		if err := WriteMsg(&wire, msg); err != nil {
+			b.Fatalf("WriteMsg: %v", err)
+		}
+		raw := append([]byte(nil), wire.Bytes()...)
+
+		b.ReportAllocs()
+		for b.Loop() {
+			if _, err := ReadMsg(bytes.NewReader(raw)); err != nil {
+				b.Fatalf("ReadMsg: %v", err)
+			}
+		}
+	})
+
+	b.Run("read/binary", func(b *testing.B) {
+		var wire bytes.Buffer
+		writer := NewWriter(&wire)
+		writer.SetBinaryPaneHistory(true)
+		if err := writer.WriteMsg(msg); err != nil {
+			b.Fatalf("WriteMsg: %v", err)
+		}
+		raw := append([]byte(nil), wire.Bytes()...)
+
+		b.ReportAllocs()
+		for b.Loop() {
+			if _, err := ReadMsg(bytes.NewReader(raw)); err != nil {
+				b.Fatalf("ReadMsg: %v", err)
+			}
+		}
+	})
+}
+
+func benchmarkPaneHistoryMessage(lineCount, width int) *Message {
+	styles := []uv.Style{
+		{Fg: ansi.BasicColor(2)},
+		{Fg: ansi.BasicColor(6), Attrs: uv.AttrBold},
+		{Fg: ansi.RGBColor{R: 0xff, G: 0x88}, Bg: ansi.BasicColor(0)},
+	}
+
+	history := make([]string, lineCount)
+	styled := make([]StyledLine, lineCount)
+	contentWidth := width - 24
+	if contentWidth < 1 {
+		contentWidth = width
+	}
+	alphabet := "abcdefghijklmnopqrstuvwxyz0123456789"
+
+	for i := 0; i < lineCount; i++ {
+		cells := make([]Cell, width)
+		var text strings.Builder
+		for x := 0; x < width; x++ {
+			style := styles[(i/8+x/24)%len(styles)]
+			if x < contentWidth {
+				ch := string(alphabet[(i+x)%len(alphabet)])
+				cells[x] = Cell{Char: ch, Width: 1, Style: style}
+				text.WriteString(ch)
+				continue
+			}
+			cells[x] = Cell{Char: " ", Width: 1, Style: style}
+		}
+		history[i] = text.String()
+		styled[i] = StyledLine{
+			Text:  history[i],
+			Cells: cells,
+		}
+	}
+
+	return &Message{
+		Type:          MsgTypePaneHistory,
+		PaneID:        9,
+		History:       history,
+		StyledHistory: styled,
+	}
 }

--- a/internal/proto/wire_pane_history_test.go
+++ b/internal/proto/wire_pane_history_test.go
@@ -1,0 +1,411 @@
+package proto
+
+import (
+	"bytes"
+	"encoding/binary"
+	"image/color"
+	"reflect"
+	"strings"
+	"testing"
+
+	uv "github.com/charmbracelet/ultraviolet"
+	"github.com/charmbracelet/x/ansi"
+)
+
+const testWireFormatPaneHistory byte = 0x02
+
+const (
+	testPaneHistoryFlagHistoryFromStyledText byte = 1 << iota
+)
+
+const (
+	testPaneHistoryLineFlagTextFromCells byte = 1 << iota
+	testPaneHistoryLineFlagHasCells
+)
+
+const (
+	testPaneHistoryColorNil byte = iota
+	testPaneHistoryColorBasic
+	testPaneHistoryColorIndexed
+	testPaneHistoryColorRGB
+	testPaneHistoryColorRGBA
+	testPaneHistoryColorRGBA64
+)
+
+func TestReadMsgPaneHistoryBinaryFrameWithStyledCells(t *testing.T) {
+	t.Parallel()
+
+	msg := &Message{
+		Type:   MsgTypePaneHistory,
+		PaneID: 42,
+		History: []string{
+			"plain line",
+			"styled line",
+		},
+		StyledHistory: []StyledLine{
+			{Text: "plain line"},
+			{
+				Text: "styled line",
+				Cells: []Cell{
+					{Char: "s", Width: 1, Style: uv.Style{Fg: ansi.Red}},
+					{Char: "t", Width: 1, Style: uv.Style{Fg: ansi.Red}},
+					{Char: "y", Width: 1, Style: uv.Style{Fg: ansi.IndexedColor(42), Bg: ansi.RGBColor{R: 0xff, G: 0x88}}},
+				},
+			},
+		},
+	}
+
+	got, err := ReadMsg(bytes.NewReader(encodeTestPaneHistoryFrame(t, msg)))
+	if err != nil {
+		t.Fatalf("ReadMsg: %v", err)
+	}
+
+	if !reflect.DeepEqual(got, msg) {
+		t.Fatalf("round-trip mismatch:\n got: %#v\nwant: %#v", got, msg)
+	}
+}
+
+func TestReaderReadMsgMixedStreamWithPaneHistoryBinaryFrame(t *testing.T) {
+	t.Parallel()
+
+	msgs := []*Message{
+		{Type: MsgTypeLayout, Layout: sampleLayoutSnapshot()},
+		{
+			Type:   MsgTypePaneHistory,
+			PaneID: 7,
+			History: []string{
+				"bootstrap",
+				"history",
+			},
+			StyledHistory: []StyledLine{
+				{Text: "bootstrap"},
+				{
+					Text: "history",
+					Cells: []Cell{
+						{Char: "h", Width: 1, Style: uv.Style{Fg: ansi.BasicColor(3)}},
+						{Char: "i", Width: 1, Style: uv.Style{Fg: ansi.BasicColor(3)}},
+						{Char: "s", Width: 1, Style: uv.Style{Fg: ansi.BasicColor(3)}},
+						{Char: "t", Width: 1, Style: uv.Style{Fg: ansi.BasicColor(3)}},
+						{Char: "o", Width: 1, Style: uv.Style{Fg: ansi.BasicColor(3)}},
+						{Char: "r", Width: 1, Style: uv.Style{Fg: ansi.BasicColor(3)}},
+						{Char: "y", Width: 1, Style: uv.Style{Fg: ansi.BasicColor(3)}},
+					},
+				},
+			},
+		},
+		{Type: MsgTypeCommand, CmdName: "list", CmdArgs: []string{"--json"}},
+	}
+
+	var wire bytes.Buffer
+	if err := WriteMsg(&wire, msgs[0]); err != nil {
+		t.Fatalf("WriteMsg layout: %v", err)
+	}
+	if _, err := wire.Write(encodeTestPaneHistoryFrame(t, msgs[1])); err != nil {
+		t.Fatalf("write pane history frame: %v", err)
+	}
+	if err := WriteMsg(&wire, msgs[2]); err != nil {
+		t.Fatalf("WriteMsg command: %v", err)
+	}
+
+	reader := NewReader(bytes.NewReader(wire.Bytes()))
+	for i, want := range msgs {
+		got, err := reader.ReadMsg()
+		if err != nil {
+			t.Fatalf("ReadMsg(%d): %v", i, err)
+		}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("message %d mismatch:\n got: %#v\nwant: %#v", i, got, want)
+		}
+	}
+}
+
+func TestWriterWriteMsgPaneHistoryUsesBinaryFrameWhenEnabled(t *testing.T) {
+	t.Parallel()
+
+	msg := &Message{
+		Type:   MsgTypePaneHistory,
+		PaneID: 5,
+		History: []string{
+			"one",
+			"two",
+		},
+		StyledHistory: []StyledLine{
+			{Text: "one"},
+			{Text: "two"},
+		},
+	}
+
+	var buf bytes.Buffer
+	writer := NewWriter(&buf)
+	enableWriterPaneHistoryBinary(t, writer)
+	if err := writer.WriteMsg(msg); err != nil {
+		t.Fatalf("WriteMsg: %v", err)
+	}
+
+	raw := buf.Bytes()
+	if len(raw) < 9 {
+		t.Fatalf("encoded length = %d, want at least 9", len(raw))
+	}
+	if raw[0] != testWireFormatPaneHistory {
+		t.Fatalf("discriminator = %#x, want %#x", raw[0], testWireFormatPaneHistory)
+	}
+
+	got, err := ReadMsg(bytes.NewReader(raw))
+	if err != nil {
+		t.Fatalf("ReadMsg: %v", err)
+	}
+	if !reflect.DeepEqual(got, msg) {
+		t.Fatalf("round-trip mismatch:\n got: %#v\nwant: %#v", got, msg)
+	}
+}
+
+func enableWriterPaneHistoryBinary(t *testing.T, writer *Writer) {
+	t.Helper()
+
+	field := reflect.ValueOf(writer).Elem().FieldByName("binaryPaneHistory")
+	if !field.IsValid() {
+		t.Fatal("Writer.binaryPaneHistory field not found")
+	}
+	if !field.CanSet() || field.Kind() != reflect.Bool {
+		t.Fatal("Writer.binaryPaneHistory field is not a settable bool")
+	}
+	field.SetBool(true)
+}
+
+func encodeTestPaneHistoryFrame(t *testing.T, msg *Message) []byte {
+	t.Helper()
+
+	payload := encodeTestPaneHistoryPayload(t, msg)
+	var hdr [9]byte
+	hdr[0] = testWireFormatPaneHistory
+	binary.BigEndian.PutUint32(hdr[1:5], msg.PaneID)
+	binary.BigEndian.PutUint32(hdr[5:9], uint32(len(payload)))
+
+	var frame bytes.Buffer
+	frame.Write(hdr[:])
+	frame.Write(payload)
+	return frame.Bytes()
+}
+
+func encodeTestPaneHistoryPayload(t *testing.T, msg *Message) []byte {
+	t.Helper()
+
+	var payload bytes.Buffer
+	flags := byte(0)
+	if testHistoryMatchesStyledText(msg.History, msg.StyledHistory) {
+		flags |= testPaneHistoryFlagHistoryFromStyledText
+	}
+	payload.WriteByte(flags)
+	writeTestUvarint(&payload, uint64(len(msg.History)))
+	writeTestUvarint(&payload, uint64(len(msg.StyledHistory)))
+
+	if flags&testPaneHistoryFlagHistoryFromStyledText == 0 {
+		for _, line := range msg.History {
+			writeTestString(&payload, line)
+		}
+	}
+
+	styleTable, styleIndex := buildTestStyleTable(msg.StyledHistory)
+	writeTestUvarint(&payload, uint64(len(styleTable)))
+	for _, style := range styleTable {
+		writeTestStyle(t, &payload, style)
+	}
+
+	for _, line := range msg.StyledHistory {
+		lineFlags := byte(0)
+		if len(line.Cells) > 0 {
+			lineFlags |= testPaneHistoryLineFlagHasCells
+			if testCellsText(line.Cells) == line.Text {
+				lineFlags |= testPaneHistoryLineFlagTextFromCells
+			}
+		}
+		payload.WriteByte(lineFlags)
+		if lineFlags&testPaneHistoryLineFlagTextFromCells == 0 {
+			writeTestString(&payload, line.Text)
+		}
+		if lineFlags&testPaneHistoryLineFlagHasCells == 0 {
+			continue
+		}
+
+		runs := testCellRuns(line.Cells)
+		writeTestUvarint(&payload, uint64(len(runs)))
+		for _, run := range runs {
+			writeTestUvarint(&payload, uint64(run.count))
+			writeTestString(&payload, run.cell.Char)
+			writeTestUvarint(&payload, uint64(run.cell.Width))
+			writeTestUvarint(&payload, uint64(styleIndex[testStyleKey(run.cell.Style)]))
+		}
+	}
+
+	return payload.Bytes()
+}
+
+func writeTestStyle(t *testing.T, dst *bytes.Buffer, style uv.Style) {
+	t.Helper()
+
+	writeTestColor(t, dst, style.Fg)
+	writeTestColor(t, dst, style.Bg)
+	writeTestColor(t, dst, style.UnderlineColor)
+	dst.WriteByte(byte(style.Underline))
+	dst.WriteByte(style.Attrs)
+}
+
+func writeTestColor(t *testing.T, dst *bytes.Buffer, c color.Color) {
+	t.Helper()
+
+	switch v := c.(type) {
+	case nil:
+		dst.WriteByte(testPaneHistoryColorNil)
+	case ansi.BasicColor:
+		dst.WriteByte(testPaneHistoryColorBasic)
+		dst.WriteByte(byte(v))
+	case ansi.IndexedColor:
+		dst.WriteByte(testPaneHistoryColorIndexed)
+		dst.WriteByte(byte(v))
+	case ansi.RGBColor:
+		dst.WriteByte(testPaneHistoryColorRGB)
+		dst.WriteByte(v.R)
+		dst.WriteByte(v.G)
+		dst.WriteByte(v.B)
+	case color.RGBA:
+		dst.WriteByte(testPaneHistoryColorRGBA)
+		dst.WriteByte(v.R)
+		dst.WriteByte(v.G)
+		dst.WriteByte(v.B)
+		dst.WriteByte(v.A)
+	case color.RGBA64:
+		dst.WriteByte(testPaneHistoryColorRGBA64)
+		writeTestUint16(dst, v.R)
+		writeTestUint16(dst, v.G)
+		writeTestUint16(dst, v.B)
+		writeTestUint16(dst, v.A)
+	default:
+		r, g, b, a := v.RGBA()
+		dst.WriteByte(testPaneHistoryColorRGBA64)
+		writeTestUint16(dst, uint16(r))
+		writeTestUint16(dst, uint16(g))
+		writeTestUint16(dst, uint16(b))
+		writeTestUint16(dst, uint16(a))
+	}
+}
+
+func writeTestUint16(dst *bytes.Buffer, v uint16) {
+	var buf [2]byte
+	binary.BigEndian.PutUint16(buf[:], v)
+	dst.Write(buf[:])
+}
+
+func writeTestString(dst *bytes.Buffer, s string) {
+	writeTestUvarint(dst, uint64(len(s)))
+	dst.WriteString(s)
+}
+
+func writeTestUvarint(dst *bytes.Buffer, v uint64) {
+	var buf [binary.MaxVarintLen64]byte
+	n := binary.PutUvarint(buf[:], v)
+	dst.Write(buf[:n])
+}
+
+type testCellRun struct {
+	count int
+	cell  Cell
+}
+
+func testCellRuns(cells []Cell) []testCellRun {
+	if len(cells) == 0 {
+		return nil
+	}
+
+	runs := make([]testCellRun, 0, len(cells))
+	current := testCellRun{count: 1, cell: cells[0]}
+	for _, cell := range cells[1:] {
+		if reflect.DeepEqual(cell, current.cell) {
+			current.count++
+			continue
+		}
+		runs = append(runs, current)
+		current = testCellRun{count: 1, cell: cell}
+	}
+	runs = append(runs, current)
+	return runs
+}
+
+func buildTestStyleTable(lines []StyledLine) ([]uv.Style, map[string]int) {
+	styles := make([]uv.Style, 0)
+	index := make(map[string]int)
+	for _, line := range lines {
+		for _, cell := range line.Cells {
+			key := testStyleKey(cell.Style)
+			if _, ok := index[key]; ok {
+				continue
+			}
+			index[key] = len(styles)
+			styles = append(styles, cell.Style)
+		}
+	}
+	return styles, index
+}
+
+func testStyleKey(style uv.Style) string {
+	var b strings.Builder
+	b.WriteString(testColorKey(style.Fg))
+	b.WriteByte('|')
+	b.WriteString(testColorKey(style.Bg))
+	b.WriteByte('|')
+	b.WriteString(testColorKey(style.UnderlineColor))
+	b.WriteByte('|')
+	b.WriteByte(byte(style.Underline))
+	b.WriteByte('|')
+	b.WriteByte(style.Attrs)
+	return b.String()
+}
+
+func testColorKey(c color.Color) string {
+	switch v := c.(type) {
+	case nil:
+		return "nil"
+	case ansi.BasicColor:
+		return "basic:" + string([]byte{byte(v)})
+	case ansi.IndexedColor:
+		return "indexed:" + string([]byte{byte(v)})
+	case ansi.RGBColor:
+		return "rgb:" + string([]byte{v.R, v.G, v.B})
+	case color.RGBA:
+		return "rgba:" + string([]byte{v.R, v.G, v.B, v.A})
+	case color.RGBA64:
+		var buf [8]byte
+		binary.BigEndian.PutUint16(buf[0:2], v.R)
+		binary.BigEndian.PutUint16(buf[2:4], v.G)
+		binary.BigEndian.PutUint16(buf[4:6], v.B)
+		binary.BigEndian.PutUint16(buf[6:8], v.A)
+		return "rgba64:" + string(buf[:])
+	default:
+		r, g, b, a := v.RGBA()
+		var buf [8]byte
+		binary.BigEndian.PutUint16(buf[0:2], uint16(r))
+		binary.BigEndian.PutUint16(buf[2:4], uint16(g))
+		binary.BigEndian.PutUint16(buf[4:6], uint16(b))
+		binary.BigEndian.PutUint16(buf[6:8], uint16(a))
+		return "generic:" + string(buf[:])
+	}
+}
+
+func testHistoryMatchesStyledText(history []string, styled []StyledLine) bool {
+	if len(history) == 0 || len(history) != len(styled) {
+		return false
+	}
+	for i, line := range styled {
+		if history[i] != line.Text {
+			return false
+		}
+	}
+	return true
+}
+
+func testCellsText(cells []Cell) string {
+	var b strings.Builder
+	for _, cell := range cells {
+		b.WriteString(cell.Char)
+	}
+	return b.String()
+}

--- a/internal/server/client_conn.go
+++ b/internal/server/client_conn.go
@@ -66,6 +66,7 @@ func newClientConn(conn net.Conn) *clientConn {
 
 func (cc *clientConn) setNegotiatedCapabilities(caps proto.ClientCapabilities) {
 	cc.capabilities = caps
+	cc.ensureWriter().setBinaryPaneHistory(caps.BinaryPaneHistory)
 }
 
 func (cc *clientConn) capabilitySummary() string {

--- a/internal/server/client_conn.go
+++ b/internal/server/client_conn.go
@@ -226,6 +226,7 @@ func cloneMessage(msg *Message) *Message {
 	cp.RenderData = append([]byte(nil), msg.RenderData...)
 	cp.PaneData = append([]byte(nil), msg.PaneData...)
 	cp.History = append([]string(nil), msg.History...)
+	cp.StyledHistory = proto.CloneStyledLines(msg.StyledHistory)
 	return &cp
 }
 

--- a/internal/server/client_conn_clone_test.go
+++ b/internal/server/client_conn_clone_test.go
@@ -1,0 +1,49 @@
+package server
+
+import (
+	"testing"
+
+	uv "github.com/charmbracelet/ultraviolet"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/weill-labs/amux/internal/proto"
+)
+
+func TestCloneMessageDeepCopiesPaneHistorySlices(t *testing.T) {
+	t.Parallel()
+
+	original := &Message{
+		Type:    MsgTypePaneHistory,
+		PaneID:  9,
+		History: []string{"plain"},
+		StyledHistory: []proto.StyledLine{
+			{
+				Text: "styled",
+				Cells: []proto.Cell{
+					{Char: "x", Width: 1, Style: uv.Style{Fg: ansi.BasicColor(2)}},
+				},
+			},
+		},
+	}
+
+	cloned := cloneMessage(original)
+	if cloned == nil {
+		t.Fatal("cloneMessage() = nil, want clone")
+	}
+	if len(cloned.History) != 1 || len(cloned.StyledHistory) != 1 || len(cloned.StyledHistory[0].Cells) != 1 {
+		t.Fatalf("cloneMessage() = %#v, want populated deep copy", cloned)
+	}
+
+	cloned.History[0] = "mutated plain"
+	cloned.StyledHistory[0].Text = "mutated styled"
+	cloned.StyledHistory[0].Cells[0].Char = "y"
+
+	if original.History[0] != "plain" {
+		t.Fatalf("original history = %q, want plain", original.History[0])
+	}
+	if original.StyledHistory[0].Text != "styled" {
+		t.Fatalf("original styled text = %q, want styled", original.StyledHistory[0].Text)
+	}
+	if original.StyledHistory[0].Cells[0].Char != "x" {
+		t.Fatalf("original styled char = %q, want x", original.StyledHistory[0].Cells[0].Char)
+	}
+}

--- a/internal/server/client_writer.go
+++ b/internal/server/client_writer.go
@@ -182,6 +182,13 @@ func newClientWriter(conn net.Conn) *clientWriter {
 	return w
 }
 
+func (w *clientWriter) setBinaryPaneHistory(enabled bool) {
+	if w == nil || w.wire == nil {
+		return
+	}
+	w.wire.SetBinaryPaneHistory(enabled)
+}
+
 func (w *clientWriter) loop() {
 	defer close(w.done)
 

--- a/internal/server/client_writer_test.go
+++ b/internal/server/client_writer_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"bytes"
 	"net"
 	"testing"
 	"time"
@@ -198,6 +199,29 @@ func TestClientWriterBootstrappingStopsOnRequestStop(t *testing.T) {
 	case <-w.done:
 	case <-time.After(time.Second):
 		t.Fatal("clientWriter loop did not exit after stop during bootstrap")
+	}
+}
+
+func TestClientWriterSetBinaryPaneHistory(t *testing.T) {
+	t.Parallel()
+
+	var nilWriter *clientWriter
+	nilWriter.setBinaryPaneHistory(true)
+
+	msg := &Message{
+		Type:          MsgTypePaneHistory,
+		PaneID:        4,
+		History:       []string{"x"},
+		StyledHistory: []proto.StyledLine{{Text: "x"}},
+	}
+	var buf bytes.Buffer
+	w := &clientWriter{wire: proto.NewWriter(&buf)}
+	w.setBinaryPaneHistory(true)
+	if err := w.wire.WriteMsg(msg); err != nil {
+		t.Fatalf("WriteMsg: %v", err)
+	}
+	if got := buf.Bytes(); len(got) == 0 || got[0] != 0x02 {
+		t.Fatalf("pane history frame discriminator = %#v, want 0x02", got)
 	}
 }
 

--- a/internal/server/pane_history_chunk.go
+++ b/internal/server/pane_history_chunk.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"bytes"
-	"encoding/gob"
 	"fmt"
 
 	"github.com/weill-labs/amux/internal/proto"
@@ -11,6 +10,10 @@ import (
 const paneHistoryChunkThreshold = 4 * 1024 * 1024
 
 func chunkPaneHistoryMessages(paneID uint32, history []proto.StyledLine, maxChunkSize int) ([]*Message, error) {
+	return chunkPaneHistoryMessagesWithEncoding(paneID, history, maxChunkSize, false)
+}
+
+func chunkPaneHistoryMessagesWithEncoding(paneID uint32, history []proto.StyledLine, maxChunkSize int, binaryPaneHistory bool) ([]*Message, error) {
 	if len(history) == 0 {
 		return nil, nil
 	}
@@ -20,7 +23,7 @@ func chunkPaneHistoryMessages(paneID uint32, history []proto.StyledLine, maxChun
 
 	messages := make([]*Message, 0, 1)
 	for start := 0; start < len(history); {
-		end, err := findPaneHistoryChunkEnd(paneID, history, start, maxChunkSize)
+		end, err := findPaneHistoryChunkEnd(paneID, history, start, maxChunkSize, binaryPaneHistory)
 		if err != nil {
 			return nil, err
 		}
@@ -30,12 +33,12 @@ func chunkPaneHistoryMessages(paneID uint32, history []proto.StyledLine, maxChun
 	return messages, nil
 }
 
-func findPaneHistoryChunkEnd(paneID uint32, history []proto.StyledLine, start, maxChunkSize int) (int, error) {
+func findPaneHistoryChunkEnd(paneID uint32, history []proto.StyledLine, start, maxChunkSize int, binaryPaneHistory bool) (int, error) {
 	lo, hi := start+1, len(history)
 	best := start
 	for lo <= hi {
 		mid := lo + (hi-lo)/2
-		size, err := estimatePaneHistoryMessageSize(newPaneHistoryMessage(paneID, history[start:mid]))
+		size, err := estimatePaneHistoryMessageSizeWithEncoding(newPaneHistoryMessage(paneID, history[start:mid]), binaryPaneHistory)
 		if err != nil {
 			return 0, err
 		}
@@ -62,8 +65,14 @@ func newPaneHistoryMessage(paneID uint32, history []proto.StyledLine) *Message {
 }
 
 func estimatePaneHistoryMessageSize(msg *Message) (int, error) {
+	return estimatePaneHistoryMessageSizeWithEncoding(msg, false)
+}
+
+func estimatePaneHistoryMessageSizeWithEncoding(msg *Message, binaryPaneHistory bool) (int, error) {
 	var buf bytes.Buffer
-	if err := gob.NewEncoder(&buf).Encode(msg); err != nil {
+	writer := proto.NewWriter(&buf)
+	writer.SetBinaryPaneHistory(binaryPaneHistory)
+	if err := writer.WriteMsg(msg); err != nil {
 		return 0, fmt.Errorf("encoding pane history message: %w", err)
 	}
 	return buf.Len(), nil

--- a/internal/server/pane_history_chunk.go
+++ b/internal/server/pane_history_chunk.go
@@ -9,11 +9,7 @@ import (
 
 const paneHistoryChunkThreshold = 4 * 1024 * 1024
 
-func chunkPaneHistoryMessages(paneID uint32, history []proto.StyledLine, maxChunkSize int) ([]*Message, error) {
-	return chunkPaneHistoryMessagesWithEncoding(paneID, history, maxChunkSize, false)
-}
-
-func chunkPaneHistoryMessagesWithEncoding(paneID uint32, history []proto.StyledLine, maxChunkSize int, binaryPaneHistory bool) ([]*Message, error) {
+func chunkPaneHistoryMessages(paneID uint32, history []proto.StyledLine, maxChunkSize int, binaryPaneHistory bool) ([]*Message, error) {
 	if len(history) == 0 {
 		return nil, nil
 	}
@@ -38,7 +34,7 @@ func findPaneHistoryChunkEnd(paneID uint32, history []proto.StyledLine, start, m
 	best := start
 	for lo <= hi {
 		mid := lo + (hi-lo)/2
-		size, err := estimatePaneHistoryMessageSizeWithEncoding(newPaneHistoryMessage(paneID, history[start:mid]), binaryPaneHistory)
+		size, err := estimatePaneHistoryMessageSize(newPaneHistoryMessage(paneID, history[start:mid]), binaryPaneHistory)
 		if err != nil {
 			return 0, err
 		}
@@ -64,11 +60,7 @@ func newPaneHistoryMessage(paneID uint32, history []proto.StyledLine) *Message {
 	}
 }
 
-func estimatePaneHistoryMessageSize(msg *Message) (int, error) {
-	return estimatePaneHistoryMessageSizeWithEncoding(msg, false)
-}
-
-func estimatePaneHistoryMessageSizeWithEncoding(msg *Message, binaryPaneHistory bool) (int, error) {
+func estimatePaneHistoryMessageSize(msg *Message, binaryPaneHistory bool) (int, error) {
 	var buf bytes.Buffer
 	writer := proto.NewWriter(&buf)
 	writer.SetBinaryPaneHistory(binaryPaneHistory)

--- a/internal/server/pane_history_chunk_test.go
+++ b/internal/server/pane_history_chunk_test.go
@@ -29,7 +29,7 @@ func TestChunkPaneHistoryMessagesSplitsLargeHistoryUnderThreshold(t *testing.T) 
 	pane.SetRetainedHistory(lines)
 
 	styledHistory, _, _ := pane.StyledHistoryScreenSnapshot()
-	chunks, err := chunkPaneHistoryMessages(pane.ID, styledHistory, chunkThreshold)
+	chunks, err := chunkPaneHistoryMessagesWithEncoding(pane.ID, styledHistory, chunkThreshold, true)
 	if err != nil {
 		t.Fatalf("chunkPaneHistoryMessages: %v", err)
 	}
@@ -45,7 +45,7 @@ func TestChunkPaneHistoryMessagesSplitsLargeHistoryUnderThreshold(t *testing.T) 
 		if msg.PaneID != pane.ID {
 			t.Fatalf("chunk %d pane id = %d, want %d", i, msg.PaneID, pane.ID)
 		}
-		size, err := estimatePaneHistoryMessageSize(msg)
+		size, err := estimatePaneHistoryMessageSizeWithEncoding(msg, true)
 		if err != nil {
 			t.Fatalf("estimate chunk %d size: %v", i, err)
 		}
@@ -138,6 +138,9 @@ func TestHandleAttachChunksLargePaneHistoryDuringBootstrap(t *testing.T) {
 			Session: sess.Name,
 			Cols:    80,
 			Rows:    24,
+			AttachCapabilities: &proto.ClientCapabilities{
+				BinaryPaneHistory: true,
+			},
 		})
 	}()
 

--- a/internal/server/pane_history_chunk_test.go
+++ b/internal/server/pane_history_chunk_test.go
@@ -29,7 +29,7 @@ func TestChunkPaneHistoryMessagesSplitsLargeHistoryUnderThreshold(t *testing.T) 
 	pane.SetRetainedHistory(lines)
 
 	styledHistory, _, _ := pane.StyledHistoryScreenSnapshot()
-	chunks, err := chunkPaneHistoryMessagesWithEncoding(pane.ID, styledHistory, chunkThreshold, true)
+	chunks, err := chunkPaneHistoryMessages(pane.ID, styledHistory, chunkThreshold, true)
 	if err != nil {
 		t.Fatalf("chunkPaneHistoryMessages: %v", err)
 	}
@@ -45,7 +45,7 @@ func TestChunkPaneHistoryMessagesSplitsLargeHistoryUnderThreshold(t *testing.T) 
 		if msg.PaneID != pane.ID {
 			t.Fatalf("chunk %d pane id = %d, want %d", i, msg.PaneID, pane.ID)
 		}
-		size, err := estimatePaneHistoryMessageSizeWithEncoding(msg, true)
+		size, err := estimatePaneHistoryMessageSize(msg, true)
 		if err != nil {
 			t.Fatalf("estimate chunk %d size: %v", i, err)
 		}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -811,7 +811,7 @@ func (s *Server) handleAttach(cc *clientConn, msg *Message) {
 	bootstrapSeqs := make(map[uint32]uint64, len(res.paneSnapshots))
 	for _, ps := range res.paneSnapshots {
 		if len(ps.styledHistory) > 0 {
-			messages, err := chunkPaneHistoryMessages(ps.paneID, ps.styledHistory, paneHistoryChunkThreshold)
+			messages, err := chunkPaneHistoryMessagesWithEncoding(ps.paneID, ps.styledHistory, paneHistoryChunkThreshold, cc.capabilities.BinaryPaneHistory)
 			if err != nil {
 				cc.Close()
 				return

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -811,7 +811,7 @@ func (s *Server) handleAttach(cc *clientConn, msg *Message) {
 	bootstrapSeqs := make(map[uint32]uint64, len(res.paneSnapshots))
 	for _, ps := range res.paneSnapshots {
 		if len(ps.styledHistory) > 0 {
-			messages, err := chunkPaneHistoryMessagesWithEncoding(ps.paneID, ps.styledHistory, paneHistoryChunkThreshold, cc.capabilities.BinaryPaneHistory)
+			messages, err := chunkPaneHistoryMessages(ps.paneID, ps.styledHistory, paneHistoryChunkThreshold, cc.capabilities.BinaryPaneHistory)
 			if err != nil {
 				cc.Close()
 				return


### PR DESCRIPTION
## Motivation

MsgTypePaneHistory is the highest-volume gob message during attach bootstrap, and pprof showed gob buffer growth dominating cumulative allocations. This change moves pane-history bootstrapping onto a compact binary frame while keeping legacy peers on gob unless they explicitly negotiate support.

## Summary

- add a negotiated `binary_pane_history` capability and a dedicated `0x02` wire frame for `MsgTypePaneHistory`
- encode pane history payloads compactly by omitting duplicate plain history when it matches styled text, interning message-local styles, and RLE-encoding repeated cells
- stream binary pane-history decoding on the client to avoid a second full-message buffer during bootstrap
- size bootstrap pane-history chunks against the negotiated on-wire encoding instead of always estimating gob size
- cover the new frame with mixed-stream round trips, bootstrap chunking tests, capability expectations, and a gob-vs-binary benchmark for realistic 1024-line history payloads

## Testing

- `go test ./internal/proto ./internal/client ./internal/server -run 'Test(ReadMsgPaneHistoryBinaryFrameWithStyledCells|ReaderReadMsgMixedStreamWithPaneHistoryBinaryFrame|WriterWriteMsgPaneHistoryUsesBinaryFrameWhenEnabled|ChunkPaneHistoryMessagesSplitsLargeHistoryUnderThreshold|HandleAttachChunksLargePaneHistoryDuringBootstrap|ReadAttachBootstrapKeepsPeakHeapUnderBound|DetectAttachCapabilitiesFromEnv|DetectAttachCapabilitiesFromEnvOverride|AdvertisedAttachCapabilitiesUsesProcessEnv|AdvertisedAttachCapabilitiesUsesEnvironment|HandleAttachStoresNegotiatedCapabilities)$' -count=100`
- `go test ./internal/proto -run '^$' -bench 'BenchmarkPaneHistoryMessageWire' -benchmem`
- `go test ./... -timeout 120s`

## Review Focus

- the binary pane-history payload layout in `internal/proto/wire_pane_history.go`, especially history omission, style interning, and cell-run encoding
- attach-time compatibility gating: modern peers opt into `0x02`, legacy peers stay on gob, and bootstrap chunk sizing follows the negotiated encoding
- the client-side streaming decoder and heap-test subprocess path, which keep attach bootstrap memory bounded without breaking the repo parallel-test audit

## Baseline numbers

Apple M4 / linux amd64 runner equivalent CPU reported by Go benchmark as `AMD EPYC-Milan Processor`

| Benchmark | Gob | Binary |
| --- | ---: | ---: |
| write | 72.3 ms/op, 62.2 MB/op, 139 allocs/op | 26.5 ms/op, 13.3 MB/op, 1,045 allocs/op |
| read | 103.3 ms/op, 28.0 MB/op, 497,249 allocs/op | 15.1 ms/op, 25.5 MB/op, 103,438 allocs/op |

Closes LAB-1303
