### PR TITLE
Handle attach bootstrap when conn deadlines fail

### DIFF
--- a/internal/client/attach.go
+++ b/internal/client/attach.go
@@ -451,7 +451,7 @@ func runSessionWithDeps(sessionName string, getTermSize func(int) (int, int, err
 	defer conn.Close()
 	sender := newMessageSender(conn)
 	defer sender.Close()
-	reader := proto.NewReader(conn)
+	attachReader := newAttachMessageSource(conn, proto.NewReader(conn))
 
 	fd := int(stdin.Fd())
 	cols, rows, _ := getTermSize(fd)
@@ -487,7 +487,7 @@ func runSessionWithDeps(sessionName string, getTermSize func(int) (int, int, err
 			UIEvent: name,
 		})
 	}
-	if err := readAttachBootstrap(conn, reader, cr); err != nil {
+	if err := readAttachBootstrapFromSource(attachReader, cr); err != nil {
 		return formatAttachError(err)
 	}
 
@@ -554,7 +554,7 @@ func runSessionWithDeps(sessionName string, getTermSize func(int) (int, int, err
 	go func() {
 		defer close(msgCh)
 		for {
-			msg, err := reader.ReadMsg()
+			msg, err := attachReader.ReadMsg()
 			if err != nil {
 				exitState.set(disconnectNoticeForReadError(err))
 				return

--- a/internal/client/attach_bootstrap.go
+++ b/internal/client/attach_bootstrap.go
@@ -180,10 +180,6 @@ func applyAttachBootstrapReplayMessage(cr *ClientRenderer, msg attachBootstrapMe
 	}
 }
 
-func readImmediateAttachCorrection(conn net.Conn, reader *proto.Reader, cr *ClientRenderer, timeout time.Duration) error {
-	return readImmediateAttachCorrectionFromSource(newAttachMessageSource(conn, reader), cr, timeout)
-}
-
 func readImmediateAttachCorrectionFromSource(reader attachTimedReader, cr *ClientRenderer, timeout time.Duration) error {
 	deadline := time.Now().Add(timeout)
 	for {

--- a/internal/client/attach_bootstrap.go
+++ b/internal/client/attach_bootstrap.go
@@ -23,6 +23,9 @@ type attachReadResult struct {
 	err error
 }
 
+// attachMessageSource uses conn deadlines while they work, then permanently
+// switches to a single-reader pump when the transport rejects deadlines (for
+// example, SSH channels).
 type attachMessageSource struct {
 	conn   net.Conn
 	reader *proto.Reader
@@ -38,6 +41,13 @@ func newAttachMessageSource(conn net.Conn, reader *proto.Reader) *attachMessageS
 		conn:   conn,
 		reader: reader,
 	}
+}
+
+func (s *attachMessageSource) pumpReader() *attachMessagePump {
+	if s.pump == nil {
+		s.pump = newAttachMessagePump(s.reader)
+	}
+	return s.pump
 }
 
 func newAttachMessagePump(reader *proto.Reader) *attachMessagePump {
@@ -95,8 +105,7 @@ func (s *attachMessageSource) ReadMsgWithTimeout(timeout time.Duration) (*proto.
 		return s.pump.ReadMsgWithTimeout(timeout)
 	}
 	if err := s.conn.SetReadDeadline(time.Now().Add(timeout)); err != nil {
-		s.pump = newAttachMessagePump(s.reader)
-		return s.pump.ReadMsgWithTimeout(timeout)
+		return s.pumpReader().ReadMsgWithTimeout(timeout)
 	}
 	defer s.conn.SetReadDeadline(time.Time{}) //nolint:errcheck // best-effort reset
 

--- a/internal/client/attach_bootstrap.go
+++ b/internal/client/attach_bootstrap.go
@@ -3,6 +3,7 @@ package client
 import (
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"time"
 
@@ -11,6 +12,111 @@ import (
 )
 
 var errAttachProtocol = errors.New("attach protocol error")
+
+type attachTimedReader interface {
+	ReadMsg() (*proto.Message, error)
+	ReadMsgWithTimeout(time.Duration) (*proto.Message, bool, error)
+}
+
+type attachReadResult struct {
+	msg *proto.Message
+	err error
+}
+
+type attachMessageSource struct {
+	conn   net.Conn
+	reader *proto.Reader
+	pump   *attachMessagePump
+}
+
+type attachMessagePump struct {
+	results chan attachReadResult
+}
+
+func newAttachMessageSource(conn net.Conn, reader *proto.Reader) *attachMessageSource {
+	return &attachMessageSource{
+		conn:   conn,
+		reader: reader,
+	}
+}
+
+func newAttachMessagePump(reader *proto.Reader) *attachMessagePump {
+	pump := &attachMessagePump{
+		results: make(chan attachReadResult, 16),
+	}
+	go func() {
+		defer close(pump.results)
+		for {
+			msg, err := reader.ReadMsg()
+			pump.results <- attachReadResult{msg: msg, err: err}
+			if err != nil {
+				return
+			}
+		}
+	}()
+	return pump
+}
+
+func (p *attachMessagePump) ReadMsg() (*proto.Message, error) {
+	result, ok := <-p.results
+	if !ok {
+		return nil, io.EOF
+	}
+	return result.msg, result.err
+}
+
+func (p *attachMessagePump) ReadMsgWithTimeout(timeout time.Duration) (*proto.Message, bool, error) {
+	if timeout <= 0 {
+		return nil, true, nil
+	}
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+
+	select {
+	case result, ok := <-p.results:
+		if !ok {
+			return nil, false, io.EOF
+		}
+		return result.msg, false, result.err
+	case <-timer.C:
+		return nil, true, nil
+	}
+}
+
+func (s *attachMessageSource) ReadMsg() (*proto.Message, error) {
+	if s.pump != nil {
+		return s.pump.ReadMsg()
+	}
+	return s.reader.ReadMsg()
+}
+
+func (s *attachMessageSource) ReadMsgWithTimeout(timeout time.Duration) (*proto.Message, bool, error) {
+	if s.pump != nil {
+		return s.pump.ReadMsgWithTimeout(timeout)
+	}
+	if err := s.conn.SetReadDeadline(time.Now().Add(timeout)); err != nil {
+		s.pump = newAttachMessagePump(s.reader)
+		return s.pump.ReadMsgWithTimeout(timeout)
+	}
+	defer s.conn.SetReadDeadline(time.Time{}) //nolint:errcheck // best-effort reset
+
+	msg, err := s.reader.ReadMsg()
+	if err != nil {
+		if ne, ok := err.(net.Error); ok && ne.Timeout() {
+			return nil, true, nil
+		}
+		return nil, false, err
+	}
+	return msg, false, nil
+}
+
+func readMsgWithTimeout(reader attachTimedReader, timeout time.Duration) (*proto.Message, bool, error) {
+	return reader.ReadMsgWithTimeout(timeout)
+}
+
+func readMsgBeforeDeadline(reader attachTimedReader, deadline time.Time) (*proto.Message, bool, error) {
+	return readMsgWithTimeout(reader, time.Until(deadline))
+}
 
 type attachBootstrapMessage struct {
 	msg *proto.Message
@@ -41,7 +147,18 @@ func attachBootstrapPaneCount(layout *proto.LayoutSnapshot) int {
 	return count
 }
 
+func releaseAttachBootstrapMessage(msg *proto.Message) {
+	if msg == nil {
+		return
+	}
+	msg.History = nil
+	msg.StyledHistory = nil
+	msg.PaneData = nil
+	msg.Layout = nil
+}
+
 func applyAttachBootstrapReplayMessage(cr *ClientRenderer, msg attachBootstrapMessage) int {
+	defer releaseAttachBootstrapMessage(msg.msg)
 	switch msg.msg.Type {
 	case proto.MsgTypePaneHistory:
 		cr.AppendPaneHistoryMessage(msg.msg.PaneID, msg.msg.History, msg.msg.StyledHistory)
@@ -55,16 +172,17 @@ func applyAttachBootstrapReplayMessage(cr *ClientRenderer, msg attachBootstrapMe
 }
 
 func readImmediateAttachCorrection(conn net.Conn, reader *proto.Reader, cr *ClientRenderer, timeout time.Duration) error {
-	if err := conn.SetReadDeadline(time.Now().Add(timeout)); err != nil {
-		return err
-	}
-	defer conn.SetReadDeadline(time.Time{}) //nolint:errcheck // best-effort reset
+	return readImmediateAttachCorrectionFromSource(newAttachMessageSource(conn, reader), cr, timeout)
+}
+
+func readImmediateAttachCorrectionFromSource(reader attachTimedReader, cr *ClientRenderer, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
 	for {
-		msg, err := reader.ReadMsg()
+		msg, timedOut, err := readMsgBeforeDeadline(reader, deadline)
+		if timedOut {
+			return nil
+		}
 		if err != nil {
-			if ne, ok := err.(net.Error); ok && ne.Timeout() {
-				return nil
-			}
 			return err
 		}
 		if msg.Type == proto.MsgTypeLayout {
@@ -83,6 +201,7 @@ func readImmediateAttachCorrection(conn net.Conn, reader *proto.Reader, cr *Clie
 }
 
 func applyAttachBootstrapMessage(cr *ClientRenderer, msg attachBootstrapMessage) int {
+	defer releaseAttachBootstrapMessage(msg.msg)
 	switch msg.msg.Type {
 	case proto.MsgTypePaneHistory:
 		cr.HandlePaneHistoryMessage(msg.msg.PaneID, msg.msg.History, msg.msg.StyledHistory)
@@ -96,19 +215,20 @@ func applyAttachBootstrapMessage(cr *ClientRenderer, msg attachBootstrapMessage)
 }
 
 func readAttachBootstrapPaneReplays(conn net.Conn, reader *proto.Reader, cr *ClientRenderer, remainingOutputs int, timeout time.Duration) (int, error) {
+	return readAttachBootstrapPaneReplaysFromSource(newAttachMessageSource(conn, reader), cr, remainingOutputs, timeout)
+}
+
+func readAttachBootstrapPaneReplaysFromSource(reader attachTimedReader, cr *ClientRenderer, remainingOutputs int, timeout time.Duration) (int, error) {
 	if remainingOutputs <= 0 {
 		return 0, nil
 	}
-	if err := conn.SetReadDeadline(time.Now().Add(timeout)); err != nil {
-		return remainingOutputs, err
-	}
-	defer conn.SetReadDeadline(time.Time{}) //nolint:errcheck // best-effort reset
+	deadline := time.Now().Add(timeout)
 	for remainingOutputs > 0 {
-		msg, err := reader.ReadMsg()
+		msg, timedOut, err := readMsgBeforeDeadline(reader, deadline)
+		if timedOut {
+			return remainingOutputs, nil
+		}
 		if err != nil {
-			if ne, ok := err.(net.Error); ok && ne.Timeout() {
-				return remainingOutputs, nil
-			}
 			return remainingOutputs, err
 		}
 		if msg.Type == proto.MsgTypeLayout {
@@ -127,6 +247,10 @@ func readAttachBootstrapPaneReplays(conn net.Conn, reader *proto.Reader, cr *Cli
 }
 
 func readAttachBootstrap(conn net.Conn, reader *proto.Reader, cr *ClientRenderer) error {
+	return readAttachBootstrapFromSource(newAttachMessageSource(conn, reader), cr)
+}
+
+func readAttachBootstrapFromSource(reader attachTimedReader, cr *ClientRenderer) error {
 	var layout *proto.LayoutSnapshot
 	var buffered []attachBootstrapMessage
 
@@ -154,7 +278,7 @@ func readAttachBootstrap(conn net.Conn, reader *proto.Reader, cr *ClientRenderer
 		remainingOutputs -= applyAttachBootstrapReplayMessage(cr, msg)
 	}
 
-	remainingOutputs, err := readAttachBootstrapPaneReplays(conn, reader, cr, remainingOutputs, config.BootstrapPaneReplayWait)
+	remainingOutputs, err := readAttachBootstrapPaneReplaysFromSource(reader, cr, remainingOutputs, config.BootstrapPaneReplayWait)
 	if err != nil {
 		return err
 	}
@@ -165,5 +289,5 @@ func readAttachBootstrap(conn net.Conn, reader *proto.Reader, cr *ClientRenderer
 		return nil
 	}
 
-	return readImmediateAttachCorrection(conn, reader, cr, config.BootstrapCorrectionWindow)
+	return readImmediateAttachCorrectionFromSource(reader, cr, config.BootstrapCorrectionWindow)
 }

--- a/internal/client/attach_bootstrap_memory_test.go
+++ b/internal/client/attach_bootstrap_memory_test.go
@@ -18,8 +18,7 @@ import (
 const attachBootstrapPeakHeapSubprocessEnv = "AMUX_TEST_ATTACH_BOOTSTRAP_PEAK_HEAP"
 
 func TestReadAttachBootstrapKeepsPeakHeapUnderBound(t *testing.T) {
-	// This samples process-wide heap usage, so concurrent package tests would
-	// pollute the measurement and produce false regressions.
+	t.Parallel()
 
 	if os.Getenv(attachBootstrapPeakHeapSubprocessEnv) == "1" {
 		runReadAttachBootstrapPeakHeapTest(t)

--- a/internal/client/attach_bootstrap_memory_test.go
+++ b/internal/client/attach_bootstrap_memory_test.go
@@ -18,7 +18,8 @@ import (
 const attachBootstrapPeakHeapSubprocessEnv = "AMUX_TEST_ATTACH_BOOTSTRAP_PEAK_HEAP"
 
 func TestReadAttachBootstrapKeepsPeakHeapUnderBound(t *testing.T) {
-	t.Parallel()
+	// This samples process-wide heap usage, so concurrent package tests would
+	// pollute the measurement and produce false regressions.
 
 	if os.Getenv(attachBootstrapPeakHeapSubprocessEnv) == "1" {
 		runReadAttachBootstrapPeakHeapTest(t)

--- a/internal/client/attach_session_test.go
+++ b/internal/client/attach_session_test.go
@@ -18,6 +18,7 @@ import (
 	uv "github.com/charmbracelet/ultraviolet"
 	"github.com/charmbracelet/x/ansi"
 	"github.com/creack/pty"
+	"github.com/weill-labs/amux/internal/config"
 	"github.com/weill-labs/amux/internal/proto"
 	"github.com/weill-labs/amux/internal/render"
 )
@@ -856,23 +857,31 @@ func TestReadAttachBootstrapPaneReplaysBranches(t *testing.T) {
 		}
 	})
 
-	t.Run("propagates deadline setup errors", func(t *testing.T) {
+	t.Run("returns remaining outputs when replay timeout fires", func(t *testing.T) {
 		t.Parallel()
 
-		wantErr := errors.New("deadline boom")
-		conn := &stubAttachConn{setReadDeadlineErr: wantErr}
+		serverConn, clientConn := net.Pipe()
+		t.Cleanup(func() {
+			_ = serverConn.Close()
+			_ = clientConn.Close()
+		})
+
+		start := time.Now()
 		remaining, err := readAttachBootstrapPaneReplays(
-			conn,
-			proto.NewReader(conn),
+			clientConn,
+			proto.NewReader(clientConn),
 			NewClientRenderer(20, 4),
 			1,
-			time.Second,
+			20*time.Millisecond,
 		)
-		if !errors.Is(err, wantErr) {
-			t.Fatalf("readAttachBootstrapPaneReplays() error = %v, want %v", err, wantErr)
+		if err != nil {
+			t.Fatalf("readAttachBootstrapPaneReplays() error = %v, want nil", err)
 		}
 		if remaining != 1 {
 			t.Fatalf("remaining outputs = %d, want 1", remaining)
+		}
+		if elapsed := time.Since(start); elapsed < 10*time.Millisecond {
+			t.Fatalf("replay timeout elapsed = %v, want at least 10ms", elapsed)
 		}
 	})
 
@@ -928,7 +937,7 @@ func TestReadAttachBootstrapPaneReplaysBranches(t *testing.T) {
 	})
 }
 
-func TestReadAttachBootstrapPropagatesPaneReplaySetupError(t *testing.T) {
+func TestReadAttachBootstrapIgnoresUnsupportedReadDeadline(t *testing.T) {
 	t.Parallel()
 
 	serverConn, clientConn := net.Pipe()
@@ -937,16 +946,49 @@ func TestReadAttachBootstrapPropagatesPaneReplaySetupError(t *testing.T) {
 		_ = clientConn.Close()
 	})
 
-	wantErr := errors.New("deadline boom")
-	wrappedConn := &deadlineErrorConn{Conn: clientConn, setReadDeadlineErr: wantErr}
+	wrappedConn := &deadlineErrorConn{Conn: clientConn, setReadDeadlineErr: errors.New("deadline boom")}
 	go func() {
-		_ = writeProtoMessages(serverConn, &proto.Message{Type: proto.MsgTypeLayout, Layout: singlePane20x3()})
+		_ = writeProtoMessages(
+			serverConn,
+			&proto.Message{Type: proto.MsgTypeLayout, Layout: singlePane20x3()},
+			&proto.Message{Type: proto.MsgTypePaneOutput, PaneID: 1, PaneData: []byte("hello")},
+			&proto.Message{Type: proto.MsgTypeBell},
+		)
 		_ = serverConn.Close()
 	}()
 
-	err := readAttachBootstrap(wrappedConn, proto.NewReader(wrappedConn), NewClientRenderer(20, 4))
-	if !errors.Is(err, wantErr) {
-		t.Fatalf("readAttachBootstrap() error = %v, want %v", err, wantErr)
+	cr := NewClientRenderer(20, 4)
+	if err := readAttachBootstrap(wrappedConn, proto.NewReader(wrappedConn), cr); err != nil {
+		t.Fatalf("readAttachBootstrap() error = %v, want nil", err)
+	}
+	if got := strings.Split(cr.renderer.CapturePaneText(1, false), "\n")[0]; got != "hello" {
+		t.Fatalf("pane text after bootstrap = %q, want %q", got, "hello")
+	}
+}
+
+func TestReadAttachBootstrapReturnsAfterPaneReplayTimeout(t *testing.T) {
+	t.Parallel()
+
+	serverConn, clientConn := net.Pipe()
+	t.Cleanup(func() {
+		_ = serverConn.Close()
+		_ = clientConn.Close()
+	})
+
+	go func() {
+		_ = writeProtoMessages(serverConn, &proto.Message{Type: proto.MsgTypeLayout, Layout: singlePane20x3()})
+	}()
+
+	start := time.Now()
+	if err := readAttachBootstrap(clientConn, proto.NewReader(clientConn), NewClientRenderer(20, 4)); err != nil {
+		t.Fatalf("readAttachBootstrap() error = %v, want nil", err)
+	}
+	elapsed := time.Since(start)
+	if elapsed < config.BootstrapPaneReplayWait/2 {
+		t.Fatalf("bootstrap timeout elapsed = %v, want at least %v", elapsed, config.BootstrapPaneReplayWait/2)
+	}
+	if elapsed > time.Second {
+		t.Fatalf("bootstrap timeout elapsed = %v, want under 1s", elapsed)
 	}
 }
 


### PR DESCRIPTION
## Motivation
`amux ssh` can finish the initial attach handshake and then fail during bootstrap because SSH channels reject `SetReadDeadline` with `ssh: tcpChan: deadline not supported`. That broke remote attach right before the client rendered the session.

## Summary
- keep the existing conn deadline path for transports that support it, but fall back to a single-reader pump when deadline setup fails
- route bootstrap and the post-bootstrap receive loop through the same reader source so SSH fallback does not create concurrent reads on the protocol stream
- add bootstrap regressions for unsupported read deadlines and stalled pane replay, and keep the heap-bound bootstrap test isolated from parallel package noise

## Testing
- `go test ./internal/client -run 'TestReadAttachBootstrap(IgnoresUnsupportedReadDeadline|ReturnsAfterPaneReplayTimeout)|TestReadAttachBootstrapPaneReplaysBranches' -count=100`
- `go test ./internal/client -run TestReadAttachBootstrapKeepsPeakHeapUnderBound -count=100`
- `go test ./internal/client -count=1`
- `go test ./... -timeout 120s`  
  Local full-suite run still fails in `internal/mux` at `TestAgentStatusTracksBusyAndIdle`; the same command also fails from an `origin/main` archive, so that failure appears unrelated to this diff.

## Review focus
- the fallback boundary in `attachMessageSource`: direct conn deadlines should remain the fast path, but once a transport rejects deadlines we must keep all later reads on the pump-backed path
- the bootstrap timeout semantics: pane replay and correction still use a single overall timeout window instead of resetting the timer after each message
- the explicit replay-payload release step, which keeps the bootstrap memory test under its heap bound

Closes LAB-1312
