### PR TITLE
Preserve attach error detail on connection loss

### DIFF
--- a/internal/client/attach.go
+++ b/internal/client/attach.go
@@ -114,7 +114,7 @@ func formatAttachError(err error) error {
 	case isSocketNotFoundError(err):
 		return fmt.Errorf("attach failed: socket not found")
 	case isConnectionLostError(err):
-		return fmt.Errorf("attach failed: connection lost")
+		return fmt.Errorf("attach failed: connection lost: %v", err)
 	default:
 		return fmt.Errorf("attach failed: %w", err)
 	}

--- a/internal/client/attach_test.go
+++ b/internal/client/attach_test.go
@@ -252,22 +252,22 @@ func TestFormatAttachError(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name string
-		err  error
-		want string
+		name         string
+		err          error
+		wantContains string
 	}{
-		{name: "protocol error", err: fmt.Errorf("%w: bad bootstrap", errAttachProtocol), want: "attach failed: protocol error"},
-		{name: "socket missing", err: os.ErrNotExist, want: "attach failed: socket not found"},
-		{name: "connection lost eof", err: io.EOF, want: "attach failed: connection lost"},
+		{name: "protocol error", err: fmt.Errorf("%w: bad bootstrap", errAttachProtocol), wantContains: "attach failed: protocol error"},
+		{name: "socket missing", err: os.ErrNotExist, wantContains: "attach failed: socket not found"},
+		{name: "connection lost eof", err: io.EOF, wantContains: "attach failed: connection lost"},
 		{
-			name: "ssh handshake keeps detail",
-			err:  fmt.Errorf("SSH dial: ssh: handshake failed: %w", io.EOF),
-			want: "SSH dial: ssh: handshake failed",
+			name:         "ssh handshake keeps detail",
+			err:          fmt.Errorf("SSH dial: ssh: handshake failed: %w", io.EOF),
+			wantContains: "SSH dial: ssh: handshake failed",
 		},
 		{
-			name: "connection reset keeps detail",
-			err:  errors.New("read unix /tmp/amux.sock->/tmp/amux.sock: connection reset by peer"),
-			want: "connection reset by peer",
+			name:         "connection reset keeps detail",
+			err:          errors.New("read unix /tmp/amux.sock->/tmp/amux.sock: connection reset by peer"),
+			wantContains: "connection reset by peer",
 		},
 	}
 
@@ -277,8 +277,8 @@ func TestFormatAttachError(t *testing.T) {
 			t.Parallel()
 
 			err := formatAttachError(tt.err)
-			if err == nil || !strings.Contains(err.Error(), tt.want) {
-				t.Fatalf("formatAttachError(%v) = %v, want substring %q", tt.err, err, tt.want)
+			if err == nil || !strings.Contains(err.Error(), tt.wantContains) {
+				t.Fatalf("formatAttachError(%v) = %v, want substring %q", tt.err, err, tt.wantContains)
 			}
 		})
 	}

--- a/internal/client/attach_test.go
+++ b/internal/client/attach_test.go
@@ -258,7 +258,17 @@ func TestFormatAttachError(t *testing.T) {
 	}{
 		{name: "protocol error", err: fmt.Errorf("%w: bad bootstrap", errAttachProtocol), want: "attach failed: protocol error"},
 		{name: "socket missing", err: os.ErrNotExist, want: "attach failed: socket not found"},
-		{name: "connection lost", err: io.EOF, want: "attach failed: connection lost"},
+		{name: "connection lost eof", err: io.EOF, want: "attach failed: connection lost"},
+		{
+			name: "ssh handshake keeps detail",
+			err:  fmt.Errorf("SSH dial: ssh: handshake failed: %w", io.EOF),
+			want: "SSH dial: ssh: handshake failed",
+		},
+		{
+			name: "connection reset keeps detail",
+			err:  errors.New("read unix /tmp/amux.sock->/tmp/amux.sock: connection reset by peer"),
+			want: "connection reset by peer",
+		},
 	}
 
 	for _, tt := range tests {
@@ -269,6 +279,37 @@ func TestFormatAttachError(t *testing.T) {
 			err := formatAttachError(tt.err)
 			if err == nil || !strings.Contains(err.Error(), tt.want) {
 				t.Fatalf("formatAttachError(%v) = %v, want substring %q", tt.err, err, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsConnectionLostError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil", err: nil, want: false},
+		{name: "eof", err: io.EOF, want: true},
+		{name: "unexpected eof", err: io.ErrUnexpectedEOF, want: true},
+		{name: "wrapped eof", err: fmt.Errorf("ssh handshake: %w", io.EOF), want: true},
+		{name: "closed network", err: net.ErrClosed, want: true},
+		{name: "closed network text", err: errors.New("use of closed network connection"), want: true},
+		{name: "broken pipe text", err: errors.New("write unix /tmp/amux.sock: broken pipe"), want: true},
+		{name: "connection reset text", err: errors.New("connection reset by peer"), want: true},
+		{name: "other error", err: errors.New("permission denied"), want: false},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := isConnectionLostError(tt.err); got != tt.want {
+				t.Fatalf("isConnectionLostError(%v) = %v, want %v", tt.err, got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
## Motivation
`formatAttachError` started collapsing wrapped EOFs to a generic `attach failed: connection lost` after `io.ErrUnexpectedEOF` was added to `isConnectionLostError` in `30614e4`. That hides actionable SSH dial and handshake failures behind a misleading attach error, which made bad-user debugging much harder.

## Summary
- include the underlying error text in the `connection lost` attach error path so wrapped SSH failures keep their diagnostic detail
- add `formatAttachError` coverage for SSH handshake and reset-by-peer errors
- add a table-driven `isConnectionLostError` regression test covering the current classifier behavior

## Testing
- `go test ./internal/client -run 'TestFormatAttachError|TestIsConnectionLostError' -count=100`
- `go test ./internal/client -run TestReadAttachBootstrapKeepsPeakHeapUnderBound -count=3`
- `go test ./internal/mux -run TestAgentStatusTracksBusyAndIdle -count=3` (fails locally outside this diff)
- `go test ./... -timeout 120s` (local checkout currently fails outside this diff in `internal/mux` and `test`; the attach slice passes)

## Review focus
The only production behavior change is the `isConnectionLostError` branch in `formatAttachError`. I intentionally did not add an SSH-specific classifier or `AMUX_DEBUG_ATTACH`; this keeps the fix at the single formatting point while preserving the existing connection-loss classifier behavior.

Closes LAB-1314
