### PR TITLE
Require LAB-XXX prefix in PR titles for scannability

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,7 +141,7 @@ Commit design specs and implementation plans to the feature branch, not main. Co
 
 PR title and description are the permanent record of why a change was made. Write them for a reviewer seeing the diff for the first time.
 
-**Title**: State what changed in imperative mood, under 70 characters. Example: "Timestamp crash checkpoint filenames to prevent overwriting". Omit ticket prefixes like `LAB-314:` — link tickets in the description body instead.
+**Title**: State what changed in imperative mood, under 70 characters. Always include the Linear issue prefix (e.g., `LAB-314:`) when a ticket exists, so the PR list shows the ticket inline. Example: "LAB-314: Timestamp crash checkpoint filenames to prevent overwriting". Also add `Closes LAB-NNN` in the description body for auto-close on merge.
 
 **Description** must include four sections:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,7 +141,7 @@ Commit design specs and implementation plans to the feature branch, not main. Co
 
 PR title and description are the permanent record of why a change was made. Write them for a reviewer seeing the diff for the first time.
 
-**Title**: State what changed in imperative mood, under 70 characters. Always include the Linear issue prefix (e.g., `LAB-314:`) when a ticket exists, so the PR list shows the ticket inline. Example: "LAB-314: Timestamp crash checkpoint filenames to prevent overwriting". Also add `Closes LAB-NNN` in the description body for auto-close on merge.
+**Title**: State what changed in imperative mood, under 70 characters. Always include the Linear issue prefix (e.g., `LAB-314:`) when a ticket exists, so the PR list shows the ticket inline. Example: "LAB-314: Timestamp crash checkpoint filenames to prevent overwriting".
 
 **Description** must include four sections:
 


### PR DESCRIPTION
## Motivation

Reverse previous guidance that said to omit ticket prefixes from PR titles. In practice, having the Linear ticket ID in the title makes the GitHub PR list scannable at a glance, lets external tooling (orca, reviewers, grep) lock onto a specific ticket, and costs nothing — the existing `Closes LAB-NNN` body convention still drives GitHub's auto-close on merge.

## Summary

One-line CLAUDE.md edit under "PR Title And Description" flipping the rule from "omit prefixes" to "always include the LAB-XXX prefix when a ticket exists."

## Testing

Documentation-only change; no behavior impact.

## Review focus

Whether this is the right direction for the convention — if anyone has a strong case for the previous rule, speak up.