### PR TITLE
Fall back to REST when watch-pr-ci is rate-limited

### DIFF
--- a/scripts/watch-pr-ci.sh
+++ b/scripts/watch-pr-ci.sh
@@ -23,6 +23,7 @@ head_runs_json=""
 latest_checks_json=""
 poll_output=""
 poll_status=0
+used_rest_required_checks=0
 
 declare -A last_check_state=()
 last_waiting_line=""
@@ -171,6 +172,28 @@ rest_required_checks_json() {
           end
         | sort_by(.name)
     '
+}
+
+prefer_rest_required_checks_json() {
+    local checks_json="$1"
+    local gh_status="${2:-0}"
+    local gh_output="${3:-}"
+    local rest_output
+
+    used_rest_required_checks=0
+    if (( gh_status == 0 )) || ! is_graphql_rate_limit_error "$gh_output"; then
+        printf '%s\n' "$checks_json"
+        return 0
+    fi
+
+    rest_output="$(rest_required_checks_json "$pr_repo" "$head_sha" "$base_ref" || true)"
+    if json_is_array "$rest_output"; then
+        used_rest_required_checks=1
+        printf '%s\n' "$rest_output"
+        return 0
+    fi
+
+    printf '%s\n' "$checks_json"
 }
 
 timestamp_to_epoch() {
@@ -363,16 +386,11 @@ watch_required_checks() {
     local next_heartbeat=0
     local no_checks_retries=0
     local now
-    local rest_output
-
     while :; do
         poll_required_checks "$pr_number"
-        if [[ "$poll_status" -ne 0 ]] && is_graphql_rate_limit_error "$poll_output"; then
-            rest_output="$(rest_required_checks_json "$pr_repo" "$head_sha" "$base_ref" || true)"
-            if json_is_array "$rest_output"; then
-                poll_output="$rest_output"
-                poll_status=0
-            fi
+        poll_output="$(prefer_rest_required_checks_json "$poll_output" "$poll_status" "$poll_output")"
+        if (( used_rest_required_checks == 1 )); then
+            poll_status=0
         fi
 
         if json_is_array "$poll_output" && json_has_items "$poll_output"; then
@@ -457,8 +475,8 @@ checks_json="$latest_checks_json"
 if [[ -z "$checks_json" ]]; then
     checks_json="$(gh pr checks "$pr_num" --required --json name,link,bucket,state,workflow 2>/dev/null || true)"
 fi
-if [[ -z "$checks_json" || "$checks_json" == "null" ]] && is_graphql_rate_limit_error "$poll_output"; then
-    checks_json="$(rest_required_checks_json "$pr_repo" "$head_sha" "$base_ref" || true)"
+if [[ -z "$checks_json" || "$checks_json" == "null" ]]; then
+    checks_json="$(prefer_rest_required_checks_json "$checks_json" 1 "$poll_output")"
 fi
 if json_has_items "$checks_json"; then
     if ! printf '%s\n' "$checks_json" | jq -e '.[] | select(.bucket == "fail" or .bucket == "cancel")' >/dev/null 2>&1; then

--- a/scripts/watch-pr-ci.sh
+++ b/scripts/watch-pr-ci.sh
@@ -389,7 +389,7 @@ watch_required_checks() {
     while :; do
         poll_required_checks "$pr_number"
         poll_output="$(prefer_rest_required_checks_json "$poll_output" "$poll_status" "$poll_output")"
-        if (( used_rest_required_checks == 1 )); then
+        if (( used_rest_required_checks == 1 )) && json_has_items "$poll_output"; then
             poll_status=0
         fi
 

--- a/scripts/watch-pr-ci.sh
+++ b/scripts/watch-pr-ci.sh
@@ -26,6 +26,8 @@ poll_status=0
 
 declare -A last_check_state=()
 last_waiting_line=""
+pr_repo=""
+base_ref=""
 
 current_epoch() {
     date +%s
@@ -46,6 +48,27 @@ json_is_array() {
 json_has_items() {
     local json="$1"
     [[ -n "$json" ]] && printf '%s\n' "$json" | jq -e 'length > 0' >/dev/null 2>&1
+}
+
+is_graphql_rate_limit_error() {
+    local output="$1"
+    [[ "$output" == *"GraphQL:"*"rate limit"* ]] ||
+        [[ "$output" == *"secondary rate limit"* ]] ||
+        [[ "$output" == *"API rate limit exceeded"* ]]
+}
+
+repo_slug_from_pr_url() {
+    local url="$1"
+    if [[ "$url" =~ github\.com/([^/]+/[^/]+)/pull/ ]]; then
+        printf '%s\n' "${BASH_REMATCH[1]}"
+        return 0
+    fi
+    return 1
+}
+
+urlencode_component() {
+    local value="$1"
+    jq -nr --arg value "$value" '$value | @uri'
 }
 
 check_rows_tsv() {
@@ -75,6 +98,79 @@ poll_required_checks() {
     poll_output="$(gh pr checks "$pr_number" --required --json name,link,bucket,state,workflow,startedAt,completedAt 2>&1)"
     poll_status=$?
     set -e
+}
+
+rest_required_checks_json() {
+    local repo="$1"
+    local sha="$2"
+    local base_branch="$3"
+    local branch_ref required_json check_runs_json status_json required_contexts
+
+    [[ -n "$repo" && -n "$sha" ]] || return 1
+
+    branch_ref="$(urlencode_component "$base_branch")"
+    required_json="$(gh api "repos/$repo/branches/$branch_ref/protection/required_status_checks" 2>/dev/null || true)"
+    check_runs_json="$(gh api "repos/$repo/commits/$sha/check-runs?per_page=100" 2>/dev/null || true)"
+    status_json="$(gh api "repos/$repo/commits/$sha/status" 2>/dev/null || true)"
+
+    [[ -n "$check_runs_json" ]] || check_runs_json='{}'
+    [[ -n "$status_json" ]] || status_json='{}'
+
+    required_contexts="$(
+        if [[ -n "$required_json" ]]; then
+            printf '%s\n' "$required_json" |
+                jq -c '((.checks // []) | map(.context)) + (.contexts // []) | map(select(. != null and . != "")) | unique' 2>/dev/null || printf '[]\n'
+        else
+            printf '[]\n'
+        fi
+    )"
+
+    jq -cn \
+        --argjson check_runs "$check_runs_json" \
+        --argjson statuses "$status_json" \
+        --argjson required "$required_contexts" '
+        def bucket_from_check:
+            if (.status // "") != "completed" then "pending"
+            elif (.conclusion // "") == "success" then "pass"
+            elif (.conclusion // "") == "cancelled" then "cancel"
+            elif ((.conclusion // "") == "neutral" or (.conclusion // "") == "skipped") then "skipping"
+            else "fail"
+            end;
+        def bucket_from_status:
+            if (.state // "") == "success" then "pass"
+            elif (.state // "") == "pending" then "pending"
+            else "fail"
+            end;
+        [
+            (($statuses.statuses // []) | map({
+                name: (.context // "status"),
+                link: (.target_url // ""),
+                bucket: bucket_from_status,
+                state: (.state // ""),
+                workflow: "status",
+                startedAt: (.created_at // .updated_at // ""),
+                completedAt: (if (.state // "") == "pending" then "" else (.updated_at // "") end)
+            })[]),
+            (($check_runs.check_runs // []) | map({
+                name: (.name // "check"),
+                link: (.html_url // ""),
+                bucket: bucket_from_check,
+                state: (.status // .conclusion // ""),
+                workflow: (.app.slug // .app.name // "check"),
+                startedAt: (.started_at // ""),
+                completedAt: (.completed_at // "")
+            })[])
+        ]
+        | flatten
+        | reduce .[] as $check ({}; .[$check.name] = $check)
+        | [.[]]
+        | if ($required | length) > 0 then
+            map(select(.name as $name | $required | index($name)))
+          else
+            .
+          end
+        | sort_by(.name)
+    '
 }
 
 timestamp_to_epoch() {
@@ -267,9 +363,17 @@ watch_required_checks() {
     local next_heartbeat=0
     local no_checks_retries=0
     local now
+    local rest_output
 
     while :; do
         poll_required_checks "$pr_number"
+        if [[ "$poll_status" -ne 0 ]] && is_graphql_rate_limit_error "$poll_output"; then
+            rest_output="$(rest_required_checks_json "$pr_repo" "$head_sha" "$base_ref" || true)"
+            if json_is_array "$rest_output"; then
+                poll_output="$rest_output"
+                poll_status=0
+            fi
+        fi
 
         if json_is_array "$poll_output" && json_has_items "$poll_output"; then
             latest_checks_json="$poll_output"
@@ -316,9 +420,9 @@ watch_required_checks() {
 
 pr_json="$(
     if [[ -n "$pr_ref" ]]; then
-        gh pr view "$pr_ref" --json number,url,headRefName,headRefOid 2>/dev/null || true
+        gh pr view "$pr_ref" --json number,url,headRefName,headRefOid,baseRefName 2>/dev/null || true
     else
-        gh pr view --json number,url,headRefName,headRefOid 2>/dev/null || true
+        gh pr view --json number,url,headRefName,headRefOid,baseRefName 2>/dev/null || true
     fi
 )"
 
@@ -329,6 +433,8 @@ fi
 
 pr_num="$(printf '%s\n' "$pr_json" | jq -r '.number')"
 pr_url="$(printf '%s\n' "$pr_json" | jq -r '.url')"
+base_ref="$(printf '%s\n' "$pr_json" | jq -r '.baseRefName // "main"')"
+pr_repo="$(repo_slug_from_pr_url "$pr_url" || true)"
 head_sha="$(git rev-parse HEAD 2>/dev/null || true)"
 if [[ -z "$head_sha" ]]; then
     head_sha="$(printf '%s\n' "$pr_json" | jq -r '.headRefOid')"
@@ -350,6 +456,9 @@ echo "Failed required checks:"
 checks_json="$latest_checks_json"
 if [[ -z "$checks_json" ]]; then
     checks_json="$(gh pr checks "$pr_num" --required --json name,link,bucket,state,workflow 2>/dev/null || true)"
+fi
+if [[ -z "$checks_json" || "$checks_json" == "null" ]] && is_graphql_rate_limit_error "$poll_output"; then
+    checks_json="$(rest_required_checks_json "$pr_repo" "$head_sha" "$base_ref" || true)"
 fi
 if json_has_items "$checks_json"; then
     if ! printf '%s\n' "$checks_json" | jq -e '.[] | select(.bucket == "fail" or .bucket == "cancel")' >/dev/null 2>&1; then

--- a/test/pr_ci_watch_test.go
+++ b/test/pr_ci_watch_test.go
@@ -377,6 +377,231 @@ exit 1
 	}
 }
 
+func TestWatchPRCIScriptFallsBackToRESTPollingOnGraphQLRateLimit(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	ghLog := filepath.Join(tempDir, "gh.log")
+	ghState := filepath.Join(tempDir, "gh.state")
+	writeExecutable(t, filepath.Join(tempDir, "git"), `#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${1:-}" == "rev-parse" && "${2:-}" == "HEAD" ]]; then
+	printf 'deadbeef\n'
+	exit 0
+fi
+
+echo "unexpected git invocation: $*" >&2
+exit 1
+`)
+	writeExecutable(t, filepath.Join(tempDir, "gh"), `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >>"$FAKE_GH_LOG"
+
+if [[ "${1:-}" == "pr" && "${2:-}" == "view" ]]; then
+	cat <<'EOF'
+{"number":422,"url":"https://github.com/weill-labs/amux/pull/422","headRefName":"feat/ci-watch","headRefOid":"stale-sha"}
+EOF
+	exit 0
+fi
+
+if [[ "${1:-}" == "run" && "${2:-}" == "list" ]]; then
+	cat <<'EOF'
+[{"databaseId":999,"workflowName":"CI","displayTitle":"ci / test","url":"https://github.com/weill-labs/amux/actions/runs/999","conclusion":"","status":"in_progress"}]
+EOF
+	exit 0
+fi
+
+if [[ "${1:-}" == "pr" && "${2:-}" == "checks" && " $* " == *" --json "* ]]; then
+	echo "GraphQL: API rate limit already exceeded for user ID 2343711." >&2
+	exit 1
+fi
+
+if [[ "${1:-}" == "api" && "${2:-}" == "repos/weill-labs/amux/branches/main/protection/required_status_checks" ]]; then
+	cat <<'EOF'
+{"strict":true,"contexts":["test"],"checks":[{"context":"test","app_id":15368}]}
+EOF
+	exit 0
+fi
+
+if [[ "${1:-}" == "api" && "${2:-}" == "repos/weill-labs/amux/commits/deadbeef/check-runs"* ]]; then
+	count=0
+	if [[ -f "$FAKE_GH_STATE" ]]; then
+		count="$(cat "$FAKE_GH_STATE")"
+	fi
+	count=$((count + 1))
+	printf '%s\n' "$count" >"$FAKE_GH_STATE"
+	if [[ "$count" -eq 1 ]]; then
+		cat <<'EOF'
+{"check_runs":[{"name":"test","status":"in_progress","conclusion":null,"html_url":"https://github.com/weill-labs/amux/actions/runs/999/job/123","started_at":"2024-01-01T00:00:00Z","completed_at":null,"app":{"slug":"github-actions"}},{"name":"claude-review","status":"completed","conclusion":"failure","html_url":"https://github.com/weill-labs/amux/actions/runs/1000/job/456","started_at":"2024-01-01T00:00:00Z","completed_at":"2024-01-01T00:00:05Z","app":{"slug":"github-actions"}}]}
+EOF
+		exit 0
+	fi
+	cat <<'EOF'
+{"check_runs":[{"name":"test","status":"completed","conclusion":"success","html_url":"https://github.com/weill-labs/amux/actions/runs/999/job/123","started_at":"2024-01-01T00:00:00Z","completed_at":"2024-01-01T00:00:05Z","app":{"slug":"github-actions"}},{"name":"claude-review","status":"completed","conclusion":"failure","html_url":"https://github.com/weill-labs/amux/actions/runs/1000/job/456","started_at":"2024-01-01T00:00:00Z","completed_at":"2024-01-01T00:00:05Z","app":{"slug":"github-actions"}}]}
+EOF
+	exit 0
+fi
+
+if [[ "${1:-}" == "api" && "${2:-}" == "repos/weill-labs/amux/commits/deadbeef/status" ]]; then
+	cat <<'EOF'
+{"statuses":[]}
+EOF
+	exit 0
+fi
+
+echo "unexpected gh invocation: $*" >&2
+exit 1
+`)
+
+	cmd := exec.Command("bash", repoPath(t, "scripts/watch-pr-ci.sh"))
+	cmd.Dir = repoRoot(t)
+	cmd.Env = ciWatchScriptEnv(
+		t,
+		tempDir,
+		"FAKE_GH_LOG="+ghLog,
+		"FAKE_GH_STATE="+ghState,
+		"AMUX_PR_RUN_DISCOVERY_TIMEOUT=1",
+		"AMUX_PR_RUN_DISCOVERY_INTERVAL=0",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("expected success: %v\n%s", err, out)
+	}
+
+	output := string(out)
+	for _, want := range []string{
+		"Waiting for: test",
+		"test: in_progress",
+		"test: completed (pass)",
+		"PR #422 CI passed",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("output missing %q:\n%s", want, out)
+		}
+	}
+	if strings.Contains(output, "claude-review") {
+		t.Fatalf("output should ignore non-required REST fallback checks:\n%s", out)
+	}
+
+	logBytes, err := os.ReadFile(ghLog)
+	if err != nil {
+		t.Fatalf("read gh log: %v", err)
+	}
+	log := string(logBytes)
+	for _, want := range []string{
+		"pr checks 422 --required --json name,link,bucket,state,workflow,startedAt,completedAt",
+		"api repos/weill-labs/amux/branches/main/protection/required_status_checks",
+		"api repos/weill-labs/amux/commits/deadbeef/check-runs?per_page=100",
+		"api repos/weill-labs/amux/commits/deadbeef/status",
+	} {
+		if !strings.Contains(log, want) {
+			t.Fatalf("gh log missing %q:\n%s", want, log)
+		}
+	}
+}
+
+func TestWatchPRCIScriptReportsRESTFallbackFailuresOnGraphQLRateLimit(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	ghLog := filepath.Join(tempDir, "gh.log")
+	writeExecutable(t, filepath.Join(tempDir, "git"), `#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${1:-}" == "rev-parse" && "${2:-}" == "HEAD" ]]; then
+	printf 'deadbeef\n'
+	exit 0
+fi
+
+echo "unexpected git invocation: $*" >&2
+exit 1
+`)
+	writeExecutable(t, filepath.Join(tempDir, "gh"), `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >>"$FAKE_GH_LOG"
+
+if [[ "${1:-}" == "pr" && "${2:-}" == "view" ]]; then
+	cat <<'EOF'
+{"number":422,"url":"https://github.com/weill-labs/amux/pull/422","headRefName":"feat/ci-watch","headRefOid":"stale-sha"}
+EOF
+	exit 0
+fi
+
+if [[ "${1:-}" == "pr" && "${2:-}" == "checks" && " $* " == *" --json "* ]]; then
+	echo "GraphQL: API rate limit already exceeded for user ID 2343711." >&2
+	exit 1
+fi
+
+if [[ "${1:-}" == "run" && "${2:-}" == "list" ]]; then
+	cat <<'EOF'
+[{"databaseId":999,"workflowName":"CI","displayTitle":"ci / test","url":"https://github.com/weill-labs/amux/actions/runs/999","conclusion":"failure","status":"completed"}]
+EOF
+	exit 0
+fi
+
+if [[ "${1:-}" == "run" && "${2:-}" == "view" && "${3:-}" == "999" && "${4:-}" == "--log-failed" ]]; then
+	cat <<'EOF'
+FAIL step output
+--- FAIL: TestRESTFallbackFailure
+EOF
+	exit 0
+fi
+
+if [[ "${1:-}" == "api" && "${2:-}" == "repos/weill-labs/amux/branches/main/protection/required_status_checks" ]]; then
+	cat <<'EOF'
+{"strict":true,"contexts":["test"],"checks":[{"context":"test","app_id":15368}]}
+EOF
+	exit 0
+fi
+
+if [[ "${1:-}" == "api" && "${2:-}" == "repos/weill-labs/amux/commits/deadbeef/check-runs"* ]]; then
+	cat <<'EOF'
+{"check_runs":[{"name":"test","status":"completed","conclusion":"failure","html_url":"https://github.com/weill-labs/amux/actions/runs/999/job/123","started_at":"2024-01-01T00:00:00Z","completed_at":"2024-01-01T00:00:05Z","app":{"slug":"github-actions"}},{"name":"claude-review","status":"completed","conclusion":"success","html_url":"https://github.com/weill-labs/amux/actions/runs/1000/job/456","started_at":"2024-01-01T00:00:00Z","completed_at":"2024-01-01T00:00:05Z","app":{"slug":"github-actions"}}]}
+EOF
+	exit 0
+fi
+
+if [[ "${1:-}" == "api" && "${2:-}" == "repos/weill-labs/amux/commits/deadbeef/status" ]]; then
+	cat <<'EOF'
+{"statuses":[]}
+EOF
+	exit 0
+fi
+
+echo "unexpected gh invocation: $*" >&2
+exit 1
+`)
+
+	cmd := exec.Command("bash", repoPath(t, "scripts/watch-pr-ci.sh"))
+	cmd.Dir = repoRoot(t)
+	cmd.Env = ciWatchScriptEnv(t, tempDir, "FAKE_GH_LOG="+ghLog)
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected failure when REST fallback required check fails\n%s", out)
+	}
+
+	exitErr := mustExitError(t, err, out)
+	if exitErr.ExitCode() != 1 {
+		t.Fatalf("exit code = %d, want 1\n%s", exitErr.ExitCode(), out)
+	}
+
+	output := string(out)
+	for _, want := range []string{
+		"PR #422 CI failed",
+		"- test (github-actions): https://github.com/weill-labs/amux/actions/runs/999/job/123",
+		"FAIL step output",
+		"TestRESTFallbackFailure",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("output missing %q:\n%s", want, out)
+		}
+	}
+	if strings.Contains(output, "claude-review") {
+		t.Fatalf("output should not report non-required REST fallback failures:\n%s", out)
+	}
+}
+
 func TestPushAndWatchCIScriptRunsPushBeforeWatching(t *testing.T) {
 	t.Parallel()
 

--- a/test/pr_ci_watch_test.go
+++ b/test/pr_ci_watch_test.go
@@ -602,6 +602,92 @@ exit 1
 	}
 }
 
+func TestWatchPRCIScriptDoesNotPassWhenRESTFallbackHasNoChecksYet(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	writeExecutable(t, filepath.Join(tempDir, "git"), `#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${1:-}" == "rev-parse" && "${2:-}" == "HEAD" ]]; then
+	printf 'deadbeef\n'
+	exit 0
+fi
+
+echo "unexpected git invocation: $*" >&2
+exit 1
+`)
+	writeExecutable(t, filepath.Join(tempDir, "gh"), `#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${1:-}" == "pr" && "${2:-}" == "view" ]]; then
+	cat <<'EOF'
+{"number":422,"url":"https://github.com/weill-labs/amux/pull/422","headRefName":"feat/ci-watch","headRefOid":"stale-sha"}
+EOF
+	exit 0
+fi
+
+if [[ "${1:-}" == "pr" && "${2:-}" == "checks" && " $* " == *" --json "* ]]; then
+	echo "GraphQL: API rate limit already exceeded for user ID 2343711." >&2
+	exit 1
+fi
+
+if [[ "${1:-}" == "api" && "${2:-}" == "repos/weill-labs/amux/branches/main/protection/required_status_checks" ]]; then
+	cat <<'EOF'
+{"strict":true,"contexts":["test"],"checks":[{"context":"test","app_id":15368}]}
+EOF
+	exit 0
+fi
+
+if [[ "${1:-}" == "api" && "${2:-}" == "repos/weill-labs/amux/commits/deadbeef/check-runs"* ]]; then
+	cat <<'EOF'
+{"check_runs":[]}
+EOF
+	exit 0
+fi
+
+if [[ "${1:-}" == "api" && "${2:-}" == "repos/weill-labs/amux/commits/deadbeef/status" ]]; then
+	cat <<'EOF'
+{"statuses":[]}
+EOF
+	exit 0
+fi
+
+if [[ "${1:-}" == "run" && "${2:-}" == "list" ]]; then
+	cat <<'EOF'
+[]
+EOF
+	exit 0
+fi
+
+echo "unexpected gh invocation: $*" >&2
+exit 1
+`)
+
+	cmd := exec.Command("bash", repoPath(t, "scripts/watch-pr-ci.sh"))
+	cmd.Dir = repoRoot(t)
+	cmd.Env = ciWatchScriptEnv(
+		t,
+		tempDir,
+		"AMUX_PR_RUN_DISCOVERY_TIMEOUT=0",
+		"AMUX_PR_RUN_DISCOVERY_INTERVAL=0",
+		"AMUX_PR_CHECK_INTERVAL=0",
+		"AMUX_PR_HEARTBEAT_INTERVAL=0",
+	)
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected failure when REST fallback reports no checks yet\n%s", out)
+	}
+
+	output := string(out)
+	if strings.Contains(output, "PR #422 CI passed") {
+		t.Fatalf("output should not report success:\n%s", out)
+	}
+	if !strings.Contains(output, "PR #422 CI failed") {
+		t.Fatalf("output missing failure message:\n%s", out)
+	}
+}
+
 func TestPushAndWatchCIScriptRunsPushBeforeWatching(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Motivation
`scripts/watch-pr-ci.sh` currently depends on `gh pr checks`, which uses GitHub's GraphQL API. When that call is rate-limited, the script exits early and stops surfacing required-check status or failed logs even though the same data is still available from REST endpoints.

## Summary
- fall back to GitHub REST endpoints for required check polling when `gh pr checks` fails due to rate limiting
- normalize REST check-runs and classic commit statuses into the same required-check shape the watcher already understands
- filter REST fallback output down to branch-protection required contexts and keep waiting when REST still reports no checks yet
- add regression coverage for success, failure, and empty-check fallback cases

## Testing
- `go test ./test -run 'TestWatchPRCIScript(FallsBackToRESTPollingOnGraphQLRateLimit|ReportsRESTFallbackFailuresOnGraphQLRateLimit|DoesNotPassWhenRESTFallbackHasNoChecksYet)' -count=100`
- `go test ./... -timeout 120s`

## Review focus
- Verify the REST normalization and required-context filtering in `scripts/watch-pr-ci.sh`, especially the empty-array case after a GraphQL rate-limit response.
- Check that the new tests in `test/pr_ci_watch_test.go` exercise the real failure mode without depending on non-required checks.
