### PR TITLE
Fix SSH host key mismatch recovery command

### DIFF
--- a/internal/remote/hostkey_test.go
+++ b/internal/remote/hostkey_test.go
@@ -102,8 +102,9 @@ func TestHostKeyMismatch(t *testing.T) {
 	if !strings.Contains(msg, "CHANGED") {
 		t.Errorf("error should mention CHANGED, got: %s", msg)
 	}
-	if !strings.Contains(msg, "ssh-keygen -R") {
-		t.Errorf("error should suggest ssh-keygen -R, got: %s", msg)
+	wantCmd := "ssh-keygen -f " + path + " -R example.com"
+	if !strings.Contains(msg, wantCmd) {
+		t.Errorf("error = %q, want %q", msg, wantCmd)
 	}
 }
 

--- a/internal/transport/ssh/ssh.go
+++ b/internal/transport/ssh/ssh.go
@@ -240,7 +240,11 @@ func hostKeyChangedError(hostname, knownHostsPath string, keyErr *knownhosts.Key
 The host key for %s has changed.
 Known key: %s in %s:%d
 To fix: remove the old key with
-  ssh-keygen -f %s -R %s`, hostname, hostname, want.Key.Type(), want.Filename, want.Line, knownHostsPath, knownhosts.Normalize(hostname))
+  %s`, hostname, hostname, want.Key.Type(), want.Filename, want.Line, hostKeyRemovalCommand(knownHostsPath, hostname))
+}
+
+func hostKeyRemovalCommand(knownHostsPath, hostname string) string {
+	return fmt.Sprintf("ssh-keygen -f %s -R %s", knownHostsPath, knownhosts.Normalize(hostname))
 }
 
 func hasPort(addr string) bool {

--- a/internal/transport/ssh/ssh.go
+++ b/internal/transport/ssh/ssh.go
@@ -102,7 +102,7 @@ func HostKeyCallback(knownHostsPath string, loggers ...*charmlog.Logger) ssh.Hos
 			var keyErr *knownhosts.KeyError
 			if errors.As(err, &keyErr) {
 				if len(keyErr.Want) > 0 {
-					return hostKeyChangedError(hostname, keyErr)
+					return hostKeyChangedError(hostname, path, keyErr)
 				}
 			} else {
 				return err
@@ -228,8 +228,11 @@ func startSocatBridge(client *ssh.Client, sockPath string) (int, error) {
 	return port, nil
 }
 
-func hostKeyChangedError(hostname string, keyErr *knownhosts.KeyError) error {
+func hostKeyChangedError(hostname, knownHostsPath string, keyErr *knownhosts.KeyError) error {
 	want := keyErr.Want[0]
+	if want.Filename != "" {
+		knownHostsPath = want.Filename
+	}
 	return fmt.Errorf(`amux: SSH host key verification failed for %s
 @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
 @    WARNING: REMOTE HOST IDENTIFICATION HAS CHANGED!    @
@@ -237,7 +240,7 @@ func hostKeyChangedError(hostname string, keyErr *knownhosts.KeyError) error {
 The host key for %s has changed.
 Known key: %s in %s:%d
 To fix: remove the old key with
-  ssh-keygen -R %s`, hostname, hostname, want.Key.Type(), want.Filename, want.Line, hostname)
+  ssh-keygen -f %s -R %s`, hostname, hostname, want.Key.Type(), want.Filename, want.Line, knownHostsPath, knownhosts.Normalize(hostname))
 }
 
 func hasPort(addr string) bool {

--- a/internal/transport/ssh/ssh_test.go
+++ b/internal/transport/ssh/ssh_test.go
@@ -149,8 +149,9 @@ func TestHostKeyCallbackRejectsChangedKey(t *testing.T) {
 	if !strings.Contains(err.Error(), "CHANGED") {
 		t.Fatalf("HostKeyCallback() error = %q, want changed-host warning", err)
 	}
-	if !strings.Contains(err.Error(), "ssh-keygen -R") {
-		t.Fatalf("HostKeyCallback() error = %q, want ssh-keygen guidance", err)
+	wantCmd := fmt.Sprintf("ssh-keygen -f %s -R example.com", path)
+	if !strings.Contains(err.Error(), wantCmd) {
+		t.Fatalf("HostKeyCallback() error = %q, want %q", err, wantCmd)
 	}
 }
 


### PR DESCRIPTION
## Motivation
When SSH host key verification failed on a changed host key, amux suggested an `ssh-keygen -R` command that could target the wrong host format and omitted the actual `known_hosts` file in use. That made the recovery instructions unreliable, especially when amux was not using the default `~/.ssh/known_hosts` path.

## Summary
- build the host key mismatch recovery hint from amux's resolved `known_hosts` path instead of a hardcoded default
- normalize the host argument in the suggested `ssh-keygen -R` command so standard-port entries use the OpenSSH lookup form
- strengthen the remote and transport mismatch tests to assert the full recovery command

## Testing
- `go test ./internal/transport/ssh -run TestHostKeyCallbackRejectsChangedKey -count=100`
- `go test ./internal/remote -run TestHostKeyMismatch -count=100`
- `go test ./internal/remote/... ./internal/transport/... -timeout 60s`

## Review focus
- confirm the recovery hint now points at the exact `known_hosts` file amux resolved for the callback
- confirm the host target passed to `ssh-keygen -R` matches OpenSSH's normalized known_hosts format

Closes LAB-1340
