### PR TITLE
LAB-1368: Heal lower-row pane-header padding

### DIFF
--- a/internal/render/screen.go
+++ b/internal/render/screen.go
@@ -124,6 +124,7 @@ func DiffGrid(prev, next *ScreenGrid) []CellChange {
 		if firstChanged < 0 {
 			continue
 		}
+		lastChanged = extendChangedStatusTail(next, y, firstChanged, lastChanged)
 		for x := firstChanged; x <= lastChanged; x++ {
 			idx := y*next.Width + x
 			changes = append(changes, CellChange{
@@ -132,6 +133,55 @@ func DiffGrid(prev, next *ScreenGrid) []CellChange {
 		}
 	}
 	return changes
+}
+
+// Rows directly below a horizontal separator are pane-header rows. If a
+// header update changes earlier metadata but leaves the clipped tail
+// text/padding identical in the grid, the terminal can retain stale cells in
+// that tail from a previous partial write. Extend the rewrite through the rest
+// of the styled status-line segment so the lower-row header fully heals.
+func extendChangedStatusTail(next *ScreenGrid, y, firstChanged, lastChanged int) int {
+	if y <= 0 || !rowHasHorizontalSeparator(next, y-1) {
+		return lastChanged
+	}
+	if next.Get(firstChanged, y).Style.Bg == nil {
+		return lastChanged
+	}
+
+	end := lastChanged
+	for x := lastChanged + 1; x < next.Width; x++ {
+		cell := next.Get(x, y)
+		if cell.Width == 0 {
+			end = x
+			continue
+		}
+		if cell.Style.Bg == nil {
+			break
+		}
+		end = x
+	}
+	return end
+}
+
+func rowHasHorizontalSeparator(g *ScreenGrid, y int) bool {
+	if y < 0 || y >= g.Height {
+		return false
+	}
+	for x := 0; x < g.Width; x++ {
+		if isHorizontalSeparatorChar(g.Get(x, y).Char) {
+			return true
+		}
+	}
+	return false
+}
+
+func isHorizontalSeparatorChar(ch string) bool {
+	switch ch {
+	case "─", "┬", "┴", "┼", "├", "┤":
+		return true
+	default:
+		return false
+	}
 }
 
 // EmitDiff produces minimal ANSI output for the given cell changes.

--- a/internal/render/screen_test.go
+++ b/internal/render/screen_test.go
@@ -1553,13 +1553,14 @@ func TestRenderDiff_BelowSeparatorStatusRewriteClearsStalePaddingBeforeBorder(t 
 	rowRunes := []rune(displayRow(display, width, statusY))
 	leftPane := string(rowRunes[:pane1W])
 	trimmed := strings.TrimRight(leftPane, " ")
+	trimmedRunes := []rune(trimmed)
 	if !strings.HasSuffix(trimmed, "…") {
 		t.Fatalf("lower status row %q should end with an ellipsis before padding", leftPane)
 	}
 	if trimmed == leftPane {
 		t.Fatalf("lower status row %q should keep padding spaces before the border", leftPane)
 	}
-	for _, r := range []rune(leftPane[len(trimmed):]) {
+	for _, r := range rowRunes[len(trimmedRunes):pane1W] {
 		if r != ' ' {
 			t.Fatalf("lower status row %q should clear stale padding before the border", leftPane)
 		}

--- a/internal/render/screen_test.go
+++ b/internal/render/screen_test.go
@@ -1461,6 +1461,114 @@ func TestRenderDiff_TruncatedStatusLinePreservesPaddingBeforeBorder(t *testing.T
 	}
 }
 
+func TestRenderDiff_BelowSeparatorStatusRewriteClearsStalePaddingBeforeBorder(t *testing.T) {
+	t.Parallel()
+
+	const (
+		pane1W = 52
+		pane2W = 20
+		topH   = 3
+		botH   = 3
+	)
+	width := pane1W + 1 + pane2W
+	height := topH + 1 + botH
+	totalH := height + GlobalBarHeight
+
+	root := mkSplit(mux.SplitHorizontal, 0, 0, width, height,
+		mux.NewLeafByID(1, 0, 0, width, topH),
+		mkSplit(mux.SplitVertical, 0, topH+1, width, botH,
+			mux.NewLeafByID(2, 0, topH+1, pane1W, botH),
+			mux.NewLeafByID(3, pane1W+1, topH+1, pane2W, botH),
+		),
+	)
+
+	completedIssues := func(ids ...string) []proto.TrackedIssue {
+		issues := make([]proto.TrackedIssue, 0, len(ids))
+		for _, id := range ids {
+			issues = append(issues, proto.TrackedIssue{
+				ID:     id,
+				Status: proto.TrackedStatusCompleted,
+			})
+		}
+		return issues
+	}
+
+	pane2 := &statusPaneData{
+		id:           2,
+		name:         "w-LAB-1272",
+		color:        config.TextColorHex,
+		idle:         true,
+		cursorHidden: true,
+		trackedIssues: completedIssues(
+			"LAB-1306",
+			"LAB-1307",
+			"LAB-1308",
+			"LAB-1309",
+		),
+	}
+	lookup := func(id uint32) PaneData {
+		switch id {
+		case 1:
+			return &statusPaneData{
+				id:           1,
+				name:         "pane-1",
+				color:        config.TextColorHex,
+				idle:         true,
+				cursorHidden: true,
+			}
+		case 2:
+			return pane2
+		case 3:
+			return &statusPaneData{
+				id:           3,
+				name:         "pane-3",
+				color:        config.TextColorHex,
+				idle:         true,
+				cursorHidden: true,
+			}
+		}
+		return nil
+	}
+
+	comp := newTestCompositor(width, totalH, "test")
+	display := vt.NewSafeEmulator(width, totalH)
+
+	initial := comp.RenderDiff(root, 3, lookup)
+	mustWrite(t, display, []byte(initial))
+
+	statusY := topH + 1
+	for x := pane1W - 8; x < pane1W; x++ {
+		mustWrite(t, display, []byte(fmt.Sprintf("\x1b[%d;%dH#", statusY+1, x+1)))
+	}
+
+	pane2.trackedIssues = completedIssues(
+		"LAB-1406",
+		"LAB-1407",
+		"LAB-1408",
+		"LAB-1409",
+	)
+	update := comp.RenderDiff(root, 3, lookup)
+	mustWrite(t, display, []byte(update))
+
+	rowRunes := []rune(displayRow(display, width, statusY))
+	leftPane := string(rowRunes[:pane1W])
+	trimmed := strings.TrimRight(leftPane, " ")
+	if !strings.HasSuffix(trimmed, "…") {
+		t.Fatalf("lower status row %q should end with an ellipsis before padding", leftPane)
+	}
+	if trimmed == leftPane {
+		t.Fatalf("lower status row %q should keep padding spaces before the border", leftPane)
+	}
+	for _, r := range []rune(leftPane[len(trimmed):]) {
+		if r != ' ' {
+			t.Fatalf("lower status row %q should clear stale padding before the border", leftPane)
+		}
+	}
+	if got := rowRunes[pane1W]; got != '│' {
+		t.Fatalf("border column = %q, want vertical border", string(got))
+	}
+}
+
 func TestRenderDiff_ColorOracle_LongLines(t *testing.T) {
 	t.Parallel()
 	pane1W := 20


### PR DESCRIPTION
## Motivation
PR #719 expanded dirty row spans for truncated pane-header updates, but lower-row headers sitting below a horizontal split could still leave stale padding at the border edge. When later metadata changes only touched earlier cells in that header, the diff stopped before the clipped tail and failed to heal the border-side padding.

## Summary
- add a renderer regression for lower-row pane headers beneath a horizontal separator that seeds stale padding before the border and verifies a later diff clears it
- extend `DiffGrid` so rows directly below a horizontal separator rewrite the rest of their styled status-line tail when an earlier header cell changes
- keep the scope in `internal/render` only; no compositor layout changes or protocol changes

## Testing
- `go test ./internal/render -run 'TestRenderDiff_(TruncatedStatusLinePreservesPaddingBeforeBorder|BelowSeparatorStatusRewriteClearsStalePaddingBeforeBorder)' -count=100`
- `go test ./... -timeout 120s`

## Review focus
- `internal/render/screen.go`: the new tail extension only applies to rows immediately below a horizontal separator, which are pane-header rows; review that heuristic and its rightward scan boundary
- `internal/render/screen_test.go`: the new regression explicitly models the stale-terminal recovery path by seeding bogus tail cells before applying the second diff

Closes LAB-1368
