### PR TITLE
LAB-1355: Replay hidden pane output at buffered dimensions

### DIFF
--- a/internal/client/renderer.go
+++ b/internal/client/renderer.go
@@ -117,7 +117,10 @@ func (r *Renderer) HandleLayout(snap *proto.LayoutSnapshot) bool {
 			if !next.paneInActiveLayout(ps.ID) {
 				continue
 			}
-			w, h := proto.FindPaneDimensions(snap, activeRoot, ps.ID, mux.PaneContentHeight)
+			w, h, ok := st.paneEmulatorDimensions(next, ps.ID)
+			if !ok {
+				continue
+			}
 			nextEmulators[ps.ID] = mux.NewVTEmulatorWithDrainAndScrollback(w, h, next.scrollbackLines)
 		}
 

--- a/internal/client/renderer_state.go
+++ b/internal/client/renderer_state.go
@@ -186,6 +186,10 @@ func (st *rendererActorState) bufferPaneOutput(paneID uint32, data []byte) {
 	buf.appendChunk(data)
 }
 
+// paneEmulatorDimensions returns the size a cold emulator should use before any
+// buffered replay runs. Hidden panes prefer the buffered source dimensions so
+// VT replay matches the shell's original cursor math; once visible, the normal
+// resize path updates the emulator to the current layout dimensions.
 func (st *rendererActorState) paneEmulatorDimensions(snap *rendererSnapshot, paneID uint32) (int, int, bool) {
 	if buf := st.pendingPaneOutput[paneID]; buf != nil {
 		if width, height, ok := buf.replayDimensions(); ok {

--- a/internal/client/renderer_state.go
+++ b/internal/client/renderer_state.go
@@ -129,8 +129,13 @@ type rendererActorState struct {
 // paneOutputBuffer keeps raw PTY bytes for hidden panes until a visible or
 // capture path needs emulator state. This intentionally trades CPU for memory;
 // hidden-pane buffers are uncapped for now and can grow with hidden output.
+// replayWidth/replayHeight capture the pane size the hidden shell was still
+// using when buffering started so a cold emulator can replay at the source
+// width before the normal visible-pane resize path catches up.
 type paneOutputBuffer struct {
-	chunks [][]byte
+	chunks       [][]byte
+	replayWidth  int
+	replayHeight int
 }
 
 func (b *paneOutputBuffer) appendChunk(data []byte) {
@@ -142,6 +147,21 @@ func (b *paneOutputBuffer) appendChunk(data []byte) {
 
 func (b *paneOutputBuffer) empty() bool {
 	return len(b.chunks) == 0
+}
+
+func (b *paneOutputBuffer) setReplayDimensions(width, height int) {
+	if width <= 0 || height <= 0 || (b.replayWidth > 0 && b.replayHeight > 0) {
+		return
+	}
+	b.replayWidth = width
+	b.replayHeight = height
+}
+
+func (b *paneOutputBuffer) replayDimensions() (int, int, bool) {
+	if b.replayWidth <= 0 || b.replayHeight <= 0 {
+		return 0, 0, false
+	}
+	return b.replayWidth, b.replayHeight, true
 }
 
 func (b *paneOutputBuffer) flush(emu mux.TerminalEmulator) {
@@ -160,7 +180,19 @@ func (st *rendererActorState) bufferPaneOutput(paneID uint32, data []byte) {
 		buf = &paneOutputBuffer{}
 		st.pendingPaneOutput[paneID] = buf
 	}
+	if width, height, ok := st.snapshot.paneDimensions(paneID); ok {
+		buf.setReplayDimensions(width, height)
+	}
 	buf.appendChunk(data)
+}
+
+func (st *rendererActorState) paneEmulatorDimensions(snap *rendererSnapshot, paneID uint32) (int, int, bool) {
+	if buf := st.pendingPaneOutput[paneID]; buf != nil {
+		if width, height, ok := buf.replayDimensions(); ok {
+			return width, height, true
+		}
+	}
+	return snap.paneDimensions(paneID)
 }
 
 func (st *rendererActorState) ensurePaneEmulator(paneID uint32) mux.TerminalEmulator {
@@ -173,7 +205,7 @@ func (st *rendererActorState) ensurePaneEmulator(paneID uint32) mux.TerminalEmul
 	if _, ok := st.snapshot.paneInfo[paneID]; !ok {
 		return nil
 	}
-	width, height, ok := st.snapshot.paneDimensions(paneID)
+	width, height, ok := st.paneEmulatorDimensions(st.snapshot, paneID)
 	if !ok {
 		return nil
 	}

--- a/test/server_harness_test.go
+++ b/test/server_harness_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -1840,6 +1841,51 @@ func TestServerHarnessLateGenerationAndAttachSurviveHeadlessClientDetach(t *test
 	}
 	if len(msg.Layout.Panes) != 2 {
 		t.Fatalf("late attach returned %d panes, want 2", len(msg.Layout.Panes))
+	}
+}
+
+func TestHiddenWindowReplayMatchesHistoryAfterResizeAndWindowSwitch(t *testing.T) {
+	t.Parallel()
+
+	h := newServerHarnessWithSize(t, 20, 6)
+
+	h.client.close()
+	h.client = nil
+
+	h.runCmd("new-window", "--name", "hidden")
+	h.runCmd("select-window", "1")
+
+	if err := h.ensureControlClient(); err != nil {
+		t.Fatalf("ensureControlClient: %v", err)
+	}
+
+	h.sendKeys("pane-2",
+		`printf '\033[2J\033[Hgit pull and make install and restart binary\033[2;1HBash(git pull && make install && orca stop; orca start)\033[3;1HFrom github.com:weill-labs/orca'`,
+		"Enter",
+	)
+	h.waitIdle("pane-2")
+
+	gen := h.generation()
+	h.client.resizeTerminal(30, 6)
+	h.waitLayout(gen)
+
+	gen = h.generation()
+	h.runCmd("select-window", "2")
+	h.waitLayout(gen)
+
+	plain := capturePaneJSONFor(t, "pane-2", h.runCmd)
+
+	historyRaw := h.runCmd("capture", "--history", "--format", "json", "pane-2")
+	var history proto.CapturePane
+	if err := json.Unmarshal([]byte(historyRaw), &history); err != nil {
+		t.Fatalf("json.Unmarshal(history): %v\nraw:\n%s", err, historyRaw)
+	}
+
+	if got, want := plain.Content, history.Content; !slices.Equal(got, want) {
+		t.Fatalf("plain content = %q, want %q", got, want)
+	}
+	if got, want := plain.Cursor, history.Cursor; got != want {
+		t.Fatalf("plain cursor = %+v, want %+v", got, want)
 	}
 }
 


### PR DESCRIPTION
## Motivation

Hidden-window client captures were replaying buffered PTY output into a fresh emulator sized for the newly active window, not the size the hidden shell had actually rendered at. That let the client-side path diverge from `capture --history`, producing bleed and duplicate rows when a hidden window was activated after an outer-terminal resize.

## Summary

- add a server-harness regression that keeps the hidden window pane cold, resizes the attached client while the window stays hidden, and asserts `capture` matches `capture --history`
- record the source pane dimensions when hidden output buffering starts so cold emulators can replay buffered chunks at the shell's original width
- use those buffered replay dimensions when creating client emulators for hidden panes, then let the normal visible-pane resize path catch the emulator up to the active layout

## Testing

- `go test ./test -run TestHiddenWindowReplayMatchesHistoryAfterResizeAndWindowSwitch -count=100`
- `go test ./... -timeout 120s`

## Review Focus

- cold hidden panes now replay buffered output at the source dimensions before the existing layout resize path runs on visibility
- the fix intentionally tracks one buffered source size per hidden period, which matches the server's deferred hidden-window resize behavior from LAB-1355's repro

Closes LAB-1355
