### PR TITLE
Default implicit SSH user to current OS user

### DIFF
--- a/internal/cli/cli_commands_ssh.go
+++ b/internal/cli/cli_commands_ssh.go
@@ -36,7 +36,7 @@ func resolveCLISSHTarget(raw string) (sshutil.SSHTarget, error) {
 		return sshutil.SSHTarget{}, fmt.Errorf("loading config: %w", err)
 	}
 
-	target, err := sshutil.ParseTarget(raw, "ubuntu")
+	target, err := sshutil.ParseTarget(raw, "")
 	if err != nil {
 		return sshutil.SSHTarget{}, err
 	}

--- a/internal/cli/cli_commands_ssh_test.go
+++ b/internal/cli/cli_commands_ssh_test.go
@@ -52,8 +52,9 @@ func TestResolveCLISSHTargetUsesDefaultSSHUser(t *testing.T) {
 	if err != nil {
 		t.Fatalf("resolveCLISSHTarget() error = %v", err)
 	}
-	if target.User != sshutil.DefaultSSHUser() {
-		t.Fatalf("resolveCLISSHTarget() user = %q, want %q", target.User, sshutil.DefaultSSHUser())
+	wantUser := sshutil.DefaultSSHUser()
+	if target.User != wantUser {
+		t.Fatalf("resolveCLISSHTarget() user = %q, want %q", target.User, wantUser)
 	}
 	if target.Host != "builder" || target.Session != "work" {
 		t.Fatalf("resolveCLISSHTarget() = %#v, want builder/work target", target)

--- a/internal/cli/cli_commands_ssh_test.go
+++ b/internal/cli/cli_commands_ssh_test.go
@@ -3,6 +3,8 @@ package cli
 import (
 	"os"
 	"testing"
+
+	"github.com/weill-labs/amux/internal/sshutil"
 )
 
 func TestResolveCLISSHTargetKeepsExplicitUser(t *testing.T) {
@@ -36,5 +38,24 @@ func TestResolveCLISSHTargetReturnsConfigError(t *testing.T) {
 
 	if _, err := resolveCLISSHTarget("builder"); err == nil {
 		t.Fatal("resolveCLISSHTarget() error = nil, want config parse failure")
+	}
+}
+
+func TestResolveCLISSHTargetUsesDefaultSSHUser(t *testing.T) {
+	configPath := t.TempDir() + "/config.toml"
+	if err := os.WriteFile(configPath, []byte(""), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	t.Setenv("AMUX_CONFIG", configPath)
+
+	target, err := resolveCLISSHTarget("builder:work")
+	if err != nil {
+		t.Fatalf("resolveCLISSHTarget() error = %v", err)
+	}
+	if target.User != sshutil.DefaultSSHUser() {
+		t.Fatalf("resolveCLISSHTarget() user = %q, want %q", target.User, sshutil.DefaultSSHUser())
+	}
+	if target.Host != "builder" || target.Session != "work" {
+		t.Fatalf("resolveCLISSHTarget() = %#v, want builder/work target", target)
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/BurntSushi/toml"
 	"github.com/weill-labs/amux/internal/proto"
+	"github.com/weill-labs/amux/internal/sshutil"
 )
 
 // catppuccinMocha is the accent palette in official order (catppuccin.com/palette).
@@ -202,12 +203,12 @@ func ColorForHost(hostname string) string {
 	return AccentColor(h)
 }
 
-// HostUser returns the SSH user for a host, defaulting to "ubuntu".
+// HostUser returns the SSH user for a host, defaulting to the current OS user.
 func (c *Config) HostUser(hostname string) string {
 	if h, ok := c.Hosts[hostname]; ok && h.User != "" {
 		return h.User
 	}
-	return "ubuntu"
+	return sshutil.DefaultSSHUser()
 }
 
 // HostAddress returns the address for a host, falling back to the hostname itself.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/weill-labs/amux/internal/proto"
+	"github.com/weill-labs/amux/internal/sshutil"
 )
 
 func TestLoadMissing(t *testing.T) {
@@ -88,23 +89,28 @@ func TestColorForHost(t *testing.T) {
 
 func TestHostUser(t *testing.T) {
 	t.Parallel()
+
 	cfg := &Config{
 		Hosts: map[string]Host{
 			"myhost": {User: "admin"},
 		},
 	}
+	defaultUser := sshutil.DefaultSSHUser()
 
 	tests := []struct {
+		name string
 		host string
 		want string
 	}{
-		{"myhost", "admin"},
-		{"unknown", "ubuntu"},
+		{name: "configured user wins", host: "myhost", want: "admin"},
+		{name: "missing host falls back to shared default user", host: "unknown", want: defaultUser},
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.host, func(t *testing.T) {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+
 			if got := cfg.HostUser(tt.host); got != tt.want {
 				t.Errorf("HostUser(%q) = %q, want %q", tt.host, got, tt.want)
 			}

--- a/internal/remote/host_conn_test.go
+++ b/internal/remote/host_conn_test.go
@@ -494,8 +494,9 @@ func TestBuildSSHConfigDefaultUser(t *testing.T) {
 	if err != nil {
 		t.Fatalf("buildSSHConfig() error: %v", err)
 	}
-	if cfg.User != sshutil.DefaultSSHUser() {
-		t.Errorf("User = %q, want %q (default)", cfg.User, sshutil.DefaultSSHUser())
+	wantUser := sshutil.DefaultSSHUser()
+	if cfg.User != wantUser {
+		t.Errorf("User = %q, want %q (default)", cfg.User, wantUser)
 	}
 }
 

--- a/internal/remote/host_conn_test.go
+++ b/internal/remote/host_conn_test.go
@@ -494,8 +494,8 @@ func TestBuildSSHConfigDefaultUser(t *testing.T) {
 	if err != nil {
 		t.Fatalf("buildSSHConfig() error: %v", err)
 	}
-	if cfg.User != "ubuntu" {
-		t.Errorf("User = %q, want ubuntu (default)", cfg.User)
+	if cfg.User != sshutil.DefaultSSHUser() {
+		t.Errorf("User = %q, want %q (default)", cfg.User, sshutil.DefaultSSHUser())
 	}
 }
 

--- a/internal/sshutil/default_user.go
+++ b/internal/sshutil/default_user.go
@@ -1,0 +1,31 @@
+package sshutil
+
+import (
+	"os"
+	"os/user"
+
+	charmlog "github.com/charmbracelet/log"
+)
+
+// DefaultSSHUser returns the current OS user for implicit SSH targets.
+// If user lookup fails, it logs the error and falls back to $USER or empty.
+func DefaultSSHUser() string {
+	return defaultSSHUser(user.Current, os.Getenv, func(err error) {
+		charmlog.Warn("failed to determine current ssh user", "error", err)
+	})
+}
+
+func defaultSSHUser(
+	currentUser func() (*user.User, error),
+	getenv func(string) string,
+	logLookupError func(error),
+) string {
+	usr, err := currentUser()
+	if err == nil && usr != nil && usr.Username != "" {
+		return usr.Username
+	}
+	if err != nil && logLookupError != nil {
+		logLookupError(err)
+	}
+	return getenv("USER")
+}

--- a/internal/sshutil/default_user_test.go
+++ b/internal/sshutil/default_user_test.go
@@ -1,0 +1,60 @@
+package sshutil
+
+import (
+	"errors"
+	"os/user"
+	"testing"
+)
+
+func TestDefaultSSHUserResolution(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		envUser     string
+		currentUser func() (*user.User, error)
+		want        string
+	}{
+		{
+			name:    "uses current user when lookup succeeds",
+			envUser: "",
+			currentUser: func() (*user.User, error) {
+				return &user.User{Username: "alice"}, nil
+			},
+			want: "alice",
+		},
+		{
+			name:    "falls back to USER when lookup fails",
+			envUser: "builder",
+			currentUser: func() (*user.User, error) {
+				return nil, errors.New("lookup failed")
+			},
+			want: "builder",
+		},
+		{
+			name:    "returns empty when lookup fails and USER is unset",
+			envUser: "",
+			currentUser: func() (*user.User, error) {
+				return nil, errors.New("lookup failed")
+			},
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := defaultSSHUser(tt.currentUser, func(key string) string {
+				if key != "USER" {
+					t.Fatalf("lookup env key = %q, want USER", key)
+				}
+				return tt.envUser
+			}, func(error) {})
+			if got != tt.want {
+				t.Fatalf("defaultSSHUser() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/sshutil/sshutil.go
+++ b/internal/sshutil/sshutil.go
@@ -50,7 +50,7 @@ func BuildSSHConfig(user, identityFile string) (*ssh.ClientConfig, error) {
 	}
 
 	if user == "" {
-		user = "ubuntu"
+		user = DefaultSSHUser()
 	}
 
 	var hostKeyCallback ssh.HostKeyCallback

--- a/internal/sshutil/sshutil_test.go
+++ b/internal/sshutil/sshutil_test.go
@@ -69,8 +69,9 @@ func TestBuildSSHConfigUsesDefaultUserAndTOFUCallback(t *testing.T) {
 	if err != nil {
 		t.Fatalf("BuildSSHConfig() error = %v", err)
 	}
-	if cfg.User != DefaultSSHUser() {
-		t.Fatalf("BuildSSHConfig() user = %q, want %q", cfg.User, DefaultSSHUser())
+	wantUser := DefaultSSHUser()
+	if cfg.User != wantUser {
+		t.Fatalf("BuildSSHConfig() user = %q, want %q", cfg.User, wantUser)
 	}
 
 	key := testHostKey(t)

--- a/internal/sshutil/sshutil_test.go
+++ b/internal/sshutil/sshutil_test.go
@@ -69,8 +69,8 @@ func TestBuildSSHConfigUsesDefaultUserAndTOFUCallback(t *testing.T) {
 	if err != nil {
 		t.Fatalf("BuildSSHConfig() error = %v", err)
 	}
-	if cfg.User != "ubuntu" {
-		t.Fatalf("BuildSSHConfig() user = %q, want ubuntu", cfg.User)
+	if cfg.User != DefaultSSHUser() {
+		t.Fatalf("BuildSSHConfig() user = %q, want %q", cfg.User, DefaultSSHUser())
 	}
 
 	key := testHostKey(t)

--- a/internal/sshutil/target.go
+++ b/internal/sshutil/target.go
@@ -17,14 +17,14 @@ func ParseTarget(raw, defaultUser string) (SSHTarget, error) {
 	if raw == "" {
 		return SSHTarget{}, fmt.Errorf("ssh target is required")
 	}
+	if defaultUser == "" {
+		defaultUser = DefaultSSHUser()
+	}
 
 	target := SSHTarget{
 		User:    defaultUser,
 		Port:    "22",
 		Session: "main",
-	}
-	if target.User == "" {
-		target.User = "ubuntu"
 	}
 
 	if at := strings.LastIndex(raw, "@"); at >= 0 {
@@ -33,9 +33,6 @@ func ParseTarget(raw, defaultUser string) (SSHTarget, error) {
 		}
 		target.User = raw[:at]
 		raw = raw[at+1:]
-	}
-	if target.User == "" {
-		return SSHTarget{}, fmt.Errorf("ssh target user is required")
 	}
 	if raw == "" {
 		return SSHTarget{}, fmt.Errorf("ssh target host is required")

--- a/internal/sshutil/target_test.go
+++ b/internal/sshutil/target_test.go
@@ -8,6 +8,7 @@ import (
 func TestParseTarget(t *testing.T) {
 	t.Parallel()
 
+	defaultUser := DefaultSSHUser()
 	tests := []struct {
 		name        string
 		raw         string
@@ -66,6 +67,17 @@ func TestParseTarget(t *testing.T) {
 			want: SSHTarget{
 				User:    "ubuntu",
 				Host:    "::1",
+				Port:    "22",
+				Session: "main",
+			},
+		},
+		{
+			name:        "blank default uses resolved current user",
+			raw:         "builder",
+			defaultUser: "",
+			want: SSHTarget{
+				User:    defaultUser,
+				Host:    "builder",
 				Port:    "22",
 				Session: "main",
 			},


### PR DESCRIPTION
## Motivation

`amux ssh <host>` fell back to `ubuntu@host` whenever the host was missing from `hosts.toml`. On most developer machines that user does not exist, so the SSH handshake fails with a generic connection loss instead of using the invoking user's account.

## Summary

- add `sshutil.DefaultSSHUser()` to resolve the implicit SSH user from `os/user.Current()` with `$USER` fallback and logging on lookup failure
- route `Config.HostUser`, `sshutil.BuildSSHConfig`, and `sshutil.ParseTarget` through the shared default-user helper instead of hardcoding `ubuntu`
- update CLI and unit coverage for config, target parsing, SSH config building, and the implicit CLI SSH path

## Testing

- `go test ./internal/config ./internal/sshutil ./internal/cli ./internal/remote`
- `go test ./internal/config -run TestHostUser -count=100`
- `go test ./internal/sshutil -run 'Test(DefaultSSHUserResolution|BuildSSHConfigUsesDefaultUserAndTOFUCallback|ParseTarget)$' -count=100`
- `go test ./internal/cli -run TestResolveCLISSHTargetUsesDefaultSSHUser -count=100`
- `go test ./internal/remote -run TestBuildSSHConfigDefaultUser -count=100`
- `go test ./... -timeout 120s`  
  fails in `internal/mux` at `TestAgentStatusTracksBusyAndIdle` with `timed out waiting for condition`; this appears unrelated to the SSH-user change and reproduced in a direct rerun with `go test ./internal/mux -run TestAgentStatusTracksBusyAndIdle -count=10`

## Review focus

- `ParseTarget` now treats an omitted user plus failed default-user lookup as an empty user instead of a parse error so the SSH client config can fall through to its own behavior
- `DefaultSSHUser` is the single implicit-user source of truth across config lookup, CLI parsing, and SSH config construction

Closes LAB-1311
