### PR TITLE
Auto-stash benign changes in post-merge main sync

### DIFF
--- a/scripts/post-merge-main-sync.sh
+++ b/scripts/post-merge-main-sync.sh
@@ -12,6 +12,22 @@ is_ignored_tracked_path() {
     grep -Fqx -- "$path" <<<"$ignored_tracked_paths"
 }
 
+restore_auto_stash_after_failed_sync() {
+    [[ "$stashed_benign_changes" -eq 1 ]] || return 0
+
+    local sync_failure_output="$1"
+    local restore_output
+    if restore_output=$(git stash pop 2>&1); then
+        echo "Restored auto-stashed benign changes after sync failed." >&2
+    else
+        echo "Sync failed and restoring auto-stashed benign changes also hit conflicts; stash entry was kept for manual recovery." >&2
+        echo "$restore_output" >&2
+    fi
+
+    echo "$sync_failure_output" >&2
+    exit 1
+}
+
 status_output=$(git status --porcelain --untracked-files=all)
 if [[ -n "$status_output" ]]; then
     ignored_tracked_paths=$(git ls-files -ci --exclude-standard)
@@ -61,8 +77,7 @@ fi
 current_branch=$(git branch --show-current 2>/dev/null || true)
 if [[ "$current_branch" != "main" ]]; then
     if ! checkout_output=$(git checkout main 2>&1); then
-        echo "$checkout_output" >&2
-        exit 1
+        restore_auto_stash_after_failed_sync "$checkout_output"
     fi
     checked_out_main=1
 else
@@ -70,8 +85,7 @@ else
 fi
 
 if ! pull_output=$(git pull --ff-only 2>&1); then
-    echo "$pull_output" >&2
-    exit 1
+    restore_auto_stash_after_failed_sync "$pull_output"
 fi
 
 if [[ "$checked_out_main" -eq 1 ]]; then

--- a/scripts/post-merge-main-sync.sh
+++ b/scripts/post-merge-main-sync.sh
@@ -1,33 +1,95 @@
 #!/bin/bash
 set -euo pipefail
 
-if ! git diff --quiet --ignore-submodules --; then
-    echo "Cannot auto-sync main after merge: worktree has unstaged changes." >&2
-    exit 1
-fi
+stash_message="auto-stash by post-merge-main-sync"
+ignored_tracked_paths=""
+stashed_benign_changes=0
 
-if ! git diff --cached --quiet --ignore-submodules --; then
-    echo "Cannot auto-sync main after merge: worktree has staged changes." >&2
-    exit 1
-fi
+is_ignored_tracked_path() {
+    local path="$1"
 
-if [[ -n "$(git ls-files --others --exclude-standard)" ]]; then
-    echo "Cannot auto-sync main after merge: worktree has untracked files." >&2
-    exit 1
+    [[ -n "$ignored_tracked_paths" ]] || return 1
+    grep -Fqx -- "$path" <<<"$ignored_tracked_paths"
+}
+
+status_output=$(git status --porcelain --untracked-files=all)
+if [[ -n "$status_output" ]]; then
+    ignored_tracked_paths=$(git ls-files -ci --exclude-standard)
+    staged_changes=()
+    non_benign_changes=()
+
+    while IFS= read -r line; do
+        [[ -n "$line" ]] || continue
+
+        index_status=${line:0:1}
+        worktree_status=${line:1:1}
+        path=${line:3}
+
+        if [[ "$index_status" != " " && "$index_status" != "?" ]]; then
+            staged_changes+=("$line")
+            continue
+        fi
+
+        if [[ "$index_status$worktree_status" == "??" ]]; then
+            continue
+        fi
+
+        if is_ignored_tracked_path "$path"; then
+            continue
+        fi
+
+        non_benign_changes+=("$line")
+    done <<<"$status_output"
+
+    if [[ ${#staged_changes[@]} -gt 0 ]]; then
+        echo "Cannot auto-sync main after merge: worktree has staged changes. Leave staged changes alone and sync main manually after you commit or unstage them." >&2
+        printf '  %s\n' "${staged_changes[@]}" >&2
+        exit 1
+    fi
+
+    if [[ ${#non_benign_changes[@]} -gt 0 ]]; then
+        echo "Cannot auto-sync main after merge: worktree has non-benign unstaged changes." >&2
+        echo "Commit, stash, or discard them first:" >&2
+        printf '  %s\n' "${non_benign_changes[@]}" >&2
+        exit 1
+    fi
+
+    git stash push -u -m "$stash_message" >/dev/null
+    stashed_benign_changes=1
 fi
 
 current_branch=$(git branch --show-current 2>/dev/null || true)
 if [[ "$current_branch" != "main" ]]; then
-    git checkout main >/dev/null
+    if ! checkout_output=$(git checkout main 2>&1); then
+        echo "$checkout_output" >&2
+        exit 1
+    fi
     checked_out_main=1
 else
     checked_out_main=0
 fi
 
-git pull --ff-only >/dev/null
+if ! pull_output=$(git pull --ff-only 2>&1); then
+    echo "$pull_output" >&2
+    exit 1
+fi
 
 if [[ "$checked_out_main" -eq 1 ]]; then
-    echo "Checked out main and pulled latest origin/main."
+    sync_message="Checked out main and pulled latest origin/main."
 else
-    echo "Pulled latest origin/main on main."
+    sync_message="Pulled latest origin/main on main."
 fi
+
+if [[ "$stashed_benign_changes" -eq 0 ]]; then
+    echo "$sync_message"
+    exit 0
+fi
+
+if stash_pop_output=$(git stash pop 2>&1); then
+    echo "$sync_message Restored auto-stashed benign changes."
+    exit 0
+fi
+
+echo "$sync_message"
+echo "Restoring auto-stashed benign changes hit conflicts; stash entry was kept for manual recovery."
+echo "$stash_pop_output"

--- a/test/post_merge_hook_test.go
+++ b/test/post_merge_hook_test.go
@@ -28,8 +28,7 @@ func TestPostMergeMainSyncScriptChecksOutMainAndPulls(t *testing.T) {
 
 	gotLog := readTrimmedFile(t, gitLogPath)
 	for _, want := range []string{
-		"diff --quiet --ignore-submodules --",
-		"diff --cached --quiet --ignore-submodules --",
+		"status --porcelain --untracked-files=all",
 		"branch --show-current",
 		"checkout main",
 		"pull --ff-only",
@@ -40,7 +39,7 @@ func TestPostMergeMainSyncScriptChecksOutMainAndPulls(t *testing.T) {
 	}
 }
 
-func TestPostMergeMainSyncScriptSkipsDirtyWorktree(t *testing.T) {
+func TestPostMergeMainSyncScriptAutoStashesUntrackedFiles(t *testing.T) {
 	t.Parallel()
 
 	tempDir := t.TempDir()
@@ -49,22 +48,29 @@ func TestPostMergeMainSyncScriptSkipsDirtyWorktree(t *testing.T) {
 
 	out, exitCode := runBashScriptWithInput(t, "scripts/post-merge-main-sync.sh", "", postMergeHookEnv(tempDir,
 		"FAKE_GIT_LOG="+gitLogPath,
-		"FAKE_GIT_DIRTY=1",
+		"FAKE_GIT_STATUS=?? scratch.txt",
 	))
-	if exitCode != 1 {
-		t.Fatalf("exit code = %d, want 1\n%s", exitCode, out)
+	if exitCode != 0 {
+		t.Fatalf("exit code = %d, want 0\n%s", exitCode, out)
 	}
-	if !strings.Contains(out, "Cannot auto-sync main after merge: worktree has unstaged changes.") {
-		t.Fatalf("output = %q, want dirty-worktree warning", out)
+	if strings.TrimSpace(out) != "Checked out main and pulled latest origin/main. Restored auto-stashed benign changes." {
+		t.Fatalf("output = %q, want auto-stash confirmation", out)
 	}
 
 	gotLog := readTrimmedFile(t, gitLogPath)
-	if strings.Contains(gotLog, "checkout main") || strings.Contains(gotLog, "pull --ff-only") {
-		t.Fatalf("dirty worktree should not attempt checkout or pull:\n%s", gotLog)
+	for _, want := range []string{
+		"stash push -u -m auto-stash by post-merge-main-sync",
+		"checkout main",
+		"pull --ff-only",
+		"stash pop",
+	} {
+		if !strings.Contains(gotLog, want) {
+			t.Fatalf("git log missing %q:\n%s", want, gotLog)
+		}
 	}
 }
 
-func TestPostMergeMainSyncScriptSkipsUntrackedFiles(t *testing.T) {
+func TestPostMergeMainSyncScriptAutoStashesIgnoredTrackedModifications(t *testing.T) {
 	t.Parallel()
 
 	tempDir := t.TempDir()
@@ -73,21 +79,118 @@ func TestPostMergeMainSyncScriptSkipsUntrackedFiles(t *testing.T) {
 
 	out, exitCode := runBashScriptWithInput(t, "scripts/post-merge-main-sync.sh", "", postMergeHookEnv(tempDir,
 		"FAKE_GIT_LOG="+gitLogPath,
-		"FAKE_GIT_UNTRACKED=1",
+		"FAKE_GIT_STATUS= M docs/superpowers/specs/2026-03-14-hot-reload-design.md",
+		"FAKE_GIT_IGNORED_TRACKED=docs/superpowers/specs/2026-03-14-hot-reload-design.md",
+	))
+	if exitCode != 0 {
+		t.Fatalf("exit code = %d, want 0\n%s", exitCode, out)
+	}
+	if strings.TrimSpace(out) != "Checked out main and pulled latest origin/main. Restored auto-stashed benign changes." {
+		t.Fatalf("output = %q, want auto-stash confirmation", out)
+	}
+
+	gotLog := readTrimmedFile(t, gitLogPath)
+	for _, want := range []string{
+		"status --porcelain --untracked-files=all",
+		"ls-files -ci --exclude-standard",
+		"stash push -u -m auto-stash by post-merge-main-sync",
+		"stash pop",
+	} {
+		if !strings.Contains(gotLog, want) {
+			t.Fatalf("git log missing %q:\n%s", want, gotLog)
+		}
+	}
+}
+
+func TestPostMergeMainSyncScriptSkipsNonBenignTrackedModifications(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	gitLogPath := filepath.Join(tempDir, "git.log")
+	writeFakeGit(t, tempDir)
+
+	out, exitCode := runBashScriptWithInput(t, "scripts/post-merge-main-sync.sh", "", postMergeHookEnv(tempDir,
+		"FAKE_GIT_LOG="+gitLogPath,
+		"FAKE_GIT_STATUS= M mux/window.go",
 	))
 	if exitCode != 1 {
 		t.Fatalf("exit code = %d, want 1\n%s", exitCode, out)
 	}
-	if !strings.Contains(out, "Cannot auto-sync main after merge: worktree has untracked files.") {
-		t.Fatalf("output = %q, want untracked-files warning", out)
+	if !strings.Contains(out, "Cannot auto-sync main after merge: worktree has non-benign unstaged changes.") {
+		t.Fatalf("output = %q, want non-benign warning", out)
+	}
+	if !strings.Contains(out, "M mux/window.go") {
+		t.Fatalf("output = %q, want modified path", out)
 	}
 
 	gotLog := readTrimmedFile(t, gitLogPath)
-	if !strings.Contains(gotLog, "ls-files --others --exclude-standard") {
-		t.Fatalf("git log missing untracked-files check:\n%s", gotLog)
+	if strings.Contains(gotLog, "stash push") || strings.Contains(gotLog, "checkout main") || strings.Contains(gotLog, "pull --ff-only") {
+		t.Fatalf("non-benign changes should not attempt stash or sync:\n%s", gotLog)
 	}
-	if strings.Contains(gotLog, "checkout main") || strings.Contains(gotLog, "pull --ff-only") {
-		t.Fatalf("untracked files should not attempt checkout or pull:\n%s", gotLog)
+}
+
+func TestPostMergeMainSyncScriptSkipsStagedChanges(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	gitLogPath := filepath.Join(tempDir, "git.log")
+	writeFakeGit(t, tempDir)
+
+	out, exitCode := runBashScriptWithInput(t, "scripts/post-merge-main-sync.sh", "", postMergeHookEnv(tempDir,
+		"FAKE_GIT_LOG="+gitLogPath,
+		"FAKE_GIT_STATUS=M  scripts/post-merge-main-sync.sh",
+	))
+	if exitCode != 1 {
+		t.Fatalf("exit code = %d, want 1\n%s", exitCode, out)
+	}
+	if !strings.Contains(out, "Cannot auto-sync main after merge: worktree has staged changes.") {
+		t.Fatalf("output = %q, want staged-changes warning", out)
+	}
+	if !strings.Contains(out, "M  scripts/post-merge-main-sync.sh") {
+		t.Fatalf("output = %q, want staged path", out)
+	}
+
+	gotLog := readTrimmedFile(t, gitLogPath)
+	if strings.Contains(gotLog, "stash push") || strings.Contains(gotLog, "checkout main") || strings.Contains(gotLog, "pull --ff-only") {
+		t.Fatalf("staged changes should not attempt stash or sync:\n%s", gotLog)
+	}
+}
+
+func TestPostMergeMainSyncScriptLeavesConflictedStashForUser(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	gitLogPath := filepath.Join(tempDir, "git.log")
+	writeFakeGit(t, tempDir)
+
+	out, exitCode := runBashScriptWithInput(t, "scripts/post-merge-main-sync.sh", "", postMergeHookEnv(tempDir,
+		"FAKE_GIT_LOG="+gitLogPath,
+		"FAKE_GIT_STATUS=?? scratch.txt",
+		"FAKE_GIT_STASH_POP_FAIL=CONFLICT (content): Merge conflict in scratch.txt",
+	))
+	if exitCode != 0 {
+		t.Fatalf("exit code = %d, want 0\n%s", exitCode, out)
+	}
+	if !strings.Contains(out, "Checked out main and pulled latest origin/main.") {
+		t.Fatalf("output = %q, want sync confirmation", out)
+	}
+	if !strings.Contains(out, "Restoring auto-stashed benign changes hit conflicts; stash entry was kept for manual recovery.") {
+		t.Fatalf("output = %q, want stash-conflict warning", out)
+	}
+	if !strings.Contains(out, "CONFLICT (content): Merge conflict in scratch.txt") {
+		t.Fatalf("output = %q, want git stash pop conflict details", out)
+	}
+
+	gotLog := readTrimmedFile(t, gitLogPath)
+	for _, want := range []string{
+		"stash push -u -m auto-stash by post-merge-main-sync",
+		"checkout main",
+		"pull --ff-only",
+		"stash pop",
+	} {
+		if !strings.Contains(gotLog, want) {
+			t.Fatalf("git log missing %q:\n%s", want, gotLog)
+		}
 	}
 }
 
@@ -188,15 +291,18 @@ fi
 	    rev-parse)
 	        printf '%s\n' "${FAKE_GIT_TOPLEVEL:-$PWD}"
 	        ;;
-	    diff)
-        if [ "$1" = "--cached" ]; then
-            [ -n "$FAKE_GIT_CACHED_DIRTY" ] && exit 1
-            exit 0
-        fi
-	        [ -n "$FAKE_GIT_DIRTY" ] && exit 1
-	        exit 0
+	    status)
+	        if [ -n "$FAKE_GIT_STATUS" ]; then
+	            printf '%s\n' "$FAKE_GIT_STATUS"
+	        fi
 	        ;;
 	    ls-files)
+	        if [ "$1" = "-ci" ]; then
+	            if [ -n "$FAKE_GIT_IGNORED_TRACKED" ]; then
+	                printf '%s\n' "$FAKE_GIT_IGNORED_TRACKED"
+	            fi
+	            exit 0
+	        fi
 	        if [ -n "$FAKE_GIT_UNTRACKED" ]; then
 	            printf '%s\n' "scratch.txt"
 	        fi
@@ -204,6 +310,24 @@ fi
 	    branch)
 	        if [ "$1" = "--show-current" ]; then
 	            printf '%s\n' "${FAKE_GIT_BRANCH:-feature-branch}"
+        fi
+        ;;
+    stash)
+        if [ "$1" = "push" ]; then
+            if [ -n "$FAKE_GIT_STASH_PUSH_FAIL" ]; then
+                printf '%s\n' "$FAKE_GIT_STASH_PUSH_FAIL" >&2
+                exit 1
+            fi
+            printf '%s\n' "Saved working directory and index state WIP on ${FAKE_GIT_BRANCH:-feature-branch}: auto-stash by post-merge-main-sync"
+            exit 0
+        fi
+        if [ "$1" = "pop" ]; then
+            if [ -n "$FAKE_GIT_STASH_POP_FAIL" ]; then
+                printf '%s\n' "$FAKE_GIT_STASH_POP_FAIL" >&2
+                exit 1
+            fi
+            printf '%s\n' "Dropped refs/stash@{0}"
+            exit 0
         fi
         ;;
     checkout)


### PR DESCRIPTION
**Motivation**
After `gh pr merge`, `scripts/post-merge-main-sync.sh` would abort on any local dirt. That blocked a common case where the only local state was benign machine-local work such as untracked files or edits to paths already matched by ignore rules.

**Summary**
- Classify `git status --porcelain` entries into staged, benign, and non-benign buckets before switching branches.
- Auto-stash only benign worktree state: untracked files plus worktree-only edits to tracked paths that match ignore patterns.
- Restore the stash after syncing `main`, and leave the stash in place with a clear warning if `git stash pop` conflicts.
- Add hermetic hook coverage for clean trees, benign auto-stash cases, staged/non-benign refusals, and stash-pop conflicts.

**Testing**
- `go test ./test -run 'TestPostMerge(MainSyncScript|Hook)' -count=100`
- `go test ./... -timeout 120s`

**Review focus**
- Check the benign-change classification in `scripts/post-merge-main-sync.sh`, especially the use of `git ls-files -ci --exclude-standard` for tracked paths that intentionally match ignore patterns.
- Check the stash restore paths: successful restore after sync, conflict handling after `git stash pop`, and the refactor that restores the stash if checkout/pull fails after the auto-stash.

Closes LAB-1342
