### PR TITLE
LAB-1349: Drop listing pane metadata clones

### DIFF
--- a/internal/server/commands_listing.go
+++ b/internal/server/commands_listing.go
@@ -3,8 +3,6 @@ package server
 import (
 	"os"
 
-	"github.com/weill-labs/amux/internal/mux"
-	"github.com/weill-labs/amux/internal/proto"
 	listingcmd "github.com/weill-labs/amux/internal/server/commands/listing"
 )
 
@@ -19,9 +17,9 @@ func toListingPaneEntry(entry paneListEntry) listingcmd.PaneEntry {
 		GitBranch:     entry.gitBranch,
 		Idle:          entry.idle,
 		PR:            entry.pr,
-		KV:            mux.CloneMetaKV(entry.kv),
-		TrackedPRs:    proto.CloneTrackedPRs(entry.prs),
-		TrackedIssues: proto.CloneTrackedIssues(entry.issues),
+		KV:            entry.kv,
+		TrackedPRs:    entry.prs,
+		TrackedIssues: entry.issues,
 		Active:        entry.active,
 		Lead:          entry.lead,
 	}

--- a/internal/server/commands_listing.go
+++ b/internal/server/commands_listing.go
@@ -26,9 +26,9 @@ func toListingPaneEntry(entry paneListEntry) listingcmd.PaneEntry {
 }
 
 func toListingPaneEntries(entries []paneListEntry) []listingcmd.PaneEntry {
-	out := make([]listingcmd.PaneEntry, 0, len(entries))
-	for _, entry := range entries {
-		out = append(out, toListingPaneEntry(entry))
+	out := make([]listingcmd.PaneEntry, len(entries))
+	for i, entry := range entries {
+		out[i] = toListingPaneEntry(entry)
 	}
 	return out
 }

--- a/internal/server/commands_listing_test.go
+++ b/internal/server/commands_listing_test.go
@@ -1,0 +1,99 @@
+package server
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/weill-labs/amux/internal/proto"
+	listingcmd "github.com/weill-labs/amux/internal/server/commands/listing"
+)
+
+func TestToListingPaneEntryReusesMetadataViews(t *testing.T) {
+	t.Parallel()
+
+	entry := paneListEntry{
+		paneID: 1,
+		name:   "pane-1",
+		kv: map[string]string{
+			"issue": "LAB-1349",
+		},
+		prs: []proto.TrackedPR{
+			{Number: 42},
+		},
+		issues: []proto.TrackedIssue{
+			{ID: "LAB-1349"},
+		},
+	}
+
+	got := toListingPaneEntry(entry)
+
+	entry.kv["owner"] = "codex"
+	entry.prs[0].Number = 73
+	entry.issues[0].ID = "LAB-1350"
+
+	if got.KV["owner"] != "codex" {
+		t.Fatalf("KV[owner] = %q, want codex", got.KV["owner"])
+	}
+	if got.TrackedPRs[0].Number != 73 {
+		t.Fatalf("TrackedPRs[0].Number = %d, want 73", got.TrackedPRs[0].Number)
+	}
+	if got.TrackedIssues[0].ID != "LAB-1350" {
+		t.Fatalf("TrackedIssues[0].ID = %q, want LAB-1350", got.TrackedIssues[0].ID)
+	}
+}
+
+var benchmarkListingPaneEntries []listingcmd.PaneEntry
+
+func BenchmarkToListingPaneEntries(b *testing.B) {
+	for _, paneCount := range []int{32, 256} {
+		b.Run(fmt.Sprintf("%d-panes", paneCount), func(b *testing.B) {
+			entries := benchmarkPaneListEntries(paneCount)
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for i := 0; i < b.N; i++ {
+				got := toListingPaneEntries(entries)
+				if len(got) != len(entries) {
+					b.Fatalf("len(toListingPaneEntries()) = %d, want %d", len(got), len(entries))
+				}
+				benchmarkListingPaneEntries = got
+			}
+		})
+	}
+}
+
+func benchmarkPaneListEntries(count int) []paneListEntry {
+	entries := make([]paneListEntry, 0, count)
+	for i := 0; i < count; i++ {
+		entries = append(entries, paneListEntry{
+			paneID:     uint32(i + 1),
+			name:       fmt.Sprintf("pane-%d", i+1),
+			host:       "local",
+			windowName: fmt.Sprintf("window-%d", i%8+1),
+			task:       fmt.Sprintf("LAB-%d", 1300+i),
+			cwd:        fmt.Sprintf("/tmp/project-%d", i),
+			gitBranch:  fmt.Sprintf("feature/%d", i),
+			idle:       "2m",
+			pr:         fmt.Sprintf("%d", 400+i),
+			kv: map[string]string{
+				"branch":   fmt.Sprintf("feature/%d", i),
+				"issue":    fmt.Sprintf("LAB-%d", 1300+i),
+				"owner":    "codex",
+				"pr":       fmt.Sprintf("%d", 400+i),
+				"priority": "high",
+				"task":     fmt.Sprintf("LAB-%d", 1300+i),
+			},
+			prs: []proto.TrackedPR{
+				{Number: 400 + i},
+				{Number: 500 + i},
+			},
+			issues: []proto.TrackedIssue{
+				{ID: fmt.Sprintf("LAB-%d", 1300+i)},
+				{ID: fmt.Sprintf("LAB-%d", 2300+i)},
+			},
+			active: i == 0,
+			lead:   i%4 == 0,
+		})
+	}
+	return entries
+}


### PR DESCRIPTION
## Motivation
`toListingPaneEntry` was deep-copying pane metadata that had already been snapshotted in `queryPaneList`, and pprof showed those copies as the dominant allocator on the `amux list` read path.

## Summary
- stop cloning `KV`, `TrackedPRs`, and `TrackedIssues` in `toListingPaneEntry`
- keep the clone boundary in `queryPaneList`, where pane metadata is detached from the session goroutine
- add direct coverage proving `toListingPaneEntry` reuses the snapshotted metadata views
- add a benchmark for 32- and 256-pane lists to track allocation changes on the hot path
- preallocate the output slice in `toListingPaneEntries`

## Testing
- `go test ./internal/server -run TestToListingPaneEntryReusesMetadataViews -count=100`
- `go test ./internal/server -run '^$' -bench BenchmarkToListingPaneEntries -benchmem -memprofile /tmp/lab-1349-final-after.mem -memprofilerate=1`
- `go test ./test -run TestEventsIdleBusyTransition -count=5`
- `go test ./test -run 'TestMultiClientFocusTransfersSizeOwnership|TestMouseCommandDragAutomaticallyCopiesSelection' -count=3`
- `go test ./... -timeout 120s` (hit existing flakes in `./test`: `TestEventsIdleBusyTransition`, `TestMultiClientFocusTransfersSizeOwnership`, `TestMouseCommandDragAutomaticallyCopiesSelection`; isolated reruns above passed)

## Review focus
- confirm the only clone boundary we keep is `queryPaneList`, so callers never observe live session metadata
- confirm the audit result: `listing.PaneEntry.KV` is only read in `internal/server/commands/listing/listing.go`, and there are no in-place mutations of `KV`, `TrackedPRs`, or `TrackedIssues`
- confirm the benchmark covers the realistic per-pane metadata shape we see on list output

## Baseline numbers
Hardware: AMD EPYC-Milan Processor, linux/amd64

Benchmark (`BenchmarkToListingPaneEntries/256-panes`):

| state | ns/op | B/op | allocs/op |
| --- | ---: | ---: | ---: |
| before | 2824003 | 196625 | 1025 |
| after | 19440 | 57344 | 1 |

Alloc profile (`go tool pprof -top -alloc_space` on benchmark memprofile):

| state | dominant alloc sites |
| --- | --- |
| before | `mux.CloneMetaKV` 77059.59kB flat, `proto.CloneTrackedIssues` 25686.50kB flat, `proto.CloneTrackedPRs` 22017kB flat |
| after | `toListingPaneEntries` result-slice allocation only; clone helpers no longer appear |

Closes LAB-1349
