### PR TITLE
LAB-1353: Let spawn --auto use lead panes as window hints

### DIFF
--- a/internal/cli/cli_parse.go
+++ b/internal/cli/cli_parse.go
@@ -293,12 +293,15 @@ func ParseSpawnCommandArgs(args []string) (string, []string, error) {
 	if opts.window != "" && opts.at != "" {
 		return "", nil, errors.New(spawnUsage)
 	}
-	if opts.auto && (opts.at != "" || opts.root || opts.hasExplicitDir) {
+	if opts.auto && (opts.root || opts.hasExplicitDir) {
 		return "", nil, errors.New(spawnUsage)
 	}
 
 	cmdArgs := make([]string, 0, 10)
 	if opts.auto {
+		if opts.at != "" {
+			cmdArgs = append(cmdArgs, "--at", opts.at)
+		}
 		if opts.window != "" {
 			cmdArgs = append(cmdArgs, "--window", opts.window)
 		}

--- a/internal/cli/main_test.go
+++ b/internal/cli/main_test.go
@@ -29,6 +29,7 @@ func TestParseSpawnCommandArgs(t *testing.T) {
 		{name: "focused spawn", args: []string{"--focus"}, wantCmd: "spawn", wantArgs: []string{"--focus"}},
 		{name: "auto spawn", args: []string{"--auto"}, wantCmd: "spawn", wantArgs: []string{"--auto"}},
 		{name: "auto spawn in named window", args: []string{"--auto", "--window", "logs"}, wantCmd: "spawn", wantArgs: []string{"--window", "logs", "--auto"}},
+		{name: "auto spawn at pane uses window hint", args: []string{"--auto", "--at", "pane-1"}, wantCmd: "spawn", wantArgs: []string{"--at", "pane-1", "--auto"}},
 		{name: "targeted spawn at pane", args: []string{"--at", "pane-1"}, wantCmd: "spawn", wantArgs: []string{"--at", "pane-1"}},
 		{name: "targeted spawn in named window", args: []string{"--window", "logs"}, wantCmd: "spawn", wantArgs: []string{"--window", "logs"}},
 		{name: "targeted spawn active vertical", args: []string{"--vertical"}, wantCmd: "spawn", wantArgs: []string{"--vertical"}},

--- a/internal/server/spawn_auto_command_test.go
+++ b/internal/server/spawn_auto_command_test.go
@@ -529,6 +529,130 @@ func TestCommandSpawnAutoUsesPaneTargetWindowHint(t *testing.T) {
 	}
 }
 
+func TestCommandSpawnAutoUsesLeadPaneTargetWindowHint(t *testing.T) {
+	t.Parallel()
+
+	srv, sess, cleanup := newCommandTestSession(t)
+	defer cleanup()
+
+	p1 := newTestPane(sess, 1, "pane-1")
+	p2 := newTestPane(sess, 2, "pane-2")
+	p3 := newTestPane(sess, 3, "pane-3")
+	p4 := newTestPane(sess, 4, "pane-4")
+
+	mainWindow := mux.NewWindow(p1, 80, 23)
+	mainWindow.ID = 1
+	mainWindow.Name = "main"
+
+	logsWindow := mux.NewWindow(p2, 80, 23)
+	logsWindow.ID = 4
+	logsWindow.Name = "logs"
+	if err := logsWindow.SetLead(p2.ID); err != nil {
+		t.Fatalf("SetLead pane-2: %v", err)
+	}
+	if _, err := logsWindow.SplitRoot(mux.SplitVertical, p3); err != nil {
+		t.Fatalf("SplitRoot pane-3: %v", err)
+	}
+	if _, err := logsWindow.SplitPaneWithOptions(p3.ID, mux.SplitHorizontal, p4, mux.SplitOptions{}); err != nil {
+		t.Fatalf("Split pane-3 horizontally: %v", err)
+	}
+
+	setSessionLayoutForTest(t, sess, mainWindow.ID, []*mux.Window{mainWindow, logsWindow}, p1, p2, p3, p4)
+
+	res := runTestCommand(t, srv, sess, "spawn", "--auto", "--at", "pane-2", "--name", "worker-5")
+	if res.cmdErr != "" {
+		t.Fatalf("spawn --auto --at lead failed: %s", res.cmdErr)
+	}
+
+	state := mustSessionQuery(t, sess, func(sess *Session) struct {
+		activeWindowID uint32
+		workerWindowID uint32
+		leadX          int
+		leadW          int
+		p3X            int
+		p4X            int
+		p5X            int
+		p5Y            int
+		p3Y            int
+	} {
+		worker, err := sess.findPaneByRef("worker-5")
+		if err != nil {
+			return struct {
+				activeWindowID uint32
+				workerWindowID uint32
+				leadX          int
+				leadW          int
+				p3X            int
+				p4X            int
+				p5X            int
+				p5Y            int
+				p3Y            int
+			}{}
+		}
+		workerWindow := sess.findWindowByPaneID(worker.ID)
+		leadCell := logsWindow.Root.FindPane(p2.ID)
+		p3Cell := logsWindow.Root.FindPane(p3.ID)
+		p4Cell := logsWindow.Root.FindPane(p4.ID)
+		p5Cell := logsWindow.Root.FindPane(worker.ID)
+		if workerWindow == nil || leadCell == nil || p3Cell == nil || p4Cell == nil || p5Cell == nil {
+			return struct {
+				activeWindowID uint32
+				workerWindowID uint32
+				leadX          int
+				leadW          int
+				p3X            int
+				p4X            int
+				p5X            int
+				p5Y            int
+				p3Y            int
+			}{}
+		}
+		return struct {
+			activeWindowID uint32
+			workerWindowID uint32
+			leadX          int
+			leadW          int
+			p3X            int
+			p4X            int
+			p5X            int
+			p5Y            int
+			p3Y            int
+		}{
+			activeWindowID: sess.ActiveWindowID,
+			workerWindowID: workerWindow.ID,
+			leadX:          leadCell.X,
+			leadW:          leadCell.W,
+			p3X:            p3Cell.X,
+			p4X:            p4Cell.X,
+			p5X:            p5Cell.X,
+			p5Y:            p5Cell.Y,
+			p3Y:            p3Cell.Y,
+		}
+	})
+
+	if state.activeWindowID != mainWindow.ID {
+		t.Fatalf("active window = %d, want %d", state.activeWindowID, mainWindow.ID)
+	}
+	if state.workerWindowID != logsWindow.ID {
+		t.Fatalf("worker window = %d, want %d", state.workerWindowID, logsWindow.ID)
+	}
+	if state.leadX != 0 || state.leadW == 0 {
+		t.Fatalf("lead pane should remain anchored on the left: %+v", state)
+	}
+	if state.p3X != state.p4X {
+		t.Fatalf("existing non-lead panes should remain in the same column: %+v", state)
+	}
+	if state.p5X == state.p3X {
+		t.Fatalf("worker-5 should be placed in a new non-lead column: %+v", state)
+	}
+	if state.p5X <= state.p3X {
+		t.Fatalf("worker-5 should be placed to the right of the existing non-lead column: %+v", state)
+	}
+	if state.p5Y != state.p3Y {
+		t.Fatalf("worker-5 should start at the top of the new non-lead column: %+v", state)
+	}
+}
+
 func TestCommandSpawnTargetsSpecifiedWindowActivePane(t *testing.T) {
 	t.Parallel()
 

--- a/test/window_test.go
+++ b/test/window_test.go
@@ -123,15 +123,8 @@ func TestSpawnAtLeadPaneUsesWindowPlacement(t *testing.T) {
 	if lead.Position == nil || worker1.Position == nil || worker2.Position == nil {
 		t.Fatalf("targeted spawn should include positions, lead=%+v worker-1=%+v worker-2=%+v", lead.Position, worker1.Position, worker2.Position)
 	}
-	if lead.Position.X >= worker1.Position.X || lead.Position.X >= worker2.Position.X {
-		t.Fatalf("lead pane should remain left of worker panes: lead=%+v worker-1=%+v worker-2=%+v", lead.Position, worker1.Position, worker2.Position)
-	}
-	if worker1.Position.X != worker2.Position.X {
-		t.Fatalf("targeted spawn should keep non-lead panes in the same column: worker-1=%+v worker-2=%+v", worker1.Position, worker2.Position)
-	}
-	if worker1.Position.Y == worker2.Position.Y {
-		t.Fatalf("targeted spawn should stack the non-lead panes vertically: worker-1=%+v worker-2=%+v", worker1.Position, worker2.Position)
-	}
+	assertLeadPaneLeftOfWorkers(t, lead, worker1, worker2)
+	assertWorkersStackedInSameColumn(t, "targeted spawn", worker1, worker2)
 }
 
 func TestSpawnAutoAtLeadPaneUsesWindowPlacement(t *testing.T) {
@@ -181,15 +174,8 @@ func TestSpawnAutoAtLeadPaneUsesWindowPlacement(t *testing.T) {
 	if leadAfter.Position.Height != worker3.Position.Height {
 		t.Fatalf("lead pane should remain full-height beside the auto-placed pane: lead=%+v worker-3=%+v", leadAfter.Position, worker3.Position)
 	}
-	if leadAfter.Position.X >= worker1.Position.X || leadAfter.Position.X >= worker2.Position.X || leadAfter.Position.X >= worker3.Position.X {
-		t.Fatalf("lead pane should remain left of worker panes: lead=%+v worker-1=%+v worker-2=%+v worker-3=%+v", leadAfter.Position, worker1.Position, worker2.Position, worker3.Position)
-	}
-	if worker1.Position.X != worker2.Position.X {
-		t.Fatalf("existing worker panes should remain in the same column: worker-1=%+v worker-2=%+v", worker1.Position, worker2.Position)
-	}
-	if worker1.Position.Y == worker2.Position.Y {
-		t.Fatalf("existing worker panes should stay stacked vertically: worker-1=%+v worker-2=%+v", worker1.Position, worker2.Position)
-	}
+	assertLeadPaneLeftOfWorkers(t, leadAfter, worker1, worker2, worker3)
+	assertWorkersStackedInSameColumn(t, "auto lead spawn", worker1, worker2)
 	if worker3.Position.X == worker1.Position.X {
 		t.Fatalf("auto spawn should create a new non-lead column instead of splitting the lead pane: worker-1=%+v worker-3=%+v", worker1.Position, worker3.Position)
 	}
@@ -264,6 +250,27 @@ func listLineForPane(listOut, paneName string) string {
 		}
 	}
 	return ""
+}
+
+func assertLeadPaneLeftOfWorkers(t *testing.T, lead proto.CapturePane, workers ...proto.CapturePane) {
+	t.Helper()
+
+	for _, worker := range workers {
+		if lead.Position.X >= worker.Position.X {
+			t.Fatalf("lead pane should remain left of worker panes: lead=%+v worker=%+v", lead.Position, worker.Position)
+		}
+	}
+}
+
+func assertWorkersStackedInSameColumn(t *testing.T, context string, top, bottom proto.CapturePane) {
+	t.Helper()
+
+	if top.Position.X != bottom.Position.X {
+		t.Fatalf("%s should keep non-lead panes in the same column: top=%+v bottom=%+v", context, top.Position, bottom.Position)
+	}
+	if top.Position.Y == bottom.Position.Y {
+		t.Fatalf("%s should stack the non-lead panes vertically: top=%+v bottom=%+v", context, top.Position, bottom.Position)
+	}
 }
 
 func assertAnchoredLeadSpawnLayout(t *testing.T, h *ServerHarness, capture proto.CaptureJSON, leadName, workerName string) {

--- a/test/window_test.go
+++ b/test/window_test.go
@@ -150,9 +150,6 @@ func TestSpawnAutoAtLeadPaneUsesWindowPlacement(t *testing.T) {
 		t.Fatalf("spawn --at should treat the lead pane as a window reference, got: %s", out)
 	}
 
-	before := h.captureJSON()
-	leadBefore := h.jsonPane(before, "pane-1")
-
 	out = h.runCmd("spawn", "--auto", "--at", "pane-1", "--name", "worker-3")
 	if !strings.Contains(out, "Spawned worker-3") {
 		t.Fatalf("spawn --auto --at should report the new pane, got: %s", out)
@@ -169,18 +166,20 @@ func TestSpawnAutoAtLeadPaneUsesWindowPlacement(t *testing.T) {
 	if !leadAfter.Lead {
 		t.Fatal("pane-1 should remain the lead pane after auto spawn")
 	}
-	if leadBefore.Position == nil || leadAfter.Position == nil || worker1.Position == nil || worker2.Position == nil || worker3.Position == nil {
+	if leadAfter.Position == nil || worker1.Position == nil || worker2.Position == nil || worker3.Position == nil {
 		t.Fatalf(
-			"auto lead spawn should include positions, before=%+v after=%+v worker-1=%+v worker-2=%+v worker-3=%+v",
-			leadBefore.Position,
+			"auto lead spawn should include positions, lead=%+v worker-1=%+v worker-2=%+v worker-3=%+v",
 			leadAfter.Position,
 			worker1.Position,
 			worker2.Position,
 			worker3.Position,
 		)
 	}
-	if *leadBefore.Position != *leadAfter.Position {
-		t.Fatalf("auto spawn should leave the lead pane unchanged: before=%+v after=%+v", leadBefore.Position, leadAfter.Position)
+	if leadAfter.Position.X != 0 || leadAfter.Position.Y != 0 {
+		t.Fatalf("lead pane should remain anchored at the top-left: lead=%+v", leadAfter.Position)
+	}
+	if leadAfter.Position.Height != worker3.Position.Height {
+		t.Fatalf("lead pane should remain full-height beside the auto-placed pane: lead=%+v worker-3=%+v", leadAfter.Position, worker3.Position)
 	}
 	if leadAfter.Position.X >= worker1.Position.X || leadAfter.Position.X >= worker2.Position.X || leadAfter.Position.X >= worker3.Position.X {
 		t.Fatalf("lead pane should remain left of worker panes: lead=%+v worker-1=%+v worker-2=%+v worker-3=%+v", leadAfter.Position, worker1.Position, worker2.Position, worker3.Position)

--- a/test/window_test.go
+++ b/test/window_test.go
@@ -134,6 +134,71 @@ func TestSpawnAtLeadPaneUsesWindowPlacement(t *testing.T) {
 	}
 }
 
+func TestSpawnAutoAtLeadPaneUsesWindowPlacement(t *testing.T) {
+	t.Parallel()
+
+	h := newServerHarness(t)
+	setLead(t, h, "pane-1")
+
+	out := h.runCmd("spawn", "--name", "worker-1")
+	if strings.Contains(out, "cannot operate on lead pane") {
+		t.Fatalf("spawn should not reject the pending lead pane, got: %s", out)
+	}
+
+	out = h.runCmd("spawn", "--at", "pane-1", "--name", "worker-2")
+	if strings.Contains(out, "cannot operate on lead pane") {
+		t.Fatalf("spawn --at should treat the lead pane as a window reference, got: %s", out)
+	}
+
+	before := h.captureJSON()
+	leadBefore := h.jsonPane(before, "pane-1")
+
+	out = h.runCmd("spawn", "--auto", "--at", "pane-1", "--name", "worker-3")
+	if !strings.Contains(out, "Spawned worker-3") {
+		t.Fatalf("spawn --auto --at should report the new pane, got: %s", out)
+	}
+	if strings.Contains(out, "cannot operate on lead pane") {
+		t.Fatalf("spawn --auto --at should treat the lead pane as a window reference, got: %s", out)
+	}
+
+	after := h.captureJSON()
+	leadAfter := h.jsonPane(after, "pane-1")
+	worker1 := h.jsonPane(after, "worker-1")
+	worker2 := h.jsonPane(after, "worker-2")
+	worker3 := h.jsonPane(after, "worker-3")
+	if !leadAfter.Lead {
+		t.Fatal("pane-1 should remain the lead pane after auto spawn")
+	}
+	if leadBefore.Position == nil || leadAfter.Position == nil || worker1.Position == nil || worker2.Position == nil || worker3.Position == nil {
+		t.Fatalf(
+			"auto lead spawn should include positions, before=%+v after=%+v worker-1=%+v worker-2=%+v worker-3=%+v",
+			leadBefore.Position,
+			leadAfter.Position,
+			worker1.Position,
+			worker2.Position,
+			worker3.Position,
+		)
+	}
+	if *leadBefore.Position != *leadAfter.Position {
+		t.Fatalf("auto spawn should leave the lead pane unchanged: before=%+v after=%+v", leadBefore.Position, leadAfter.Position)
+	}
+	if leadAfter.Position.X >= worker1.Position.X || leadAfter.Position.X >= worker2.Position.X || leadAfter.Position.X >= worker3.Position.X {
+		t.Fatalf("lead pane should remain left of worker panes: lead=%+v worker-1=%+v worker-2=%+v worker-3=%+v", leadAfter.Position, worker1.Position, worker2.Position, worker3.Position)
+	}
+	if worker1.Position.X != worker2.Position.X {
+		t.Fatalf("existing worker panes should remain in the same column: worker-1=%+v worker-2=%+v", worker1.Position, worker2.Position)
+	}
+	if worker1.Position.Y == worker2.Position.Y {
+		t.Fatalf("existing worker panes should stay stacked vertically: worker-1=%+v worker-2=%+v", worker1.Position, worker2.Position)
+	}
+	if worker3.Position.X == worker1.Position.X {
+		t.Fatalf("auto spawn should create a new non-lead column instead of splitting the lead pane: worker-1=%+v worker-3=%+v", worker1.Position, worker3.Position)
+	}
+	if worker3.Position.X <= worker1.Position.X {
+		t.Fatalf("auto spawn should place the new pane to the right of the existing non-lead column: worker-1=%+v worker-3=%+v", worker1.Position, worker3.Position)
+	}
+}
+
 func TestSetLeadSinglePaneWindowSurvivesCollapseAndRegrowsAnchoredLayout(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Motivation

amux already knows how to treat a lead pane as a window hint for `spawn --at`, but the real CLI path still rejected `spawn --auto --at <lead>` at argument parsing time. That blocked orca assignment whenever the caller pane was a lead pane, even though the server-side auto-placement logic already handled the intended semantics.

## Summary

- Allow `amux spawn --auto --at <pane>` through the CLI parser and forward the pane target as a window hint instead of rejecting the command.
- Add CLI parsing coverage for the `--auto` + `--at` combination.
- Add command-level and integration coverage showing that lead-pane targets auto-place inside the lead pane window, while the existing non-lead pane auto-target path still behaves as before.

## Testing

- `go test ./internal/cli -run 'TestParseSpawnCommandArgs/auto_spawn_at_pane_uses_window_hint' -count=100`
- `go test ./internal/server -run 'TestCommandSpawnAutoUses(LeadPaneTargetWindowHint|PaneTargetWindowHint)' -count=100`
- `go test ./test -run 'TestSpawnAutoAtLeadPaneUsesWindowPlacement' -count=100`
- `go test ./... -timeout 120s`

## Review focus

- `internal/cli/cli_parse.go`: `--auto` should now permit `--at` only as a window hint, while still rejecting explicit placement flags like `--root` and `--vertical`/`--horizontal`.
- The new lead-pane tests should demonstrate the intended semantics without asserting unrelated equalize details.

Closes LAB-1353
