### PR TITLE
Fix row-span clears in compositor diff rendering

### DIFF
--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/charmbracelet/x/ansi"
+	"github.com/charmbracelet/x/vt"
 	"github.com/weill-labs/amux/internal/mux"
 	"github.com/weill-labs/amux/internal/proto"
 	"github.com/weill-labs/amux/internal/render"
@@ -115,6 +116,35 @@ func singlePane20x3() *proto.LayoutSnapshot {
 
 func singlePane20x5() *proto.LayoutSnapshot {
 	return singlePane20xN(5)
+}
+
+func wideTwoPaneStatus80x23(task string) *proto.LayoutSnapshot {
+	root := proto.CellSnapshot{
+		X: 0, Y: 0, W: 80, H: 23,
+		Dir: int(mux.SplitVertical),
+		Children: []proto.CellSnapshot{
+			{X: 0, Y: 0, W: 56, H: 23, IsLeaf: true, Dir: -1, PaneID: 1},
+			{X: 57, Y: 0, W: 23, H: 23, IsLeaf: true, Dir: -1, PaneID: 2},
+		},
+	}
+	panes := []proto.PaneSnapshot{
+		{ID: 1, Name: "w-LAB-1300", Host: "local", Task: task, Color: "f5e0dc", ColumnIndex: 0, Idle: true},
+		{ID: 2, Name: "pane-2", Host: "local", Color: "f2cdcd", ColumnIndex: 1},
+	}
+	return &proto.LayoutSnapshot{
+		SessionName:  "test",
+		ActivePaneID: 2,
+		Width:        80,
+		Height:       23,
+		Root:         root,
+		Panes:        panes,
+		Windows: []proto.WindowSnapshot{{
+			ID: 1, Name: "window-1", Index: 1, ActivePaneID: 2,
+			Root:  root,
+			Panes: panes,
+		}},
+		ActiveWindowID: 1,
+	}
 }
 
 // buildTestRenderer creates a ClientRenderer with two panes in a vertical split.
@@ -1100,6 +1130,78 @@ func TestCaptureDisplayShowsPaneMetadata(t *testing.T) {
 	display := cr.CaptureDisplay()
 	if !strings.Contains(display, "#42, #314, LAB-339") {
 		t.Fatalf("display should contain pane metadata, got:\n%s", display)
+	}
+}
+
+func TestCaptureDisplayTruncatedStatusLineKeepsPaddingBeforeBorder(t *testing.T) {
+	t.Parallel()
+
+	cr := NewClientRenderer(80, 24)
+	cr.HandleLayout(wideTwoPaneStatus80x23("Eliminate double CloneStyledLinesX in renderer and compositor"))
+	if got := cr.RenderDiff(); got == "" {
+		t.Fatal("RenderDiff should render the initial status frame")
+	}
+
+	cr.HandleLayout(wideTwoPaneStatus80x23("Eliminate double CloneStyledLines in renderer and compositor"))
+
+	if got := cr.RenderDiff(); got == "" {
+		t.Fatal("RenderDiff should render the updated truncated status frame")
+	}
+
+	display := cr.CaptureDisplay()
+	lines := strings.Split(display, "\n")
+	if len(lines) == 0 {
+		t.Fatal("CaptureDisplay returned no rows")
+	}
+	if got, want := display, cr.Capture(true); got != want {
+		t.Fatalf("CaptureDisplay mismatch:\n--- display ---\n%s\n--- full ---\n%s", got, want)
+	}
+
+	leftWidth := 56
+	row := []rune(lines[0])
+	leftPane := string(row[:leftWidth])
+	trimmed := strings.TrimRight(leftPane, " ")
+	if !strings.HasSuffix(trimmed, "…") {
+		t.Fatalf("left pane status row %q should end with an ellipsis before padding", leftPane)
+	}
+	for _, r := range []rune(leftPane[len(trimmed):]) {
+		if r != ' ' {
+			t.Fatalf("left pane status row %q should pad with spaces after the ellipsis", leftPane)
+		}
+	}
+	if row[leftWidth] != '│' {
+		t.Fatalf("border column = %q, want vertical border", string(row[leftWidth]))
+	}
+}
+
+func TestRenderDiffStatusUpdateAppliedToTerminalMatchesCapture(t *testing.T) {
+	t.Parallel()
+
+	cr := NewClientRenderer(80, 24)
+	emu := vt.NewSafeEmulator(80, 24)
+
+	cr.HandleLayout(wideTwoPaneStatus80x23("Eliminate double CloneStyledLinesX in renderer and compositor"))
+	first := cr.RenderDiff()
+	if first == "" {
+		t.Fatal("RenderDiff should render the initial status frame")
+	}
+	if _, err := emu.Write([]byte(first)); err != nil {
+		t.Fatalf("writing initial diff: %v", err)
+	}
+
+	cr.HandleLayout(wideTwoPaneStatus80x23("Eliminate double CloneStyledLines in renderer and compositor"))
+	second := cr.RenderDiff()
+	if second == "" {
+		t.Fatal("RenderDiff should render the updated status frame")
+	}
+	if _, err := emu.Write([]byte(second)); err != nil {
+		t.Fatalf("writing updated diff: %v", err)
+	}
+
+	got := renderDisplayText(emu, 80, 24)
+	want := cr.Capture(true)
+	if got != want {
+		t.Fatalf("terminal display mismatch after status update:\n--- got ---\n%s\n--- want ---\n%s", got, want)
 	}
 }
 
@@ -2386,6 +2488,56 @@ func TestHandleCaptureRequest_DisplayFlag(t *testing.T) {
 			t.Errorf("--display with %v should error", args[1:])
 		}
 	}
+}
+
+func TestCaptureDisplayClearsVacatedCellsAfterShorterRedraw(t *testing.T) {
+	t.Parallel()
+
+	cr := NewClientRenderer(80, 24)
+	cr.HandleLayout(singlePane20x5())
+
+	cr.HandlePaneOutput(1, []byte("\033[2J\033[Hbranch history still stays explicit and the worktree is actually"))
+	if got := cr.RenderDiff(); got == "" {
+		t.Fatal("RenderDiff should render the initial long line")
+	}
+
+	cr.HandlePaneOutput(1, []byte("\033[Hbranch h"))
+	if got := cr.RenderDiff(); got == "" {
+		t.Fatal("RenderDiff should render the overwrite before the clear")
+	}
+
+	cr.HandlePaneOutput(1, []byte("\033[K"))
+	if got := cr.RenderDiff(); got == "" {
+		t.Fatal("RenderDiff should render the clear-only update")
+	}
+
+	display := cr.CaptureDisplay()
+	if got, want := display, cr.Capture(true); got != want {
+		t.Fatalf("CaptureDisplay mismatch after shorter redraw:\n--- display ---\n%s\n--- full ---\n%s", got, want)
+	}
+	if strings.Contains(display, "still stays explicit") {
+		t.Fatalf("CaptureDisplay retained stale characters after shorter redraw:\n%s", display)
+	}
+}
+
+func renderDisplayText(emu *vt.SafeEmulator, width, height int) string {
+	var out strings.Builder
+	for y := 0; y < height; y++ {
+		if y > 0 {
+			out.WriteByte('\n')
+		}
+		var row strings.Builder
+		for x := 0; x < width; x++ {
+			cell := emu.CellAt(x, y)
+			if cell == nil || cell.Content == "" {
+				row.WriteByte(' ')
+				continue
+			}
+			row.WriteString(cell.Content)
+		}
+		out.WriteString(strings.TrimRight(row.String(), " "))
+	}
+	return out.String()
 }
 
 func TestRenderCoalesced_FullRenderMode(t *testing.T) {

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -1164,7 +1164,7 @@ func TestCaptureDisplayTruncatedStatusLineKeepsPaddingBeforeBorder(t *testing.T)
 	if !strings.HasSuffix(trimmed, "…") {
 		t.Fatalf("left pane status row %q should end with an ellipsis before padding", leftPane)
 	}
-	for _, r := range []rune(leftPane[len(trimmed):]) {
+	for _, r := range leftPane[len(trimmed):] {
 		if r != ' ' {
 			t.Fatalf("left pane status row %q should pad with spaces after the ellipsis", leftPane)
 		}

--- a/internal/render/compositor_test.go
+++ b/internal/render/compositor_test.go
@@ -9,6 +9,7 @@ import (
 
 	uv "github.com/charmbracelet/ultraviolet"
 	"github.com/charmbracelet/x/ansi"
+	"github.com/charmbracelet/x/vt"
 	"github.com/muesli/termenv"
 	"github.com/weill-labs/amux/internal/mux"
 	"github.com/weill-labs/amux/internal/proto"
@@ -506,6 +507,60 @@ func TestRenderDiffWithOverlayDirtyMatchesFullRenderAfterShorterRecompose(t *tes
 	}
 	if errs := oobErrors(diffComp); len(errs) > 0 {
 		t.Fatalf("dirty recompose should stay within the clipped visible grid:\n%s", strings.Join(errs, "\n"))
+	}
+}
+
+func TestRenderDiffWithOverlayDirtyClearsVacatedCellsAfterShorterLine(t *testing.T) {
+	t.Parallel()
+
+	const (
+		width  = 80
+		height = 5
+		totalH = height + GlobalBarHeight
+	)
+
+	root := mux.NewLeaf(&mux.Pane{ID: 1, Meta: mux.PaneMeta{Name: "pane-1"}}, 0, 0, width, height)
+	pane := &recomposedPaneData{
+		fakePaneData: &fakePaneData{
+			id:           1,
+			name:         "pane-1",
+			cursorHidden: true,
+			screen:       "branch history still stays explicit and the worktree is actually",
+		},
+		rows: []string{"branch history still stays explicit and the worktree is actually"},
+	}
+	lookup := func(id uint32) PaneData {
+		if id != 1 {
+			return nil
+		}
+		return pane
+	}
+
+	diffComp := newTestCompositor(width, totalH, "test")
+	display := vt.NewSafeEmulator(width, totalH)
+
+	initial := diffComp.RenderDiffWithOverlayDirty(root, 1, lookup, OverlayState{}, map[uint32]struct{}{1: {}}, true)
+	if _, err := display.Write([]byte(initial)); err != nil {
+		t.Fatalf("writing initial diff: %v", err)
+	}
+
+	pane.screen = "branch h"
+	pane.rows = []string{"branch h"}
+	incremental := diffComp.RenderDiffWithOverlayDirty(root, 1, lookup, OverlayState{}, map[uint32]struct{}{1: {}}, false)
+	if _, err := display.Write([]byte(incremental)); err != nil {
+		t.Fatalf("writing incremental diff: %v", err)
+	}
+
+	fullComp := newTestCompositor(width, totalH, "test")
+	want := MaterializeGrid(fullComp.RenderFull(root, 1, lookup), width, totalH)
+	got := displayText(display, width, totalH)
+	if got != want {
+		t.Fatalf("dirty diff display =\n%s\nwant:\n%s", got, want)
+	}
+
+	contentRow := displayRow(display, width, 1)
+	if strings.Contains(contentRow, "still stays explicit") {
+		t.Fatalf("content row retained stale characters after shorter redraw:\n%s", contentRow)
 	}
 }
 

--- a/internal/render/screen.go
+++ b/internal/render/screen.go
@@ -111,13 +111,24 @@ func DiffGrid(prev, next *ScreenGrid) []CellChange {
 	}
 	var changes []CellChange
 	for y := 0; y < next.Height; y++ {
+		firstChanged, lastChanged := -1, -1
 		for x := 0; x < next.Width; x++ {
 			idx := y*next.Width + x
 			if !next.Cells[idx].Equal(prev.Cells[idx]) {
-				changes = append(changes, CellChange{
-					X: x, Y: y, Cell: next.Cells[idx],
-				})
+				if firstChanged < 0 {
+					firstChanged = x
+				}
+				lastChanged = x
 			}
+		}
+		if firstChanged < 0 {
+			continue
+		}
+		for x := firstChanged; x <= lastChanged; x++ {
+			idx := y*next.Width + x
+			changes = append(changes, CellChange{
+				X: x, Y: y, Cell: next.Cells[idx],
+			})
 		}
 	}
 	return changes

--- a/internal/render/screen_test.go
+++ b/internal/render/screen_test.go
@@ -96,6 +96,91 @@ func TestDiffGrid_NilPrev(t *testing.T) {
 	}
 }
 
+func TestDiffGrid_ExpandsChangedRowSpanAcrossSeparatedChanges(t *testing.T) {
+	t.Parallel()
+
+	oldRow := "◇ [w-LAB-1300] Eliminate double CloneStyledLinesX in re…"
+	newRow := "◇ [w-LAB-1300] Eliminate double CloneStyledLines in ren…"
+
+	prev := NewScreenGrid(len([]rune(oldRow)), 1)
+	next := NewScreenGrid(len([]rune(newRow)), 1)
+	for x, r := range []rune(oldRow) {
+		prev.Set(x, 0, ScreenCell{Char: string(r), Width: 1})
+	}
+	for x, r := range []rune(newRow) {
+		next.Set(x, 0, ScreenCell{Char: string(r), Width: 1})
+	}
+
+	changes := DiffGrid(prev, next)
+	if len(changes) == 0 {
+		t.Fatal("DiffGrid should report row changes")
+	}
+
+	firstX := changes[0].X
+	lastX := changes[len(changes)-1].X
+	wantLen := lastX - firstX + 1
+	if len(changes) != wantLen {
+		t.Fatalf("DiffGrid should expand the changed row span; got %d changes for span [%d,%d], want %d", len(changes), firstX, lastX, wantLen)
+	}
+	for i, ch := range changes {
+		if ch.Y != 0 || ch.X != firstX+i {
+			t.Fatalf("change[%d] = (%d,%d), want contiguous span starting at x=%d", i, ch.X, ch.Y, firstX)
+		}
+	}
+}
+
+func TestEmitDiff_ClearsDeletedInternalCharacters(t *testing.T) {
+	t.Parallel()
+
+	const row = "◇ [w-LAB-1300] Eliminate double CloneStyledLinesX in re…"
+	const updated = "◇ [w-LAB-1300] Eliminate double CloneStyledLines in ren…"
+
+	prev := NewScreenGrid(len([]rune(row)), 1)
+	next := NewScreenGrid(len([]rune(row)), 1)
+	for x, r := range []rune(row) {
+		prev.Set(x, 0, ScreenCell{Char: string(r), Width: 1})
+	}
+	for x, r := range []rune(updated) {
+		next.Set(x, 0, ScreenCell{Char: string(r), Width: 1})
+	}
+
+	emu := vt.NewSafeEmulator(len([]rune(row)), 1)
+	mustWrite(t, emu, []byte(EmitDiff(DiffGrid(nil, prev))))
+	mustWrite(t, emu, []byte(EmitDiff(DiffGrid(prev, next))))
+
+	if got := displayRow(emu, len([]rune(row)), 0); got != updated {
+		t.Fatalf("display row = %q, want %q", got, updated)
+	}
+}
+
+func TestEmitDiff_RewritesChangedRowSpanWithInterveningSpaces(t *testing.T) {
+	t.Parallel()
+
+	oldRow := "abcdefghijklmnopqrstuvwx"
+	newRow := "ab  ef  ij  mn  qr  uv  "
+
+	prev := NewScreenGrid(len([]rune(oldRow)), 1)
+	next := NewScreenGrid(len([]rune(newRow)), 1)
+	for x, r := range []rune(oldRow) {
+		prev.Set(x, 0, ScreenCell{Char: string(r), Width: 1})
+	}
+	for x, r := range []rune(newRow) {
+		next.Set(x, 0, ScreenCell{Char: string(r), Width: 1})
+	}
+
+	output := EmitDiff(DiffGrid(prev, next))
+	if got := countCUPs(output); got != 1 {
+		t.Fatalf("changed row diff should emit one contiguous rewrite, got %d CUPs in %q", got, output)
+	}
+
+	emu := vt.NewSafeEmulator(len([]rune(oldRow)), 1)
+	mustWrite(t, emu, []byte(EmitDiff(DiffGrid(nil, prev))))
+	mustWrite(t, emu, []byte(output))
+	if got := displayRow(emu, len([]rune(newRow)), 0); got != newRow {
+		t.Fatalf("display row = %q, want %q", got, newRow)
+	}
+}
+
 func TestEmitDiff_CUP(t *testing.T) {
 	t.Parallel()
 	changes := []CellChange{
@@ -1313,6 +1398,69 @@ func TestRenderDiff_StatusLineWideRuneMatchesRenderFullAcrossPanes(t *testing.T)
 	}
 }
 
+func TestRenderDiff_TruncatedStatusLinePreservesPaddingBeforeBorder(t *testing.T) {
+	t.Parallel()
+
+	const (
+		pane1W = 56
+		pane2W = 20
+		height = 6
+	)
+	width := pane1W + 1 + pane2W
+	totalH := height + GlobalBarHeight
+
+	root := mkSplit(mux.SplitVertical, 0, 0, width, height,
+		mux.NewLeafByID(1, 0, 0, pane1W, height),
+		mux.NewLeafByID(2, pane1W+1, 0, pane2W, height),
+	)
+	lookup := func(id uint32) PaneData {
+		switch id {
+		case 1:
+			return &statusPaneData{
+				id:           1,
+				name:         "w-LAB-1300",
+				task:         "Eliminate double CloneStyledLines in renderer and compositor",
+				color:        config.TextColorHex,
+				idle:         true,
+				screen:       "",
+				cursorHidden: true,
+			}
+		case 2:
+			return &statusPaneData{
+				id:           2,
+				name:         "pane-2",
+				color:        config.TextColorHex,
+				screen:       "",
+				cursorHidden: true,
+			}
+		}
+		return nil
+	}
+
+	comp := newTestCompositor(width, totalH, "test")
+	display := vt.NewSafeEmulator(width, totalH)
+
+	if err := oracleCheck(comp, display, root, 2, lookup, width, totalH); err != "" {
+		t.Fatalf("RenderDiff mismatch for truncated status line:\n%s", err)
+	}
+
+	rowRunes := []rune(displayRow(display, width, 0))
+	leftPane := string(rowRunes[:pane1W])
+	trimmed := strings.TrimRight(leftPane, " ")
+	if !strings.HasSuffix(trimmed, "…") {
+		t.Fatalf("left pane status row %q should end with an ellipsis before padding", leftPane)
+	}
+
+	for _, r := range []rune(leftPane[len(trimmed):]) {
+		if r != ' ' {
+			t.Fatalf("left pane status row %q should pad with spaces after the ellipsis", leftPane)
+		}
+	}
+	if got := rowRunes[pane1W]; got != '│' {
+		t.Fatalf("border column = %q, want vertical border", string(got))
+	}
+}
+
 func TestRenderDiff_ColorOracle_LongLines(t *testing.T) {
 	t.Parallel()
 	pane1W := 20
@@ -1355,6 +1503,25 @@ func TestRenderDiff_ColorOracle_LongLines(t *testing.T) {
 		t.Errorf("long-line color oracle incremental: %d mismatches:\n%s",
 			len(mismatches), strings.Join(mismatches, "\n"))
 	}
+}
+
+func displayRow(display *vt.SafeEmulator, width, y int) string {
+	var row strings.Builder
+	for x := 0; x < width; x++ {
+		row.WriteString(cellContent(display.CellAt(x, y)))
+	}
+	return row.String()
+}
+
+func displayText(display *vt.SafeEmulator, width, height int) string {
+	var out strings.Builder
+	for y := 0; y < height; y++ {
+		if y > 0 {
+			out.WriteByte('\n')
+		}
+		out.WriteString(strings.TrimRight(displayRow(display, width, y), " "))
+	}
+	return out.String()
 }
 
 func TestRenderDiff_LongLines_NinePanes(t *testing.T) {

--- a/internal/render/screen_test.go
+++ b/internal/render/screen_test.go
@@ -1451,7 +1451,7 @@ func TestRenderDiff_TruncatedStatusLinePreservesPaddingBeforeBorder(t *testing.T
 		t.Fatalf("left pane status row %q should end with an ellipsis before padding", leftPane)
 	}
 
-	for _, r := range []rune(leftPane[len(trimmed):]) {
+	for _, r := range leftPane[len(trimmed):] {
 		if r != ' ' {
 			t.Fatalf("left pane status row %q should pad with spaces after the ellipsis", leftPane)
 		}

--- a/test/render_artifacts_test.go
+++ b/test/render_artifacts_test.go
@@ -38,7 +38,7 @@ func TestCapturePreservesTruncatedStatusPaddingBeforeBorder(t *testing.T) {
 	if !strings.HasSuffix(trimmed, "…") {
 		t.Fatalf("left pane status row %q should end with an ellipsis before padding", leftPane)
 	}
-	for _, r := range []rune(leftPane[len(trimmed):]) {
+	for _, r := range leftPane[len(trimmed):] {
 		if r != ' ' {
 			t.Fatalf("left pane status row %q should pad with spaces after the ellipsis", leftPane)
 		}

--- a/test/render_artifacts_test.go
+++ b/test/render_artifacts_test.go
@@ -1,0 +1,88 @@
+package test
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCapturePreservesTruncatedStatusPaddingBeforeBorder(t *testing.T) {
+	t.Parallel()
+
+	h := newServerHarness(t)
+
+	if out := strings.TrimSpace(h.runCmd(
+		"meta", "set", "pane-1",
+		"task=Eliminate double CloneStyledLines in renderer and compositor",
+	)); out != "" {
+		t.Fatalf("meta set output = %q, want empty", out)
+	}
+	h.splitV()
+
+	lines := h.captureLines()
+	if len(lines) == 0 {
+		t.Fatal("capture returned no rows")
+	}
+
+	borderCol := h.captureVerticalBorderCol()
+	if borderCol <= 0 {
+		t.Fatalf("capture did not expose a vertical border:\n%s", h.capture())
+	}
+
+	row := []rune(lines[0])
+	if len(row) <= borderCol {
+		t.Fatalf("status row too short for border column %d: %q", borderCol, lines[0])
+	}
+	leftPane := string(row[:borderCol])
+	trimmed := strings.TrimRight(leftPane, " ")
+	if !strings.HasSuffix(trimmed, "…") {
+		t.Fatalf("left pane status row %q should end with an ellipsis before padding", leftPane)
+	}
+	for _, r := range []rune(leftPane[len(trimmed):]) {
+		if r != ' ' {
+			t.Fatalf("left pane status row %q should pad with spaces after the ellipsis", leftPane)
+		}
+	}
+	if got := row[borderCol]; got != '│' {
+		t.Fatalf("border column = %q, want vertical border", string(got))
+	}
+}
+
+func TestCaptureClearsVacatedCellsAfterShorterRedraw(t *testing.T) {
+	t.Parallel()
+
+	h := newServerHarness(t)
+
+	scriptPath := filepath.Join(t.TempDir(), "rewrite-shorter-line.sh")
+	mustWriteFile(t, scriptPath, []byte(`#!/bin/sh
+set -eu
+printf '\033[2J\033[Hbranch history still stays explicit and the worktree is actually'
+sleep 0.1
+printf '\033[Hbranch h'
+sleep 0.1
+printf '\033[K\nDONE\n'
+`), 0o755)
+
+	h.runShellCommandWithSettle("pane-1", "sh "+scriptPath, "DONE", "200ms")
+
+	serverANSI := h.runCmd("capture", "--ansi", "pane-1")
+	if !strings.Contains(serverANSI, "branch h") {
+		t.Fatalf("capture --ansi pane-1 should include the rewritten short line, got:\n%s", serverANSI)
+	}
+	if strings.Contains(serverANSI, "still stays explicit") {
+		t.Fatalf("capture --ansi pane-1 should not retain stale content, got:\n%s", serverANSI)
+	}
+
+	screen := h.capture()
+	if strings.Contains(screen, "still stays explicit") {
+		t.Fatalf("capture should not retain stale content after shorter redraw, got:\n%s", screen)
+	}
+
+	lines := h.captureLines()
+	if len(lines) < 2 {
+		t.Fatalf("capture returned fewer than 2 rows:\n%s", screen)
+	}
+	if got := strings.TrimRight(lines[1], " "); got != "branch h" {
+		t.Fatalf("first content row = %q, want %q\nscreen:\n%s", got, "branch h", screen)
+	}
+}


### PR DESCRIPTION
## Motivation
A client-side diff/compositor bug in LAB-1336 left stale cells behind after shorter redraws and could collapse truncated pane-header padding into the border. `capture --ansi` stayed clean, which pointed the fix at the grid diff path rather than the pane emulator.

## Summary
- add renderer regressions for truncated status rows and shorter same-row redraws
- make `DiffGrid` rewrite the full changed span of a dirty row so vacated cells are explicitly cleared
- add client and server-harness coverage that compares the diff path against captured client output

## Testing
- `go test ./internal/render -run 'TestDiffGrid_ExpandsChangedRowSpanAcrossSeparatedChanges|TestEmitDiff_ClearsDeletedInternalCharacters|TestEmitDiff_RewritesChangedRowSpanWithInterveningSpaces|TestRenderDiff_TruncatedStatusLinePreservesPaddingBeforeBorder|TestRenderDiffWithOverlayDirtyClearsVacatedCellsAfterShorterLine' -count=100`
- `go test ./internal/client -run 'TestCaptureDisplayTruncatedStatusLineKeepsPaddingBeforeBorder|TestRenderDiffStatusUpdateAppliedToTerminalMatchesCapture|TestCaptureDisplayClearsVacatedCellsAfterShorterRedraw' -count=100`
- `go test ./test -run 'TestCapturePreservesTruncatedStatusPaddingBeforeBorder|TestCaptureClearsVacatedCellsAfterShorterRedraw' -count=100 -timeout 120s`
- `go test ./test -run 'TestResizeKeybindNoEffect|TestSwapForward' -count=5 -timeout 120s`
- `go test ./... -timeout 120s`

## Review focus
- `DiffGrid` now expands any dirty row to a contiguous rewrite span; the key tradeoff is slightly larger sparse diffs versus guaranteed clears for vacated cells and truncated header padding
- the new coverage spans renderer unit tests, client diff application, and the server harness capture path so the failure signature is exercised at multiple layers

Closes LAB-1336
