### PR TITLE
Preserve error chains when adding context

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,11 +2,18 @@ linters:
   disable-all: true
   enable:
     - errcheck
+    - errorlint
     - govet
     - staticcheck
     - unused
     - gosimple
     - ineffassign
+
+linters-settings:
+  errorlint:
+    errorf: true
+    asserts: true
+    comparison: true
 
 issues:
   max-issues-per-linter: 0

--- a/internal/cli/main_cli_subprocess_test.go
+++ b/internal/cli/main_cli_subprocess_test.go
@@ -39,11 +39,7 @@ func runHermeticMain(t *testing.T, args ...string) (output string, exitCode int)
 	if err == nil {
 		return string(out), 0
 	}
-
-	exitErr, ok := err.(*exec.ExitError)
-	if !ok {
-		t.Fatalf("helper error = %v\n%s", err, out)
-	}
+	exitErr := requireExitError(t, err, out)
 	return string(out), exitErr.ExitCode()
 }
 
@@ -61,12 +57,18 @@ func runHermeticMainWithTimeout(t *testing.T, timeout time.Duration, args ...str
 	if errors.Is(err, context.DeadlineExceeded) {
 		return string(out), -1, true
 	}
+	exitErr := requireExitError(t, err, out)
+	return string(out), exitErr.ExitCode(), false
+}
 
-	exitErr, ok := err.(*exec.ExitError)
-	if !ok {
+func requireExitError(t *testing.T, err error, out []byte) *exec.ExitError {
+	t.Helper()
+
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
 		t.Fatalf("helper error = %v\n%s", err, out)
 	}
-	return string(out), exitErr.ExitCode(), false
+	return exitErr
 }
 
 func newHermeticMainCmd(t *testing.T, args ...string) *exec.Cmd {

--- a/internal/cli/main_reload_test.go
+++ b/internal/cli/main_reload_test.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"net"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -60,10 +59,7 @@ func TestMainCheckpointReloadStartsServerWithoutSubcommand(t *testing.T) {
 	cmd.Env = append(cmd.Env, "AMUX_CHECKPOINT=/definitely/missing")
 
 	out, err := cmd.CombinedOutput()
-	exitErr, ok := err.(*exec.ExitError)
-	if !ok {
-		t.Fatalf("helper error = %v\n%s", err, out)
-	}
+	exitErr := requireExitError(t, err, out)
 	if exitErr.ExitCode() != 1 {
 		t.Fatalf("exit code = %d, want 1\n%s", exitErr.ExitCode(), out)
 	}

--- a/internal/cli/server_bootstrap.go
+++ b/internal/cli/server_bootstrap.go
@@ -93,7 +93,7 @@ func restoreServerFromReloadCheckpointLogger(sessionName, cpPath string, scrollb
 	crashPath := crashPaths[0]
 	crashCP, crashErr := checkpoint.ReadCrash(crashPath)
 	if crashErr != nil {
-		return nil, fmt.Errorf("%w; crash fallback %s: %v", err, crashPath, crashErr)
+		return nil, fmt.Errorf("%w; crash fallback %s: %w", err, crashPath, crashErr)
 	}
 	if cp.ListenerFd <= 0 {
 		return nil, fmt.Errorf("%w; invalid listener fd %d in reload checkpoint", err, cp.ListenerFd)
@@ -348,7 +348,7 @@ func waitForTakeoverAck(stdin *os.File, fallbackSession string, timeout time.Dur
 		timeoutMS := int((remaining + time.Millisecond - 1) / time.Millisecond)
 		n, err := unix.Poll([]unix.PollFd{{Fd: fd, Events: unix.POLLIN}}, timeoutMS)
 		if err != nil {
-			if err == syscall.EINTR {
+			if errors.Is(err, syscall.EINTR) {
 				continue
 			}
 			return "", false

--- a/internal/client/attach.go
+++ b/internal/client/attach.go
@@ -110,11 +110,11 @@ func formatAttachError(err error) error {
 	}
 	switch {
 	case errors.Is(err, errAttachProtocol):
-		return fmt.Errorf("attach failed: protocol error: %v", err)
+		return fmt.Errorf("attach failed: protocol error: %w", err)
 	case isSocketNotFoundError(err):
 		return fmt.Errorf("attach failed: socket not found")
 	case isConnectionLostError(err):
-		return fmt.Errorf("attach failed: connection lost: %v", err)
+		return fmt.Errorf("attach failed: connection lost: %w", err)
 	default:
 		return fmt.Errorf("attach failed: %w", err)
 	}

--- a/internal/client/attach.go
+++ b/internal/client/attach.go
@@ -104,6 +104,14 @@ func isSocketNotFoundError(err error) bool {
 	return errors.Is(err, os.ErrNotExist) || strings.Contains(err.Error(), "no such file or directory")
 }
 
+func isTimeoutNetError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var netErr net.Error
+	return errors.As(err, &netErr) && netErr.Timeout()
+}
+
 func formatAttachError(err error) error {
 	if err == nil {
 		return nil

--- a/internal/client/attach_bootstrap.go
+++ b/internal/client/attach_bootstrap.go
@@ -111,7 +111,7 @@ func (s *attachMessageSource) ReadMsgWithTimeout(timeout time.Duration) (*proto.
 
 	msg, err := s.reader.ReadMsg()
 	if err != nil {
-		if ne, ok := err.(net.Error); ok && ne.Timeout() {
+		if isTimeoutNetError(err) {
 			return nil, true, nil
 		}
 		return nil, false, err

--- a/internal/client/attach_test.go
+++ b/internal/client/attach_test.go
@@ -37,8 +37,7 @@ func assertNoMessage(t *testing.T, conn net.Conn) {
 	if err == nil {
 		t.Fatalf("unexpected message: %+v", msg)
 	}
-	var netErr net.Error
-	if !errors.As(err, &netErr) || !netErr.Timeout() {
+	if !isTimeoutNetError(err) {
 		t.Fatalf("read error = %v, want timeout", err)
 	}
 }

--- a/internal/client/attach_test.go
+++ b/internal/client/attach_test.go
@@ -284,6 +284,17 @@ func TestFormatAttachError(t *testing.T) {
 	}
 }
 
+func TestFormatAttachErrorPreservesWrappedEOF(t *testing.T) {
+	t.Parallel()
+
+	err := fmt.Errorf("SSH dial: ssh: handshake failed: %w", io.EOF)
+
+	got := formatAttachError(err)
+	if !errors.Is(got, io.EOF) {
+		t.Fatalf("errors.Is(%v, io.EOF) = false, want true", got)
+	}
+}
+
 func TestIsConnectionLostError(t *testing.T) {
 	t.Parallel()
 

--- a/internal/client/attach_test.go
+++ b/internal/client/attach_test.go
@@ -37,7 +37,8 @@ func assertNoMessage(t *testing.T, conn net.Conn) {
 	if err == nil {
 		t.Fatalf("unexpected message: %+v", msg)
 	}
-	if ne, ok := err.(net.Error); !ok || !ne.Timeout() {
+	var netErr net.Error
+	if !errors.As(err, &netErr) || !netErr.Timeout() {
 		t.Fatalf("read error = %v, want timeout", err)
 	}
 }

--- a/internal/client/input_dispatch_test.go
+++ b/internal/client/input_dispatch_test.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"net"
 	"slices"
@@ -538,8 +537,7 @@ func TestHandleSplitBindingShowsErrorWhenLayoutNotReady(t *testing.T) {
 	if _, err := inputDispatchReader(serverConn).ReadMsg(); err == nil {
 		t.Fatal("split binding without layout should not send a command")
 	} else {
-		var netErr net.Error
-		if !errors.As(err, &netErr) || !netErr.Timeout() {
+		if !isTimeoutNetError(err) {
 			t.Fatalf("read command message error = %v, want timeout", err)
 		}
 	}

--- a/internal/client/input_dispatch_test.go
+++ b/internal/client/input_dispatch_test.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"net"
 	"slices"
@@ -536,8 +537,11 @@ func TestHandleSplitBindingShowsErrorWhenLayoutNotReady(t *testing.T) {
 	}
 	if _, err := inputDispatchReader(serverConn).ReadMsg(); err == nil {
 		t.Fatal("split binding without layout should not send a command")
-	} else if ne, ok := err.(net.Error); !ok || !ne.Timeout() {
-		t.Fatalf("read command message error = %v, want timeout", err)
+	} else {
+		var netErr net.Error
+		if !errors.As(err, &netErr) || !netErr.Timeout() {
+			t.Fatalf("read command message error = %v, want timeout", err)
+		}
 	}
 }
 

--- a/internal/client/renderer_close_test.go
+++ b/internal/client/renderer_close_test.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"errors"
 	"io"
 	"testing"
 
@@ -24,10 +25,10 @@ func TestRendererCloseClosesPaneEmulators(t *testing.T) {
 	r.Close()
 	r.Close()
 
-	if _, err := emu.Write([]byte("x")); err != io.ErrClosedPipe {
+	if _, err := emu.Write([]byte("x")); !errors.Is(err, io.ErrClosedPipe) {
 		t.Fatalf("emu.Write after Close() = %v, want %v", err, io.ErrClosedPipe)
 	}
-	if _, err := emu.Read(make([]byte, 1)); err != io.EOF {
+	if _, err := emu.Read(make([]byte, 1)); !errors.Is(err, io.EOF) {
 		t.Fatalf("emu.Read after Close() = %v, want %v", err, io.EOF)
 	}
 }
@@ -51,7 +52,7 @@ func TestHandleLayoutClosesRemovedPaneEmulators(t *testing.T) {
 	r.HandleLayout(singlePane20x3())
 
 	// The removed emulator's pipe should be closed.
-	if _, err := emu2.Read(make([]byte, 1)); err != io.EOF {
+	if _, err := emu2.Read(make([]byte, 1)); !errors.Is(err, io.EOF) {
 		t.Fatalf("removed emulator Read() = %v, want io.EOF", err)
 	}
 

--- a/internal/mux/pane_exit_reason_test.go
+++ b/internal/mux/pane_exit_reason_test.go
@@ -1,6 +1,7 @@
 package mux
 
 import (
+	"errors"
 	"fmt"
 	"os/exec"
 	"testing"
@@ -38,8 +39,8 @@ func exitError(t *testing.T, code int) *exec.ExitError {
 	if err == nil {
 		t.Fatalf("expected exit %d, got nil error", code)
 	}
-	exitErr, ok := err.(*exec.ExitError)
-	if !ok {
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
 		t.Fatalf("expected *exec.ExitError, got %T", err)
 	}
 	return exitErr

--- a/internal/remote/ssh_test_helper_test.go
+++ b/internal/remote/ssh_test_helper_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rand"
 	"encoding/binary"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -192,7 +193,8 @@ func testHandleSession(ch ssh.Channel, reqs <-chan *ssh.Request, execEnv []strin
 
 		exitCode := 0
 		if err := cmd.Run(); err != nil {
-			if exitErr, ok := err.(*exec.ExitError); ok {
+			var exitErr *exec.ExitError
+			if errors.As(err, &exitErr) {
 				exitCode = exitErr.ExitCode()
 			} else {
 				exitCode = 1

--- a/internal/server/broadcast_command_test.go
+++ b/internal/server/broadcast_command_test.go
@@ -156,6 +156,11 @@ func TestResolveBroadcastTargets(t *testing.T) {
 			args:      broadcastCommandArgs{matchPattern: "missing-*"},
 			wantError: `broadcast: no panes match "missing-*"`,
 		},
+		{
+			name:      "invalid match pattern",
+			args:      broadcastCommandArgs{matchPattern: "["},
+			wantError: `broadcast: invalid match pattern "[": syntax error in pattern`,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/server/client_conn_test.go
+++ b/internal/server/client_conn_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"errors"
 	"net"
 	"testing"
 	"time"
@@ -812,7 +813,8 @@ func assertNoClientMessage(t *testing.T, conn net.Conn) {
 		t.Fatalf("SetReadDeadline: %v", err)
 	}
 	msg, err := readMsgOnConn(conn)
-	if ne, ok := err.(net.Error); ok && ne.Timeout() {
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
 		if err := conn.SetReadDeadline(time.Time{}); err != nil {
 			t.Fatalf("reset read deadline: %v", err)
 		}

--- a/internal/server/commands/remote/reload_test.go
+++ b/internal/server/commands/remote/reload_test.go
@@ -1,6 +1,7 @@
 package remote
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -41,6 +42,32 @@ func TestRequestedReloadExecPathRejectsMissingBinary(t *testing.T) {
 	missingPath := filepath.Join(t.TempDir(), "missing-amux")
 	if _, err := RequestedReloadExecPath([]string{ReloadServerExecPathFlag, missingPath}); err == nil {
 		t.Fatalf("RequestedReloadExecPath(%q) should fail", missingPath)
+	}
+}
+
+func TestReloadServerWrapsRequestedExecPathError(t *testing.T) {
+	t.Parallel()
+
+	missingPath := filepath.Join(t.TempDir(), "missing-amux")
+	res := ReloadServer(reloadTestContext{}, []string{ReloadServerExecPathFlag, missingPath})
+	if res.Err == nil {
+		t.Fatal("ReloadServer() error = nil, want missing binary error")
+	}
+	if !errors.Is(res.Err, os.ErrNotExist) {
+		t.Fatalf("errors.Is(%v, os.ErrNotExist) = false, want true", res.Err)
+	}
+}
+
+func TestReloadServerWrapsResolverError(t *testing.T) {
+	t.Parallel()
+
+	wantErr := errors.New("boom")
+	res := ReloadServer(reloadTestContext{resolveErr: wantErr}, nil)
+	if res.Err == nil {
+		t.Fatal("ReloadServer() error = nil, want resolver error")
+	}
+	if !errors.Is(res.Err, wantErr) {
+		t.Fatalf("errors.Is(%v, wantErr) = false, want true", res.Err)
 	}
 }
 
@@ -92,8 +119,9 @@ func TestReloadServerReturnsFlushError(t *testing.T) {
 }
 
 type reloadTestContext struct {
-	execPath string
-	onReload func(string) error
+	execPath   string
+	resolveErr error
+	onReload   func(string) error
 }
 
 func (ctx reloadTestContext) HostStatuses() map[string]string { return nil }
@@ -102,7 +130,12 @@ func (ctx reloadTestContext) DisconnectHost(string) error { return nil }
 
 func (ctx reloadTestContext) ReconnectHost(string) error { return nil }
 
-func (ctx reloadTestContext) ResolveReloadExecPath() (string, error) { return ctx.execPath, nil }
+func (ctx reloadTestContext) ResolveReloadExecPath() (string, error) {
+	if ctx.resolveErr != nil {
+		return "", ctx.resolveErr
+	}
+	return ctx.execPath, nil
+}
 
 func (ctx reloadTestContext) ReloadServer(execPath string) error { return ctx.onReload(execPath) }
 

--- a/internal/server/commands/remote/remote.go
+++ b/internal/server/commands/remote/remote.go
@@ -64,12 +64,12 @@ func Reconnect(ctx Context, args []string) commandpkg.Result {
 func ReloadServer(ctx Context, args []string) commandpkg.Result {
 	execPath, err := RequestedReloadExecPath(args)
 	if err != nil {
-		return commandpkg.Result{Err: fmt.Errorf("reload: %v", err)}
+		return commandpkg.Result{Err: fmt.Errorf("reload: %w", err)}
 	}
 	if execPath == "" {
 		execPath, err = ctx.ResolveReloadExecPath()
 		if err != nil {
-			return commandpkg.Result{Err: fmt.Errorf("reload: %v", err)}
+			return commandpkg.Result{Err: fmt.Errorf("reload: %w", err)}
 		}
 	}
 	return commandpkg.Result{

--- a/internal/server/commands_input.go
+++ b/internal/server/commands_input.go
@@ -401,7 +401,7 @@ func resolveBroadcastMatchTargets(sess *Session, pattern string) ([]resolvedPane
 	for _, pane := range sess.Panes {
 		matched, err := filepath.Match(pattern, pane.Meta.Name)
 		if err != nil {
-			return nil, fmt.Errorf("broadcast: invalid match pattern %q: %v", pattern, err)
+			return nil, fmt.Errorf("broadcast: invalid match pattern %q: %w", pattern, err)
 		}
 		if !matched {
 			continue

--- a/internal/sshutil/sshutil_test.go
+++ b/internal/sshutil/sshutil_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rand"
 	"encoding/binary"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -379,7 +380,8 @@ func handleSession(ch ssh.Channel, reqs <-chan *ssh.Request, execEnv []string) {
 
 		exitCode := 0
 		if err := cmd.Run(); err != nil {
-			if exitErr, ok := err.(*exec.ExitError); ok {
+			var exitErr *exec.ExitError
+			if errors.As(err, &exitErr) {
 				exitCode = exitErr.ExitCode()
 			} else {
 				exitCode = 1

--- a/test/batch_delegate_test.go
+++ b/test/batch_delegate_test.go
@@ -213,11 +213,7 @@ func runBatchDelegateScript(t *testing.T, tempDir string, extraEnv []string, man
 	if err == nil {
 		return string(out), 0
 	}
-
-	exitErr, ok := err.(*exec.ExitError)
-	if !ok {
-		t.Fatalf("run batch-delegate: %v\n%s", err, out)
-	}
+	exitErr := mustExitError(t, err, out)
 	return string(out), exitErr.ExitCode()
 }
 

--- a/test/claude_review_check_test.go
+++ b/test/claude_review_check_test.go
@@ -173,10 +173,6 @@ func runClaudeReviewCheck(t *testing.T, tempDir string, extraEnv []string, args 
 	if err == nil {
 		return string(out), 0
 	}
-
-	exitErr, ok := err.(*exec.ExitError)
-	if !ok {
-		t.Fatalf("unexpected error: %v\n%s", err, out)
-	}
+	exitErr := mustExitError(t, err, out)
 	return string(out), exitErr.ExitCode()
 }

--- a/test/delegate_task_script_test.go
+++ b/test/delegate_task_script_test.go
@@ -184,10 +184,7 @@ func runDelegateTaskScript(t *testing.T, tempDir string, extraEnv []string, args
 	if err == nil {
 		return string(out), 0
 	}
-	exitErr, ok := err.(*exec.ExitError)
-	if !ok {
-		t.Fatalf("run delegate-task script: %v\n%s", err, out)
-	}
+	exitErr := mustExitError(t, err, out)
 	return string(out), exitErr.ExitCode()
 }
 

--- a/test/events_test.go
+++ b/test/events_test.go
@@ -652,12 +652,12 @@ func TestEventsCLIReconnectExitsAfterRetryCap(t *testing.T) {
 	}
 
 	err := proc.wait(5 * time.Second)
-	exitErr, ok := err.(*exec.ExitError)
+	exitCode, ok := exitErrorCode(err)
 	if !ok {
 		t.Fatalf("events CLI exit = %v, want nonzero exit", err)
 	}
-	if exitErr.ExitCode() != 1 {
-		t.Fatalf("events CLI exit code = %d, want 1", exitErr.ExitCode())
+	if exitCode != 1 {
+		t.Fatalf("events CLI exit code = %d, want 1", exitCode)
 	}
 	if !strings.Contains(proc.stderrString(), "reconnect failed") {
 		t.Fatalf("stderr = %q, want reconnect failure", proc.stderrString())
@@ -759,9 +759,9 @@ func TestEventsCLIConnectError(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected initial connect error")
 	}
-	if exit, ok := err.(*exec.ExitError); ok {
-		if exit.ExitCode() != 1 {
-			t.Errorf("exit code: got %d, want 1", exit.ExitCode())
+	if exitCode, ok := exitErrorCode(err); ok {
+		if exitCode != 1 {
+			t.Errorf("exit code: got %d, want 1", exitCode)
 		}
 	}
 	if got := string(out); !strings.Contains(got, "amux events: connecting to server:") || !strings.Contains(got, "no such file or directory") {

--- a/test/harness_test.go
+++ b/test/harness_test.go
@@ -48,7 +48,7 @@ func buildAmuxWithCommit(binPath, buildCommit string) error {
 	args = append(args, "-o", binPath, "..")
 	out, err := exec.Command("go", args...).CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("building amux: %v\n%s", err, out)
+		return fmt.Errorf("building amux: %w\n%s", err, out)
 	}
 	return nil
 }

--- a/test/issue_meta_check_test.go
+++ b/test/issue_meta_check_test.go
@@ -28,11 +28,7 @@ EOF
 	if err == nil {
 		t.Fatalf("expected non-zero exit when issue metadata is missing\n%s", out)
 	}
-
-	exitErr, ok := err.(*exec.ExitError)
-	if !ok {
-		t.Fatalf("unexpected error: %v\n%s", err, out)
-	}
+	exitErr := mustExitError(t, err, out)
 	if exitErr.ExitCode() != 1 {
 		t.Fatalf("exit code = %d, want 1\n%s", exitErr.ExitCode(), out)
 	}

--- a/test/lint_helpers_test.go
+++ b/test/lint_helpers_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rand"
 	"errors"
 	"io"
+	"net"
 	"os"
 	"os/exec"
 	"testing"
@@ -89,4 +90,27 @@ func ignoreCopy(dst io.Writer, src io.Reader) {
 
 func ignoreCloseWrite(ch ssh.Channel) {
 	_ = ch.CloseWrite() //nolint:errcheck // test SSH channel may already be closing
+}
+
+func mustExitError(tb testing.TB, err error, out []byte) *exec.ExitError {
+	tb.Helper()
+
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		tb.Fatalf("expected *exec.ExitError, got %v\n%s", err, out)
+	}
+	return exitErr
+}
+
+func exitErrorCode(err error) (int, bool) {
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		return 0, false
+	}
+	return exitErr.ExitCode(), true
+}
+
+func isTimeoutNetError(err error) bool {
+	var netErr net.Error
+	return errors.As(err, &netErr) && netErr.Timeout()
 }

--- a/test/post_merge_hook_test.go
+++ b/test/post_merge_hook_test.go
@@ -159,11 +159,7 @@ func runBashScriptWithInput(t *testing.T, scriptPath, input string, env []string
 	if err == nil {
 		return string(out), 0
 	}
-
-	exitErr, ok := err.(*exec.ExitError)
-	if !ok {
-		t.Fatalf("unexpected error running %s: %v\n%s", scriptPath, err, out)
-	}
+	exitErr := mustExitError(t, err, out)
 	return string(out), exitErr.ExitCode()
 }
 

--- a/test/pr_ci_watch_test.go
+++ b/test/pr_ci_watch_test.go
@@ -260,11 +260,7 @@ exit 1
 	if err == nil {
 		t.Fatalf("expected failure when CI fails\n%s", out)
 	}
-
-	exitErr, ok := err.(*exec.ExitError)
-	if !ok {
-		t.Fatalf("unexpected error: %v\n%s", err, out)
-	}
+	exitErr := mustExitError(t, err, out)
 	if exitErr.ExitCode() != 1 {
 		t.Fatalf("exit code = %d, want 1\n%s", exitErr.ExitCode(), out)
 	}

--- a/test/pr_ready_check_test.go
+++ b/test/pr_ready_check_test.go
@@ -411,10 +411,6 @@ func runPRReadyCheck(t *testing.T, tempDir string, extraEnv []string, extraArgs 
 	if err == nil {
 		return string(out), 0
 	}
-
-	exitErr, ok := err.(*exec.ExitError)
-	if !ok {
-		t.Fatalf("unexpected error: %v\n%s", err, out)
-	}
+	exitErr := mustExitError(t, err, out)
 	return string(out), exitErr.ExitCode()
 }

--- a/test/reattach_resize_test.go
+++ b/test/reattach_resize_test.go
@@ -112,7 +112,7 @@ func (h *ServerHarness) attachRendererAt(cols, rows int, afterLayout func(*clien
 	for {
 		msg, err := readMsgOnConn(conn)
 		if err != nil {
-			if ne, ok := err.(net.Error); ok && ne.Timeout() {
+			if isTimeoutNetError(err) {
 				return r
 			}
 			if errors.Is(err, io.EOF) || errors.Is(err, net.ErrClosed) || strings.Contains(err.Error(), "use of closed network connection") {

--- a/test/recover_worker_test.go
+++ b/test/recover_worker_test.go
@@ -162,11 +162,7 @@ func runRecoverWorkerScript(t *testing.T, tempDir string, extraEnv ...string) (s
 	if err == nil {
 		return string(out), 0
 	}
-
-	exitErr, ok := err.(*exec.ExitError)
-	if !ok {
-		t.Fatalf("unexpected error: %v\n%s", err, out)
-	}
+	exitErr := mustExitError(t, err, out)
 	return string(out), exitErr.ExitCode()
 }
 

--- a/test/spawn_worker_test.go
+++ b/test/spawn_worker_test.go
@@ -173,11 +173,7 @@ func runSpawnWorkerScript(t *testing.T, repoRoot, tempDir string, extraEnv []str
 	if err == nil {
 		return string(out), 0
 	}
-
-	exitErr, ok := err.(*exec.ExitError)
-	if !ok {
-		t.Fatalf("run spawn-worker script: %v\n%s", err, out)
-	}
+	exitErr := mustExitError(t, err, out)
 	return string(out), exitErr.ExitCode()
 }
 

--- a/test/test_sshd_test.go
+++ b/test/test_sshd_test.go
@@ -404,7 +404,8 @@ func runExecCommand(ctx context.Context, ch ssh.Channel, command string, execEnv
 		if errors.Is(err, exec.ErrWaitDelay) {
 			return 0
 		}
-		if exitErr, ok := err.(*exec.ExitError); ok {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
 			return exitErr.ExitCode()
 		}
 		return 1
@@ -450,7 +451,8 @@ func runShellCommand(ctx context.Context, ch ssh.Channel, command string, execEn
 
 	exitCode := 0
 	if err := cmd.Wait(); err != nil {
-		if exitErr, ok := err.(*exec.ExitError); ok {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
 			exitCode = exitErr.ExitCode()
 		} else {
 			exitCode = 1

--- a/test/worker_ci_check_test.go
+++ b/test/worker_ci_check_test.go
@@ -349,10 +349,6 @@ func runWorkerCICheck(t *testing.T, tempDir string, extraEnv []string, extraArgs
 	if err == nil {
 		return string(out), 0
 	}
-
-	exitErr, ok := err.(*exec.ExitError)
-	if !ok {
-		t.Fatalf("unexpected error: %v\n%s", err, out)
-	}
+	exitErr := mustExitError(t, err, out)
 	return string(out), exitErr.ExitCode()
 }

--- a/test/worker_status_test.go
+++ b/test/worker_status_test.go
@@ -206,11 +206,7 @@ func runWorkerStatusScript(t *testing.T, tempDir string, extraEnv ...string) (st
 	if err == nil {
 		return string(out), 0
 	}
-
-	exitErr, ok := err.(*exec.ExitError)
-	if !ok {
-		t.Fatalf("unexpected error: %v\n%s", err, out)
-	}
+	exitErr := mustExitError(t, err, out)
 	return string(out), exitErr.ExitCode()
 }
 


### PR DESCRIPTION
## Motivation
Wrapping received errors with `%v` was flattening the chain and breaking `errors.Is`/`errors.As`, which is exactly what made `formatAttachError` lose `io.EOF` during attach debugging. This change preserves the chain everywhere we add context for this issue and turns on linting so new regressions get caught.

## Summary
- switch contextual error wrapping to `%w` in attach, remote reload, broadcast matching, and reload-checkpoint fallback paths
- add a regression test that keeps `errors.Is(formatAttachError(...), io.EOF)` true through the full attach error chain
- enable `errorlint` and clean up the existing `errors.As` / `errors.Is` violations it surfaced in tests and helpers

## Testing
- `go test ./internal/client -run TestFormatAttachErrorPreservesWrappedEOF -count=100`
- `~/go/bin/golangci-lint run --disable-all --enable errorlint`
- `go test ./... -timeout 120s`
  Local full-suite run currently fails in unrelated existing tests:
  `internal/mux: TestAgentStatusTracksBusyAndIdle`
  `test: TestCaptureJSON_AgentStatus_Busy`
  `test: TestCaptureJSON_AgentStatus_SinglePane`
  The same full run also hit busy/mouse integration failures in `test` (`TestMouseDragCopiesSelectionInCopyMode`, `TestMouseClickPassThroughAppMouse`, `TestMouseScrollWheelTargetsInactivePaneWithoutFocusChange`). The touched files here are limited to error wrapping, lint config, and test assertion helpers.

## Review focus
- confirm the `%w` wrapping is preserved on every contextual error path, especially `formatAttachError` and reload fallback handling
- sanity-check the `errorlint` enablement and the helper cleanup it forced, including the small `isTimeoutNetError` extraction in the client package

Closes LAB-1321