### PR TITLE
LAB-1334: Add managed remote sessions and host pane refs

### DIFF
--- a/internal/cli/cli_commands_remote.go
+++ b/internal/cli/cli_commands_remote.go
@@ -4,6 +4,13 @@ import "fmt"
 
 func remoteCLICommands() map[string]commandHandler {
 	return map[string]commandHandler{
+		"connect": func(inv invocation, args []string) int {
+			if len(args) < 1 {
+				fmt.Fprintln(inv.runtime.Stderr, "usage: amux connect <host>")
+				return 1
+			}
+			return inv.runSessionCommand("connect", []string{args[0]})
+		},
 		"hosts": func(inv invocation, args []string) int {
 			return inv.runSessionCommand("hosts", nil)
 		},

--- a/internal/cli/cli_parse.go
+++ b/internal/cli/cli_parse.go
@@ -33,6 +33,7 @@ var canonicalSessionCommands = map[string]sessionCommandSpec{
 	"_inject-proxy": {connectName: "_inject-proxy", argMode: sessionCommandForwardArgs},
 	"_layout-json":  {connectName: "_layout-json", argMode: sessionCommandNoArgs},
 	"capture":       {connectName: "capture", argMode: sessionCommandForwardArgs},
+	"connect":       {connectName: "connect", minArgs: 1, usage: connectUsage, argMode: sessionCommandFirstArg},
 	"copy-mode":     {connectName: "copy-mode", argMode: sessionCommandForwardArgs},
 	"cursor":        {connectName: "cursor", minArgs: 1, usage: cursorUsage, argMode: sessionCommandForwardArgs},
 	"disconnect":    {connectName: "disconnect", minArgs: 1, usage: disconnectUsage, argMode: sessionCommandFirstArg},

--- a/internal/cli/cli_usage.go
+++ b/internal/cli/cli_usage.go
@@ -17,6 +17,7 @@ const (
 	spawnUsage        = "usage: amux spawn [--auto] [--at <pane>] [--window <name|id>] [--vertical|--horizontal] [--root] [--focus] [--name NAME] [--host HOST] [--task TASK] [--color COLOR]"
 	swapUsage         = "usage: amux swap <pane1> <pane2> [--tree] | amux swap forward | amux swap backward"
 	cursorUsage       = "usage: amux cursor <layout|clipboard|ui> [--client <id>]"
+	connectUsage      = "usage: amux connect <host>"
 	disconnectUsage   = "usage: amux disconnect <host>"
 	focusUsage        = "usage: amux focus <pane>"
 	listClientsUsage  = "usage: amux list-clients"
@@ -51,6 +52,7 @@ var commandUsageByName = map[string]string{
 	"capture":          "usage: amux capture [pane] [--history <pane>] [--ansi] [--colors]",
 	"copy-mode":        "usage: amux copy-mode [pane] [--wait ui=copy-mode-shown] [--timeout <duration>]",
 	"cursor":           cursorUsage,
+	"connect":          connectUsage,
 	"debug":            debugUsage,
 	"disconnect":       disconnectUsage,
 	"equalize":         "usage: amux equalize [--vertical|--all]",
@@ -168,6 +170,7 @@ Usage:
                                        Capture a pane's retained history + visible screen
   amux [-s session] capture --ansi     Capture with ANSI escape codes
   amux [-s session] capture --colors   Capture border color map
+  amux [-s session] connect <host>     Connect to a remote amux session and mirror its panes locally
   amux [-s session] send-keys <pane> [--via pty|client] [--client <id>] [--wait ready|ui=input-idle] [--timeout <duration>] [--delay-final <duration>] [--hex] <keys>...
                                        Send keystrokes to a pane
   amux [-s session] mouse [--client <id>] [--timeout <duration>] ...

--- a/internal/cli/main_test.go
+++ b/internal/cli/main_test.go
@@ -870,6 +870,12 @@ func TestRunMainHelpAndUsageErrors(t *testing.T) {
 			wantExit:   1,
 			wantStderr: sshUsage + "\n",
 		},
+		{
+			name:       "connect usage error stays in dispatch layer",
+			args:       []string{"connect"},
+			wantExit:   1,
+			wantStderr: "usage: amux connect <host>\n",
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/cli/server_bootstrap.go
+++ b/internal/cli/server_bootstrap.go
@@ -220,6 +220,7 @@ func RunServer(sessionName string, managedTakeover bool, buildVersion string) {
 			OnPaneOutput:  hooks.OnPaneOutput,
 			OnPaneExit:    hooks.OnPaneExit,
 			OnStateChange: hooks.OnStateChange,
+			OnLayout:      hooks.OnLayout,
 			Logger:        logger.With("component", "ssh"),
 		})
 	}

--- a/internal/client/ssh_attach.go
+++ b/internal/client/ssh_attach.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/weill-labs/amux/internal/config"
+	"github.com/weill-labs/amux/internal/proto"
 	"github.com/weill-labs/amux/internal/transport"
 	_ "github.com/weill-labs/amux/internal/transport/ssh"
 	"golang.org/x/term"
@@ -16,6 +17,7 @@ type sshSessionTarget struct {
 	Target     transport.Target
 	Transport  string
 	HostConfig config.Host
+	HostRef    string
 }
 
 type sshSessionState struct {
@@ -30,7 +32,27 @@ type sshRunSessionOps struct {
 }
 
 func RunSSHSession(target transport.Target) error {
-	return runSSHSession(target, term.GetSize, defaultSSHRunSessionOps(), runSessionWithDeps)
+	resolved, err := resolveSSHSessionTarget(target)
+	if err != nil {
+		return err
+	}
+	return runSSHSessionViaLocalServer(resolved, term.GetSize, proto.EnsureDaemon, runLocalServerCommand, runSessionWithDeps)
+}
+
+func runSSHSessionViaLocalServer(
+	resolved sshSessionTarget,
+	getTermSize func(int) (int, int, error),
+	ensureDaemon func(string, time.Duration) error,
+	runCommand func(string, string, []string) error,
+	runner func(string, func(int) (int, int, error), runSessionDeps) error,
+) error {
+	if err := ensureDaemon(resolved.Target.Session, 5*time.Second); err != nil {
+		return fmt.Errorf("ensuring local server: %w", err)
+	}
+	if err := runCommand(resolved.Target.Session, "connect", []string{resolved.HostRef}); err != nil {
+		return fmt.Errorf("connecting remote host: %w", err)
+	}
+	return runner(resolved.Target.Session, getTermSize, defaultRunSessionDeps())
 }
 
 func runSSHSession(
@@ -59,9 +81,17 @@ func resolveSSHSessionTarget(target transport.Target) (sshSessionTarget, error) 
 	resolved := sshSessionTarget{
 		Target:    target,
 		Transport: cfg.HostTransport(target.Host),
+		HostRef:   target.Host,
 	}
 	if hostCfg, ok := cfg.Hosts[target.Host]; ok {
 		resolved.HostConfig = hostCfg
+	}
+	configuredUser := cfg.HostUser(target.Host)
+	if resolved.HostConfig.User == "" {
+		resolved.HostConfig.User = configuredUser
+	}
+	if target.User != "" && target.User != configuredUser {
+		resolved.HostRef = target.User + "@" + target.Host
 	}
 	return resolved, nil
 }
@@ -154,4 +184,36 @@ func (s *sshSessionState) close() {
 func (s *sshSessionState) set(tr transport.Transport) {
 	s.close()
 	s.transport = tr
+}
+
+func runLocalServerCommand(sessionName, cmdName string, args []string) error {
+	conn, err := net.Dial("unix", proto.SocketPath(sessionName))
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	writer := proto.NewWriter(conn)
+	reader := proto.NewReader(conn)
+	if err := writer.WriteMsg(&proto.Message{
+		Type:    proto.MsgTypeCommand,
+		CmdName: cmdName,
+		CmdArgs: args,
+	}); err != nil {
+		return err
+	}
+
+	for {
+		reply, err := reader.ReadMsg()
+		if err != nil {
+			return err
+		}
+		if reply.Type != proto.MsgTypeCmdResult {
+			continue
+		}
+		if reply.CmdErr != "" {
+			return fmt.Errorf("%s", reply.CmdErr)
+		}
+		return nil
+	}
 }

--- a/internal/client/ssh_attach_test.go
+++ b/internal/client/ssh_attach_test.go
@@ -13,6 +13,77 @@ import (
 	"github.com/weill-labs/amux/internal/transport"
 )
 
+func TestRunSSHSessionViaLocalServer(t *testing.T) {
+	t.Parallel()
+
+	resolved := sshSessionTarget{
+		Target:  transport.Target{Host: "builder", User: "deploy", Session: "work"},
+		HostRef: "deploy@builder",
+	}
+
+	var calls []string
+	err := runSSHSessionViaLocalServer(
+		resolved,
+		func(int) (int, int, error) { return 80, 24, nil },
+		func(session string, timeout time.Duration) error {
+			calls = append(calls, "ensure:"+session)
+			if timeout != 5*time.Second {
+				t.Fatalf("ensureDaemon timeout = %v, want %v", timeout, 5*time.Second)
+			}
+			return nil
+		},
+		func(session, cmd string, args []string) error {
+			calls = append(calls, "command:"+session+":"+cmd)
+			if cmd != "connect" {
+				t.Fatalf("runCommand cmd = %q, want connect", cmd)
+			}
+			if len(args) != 1 || args[0] != "deploy@builder" {
+				t.Fatalf("runCommand args = %#v, want [deploy@builder]", args)
+			}
+			return nil
+		},
+		func(sessionName string, _ func(int) (int, int, error), deps runSessionDeps) error {
+			calls = append(calls, "runner:"+sessionName)
+			if sessionName != "work" {
+				t.Fatalf("runner session = %q, want work", sessionName)
+			}
+			if deps.ensureDaemon == nil || deps.dial == nil {
+				t.Fatal("runner deps should include default session hooks")
+			}
+			return nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("runSSHSessionViaLocalServer() error = %v", err)
+	}
+
+	want := []string{"ensure:work", "command:work:connect", "runner:work"}
+	if strings.Join(calls, ",") != strings.Join(want, ",") {
+		t.Fatalf("calls = %v, want %v", calls, want)
+	}
+}
+
+func TestRunSSHSessionViaLocalServerWrapsConnectError(t *testing.T) {
+	t.Parallel()
+
+	err := runSSHSessionViaLocalServer(
+		sshSessionTarget{
+			Target:  transport.Target{Host: "builder", Session: "work"},
+			HostRef: "builder",
+		},
+		func(int) (int, int, error) { return 80, 24, nil },
+		func(string, time.Duration) error { return nil },
+		func(string, string, []string) error { return errors.New("boom") },
+		func(string, func(int) (int, int, error), runSessionDeps) error {
+			t.Fatal("runner should not be called after connect failure")
+			return nil
+		},
+	)
+	if err == nil || !strings.Contains(err.Error(), "connecting remote host: boom") {
+		t.Fatalf("runSSHSessionViaLocalServer() error = %v, want wrapped connect failure", err)
+	}
+}
+
 func TestDefaultSSHRunSessionOps(t *testing.T) {
 	t.Parallel()
 

--- a/internal/client/ssh_attach_test.go
+++ b/internal/client/ssh_attach_test.go
@@ -3,6 +3,7 @@ package client
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net"
 	"os"
 	"strings"
@@ -10,6 +11,7 @@ import (
 	"time"
 
 	"github.com/weill-labs/amux/internal/config"
+	"github.com/weill-labs/amux/internal/proto"
 	"github.com/weill-labs/amux/internal/transport"
 )
 
@@ -81,6 +83,30 @@ func TestRunSSHSessionViaLocalServerWrapsConnectError(t *testing.T) {
 	)
 	if err == nil || !strings.Contains(err.Error(), "connecting remote host: boom") {
 		t.Fatalf("runSSHSessionViaLocalServer() error = %v, want wrapped connect failure", err)
+	}
+}
+
+func TestRunSSHSessionViaLocalServerWrapsEnsureDaemonError(t *testing.T) {
+	t.Parallel()
+
+	err := runSSHSessionViaLocalServer(
+		sshSessionTarget{
+			Target:  transport.Target{Host: "builder", Session: "work"},
+			HostRef: "builder",
+		},
+		func(int) (int, int, error) { return 80, 24, nil },
+		func(string, time.Duration) error { return errors.New("daemon down") },
+		func(string, string, []string) error {
+			t.Fatal("runCommand should not be called after ensureDaemon failure")
+			return nil
+		},
+		func(string, func(int) (int, int, error), runSessionDeps) error {
+			t.Fatal("runner should not be called after ensureDaemon failure")
+			return nil
+		},
+	)
+	if err == nil || !strings.Contains(err.Error(), "ensuring local server: daemon down") {
+		t.Fatalf("runSSHSessionViaLocalServer() error = %v, want wrapped ensureDaemon failure", err)
 	}
 }
 
@@ -382,6 +408,126 @@ func TestConnectSSHSessionClosesTransportOnEnsureFailure(t *testing.T) {
 	}
 	if !tr.closed {
 		t.Fatal("connectSSHSession() should close transport after ensure failure")
+	}
+}
+
+func TestRunLocalServerCommand(t *testing.T) {
+	t.Parallel()
+
+	session := fmt.Sprintf("run-local-server-command-%d", time.Now().UnixNano())
+	socketPath := proto.SocketPath(session)
+	if err := os.MkdirAll(proto.SocketDir(), 0o700); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	_ = os.Remove(socketPath)
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatalf("Listen() error = %v", err)
+	}
+	t.Cleanup(func() {
+		_ = listener.Close()
+		_ = os.Remove(socketPath)
+	})
+
+	received := make(chan *proto.Message, 1)
+	serverErr := make(chan error, 1)
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			serverErr <- err
+			return
+		}
+		defer conn.Close()
+
+		reader := proto.NewReader(conn)
+		writer := proto.NewWriter(conn)
+		msg, err := reader.ReadMsg()
+		if err != nil {
+			serverErr <- err
+			return
+		}
+		received <- msg
+		if err := writer.WriteMsg(&proto.Message{Type: proto.MsgTypeNotify, Text: "ignored"}); err != nil {
+			serverErr <- err
+			return
+		}
+		serverErr <- writer.WriteMsg(&proto.Message{Type: proto.MsgTypeCmdResult})
+	}()
+
+	if err := runLocalServerCommand(session, "connect", []string{"builder"}); err != nil {
+		t.Fatalf("runLocalServerCommand() error = %v", err)
+	}
+	msg := <-received
+	if msg.Type != proto.MsgTypeCommand {
+		t.Fatalf("command type = %v, want %v", msg.Type, proto.MsgTypeCommand)
+	}
+	if msg.CmdName != "connect" {
+		t.Fatalf("command name = %q, want connect", msg.CmdName)
+	}
+	if len(msg.CmdArgs) != 1 || msg.CmdArgs[0] != "builder" {
+		t.Fatalf("command args = %#v, want [builder]", msg.CmdArgs)
+	}
+	if err := <-serverErr; err != nil {
+		t.Fatalf("server goroutine error = %v", err)
+	}
+}
+
+func TestRunLocalServerCommandReturnsServerError(t *testing.T) {
+	t.Parallel()
+
+	session := fmt.Sprintf("run-local-server-command-error-%d", time.Now().UnixNano())
+	socketPath := proto.SocketPath(session)
+	if err := os.MkdirAll(proto.SocketDir(), 0o700); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	_ = os.Remove(socketPath)
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatalf("Listen() error = %v", err)
+	}
+	t.Cleanup(func() {
+		_ = listener.Close()
+		_ = os.Remove(socketPath)
+	})
+
+	serverErr := make(chan error, 1)
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			serverErr <- err
+			return
+		}
+		defer conn.Close()
+
+		reader := proto.NewReader(conn)
+		writer := proto.NewWriter(conn)
+		if _, err := reader.ReadMsg(); err != nil {
+			serverErr <- err
+			return
+		}
+		serverErr <- writer.WriteMsg(&proto.Message{
+			Type:   proto.MsgTypeCmdResult,
+			CmdErr: "boom",
+		})
+	}()
+
+	err = runLocalServerCommand(session, "disconnect", []string{"builder"})
+	if err == nil || err.Error() != "boom" {
+		t.Fatalf("runLocalServerCommand() error = %v, want boom", err)
+	}
+	if err := <-serverErr; err != nil {
+		t.Fatalf("server goroutine error = %v", err)
+	}
+}
+
+func TestRunLocalServerCommandReturnsDialError(t *testing.T) {
+	t.Parallel()
+
+	session := fmt.Sprintf("run-local-server-command-missing-%d", time.Now().UnixNano())
+	_ = os.Remove(proto.SocketPath(session))
+
+	if err := runLocalServerCommand(session, "connect", []string{"builder"}); err == nil {
+		t.Fatal("runLocalServerCommand() error = nil, want dial failure")
 	}
 }
 

--- a/internal/mux/window.go
+++ b/internal/mux/window.go
@@ -980,3 +980,94 @@ func (w *Window) UnsplicePane(hostName string, replacement *Pane) error {
 
 	return nil
 }
+
+// ApplyLayout replaces the window root and metadata with a rebuilt layout tree.
+// Callers provide pane pointers that are already wired into root.
+func (w *Window) ApplyLayout(root *LayoutCell, activePane *Pane, width, height int, zoomedPaneID, leadPaneID uint32) error {
+	w.assertOwner("ApplyLayout")
+	if root == nil {
+		return fmt.Errorf("missing layout root")
+	}
+	if width <= 0 {
+		width = root.W
+	}
+	if height <= 0 {
+		height = root.H
+	}
+
+	root.Parent = nil
+	root.X = 0
+	root.Y = 0
+	root.ResizeAll(width, height)
+
+	w.Root = root
+	w.Width = width
+	w.Height = height
+	w.ZoomedPaneID = zoomedPaneID
+	w.LeadPaneID = leadPaneID
+	if activePane == nil {
+		activePane = firstPaneInSubtree(root)
+	}
+	w.ActivePane = activePane
+	w.resizePTYs()
+	return nil
+}
+
+// SplicePaneWithLayout replaces a leaf pane with an arbitrary layout subtree.
+// The subtree is resized to the replaced pane's cell before it is installed.
+func (w *Window) SplicePaneWithLayout(oldPaneID uint32, subtree *LayoutCell, activePane *Pane) error {
+	w.assertOwner("SplicePaneWithLayout")
+	if subtree == nil {
+		return fmt.Errorf("missing subtree")
+	}
+
+	cell, err := w.mustFindPane(oldPaneID)
+	if err != nil {
+		return err
+	}
+	if w.ZoomedPaneID == oldPaneID {
+		w.ZoomedPaneID = 0
+	}
+
+	subtree.Parent = cell.Parent
+	subtree.X = cell.X
+	subtree.Y = cell.Y
+	subtree.ResizeSubtree(cell.W, cell.H)
+	subtree.FixOffsets()
+
+	if cell.Parent == nil {
+		w.Root = subtree
+	} else {
+		for i, child := range cell.Parent.Children {
+			if child == cell {
+				cell.Parent.Children[i] = subtree
+				break
+			}
+		}
+	}
+
+	if activePane == nil {
+		activePane = firstPaneInSubtree(subtree)
+	}
+	if activePane != nil {
+		w.setActive(activePane)
+	}
+
+	w.Root.FixOffsets()
+	w.resizePTYs()
+	return nil
+}
+
+func firstPaneInSubtree(root *LayoutCell) *Pane {
+	if root == nil {
+		return nil
+	}
+	var pane *Pane
+	root.Walk(func(cell *LayoutCell) {
+		if pane != nil || cell == nil || cell.Pane == nil {
+			return
+		}
+		pane = cell.Pane
+	})
+	return pane
+}

--- a/internal/mux/window_test.go
+++ b/internal/mux/window_test.go
@@ -2059,3 +2059,150 @@ func TestUnsplicePane(t *testing.T) {
 		t.Errorf("active pane = %d, want 99", w.ActivePane.ID)
 	}
 }
+
+func TestApplyLayoutRequiresRoot(t *testing.T) {
+	t.Parallel()
+
+	w := &Window{}
+	if err := w.ApplyLayout(nil, nil, 0, 0, 0, 0); err == nil || err.Error() != "missing layout root" {
+		t.Fatalf("ApplyLayout(nil) error = %v, want missing layout root", err)
+	}
+}
+
+func TestApplyLayoutUsesRootDimensionsAndFirstPane(t *testing.T) {
+	t.Parallel()
+
+	p1 := fakePaneID(1)
+	p2 := fakePaneID(2)
+	root := NewLeaf(p1, 5, 7, 60, 18)
+	mustSplitCell(t, root, SplitVertical, p2)
+	root.FixOffsets()
+
+	w := &Window{
+		Root:       NewLeaf(fakePaneID(99), 0, 0, 80, 24),
+		ActivePane: fakePaneID(99),
+		Width:      80,
+		Height:     24,
+	}
+	if err := w.ApplyLayout(root, nil, 0, 0, 42, 24); err != nil {
+		t.Fatalf("ApplyLayout() error = %v", err)
+	}
+
+	if w.Root != root {
+		t.Fatal("ApplyLayout() should replace the window root")
+	}
+	if w.Width != root.W || w.Height != root.H {
+		t.Fatalf("window size = %dx%d, want %dx%d", w.Width, w.Height, root.W, root.H)
+	}
+	if w.ActivePane != p1 {
+		t.Fatalf("active pane = %#v, want first pane %#v", w.ActivePane, p1)
+	}
+	if w.ZoomedPaneID != 42 || w.LeadPaneID != 24 {
+		t.Fatalf("zoom/lead = (%d,%d), want (42,24)", w.ZoomedPaneID, w.LeadPaneID)
+	}
+	if root.Parent != nil || root.X != 0 || root.Y != 0 {
+		t.Fatalf("root placement = parent:%v x:%d y:%d, want parent:nil x:0 y:0", root.Parent, root.X, root.Y)
+	}
+}
+
+func TestSplicePaneWithLayoutRequiresSubtree(t *testing.T) {
+	t.Parallel()
+
+	p1 := fakePaneID(1)
+	w := &Window{Root: NewLeaf(p1, 0, 0, 80, 24), ActivePane: p1, Width: 80, Height: 24}
+	if err := w.SplicePaneWithLayout(1, nil, nil); err == nil || err.Error() != "missing subtree" {
+		t.Fatalf("SplicePaneWithLayout(nil) error = %v, want missing subtree", err)
+	}
+}
+
+func TestSplicePaneWithLayoutReplacesNestedPane(t *testing.T) {
+	t.Parallel()
+
+	p1 := fakePaneID(1)
+	p2 := fakePaneID(2)
+	root := NewLeaf(p1, 0, 0, 80, 24)
+	mustSplitCell(t, root, SplitVertical, p2)
+	root.FixOffsets()
+
+	w := &Window{Root: root, ActivePane: p2, Width: 80, Height: 24, ZoomedPaneID: 1}
+	oldCell := root.FindPane(1)
+	if oldCell == nil {
+		t.Fatal("missing pane-1 cell")
+	}
+
+	p3 := fakePaneID(3)
+	p4 := fakePaneID(4)
+	subtree := NewLeaf(p3, 0, 0, 20, 10)
+	mustSplitCell(t, subtree, SplitHorizontal, p4)
+
+	if err := w.SplicePaneWithLayout(1, subtree, nil); err != nil {
+		t.Fatalf("SplicePaneWithLayout() error = %v", err)
+	}
+
+	if w.ZoomedPaneID != 0 {
+		t.Fatalf("ZoomedPaneID = %d, want 0", w.ZoomedPaneID)
+	}
+	if w.Root.Children[0] != subtree {
+		t.Fatal("subtree was not installed in the replaced child slot")
+	}
+	if subtree.Parent != w.Root {
+		t.Fatal("subtree parent should be the root split")
+	}
+	if subtree.X != oldCell.X || subtree.Y != oldCell.Y || subtree.W != oldCell.W || subtree.H != oldCell.H {
+		t.Fatalf("subtree frame = (%d,%d %dx%d), want (%d,%d %dx%d)", subtree.X, subtree.Y, subtree.W, subtree.H, oldCell.X, oldCell.Y, oldCell.W, oldCell.H)
+	}
+	if w.Root.FindPane(1) != nil {
+		t.Fatal("pane-1 should be removed after splice")
+	}
+	if w.Root.FindPane(3) == nil || w.Root.FindPane(4) == nil {
+		t.Fatal("spliced subtree panes should be present in the window")
+	}
+	if w.ActivePane != p3 {
+		t.Fatalf("active pane = %#v, want first pane %#v", w.ActivePane, p3)
+	}
+}
+
+func TestSplicePaneWithLayoutReplacesRoot(t *testing.T) {
+	t.Parallel()
+
+	p1 := fakePaneID(1)
+	w := &Window{
+		Root:         NewLeaf(p1, 0, 0, 80, 24),
+		ActivePane:   p1,
+		Width:        80,
+		Height:       24,
+		ZoomedPaneID: 1,
+	}
+	p2 := fakePaneID(2)
+	subtree := NewLeaf(p2, 0, 0, 0, 0)
+
+	if err := w.SplicePaneWithLayout(1, subtree, nil); err != nil {
+		t.Fatalf("SplicePaneWithLayout() error = %v", err)
+	}
+
+	if w.Root != subtree {
+		t.Fatal("root splice should replace the window root")
+	}
+	if w.ActivePane != p2 {
+		t.Fatalf("active pane = %#v, want %#v", w.ActivePane, p2)
+	}
+	if w.ZoomedPaneID != 0 {
+		t.Fatalf("ZoomedPaneID = %d, want 0", w.ZoomedPaneID)
+	}
+}
+
+func TestFirstPaneInSubtree(t *testing.T) {
+	t.Parallel()
+
+	if got := firstPaneInSubtree(nil); got != nil {
+		t.Fatalf("firstPaneInSubtree(nil) = %#v, want nil", got)
+	}
+
+	p1 := fakePaneID(1)
+	p2 := fakePaneID(2)
+	root := NewLeaf(p1, 0, 0, 80, 24)
+	mustSplitCell(t, root, SplitVertical, p2)
+	if got := firstPaneInSubtree(root); got != p1 {
+		t.Fatalf("firstPaneInSubtree(root) = %#v, want %#v", got, p1)
+	}
+}

--- a/internal/proto/pane_transport.go
+++ b/internal/proto/pane_transport.go
@@ -19,10 +19,13 @@ type PaneTransport interface {
 	SendResize(localPaneID uint32, cols, rows int) error
 	KillPane(localPaneID uint32, cleanup bool, timeout time.Duration) error
 	RemovePane(localPaneID uint32)
+	RegisterPane(hostName string, localPaneID uint32, remotePaneID uint32) error
 	CreatePane(hostName string, localPaneID uint32, sessionName string) (uint32, error)
+	ConnectHost(hostName string, sessionName string) (*LayoutSnapshot, error)
 	ConnStatusForPane(localPaneID uint32) string
 	HostStatus(hostName string) ConnState
 	AllHostStatus() map[string]ConnState
+	RunHostCommand(hostName string, sessionName string, cmdName string, cmdArgs []string) (string, error)
 	DisconnectHost(hostName string) error
 	ReconnectHost(hostName string, sessionName string) error
 	Shutdown()

--- a/internal/proto/pane_transport_test.go
+++ b/internal/proto/pane_transport_test.go
@@ -13,13 +13,20 @@ func (testPaneTransport) SendInput(uint32, []byte) error                    { re
 func (testPaneTransport) SendResize(uint32, int, int) error                 { return nil }
 func (testPaneTransport) KillPane(uint32, bool, time.Duration) error        { return nil }
 func (testPaneTransport) RemovePane(uint32)                                 {}
+func (testPaneTransport) RegisterPane(string, uint32, uint32) error         { return nil }
 func (testPaneTransport) CreatePane(string, uint32, string) (uint32, error) { return 0, nil }
-func (testPaneTransport) ConnStatusForPane(uint32) string                   { return "" }
-func (testPaneTransport) HostStatus(string) ConnState                       { return Disconnected }
-func (testPaneTransport) AllHostStatus() map[string]ConnState               { return map[string]ConnState{} }
-func (testPaneTransport) DisconnectHost(string) error                       { return nil }
-func (testPaneTransport) ReconnectHost(string, string) error                { return nil }
-func (testPaneTransport) Shutdown()                                         {}
+func (testPaneTransport) ConnectHost(string, string) (*LayoutSnapshot, error) {
+	return &LayoutSnapshot{}, nil
+}
+func (testPaneTransport) ConnStatusForPane(uint32) string     { return "" }
+func (testPaneTransport) HostStatus(string) ConnState         { return Disconnected }
+func (testPaneTransport) AllHostStatus() map[string]ConnState { return map[string]ConnState{} }
+func (testPaneTransport) RunHostCommand(string, string, string, []string) (string, error) {
+	return "", nil
+}
+func (testPaneTransport) DisconnectHost(string) error        { return nil }
+func (testPaneTransport) ReconnectHost(string, string) error { return nil }
+func (testPaneTransport) Shutdown()                          {}
 
 func TestConnStateConstants(t *testing.T) {
 	t.Parallel()

--- a/internal/proto/paneref.go
+++ b/internal/proto/paneref.go
@@ -1,0 +1,31 @@
+package proto
+
+import (
+	"fmt"
+	"strings"
+)
+
+type PaneRef struct {
+	Host string
+	Pane string
+}
+
+func ParsePaneRef(s string) (PaneRef, error) {
+	if s == "" {
+		return PaneRef{}, nil
+	}
+	if !strings.Contains(s, "/") {
+		return PaneRef{Pane: s}, nil
+	}
+	host, pane, ok := strings.Cut(s, "/")
+	switch {
+	case !ok:
+		return PaneRef{Pane: s}, nil
+	case host == "":
+		return PaneRef{}, fmt.Errorf("invalid pane ref %q: missing host", s)
+	case pane == "":
+		return PaneRef{}, fmt.Errorf("invalid pane ref %q: missing pane", s)
+	default:
+		return PaneRef{Host: host, Pane: pane}, nil
+	}
+}

--- a/internal/proto/paneref.go
+++ b/internal/proto/paneref.go
@@ -17,10 +17,8 @@ func ParsePaneRef(s string) (PaneRef, error) {
 	if !strings.Contains(s, "/") {
 		return PaneRef{Pane: s}, nil
 	}
-	host, pane, ok := strings.Cut(s, "/")
+	host, pane, _ := strings.Cut(s, "/")
 	switch {
-	case !ok:
-		return PaneRef{Pane: s}, nil
 	case host == "":
 		return PaneRef{}, fmt.Errorf("invalid pane ref %q: missing host", s)
 	case pane == "":

--- a/internal/proto/paneref_test.go
+++ b/internal/proto/paneref_test.go
@@ -1,0 +1,48 @@
+package proto
+
+import "testing"
+
+func TestParsePaneRef(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		raw     string
+		want    PaneRef
+		wantErr string
+	}{
+		{name: "empty", raw: "", want: PaneRef{}},
+		{name: "local pane", raw: "pane-1", want: PaneRef{Pane: "pane-1"}},
+		{name: "host pane", raw: "builder/pane-9", want: PaneRef{Host: "builder", Pane: "pane-9"}},
+		{name: "missing host", raw: "/pane-1", wantErr: `invalid pane ref "/pane-1": missing host`},
+		{name: "missing pane", raw: "builder/", wantErr: `invalid pane ref "builder/": missing pane`},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := ParsePaneRef(tt.raw)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("ParsePaneRef(%q) error = nil, want %q", tt.raw, tt.wantErr)
+				}
+				if got != (PaneRef{}) {
+					t.Fatalf("ParsePaneRef(%q) = %#v, want zero value on error", tt.raw, got)
+				}
+				if err.Error() != tt.wantErr {
+					t.Fatalf("ParsePaneRef(%q) error = %q, want %q", tt.raw, err.Error(), tt.wantErr)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("ParsePaneRef(%q) error = %v", tt.raw, err)
+			}
+			if got != tt.want {
+				t.Fatalf("ParsePaneRef(%q) = %#v, want %#v", tt.raw, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/remote/host_conn.go
+++ b/internal/remote/host_conn.go
@@ -1,6 +1,7 @@
 package remote
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net"
@@ -15,6 +16,7 @@ import (
 	"github.com/weill-labs/amux/internal/auditlog"
 	"github.com/weill-labs/amux/internal/config"
 	"github.com/weill-labs/amux/internal/proto"
+	"github.com/weill-labs/amux/internal/transport"
 	transportssh "github.com/weill-labs/amux/internal/transport/ssh"
 )
 
@@ -39,6 +41,7 @@ type HostConn struct {
 	// Actor-owned state — accessed only from eventLoop goroutine.
 	state      ConnState
 	sshClient  *ssh.Client
+	tr         transport.Transport
 	amuxConn   net.Conn // persistent attach connection for pane I/O
 	amuxReader *proto.Reader
 	amuxWriter *proto.Writer
@@ -48,10 +51,12 @@ type HostConn struct {
 	localToRemote map[uint32]uint32
 
 	// Session name for the remote amux server (includes local hostname)
-	sessionName  string
-	remoteUID    string // UID of the remote user (for socket path)
-	connectAddr  string // normalized SSH address used by the current connection
-	takeoverMode bool   // true when established via takeover
+	sessionName   string
+	remoteUID     string // UID of the remote user (for socket path)
+	connectAddr   string // normalized SSH address used by the current connection
+	connectTarget transport.Target
+	lastLayout    *proto.LayoutSnapshot
+	takeoverMode  bool // true when established via takeover
 
 	// Pending connect waiters — replied when connectDoneEvent arrives.
 	pendingConnectReplies []chan error
@@ -62,6 +67,7 @@ type HostConn struct {
 	onPaneOutput  PaneOutputCallback
 	onPaneExit    PaneExitCallback
 	onStateChange StateChangeCallback
+	onLayout      LayoutChangeCallback
 
 	// Event loop channels
 	cmds      chan hostEvent
@@ -121,6 +127,20 @@ func (hc *HostConn) State() ConnState {
 	}
 }
 
+// Layout returns the most recently observed remote layout snapshot.
+func (hc *HostConn) Layout() *proto.LayoutSnapshot {
+	reply := make(chan *proto.LayoutSnapshot, 1)
+	if !hc.enqueue(layoutQuery{reply: reply}) {
+		return nil
+	}
+	select {
+	case layout := <-reply:
+		return layout
+	case <-hc.done:
+		return nil
+	}
+}
+
 // setState updates the state and fires the callback.
 // Only called from the actor goroutine.
 func (hc *HostConn) setState(s ConnState) {
@@ -171,6 +191,29 @@ func (hc *HostConn) BeginInputBuffering() {
 	hc.enqueue(beginInputBufferingEvent{})
 }
 
+func (hc *HostConn) transportName() string {
+	if hc.config.Transport != "" {
+		return hc.config.Transport
+	}
+	return "ssh"
+}
+
+func (hc *HostConn) newTransport() (transport.Transport, error) {
+	return transport.Get(hc.transportName(), hc.config)
+}
+
+func (hc *HostConn) targetForSession(sessionName string) transport.Target {
+	target := transport.Target{
+		Host:    hc.name,
+		User:    hc.config.User,
+		Session: sessionName,
+	}
+	if hc.connectAddr != "" {
+		target.Host = hc.connectAddr
+	}
+	return target
+}
+
 // doConnect performs the SSH dial, deploy, server start, and amux attach.
 // Runs outside the actor in a spawned goroutine. Only reads immutable fields;
 // returns all results for the actor to apply.
@@ -182,116 +225,108 @@ func (hc *HostConn) doConnect(sessionName string) (*connectOutcome, error) {
 // using the supplied address. If addr is empty, the configured host address or
 // HostConn name is used.
 func (hc *HostConn) doConnectWithAddr(sessionName, addr string) (*connectOutcome, error) {
-	sshCfg, err := hc.buildSSHConfig()
-	if err != nil {
-		return nil, fmt.Errorf("building SSH config: %w", err)
+	target := hc.targetForSession(sessionName)
+	if addr != "" {
+		target.Host = addr
 	}
-
-	addr = normalizedDialAddr(hc.name, addr, hc.config.Address)
-
-	sshClient, err := ssh.Dial("tcp", addr, sshCfg)
-	if err != nil {
-		return nil, fmt.Errorf("SSH dial: %w", err)
-	}
-
-	// Query the remote user's UID for socket path construction.
-	remoteUID, err := sshOutput(sshClient, "id -u")
-	if err != nil {
-		sshClient.Close()
-		return nil, fmt.Errorf("querying remote UID: %w", err)
-	}
-
-	// Deploy local binary to remote if needed (best-effort)
-	if hc.shouldDeploy() {
-		if err := DeployBinary(sshClient, hc.buildHash); err != nil {
-			hc.logger.Warn("ssh deploy failed",
-				"event", "ssh_deploy",
-				"host", hc.name,
-				"stage", "deploy",
-				"error", err,
-			)
-		}
-	}
-
-	// Ensure remote amux server is running
-	remoteSession := ManagedSessionName(sessionName)
-	sockPath := socketPath(remoteUID, remoteSession)
-	if err := ensureRemoteServer(sshClient, sockPath, remoteSession); err != nil {
-		sshClient.Close()
-		return nil, fmt.Errorf("starting remote server: %w", err)
-	}
-
-	// Persistent attach connection for streaming pane output.
-	amuxConn, err := hc.dialRemoteSocket(sshClient, sockPath)
-	if err != nil {
-		sshClient.Close()
-		return nil, fmt.Errorf("dialing remote socket %s: %w", sockPath, err)
-	}
-
-	amuxReader := proto.NewReader(amuxConn)
-	amuxWriter := proto.NewWriter(amuxConn)
-	if err := attachAndWait(amuxConn, amuxWriter, amuxReader, remoteSession, 10*time.Second); err != nil {
-		amuxConn.Close()
-		sshClient.Close()
-		return nil, err
-	}
-
-	return &connectOutcome{
-		sshClient:   sshClient,
-		amuxConn:    amuxConn,
-		amuxReader:  amuxReader,
-		amuxWriter:  amuxWriter,
-		sessionName: remoteSession,
-		remoteUID:   remoteUID,
-		connectAddr: addr,
-	}, nil
+	return hc.doConnectTarget(target, true, false)
 }
 
 // doConnectTakeover performs the SSH dial and amux attach for a takeover.
 // Runs outside the actor in a spawned goroutine.
 func (hc *HostConn) doConnectTakeover(sessionName, remoteUID, sshAddr string) (*connectOutcome, error) {
-	sshCfg, err := hc.buildSSHConfig()
+	_ = remoteUID
+	target := hc.targetForSession(sessionName)
+	if sshAddr != "" {
+		target.Host = sshAddr
+	}
+	return hc.doConnectTarget(target, false, true)
+}
+
+func (hc *HostConn) doConnectTarget(target transport.Target, ensureServer bool, takeover bool) (*connectOutcome, error) {
+	tr, err := hc.newTransport()
 	if err != nil {
-		return nil, fmt.Errorf("building SSH config: %w", err)
+		return nil, fmt.Errorf("creating %s transport: %w", hc.transportName(), err)
 	}
 
-	sshAddr = normalizeAddr(sshAddr)
-
-	sshClient, err := ssh.Dial("tcp", sshAddr, sshCfg)
-	if err != nil {
-		return nil, fmt.Errorf("SSH dial %s: %w", sshAddr, err)
+	if ensureServer && hc.shouldDeploy() {
+		if err := tr.Deploy(context.Background(), target, hc.buildHash); err != nil {
+			hc.logger.Warn("transport deploy failed",
+				"event", "remote_deploy",
+				"host", hc.name,
+				"transport", tr.Name(),
+				"error", err,
+			)
+		}
+	}
+	if ensureServer {
+		if err := tr.EnsureServer(context.Background(), target, target.Session); err != nil {
+			_ = tr.Close()
+			if isImmediateTransportError(err) {
+				return nil, err
+			}
+			return nil, fmt.Errorf("starting remote server: %w", err)
+		}
 	}
 
-	remoteSock := socketPath(remoteUID, sessionName)
-	if err := waitForSocket(sshClient, remoteSock, 5*time.Second); err != nil {
-		sshClient.Close()
-		return nil, fmt.Errorf("waiting for remote socket %s: %w", remoteSock, err)
-	}
-
-	amuxConn, err := hc.dialRemoteSocket(sshClient, remoteSock)
+	amuxConn, err := hc.waitForDial(tr, target, 10*time.Second)
 	if err != nil {
-		sshClient.Close()
-		return nil, fmt.Errorf("dialing remote socket %s: %w", remoteSock, err)
+		_ = tr.Close()
+		return nil, err
 	}
 
 	amuxReader := proto.NewReader(amuxConn)
 	amuxWriter := proto.NewWriter(amuxConn)
-	if err := attachAndWait(amuxConn, amuxWriter, amuxReader, sessionName, 10*time.Second); err != nil {
+	initialLayout, err := attachAndWaitLayout(amuxConn, amuxWriter, amuxReader, target.Session, 10*time.Second)
+	if err != nil {
 		amuxConn.Close()
-		sshClient.Close()
+		_ = tr.Close()
 		return nil, err
 	}
 
 	return &connectOutcome{
-		sshClient:   sshClient,
-		amuxConn:    amuxConn,
-		amuxReader:  amuxReader,
-		amuxWriter:  amuxWriter,
-		sessionName: sessionName,
-		remoteUID:   remoteUID,
-		connectAddr: sshAddr,
-		takeover:    true,
+		sshClient:     hc.sshClient,
+		tr:            tr,
+		amuxConn:      amuxConn,
+		amuxReader:    amuxReader,
+		amuxWriter:    amuxWriter,
+		sessionName:   target.Session,
+		connectAddr:   target.Host,
+		connectTarget: target,
+		initialLayout: initialLayout,
+		takeover:      takeover,
 	}, nil
+}
+
+func (hc *HostConn) waitForDial(tr transport.Transport, target transport.Target, timeout time.Duration) (net.Conn, error) {
+	deadline := time.Now().Add(timeout)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		conn, err := tr.Dial(context.Background(), target)
+		if err == nil {
+			return conn, nil
+		}
+		if isImmediateTransportError(err) {
+			return nil, err
+		}
+		lastErr = err
+		time.Sleep(100 * time.Millisecond)
+	}
+	if lastErr == nil {
+		lastErr = fmt.Errorf("dial timeout")
+	}
+	return nil, fmt.Errorf("dialing remote socket: %w", lastErr)
+}
+
+func isImmediateTransportError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "SSH dial:") ||
+		strings.Contains(msg, "building SSH config:") ||
+		strings.Contains(msg, "querying remote UID:") ||
+		strings.Contains(msg, "host key verification failed")
 }
 
 // Disconnect closes the SSH connection and marks state as disconnected.
@@ -408,16 +443,52 @@ func (hc *HostConn) queryRemotePaneID(localPaneID uint32) remotePaneIDResult {
 // with the persistent readLoop on the attach connection.
 func (hc *HostConn) runCommand(cmdName string, cmdArgs []string) (string, error) {
 	info := hc.queryConnInfo()
-	if info.sshClient == nil {
+	if info.sessionName == "" {
 		return "", fmt.Errorf("not connected")
 	}
+	if info.sshClient != nil {
+		remoteSock := socketPath(info.remoteUID, info.sessionName)
+		return hc.runSocketCommand(info.sshClient, remoteSock, cmdName, cmdArgs)
+	}
 
-	remoteSock := socketPath(info.remoteUID, info.sessionName)
-	return hc.runSocketCommand(info.sshClient, remoteSock, cmdName, cmdArgs)
+	target := info.target
+	target.Session = info.sessionName
+	return hc.runTransportCommand(target, cmdName, cmdArgs)
 }
 
 func (hc *HostConn) runSocketCommand(client *ssh.Client, sockPath, cmdName string, cmdArgs []string) (string, error) {
 	conn, err := hc.dialRemoteSocket(client, sockPath)
+	if err != nil {
+		return "", fmt.Errorf("dialing remote socket: %w", err)
+	}
+	defer conn.Close()
+
+	if err := proto.WriteMsg(conn, &proto.Message{
+		Type:    proto.MsgTypeCommand,
+		CmdName: cmdName,
+		CmdArgs: cmdArgs,
+	}); err != nil {
+		return "", err
+	}
+
+	reply, err := proto.ReadMsg(conn)
+	if err != nil {
+		return "", err
+	}
+	if reply.CmdErr != "" {
+		return "", fmt.Errorf("%s", reply.CmdErr)
+	}
+	return reply.CmdOutput, nil
+}
+
+func (hc *HostConn) runTransportCommand(target transport.Target, cmdName string, cmdArgs []string) (string, error) {
+	tr, err := hc.newTransport()
+	if err != nil {
+		return "", fmt.Errorf("creating %s transport: %w", hc.transportName(), err)
+	}
+	defer tr.Close()
+
+	conn, err := tr.Dial(context.Background(), target)
 	if err != nil {
 		return "", fmt.Errorf("dialing remote socket: %w", err)
 	}
@@ -498,6 +569,10 @@ func (hc *HostConn) closeConns() {
 		hc.sshClient.Close()
 		hc.sshClient = nil
 	}
+	if hc.tr != nil {
+		_ = hc.tr.Close()
+		hc.tr = nil
+	}
 }
 
 func (hc *HostConn) sendInputNow(localPaneID uint32, data []byte) error {
@@ -534,6 +609,11 @@ func (hc *HostConn) flushPendingInputs() {
 // attachAndWait sends MsgTypeAttach and blocks until the remote server
 // responds with a MsgTypeLayout, confirming the session window exists.
 func attachAndWait(conn net.Conn, writer *proto.Writer, reader *proto.Reader, session string, timeout time.Duration) error {
+	_, err := attachAndWaitLayout(conn, writer, reader, session, timeout)
+	return err
+}
+
+func attachAndWaitLayout(conn net.Conn, writer *proto.Writer, reader *proto.Reader, session string, timeout time.Duration) (*proto.LayoutSnapshot, error) {
 	if err := writer.WriteMsg(&proto.Message{
 		Type:       proto.MsgTypeAttach,
 		Session:    session,
@@ -541,18 +621,24 @@ func attachAndWait(conn net.Conn, writer *proto.Writer, reader *proto.Reader, se
 		Rows:       24,
 		AttachMode: proto.AttachModeNonInteractive,
 	}); err != nil {
-		return fmt.Errorf("attaching to remote: %w", err)
+		return nil, fmt.Errorf("attaching to remote: %w", err)
 	}
-	if err := waitForLayout(conn, reader, timeout); err != nil {
-		return fmt.Errorf("waiting for remote layout: %w", err)
+	layout, err := waitForLayoutSnapshot(conn, reader, timeout)
+	if err != nil {
+		return nil, fmt.Errorf("waiting for remote layout: %w", err)
 	}
-	return nil
+	return layout, nil
 }
 
 // waitForLayout reads messages from conn until a usable MsgTypeLayout arrives,
 // confirming the remote server has an active window with at least one pane.
 // Non-layout or unusable layout messages are discarded until timeout.
-func waitForLayout(conn net.Conn, reader *proto.Reader, timeout time.Duration) (err error) {
+func waitForLayout(conn net.Conn, reader *proto.Reader, timeout time.Duration) error {
+	_, err := waitForLayoutSnapshot(conn, reader, timeout)
+	return err
+}
+
+func waitForLayoutSnapshot(conn net.Conn, reader *proto.Reader, timeout time.Duration) (layout *proto.LayoutSnapshot, err error) {
 	deadlineErr := conn.SetReadDeadline(time.Now().Add(timeout))
 	if deadlineErr == nil {
 		defer func() {
@@ -565,33 +651,40 @@ func waitForLayout(conn net.Conn, reader *proto.Reader, timeout time.Duration) (
 	}
 
 	if !isNoDeadlineError(deadlineErr) {
-		return deadlineErr
+		return nil, deadlineErr
 	}
 
-	result := make(chan error, 1)
+	result := make(chan struct {
+		layout *proto.LayoutSnapshot
+		err    error
+	}, 1)
 	go func() {
-		result <- readUntilReadyLayout(reader)
+		nextLayout, nextErr := readUntilReadyLayout(reader)
+		result <- struct {
+			layout *proto.LayoutSnapshot
+			err    error
+		}{layout: nextLayout, err: nextErr}
 	}()
 
 	timer := time.NewTimer(timeout)
 	defer timer.Stop()
 
 	select {
-	case err := <-result:
-		return err
+	case res := <-result:
+		return res.layout, res.err
 	case <-timer.C:
-		return os.ErrDeadlineExceeded
+		return nil, os.ErrDeadlineExceeded
 	}
 }
 
-func readUntilReadyLayout(reader *proto.Reader) error {
+func readUntilReadyLayout(reader *proto.Reader) (*proto.LayoutSnapshot, error) {
 	for {
 		msg, err := reader.ReadMsg()
 		if err != nil {
-			return err
+			return nil, err
 		}
 		if msg.Type == proto.MsgTypeLayout && msg.Layout != nil {
-			return nil
+			return msg.Layout, nil
 		}
 	}
 }

--- a/internal/remote/host_conn.go
+++ b/internal/remote/host_conn.go
@@ -784,20 +784,3 @@ func normalizeAddr(addr string) string {
 func sshOutput(client *ssh.Client, cmd string) (string, error) {
 	return transportssh.SSHOutput(client, cmd)
 }
-
-func addrOrFallback(values ...string) string {
-	for _, value := range values {
-		if value != "" {
-			return value
-		}
-	}
-	return ""
-}
-
-func normalizedDialAddr(hostName string, candidates ...string) string {
-	addr := addrOrFallback(candidates...)
-	if addr == "" {
-		addr = hostName
-	}
-	return normalizeAddr(addr)
-}

--- a/internal/remote/host_conn_events.go
+++ b/internal/remote/host_conn_events.go
@@ -8,6 +8,7 @@ import (
 	"golang.org/x/crypto/ssh"
 
 	"github.com/weill-labs/amux/internal/proto"
+	"github.com/weill-labs/amux/internal/transport"
 )
 
 var errHostConnClosed = errors.New("host connection closed")
@@ -23,14 +24,17 @@ type hostEvent interface {
 // Returned by doConnect/doConnectTakeover (which run outside the actor)
 // and applied to HostConn state by the actor.
 type connectOutcome struct {
-	sshClient   *ssh.Client
-	amuxConn    net.Conn
-	amuxReader  *proto.Reader
-	amuxWriter  *proto.Writer
-	sessionName string
-	remoteUID   string
-	connectAddr string
-	takeover    bool
+	sshClient     *ssh.Client
+	tr            transport.Transport
+	amuxConn      net.Conn
+	amuxReader    *proto.Reader
+	amuxWriter    *proto.Writer
+	sessionName   string
+	remoteUID     string
+	connectAddr   string
+	connectTarget transport.Target
+	initialLayout *proto.LayoutSnapshot
+	takeover      bool
 }
 
 // closeConns closes the connections held by a connectOutcome.
@@ -41,6 +45,9 @@ func (o *connectOutcome) closeConns() {
 	}
 	if o.sshClient != nil {
 		o.sshClient.Close()
+	}
+	if o.tr != nil {
+		_ = o.tr.Close()
 	}
 }
 
@@ -54,8 +61,17 @@ func (e stateQuery) handle(hc *HostConn) {
 	e.reply <- hc.state
 }
 
+type layoutQuery struct {
+	reply chan *proto.LayoutSnapshot
+}
+
+func (e layoutQuery) handle(hc *HostConn) {
+	e.reply <- hc.lastLayout
+}
+
 type connInfoResult struct {
 	sshClient   *ssh.Client
+	target      transport.Target
 	sessionName string
 	remoteUID   string
 }
@@ -67,6 +83,7 @@ type connInfoQuery struct {
 func (e connInfoQuery) handle(hc *HostConn) {
 	e.reply <- connInfoResult{
 		sshClient:   hc.sshClient,
+		target:      hc.connectTarget,
 		sessionName: hc.sessionName,
 		remoteUID:   hc.remoteUID,
 	}
@@ -203,7 +220,11 @@ func (e reconnectCmd) handle(hc *HostConn) {
 
 	// Start a new connect.
 	hc.startConnect(e.reply, func() (*connectOutcome, error) {
-		return hc.doConnectWithAddr(e.sessionName, hc.connectAddr)
+		sessionName := e.sessionName
+		if hc.sessionName != "" {
+			sessionName = hc.sessionName
+		}
+		return hc.doConnectWithAddr(sessionName, hc.connectAddr)
 	})
 }
 
@@ -286,6 +307,7 @@ func (e readLayoutEvent) handle(hc *HostConn) {
 	if hc.takeoverMode && !layoutReady(e.layout) {
 		return
 	}
+	hc.lastLayout = e.layout
 
 	present := make(map[uint32]struct{}, len(e.layout.Panes))
 	for _, pane := range e.layout.Panes {
@@ -309,6 +331,9 @@ func (e readLayoutEvent) handle(hc *HostConn) {
 		exited = append(exited, localPaneID)
 	}
 
+	if hc.onLayout != nil {
+		hc.onLayout(hc.name, e.layout)
+	}
 	if hc.onPaneExit == nil {
 		return
 	}
@@ -355,17 +380,23 @@ func (e reconnectDoneEvent) handle(hc *HostConn) {
 // connectDoneEvent and reconnectDoneEvent.
 func (hc *HostConn) applyOutcome(o *connectOutcome) {
 	hc.sshClient = o.sshClient
+	hc.tr = o.tr
 	hc.amuxConn = o.amuxConn
 	hc.amuxReader = o.amuxReader
 	hc.amuxWriter = o.amuxWriter
 	hc.sessionName = o.sessionName
 	hc.remoteUID = o.remoteUID
 	hc.connectAddr = o.connectAddr
+	hc.connectTarget = o.connectTarget
+	hc.lastLayout = o.initialLayout
 	if o.takeover {
 		hc.takeoverMode = true
 	}
 	hc.setState(Connected)
 	hc.logSSHConnect()
+	if hc.onLayout != nil && o.initialLayout != nil {
+		hc.onLayout(hc.name, o.initialLayout)
+	}
 	hc.bufferPendingInputs = false
 	hc.flushPendingInputs()
 	go hc.readLoop(hc.amuxReader)
@@ -387,10 +418,12 @@ func (hc *HostConn) disconnectAndDrainPending() {
 	hc.setState(Disconnected)
 	hc.bufferPendingInputs = false
 	hc.pendingInputs = nil
+	hc.lastLayout = nil
 	hc.drainPendingReplies(errHostConnClosed)
 }
 
 type reconnectTarget struct {
+	target      transport.Target
 	sessionName string
 	remoteUID   string
 	connectAddr string
@@ -400,9 +433,24 @@ type reconnectTarget struct {
 func (hc *HostConn) reconnectTarget() reconnectTarget {
 	connectAddr := hc.connectAddr
 	if connectAddr == "" {
-		connectAddr = normalizedDialAddr(hc.name, hc.config.Address)
+		switch {
+		case hc.connectTarget.Host != "":
+			connectAddr = hc.connectTarget.Host
+		case hc.config.Address != "":
+			connectAddr = normalizeAddr(hc.config.Address)
+		default:
+			connectAddr = normalizeAddr(hc.name)
+		}
 	}
+
+	target := hc.connectTarget
+	if target.Host == "" {
+		target = hc.targetForSession(hc.sessionName)
+		target.Host = connectAddr
+	}
+
 	return reconnectTarget{
+		target:      target,
 		sessionName: hc.sessionName,
 		remoteUID:   hc.remoteUID,
 		connectAddr: connectAddr,

--- a/internal/remote/host_conn_test.go
+++ b/internal/remote/host_conn_test.go
@@ -223,12 +223,10 @@ func TestReconnectTargetFallsBackToHostName(t *testing.T) {
 	hc := NewHostConn("test-remote", config.Host{}, "hash", nil, nil, nil)
 	defer hc.Close()
 
-	testInActor(hc, func(hc *HostConn) {
-		target := hc.reconnectTarget()
-		if target.connectAddr != "test-remote:22" {
-			t.Fatalf("target.connectAddr = %q, want test-remote:22", target.connectAddr)
-		}
-	})
+	target := hc.reconnectTarget()
+	if target.connectAddr != "test-remote:22" {
+		t.Fatalf("target.connectAddr = %q, want test-remote:22", target.connectAddr)
+	}
 }
 
 func TestRemovePane(t *testing.T) {

--- a/internal/remote/manager.go
+++ b/internal/remote/manager.go
@@ -5,6 +5,7 @@ package remote
 
 import (
 	"fmt"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -14,6 +15,7 @@ import (
 
 	"github.com/weill-labs/amux/internal/auditlog"
 	"github.com/weill-labs/amux/internal/config"
+	"github.com/weill-labs/amux/internal/proto"
 )
 
 // PaneCreatedCallback is called when a remote pane is created and ready.
@@ -28,6 +30,9 @@ type PaneExitCallback func(localPaneID uint32, reason string)
 
 // StateChangeCallback is called when a host's connection state changes.
 type StateChangeCallback func(hostName string, state ConnState)
+
+// LayoutChangeCallback is called when a host publishes a fresh remote layout.
+type LayoutChangeCallback func(hostName string, layout *proto.LayoutSnapshot)
 
 // HostConnFactory constructs HostConn instances for both managed and temporary
 // deploy-only connections.
@@ -45,6 +50,7 @@ type ManagerDeps struct {
 	OnPaneOutput  PaneOutputCallback
 	OnPaneExit    PaneExitCallback
 	OnStateChange StateChangeCallback
+	OnLayout      LayoutChangeCallback
 	NewHostConn   HostConnFactory
 	Logger        *charmlog.Logger
 }
@@ -67,6 +73,7 @@ type Manager struct {
 	onPaneOutput  PaneOutputCallback
 	onPaneExit    PaneExitCallback
 	onStateChange StateChangeCallback
+	onLayout      LayoutChangeCallback
 
 	// Actor-owned state.
 	hosts       map[string]*HostConn // keyed by config host name
@@ -95,6 +102,7 @@ func NewManager(cfg *config.Config, buildHash string, deps ManagerDeps) *Manager
 		onPaneOutput:  deps.OnPaneOutput,
 		onPaneExit:    deps.OnPaneExit,
 		onStateChange: deps.OnStateChange,
+		onLayout:      deps.OnLayout,
 		hosts:         make(map[string]*HostConn),
 		localToHost:   make(map[uint32]string),
 	}
@@ -112,6 +120,7 @@ func (m *Manager) Config() *config.Config {
 
 func (m *Manager) newManagedHostConn(name string, cfg config.Host) *HostConn {
 	hc := m.newHostConn(name, cfg, m.buildHash, m.onPaneOutput, m.onPaneExit, m.onStateChange)
+	hc.onLayout = m.onLayout
 	hc.logger = m.logger.With("host", name)
 	return hc
 }
@@ -120,6 +129,60 @@ func (m *Manager) newDeployHostConn(name string, cfg config.Host) *HostConn {
 	hc := m.newHostConn(name, cfg, m.buildHash, nil, nil, nil)
 	hc.logger = m.logger.With("host", name)
 	return hc
+}
+
+func (m *Manager) resolveHostConfig(hostName string) (config.Host, error) {
+	user := ""
+	if at := strings.LastIndex(hostName, "@"); at > 0 {
+		user = hostName[:at]
+		hostName = hostName[at+1:]
+	}
+
+	if host, ok := m.cfg.Hosts[hostName]; ok {
+		if host.Type == "local" {
+			return config.Host{}, fmt.Errorf("host %q is local, not remote", hostName)
+		}
+		if user != "" {
+			host.User = user
+		}
+		if host.User == "" {
+			host.User = m.cfg.HostUser(hostName)
+		}
+		if host.Address == "" {
+			host.Address = m.cfg.HostAddress(hostName)
+		}
+		if host.Color == "" {
+			host.Color = m.cfg.HostColor(hostName)
+		}
+		return host, nil
+	}
+
+	if hostName == "" {
+		return config.Host{}, fmt.Errorf("host %q not found in config", hostName)
+	}
+	if user == "" {
+		user = m.cfg.HostUser(hostName)
+	}
+	return config.Host{
+		Type:    "remote",
+		User:    user,
+		Address: hostName,
+		Color:   m.cfg.HostColor(hostName),
+	}, nil
+}
+
+func (m *Manager) managedHostConn(hostName string) (*HostConn, error) {
+	hostCfg, err := m.resolveHostConfig(hostName)
+	if err != nil {
+		return nil, err
+	}
+
+	hc, ok := m.hosts[hostName]
+	if !ok {
+		hc = m.newManagedHostConn(hostName, hostCfg)
+		m.hosts[hostName] = hc
+	}
+	return hc, nil
 }
 
 // DeployToAddress deploys the local binary to a remote host via a temporary SSH
@@ -163,18 +226,9 @@ func (m *Manager) DeployToAddress(hostName, sshAddr, sshUser string) {
 // The localPaneID is used for routing output back to the correct local pane.
 func (m *Manager) CreatePane(hostName string, localPaneID uint32, sessionName string) (uint32, error) {
 	hc, err := enqueueManagerQuery(m, func(m *Manager) (*HostConn, error) {
-		host, ok := m.cfg.Hosts[hostName]
-		if !ok {
-			return nil, fmt.Errorf("host %q not found in config", hostName)
-		}
-		if host.Type == "local" {
-			return nil, fmt.Errorf("host %q is local, not remote", hostName)
-		}
-
-		hc, ok := m.hosts[hostName]
-		if !ok {
-			hc = m.newManagedHostConn(hostName, host)
-			m.hosts[hostName] = hc
+		hc, err := m.managedHostConn(hostName)
+		if err != nil {
+			return nil, err
 		}
 		m.localToHost[localPaneID] = hostName
 		return hc, nil
@@ -193,6 +247,25 @@ func (m *Manager) CreatePane(hostName string, localPaneID uint32, sessionName st
 	}
 
 	return remotePaneID, nil
+}
+
+// ConnectHost ensures the named host is connected to the requested remote
+// session and returns the most recent layout snapshot from that host.
+func (m *Manager) ConnectHost(hostName string, sessionName string) (*proto.LayoutSnapshot, error) {
+	hc, err := enqueueManagerQuery(m, func(m *Manager) (*HostConn, error) {
+		return m.managedHostConn(hostName)
+	})
+	if err != nil {
+		return nil, err
+	}
+	if err := hc.EnsureConnected(sessionName); err != nil {
+		return nil, fmt.Errorf("connecting to %s: %w", hostName, err)
+	}
+	layout := hc.Layout()
+	if layout == nil {
+		return nil, fmt.Errorf("host %q did not publish a layout", hostName)
+	}
+	return layout, nil
 }
 
 // AttachForTakeover connects to a remote amux server that was started by a takeover
@@ -231,6 +304,24 @@ func (m *Manager) AttachForTakeover(hostName, sshAddr, sshUser, remoteUID, sessi
 	}
 
 	return hc.EnsureConnectedForTakeover(sessionName, remoteUID, sshAddr)
+}
+
+// RegisterPane registers an existing remote pane mapping for a host-backed
+// remote session.
+func (m *Manager) RegisterPane(hostName string, localPaneID uint32, remotePaneID uint32) error {
+	hc, err := enqueueManagerQuery(m, func(m *Manager) (*HostConn, error) {
+		hc, err := m.managedHostConn(hostName)
+		if err != nil {
+			return nil, err
+		}
+		m.localToHost[localPaneID] = hostName
+		return hc, nil
+	})
+	if err != nil {
+		return err
+	}
+	hc.RegisterPane(localPaneID, remotePaneID)
+	return nil
 }
 
 // findHostByAddress finds a config host entry whose Address matches sshAddr.
@@ -321,6 +412,20 @@ func (m *Manager) HostStatus(hostName string) ConnState {
 	return hc.State()
 }
 
+// RunHostCommand forwards a one-shot command to the named remote host.
+func (m *Manager) RunHostCommand(hostName string, sessionName string, cmdName string, cmdArgs []string) (string, error) {
+	hc, err := enqueueManagerQuery(m, func(m *Manager) (*HostConn, error) {
+		return m.managedHostConn(hostName)
+	})
+	if err != nil {
+		return "", err
+	}
+	if err := hc.EnsureConnected(sessionName); err != nil {
+		return "", fmt.Errorf("connecting to %s: %w", hostName, err)
+	}
+	return hc.runCommand(cmdName, cmdArgs)
+}
+
 // AllHostStatus returns connection states for all configured remote hosts.
 func (m *Manager) AllHostStatus() map[string]ConnState {
 	hosts, err := enqueueManagerQuery(m, func(m *Manager) (map[string]*HostConn, error) {
@@ -330,6 +435,11 @@ func (m *Manager) AllHostStatus() map[string]ConnState {
 				continue
 			}
 			result[name] = m.hosts[name]
+		}
+		for name, hc := range m.hosts {
+			if _, ok := result[name]; !ok {
+				result[name] = hc
+			}
 		}
 		return result, nil
 	})

--- a/internal/remote/reconnect.go
+++ b/internal/remote/reconnect.go
@@ -27,11 +27,7 @@ func (hc *HostConn) reconnectLoop(target reconnectTarget) {
 
 		var outcome *connectOutcome
 		var err error
-		if target.takeover {
-			outcome, err = hc.doConnectTakeover(target.sessionName, target.remoteUID, target.connectAddr)
-		} else {
-			outcome, err = hc.doConnectWithAddr(target.sessionName, target.connectAddr)
-		}
+		outcome, err = hc.doConnectTarget(target.target, !target.takeover, target.takeover)
 
 		if err == nil {
 			done := make(chan struct{})

--- a/internal/server/commands.go
+++ b/internal/server/commands.go
@@ -210,6 +210,7 @@ var commandRegistry = map[string]CommandHandler{
 	"_layout-json":        cmdLayoutJSON,
 	"events":              cmdEvents,
 	"hosts":               cmdHosts,
+	"connect":             cmdConnect,
 	"disconnect":          cmdDisconnect,
 	"reconnect":           cmdReconnect,
 	"reload-server":       cmdReloadServer,

--- a/internal/server/commands_capture.go
+++ b/internal/server/commands_capture.go
@@ -1,6 +1,9 @@
 package server
 
-import capturecmd "github.com/weill-labs/amux/internal/server/commands/capture"
+import (
+	caputil "github.com/weill-labs/amux/internal/capture"
+	capturecmd "github.com/weill-labs/amux/internal/server/commands/capture"
+)
 
 type captureCommandContext struct {
 	*CommandContext
@@ -19,5 +22,18 @@ func (ctx captureCommandContext) ForwardCapture(args []string) *Message {
 }
 
 func cmdCapture(ctx *CommandContext) {
+	req := caputil.ParseArgs(ctx.Args)
+	if req.PaneRef != "" {
+		ref, err := ctx.Sess.queryPaneRef(req.PaneRef)
+		if err != nil {
+			ctx.replyErr(err.Error())
+			return
+		}
+		if ref.Host != "" {
+			req.PaneRef = ref.Pane
+			ctx.applyCommandResult(remoteCommandResult(ctx.Sess, ref.Host, "capture", caputil.ArgsForRequest(req)))
+			return
+		}
+	}
 	ctx.applyCommandResult(capturecmd.Capture(captureCommandContext{ctx}, ctx.Args))
 }

--- a/internal/server/commands_input.go
+++ b/internal/server/commands_input.go
@@ -186,6 +186,17 @@ func (ctx inputCommandContext) SendKeys(actorPaneID uint32, args []string) (stri
 }
 
 func cmdSendKeys(ctx *CommandContext) {
+	if len(ctx.Args) > 0 {
+		ref, err := ctx.Sess.queryPaneRef(ctx.Args[0])
+		if err != nil {
+			ctx.replyErr(err.Error())
+			return
+		}
+		if ref.Host != "" {
+			ctx.applyCommandResult(remoteCommandResult(ctx.Sess, ref.Host, "send-keys", rewritePaneRefArg(ctx.Args, 0, ref.Pane)))
+			return
+		}
+	}
 	ctx.applyCommandResult(inputcmd.SendKeys(inputCommandContext{ctx}, ctx.ActorPaneID, ctx.Args))
 }
 

--- a/internal/server/commands_layout.go
+++ b/internal/server/commands_layout.go
@@ -729,6 +729,23 @@ func cmdReset(ctx *CommandContext) {
 }
 
 func runKill(ctx *CommandContext, actorPaneID uint32, opts killCommandArgs) commandpkg.Result {
+	if opts.paneRef != "" {
+		ref, err := ctx.Sess.queryPaneRef(opts.paneRef)
+		if err != nil {
+			return commandpkg.Result{Err: err}
+		}
+		if ref.Host != "" {
+			args := make([]string, 0, 4)
+			if opts.cleanup {
+				args = append(args, "--cleanup", "--timeout", opts.timeout.String())
+			}
+			if ref.Pane != "" {
+				args = append(args, ref.Pane)
+			}
+			return remoteCommandResult(ctx.Sess, ref.Host, "kill", args)
+		}
+	}
+
 	target, err := ctx.Sess.queryKillTarget(actorPaneID, opts.paneRef)
 	if err != nil {
 		return commandpkg.Result{Err: err}

--- a/internal/server/commands_low_coverage_test.go
+++ b/internal/server/commands_low_coverage_test.go
@@ -1437,6 +1437,32 @@ func TestCloseActiveWindowPreservesPreviousWindow(t *testing.T) {
 	}
 }
 
+func TestRemoveWindowFallsBackToRemainingActiveWindow(t *testing.T) {
+	t.Parallel()
+
+	sess := &Session{}
+	p1 := newTestPane(sess, 1, "pane-1")
+	p2 := newTestPane(sess, 2, "pane-2")
+	w1 := newTestWindowWithPanes(t, sess, 1, "one", p1)
+	w2 := newTestWindowWithPanes(t, sess, 2, "two", p2)
+	sess.Windows = []*mux.Window{w1, w2}
+	sess.ActiveWindowID = w2.ID
+	sess.PreviousWindowID = w1.ID
+	sess.refreshInputTarget()
+
+	sess.removeWindow(w2.ID)
+
+	if got := len(sess.Windows); got != 1 {
+		t.Fatalf("windows after remove = %d, want 1", got)
+	}
+	if got := sess.ActiveWindowID; got != w1.ID {
+		t.Fatalf("active window after remove = %d, want %d", got, w1.ID)
+	}
+	if got := sess.inputTargetPane(); got == nil || got.ID != p1.ID {
+		t.Fatalf("input target after remove = %v, want pane %d", got, p1.ID)
+	}
+}
+
 func TestParseKeyArgsAndEncodeKeyChunks(t *testing.T) {
 	t.Parallel()
 

--- a/internal/server/commands_remote.go
+++ b/internal/server/commands_remote.go
@@ -39,7 +39,7 @@ func (ctx remoteCommandContext) ReconnectHost(host string) error {
 	if ctx.Sess.RemoteManager == nil {
 		return fmt.Errorf("no remote hosts configured")
 	}
-	return ctx.Sess.RemoteManager.ReconnectHost(host, ctx.Sess.Name)
+	return ctx.Sess.RemoteManager.ReconnectHost(host, managedSessionName(ctx.Sess.Name))
 }
 
 func (ctx remoteCommandContext) ResolveReloadExecPath() (string, error) {
@@ -133,8 +133,65 @@ func cmdHosts(ctx *CommandContext) {
 	ctx.applyCommandResult(remotecmd.Hosts(remoteCommandContext{ctx}, ctx.Args))
 }
 
+func runConnect(ctx *CommandContext) commandpkg.Result {
+	if len(ctx.Args) < 1 {
+		return commandpkg.Result{Err: fmt.Errorf("usage: connect <host>")}
+	}
+	if ctx.Sess.RemoteManager == nil {
+		return commandpkg.Result{Err: fmt.Errorf("no remote hosts configured")}
+	}
+
+	hostName := ctx.Args[0]
+	layout, err := ctx.Sess.RemoteManager.ConnectHost(hostName, managedSessionName(ctx.Sess.Name))
+	if err != nil {
+		return commandpkg.Result{Err: err}
+	}
+
+	return toCommandResult(ctx.Sess.enqueueCommandMutation(func(mctx *MutationContext) commandMutationResult {
+		if err := mutationContextDo(mctx, func(sess *Session) error {
+			return sess.connectRemoteSession(hostName, layout, RemoteSessionConnect, 0, true)
+		}); err != nil {
+			return commandMutationResult{err: err}
+		}
+		return commandMutationResult{
+			output:          fmt.Sprintf("Connected to %s\n", hostName),
+			broadcastLayout: true,
+		}
+	}))
+}
+
+func cmdConnect(ctx *CommandContext) {
+	ctx.applyCommandResult(runConnect(ctx))
+}
+
+func runDisconnect(ctx *CommandContext) commandpkg.Result {
+	if len(ctx.Args) < 1 {
+		return commandpkg.Result{Err: fmt.Errorf("usage: disconnect <host>")}
+	}
+	if ctx.Sess.RemoteManager == nil {
+		return commandpkg.Result{Err: fmt.Errorf("no remote hosts configured")}
+	}
+
+	hostName := ctx.Args[0]
+	if err := ctx.Sess.RemoteManager.DisconnectHost(hostName); err != nil {
+		return commandpkg.Result{Err: err}
+	}
+
+	return toCommandResult(ctx.Sess.enqueueCommandMutation(func(mctx *MutationContext) commandMutationResult {
+		if err := mutationContextDo(mctx, func(sess *Session) error {
+			return sess.disconnectRemoteSession(hostName)
+		}); err != nil {
+			return commandMutationResult{err: err}
+		}
+		return commandMutationResult{
+			output:          fmt.Sprintf("Disconnected from %s\n", hostName),
+			broadcastLayout: true,
+		}
+	}))
+}
+
 func cmdDisconnect(ctx *CommandContext) {
-	ctx.applyCommandResult(remotecmd.Disconnect(remoteCommandContext{ctx}, ctx.Args))
+	ctx.applyCommandResult(runDisconnect(ctx))
 }
 
 func cmdReconnect(ctx *CommandContext) {

--- a/internal/server/commands_resize.go
+++ b/internal/server/commands_resize.go
@@ -11,5 +11,16 @@ func cmdResizeActive(ctx *CommandContext) {
 }
 
 func cmdResizePane(ctx *CommandContext) {
+	if len(ctx.Args) > 0 {
+		ref, err := ctx.Sess.queryPaneRef(ctx.Args[0])
+		if err != nil {
+			ctx.replyErr(err.Error())
+			return
+		}
+		if ref.Host != "" {
+			ctx.applyCommandResult(remoteCommandResult(ctx.Sess, ref.Host, "resize-pane", rewritePaneRefArg(ctx.Args, 0, ref.Pane)))
+			return
+		}
+	}
 	ctx.applyCommandResult(layoutcmd.ResizePane(layoutCommandContext{ctx}, ctx.ActorPaneID, ctx.Args))
 }

--- a/internal/server/commands_wait.go
+++ b/internal/server/commands_wait.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/weill-labs/amux/internal/mux"
 	"github.com/weill-labs/amux/internal/proto"
+	commandpkg "github.com/weill-labs/amux/internal/server/commands"
 	waitcmd "github.com/weill-labs/amux/internal/server/commands/wait"
 )
 
@@ -17,6 +18,37 @@ const (
 
 type waitCommandContext struct {
 	*CommandContext
+}
+
+func waitRemoteForward(ctx *CommandContext, args []string) (commandpkg.Result, bool) {
+	if len(args) == 0 {
+		return commandpkg.Result{}, false
+	}
+
+	var paneArgIndex int
+	switch args[0] {
+	case "content":
+		if len(args) < 2 {
+			return commandpkg.Result{}, false
+		}
+		paneArgIndex = 1
+	case "ready", "idle", "exited", "busy":
+		if len(args) < 2 {
+			return commandpkg.Result{}, false
+		}
+		paneArgIndex = 1
+	default:
+		return commandpkg.Result{}, false
+	}
+
+	ref, err := ctx.Sess.queryPaneRef(args[paneArgIndex])
+	if err != nil {
+		return commandpkg.Result{Err: err}, true
+	}
+	if ref.Host == "" {
+		return commandpkg.Result{}, false
+	}
+	return remoteCommandResult(ctx.Sess, ref.Host, "wait", rewritePaneRefArg(args, paneArgIndex, ref.Pane)), true
 }
 
 func (ctx waitCommandContext) Generation() uint64 {
@@ -243,6 +275,10 @@ func cmdCursor(ctx *CommandContext) {
 }
 
 func cmdWait(ctx *CommandContext) {
+	if res, ok := waitRemoteForward(ctx, ctx.Args); ok {
+		ctx.applyCommandResult(res)
+		return
+	}
 	ctx.applyCommandResult(waitcmd.Wait(waitCommandContext{ctx}, ctx.ActorPaneID, ctx.Args))
 }
 
@@ -251,10 +287,22 @@ func cmdLayoutJSON(ctx *CommandContext) {
 }
 
 func cmdWaitFor(ctx *CommandContext) {
+	if forwardedArgs := append([]string{"content"}, ctx.Args...); len(ctx.Args) > 0 {
+		if res, ok := waitRemoteForward(ctx, forwardedArgs); ok {
+			ctx.applyCommandResult(res)
+			return
+		}
+	}
 	ctx.applyCommandResult(waitcmd.WaitFor(waitCommandContext{ctx}, ctx.ActorPaneID, ctx.Args))
 }
 
 func cmdWaitBusy(ctx *CommandContext) {
+	if forwardedArgs := append([]string{"busy"}, ctx.Args...); len(ctx.Args) > 0 {
+		if res, ok := waitRemoteForward(ctx, forwardedArgs); ok {
+			ctx.applyCommandResult(res)
+			return
+		}
+	}
 	ctx.applyCommandResult(waitcmd.WaitBusy(waitCommandContext{ctx}, ctx.ActorPaneID, ctx.Args))
 }
 

--- a/internal/server/pane_ref.go
+++ b/internal/server/pane_ref.go
@@ -1,0 +1,51 @@
+package server
+
+import (
+	"fmt"
+
+	"github.com/weill-labs/amux/internal/proto"
+)
+
+func (s *Session) queryPaneRef(ref string) (proto.PaneRef, error) {
+	return enqueueSessionQuery(s, func(s *Session) (proto.PaneRef, error) {
+		return s.parsePaneRef(ref)
+	})
+}
+
+func (s *Session) parsePaneRef(ref string) (proto.PaneRef, error) {
+	parsed, err := proto.ParsePaneRef(ref)
+	if err != nil {
+		return proto.PaneRef{}, err
+	}
+	if parsed.Host != "" || parsed.Pane == "" {
+		return parsed, nil
+	}
+
+	if !s.isKnownRemoteHost(parsed.Pane) {
+		return parsed, nil
+	}
+	if s.hasExactPaneName(parsed.Pane) {
+		return proto.PaneRef{}, fmt.Errorf("ambiguous pane ref %q: matches both a remote host and a local pane; use host/pane or rename the local pane", ref)
+	}
+	return proto.PaneRef{Host: parsed.Pane}, nil
+}
+
+func (s *Session) isKnownRemoteHost(hostName string) bool {
+	if s == nil || s.RemoteManager == nil || hostName == "" {
+		return false
+	}
+	_, ok := s.RemoteManager.AllHostStatus()[hostName]
+	return ok
+}
+
+func (s *Session) hasExactPaneName(name string) bool {
+	if s == nil || name == "" {
+		return false
+	}
+	for _, pane := range s.Panes {
+		if pane != nil && pane.Meta.Name == name {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/server/pane_ref_test.go
+++ b/internal/server/pane_ref_test.go
@@ -1,0 +1,64 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/weill-labs/amux/internal/mux"
+	"github.com/weill-labs/amux/internal/proto"
+)
+
+func TestQueryPaneRefResolvesKnownHostOnlyRef(t *testing.T) {
+	t.Parallel()
+
+	_, sess, cleanup := newCommandTestSession(t)
+	defer cleanup()
+
+	installTestPaneTransport(t, sess, &stubPaneTransport{
+		hostStatusByName: map[string]proto.ConnState{"builder": proto.Connected},
+	}, nil)
+
+	got, err := sess.queryPaneRef("builder")
+	if err != nil {
+		t.Fatalf("queryPaneRef(builder) error = %v", err)
+	}
+	if got != (proto.PaneRef{Host: "builder"}) {
+		t.Fatalf("queryPaneRef(builder) = %#v, want host-only ref", got)
+	}
+}
+
+func TestQueryPaneRefRejectsHostPaneNameCollision(t *testing.T) {
+	t.Parallel()
+
+	_, sess, cleanup := newCommandTestSession(t)
+	defer cleanup()
+
+	pane := newTestPane(sess, 1, "builder")
+	window := newTestWindowWithPanes(t, sess, 1, "main", pane)
+	setSessionLayoutForTest(t, sess, window.ID, []*mux.Window{window}, pane)
+	installTestPaneTransport(t, sess, &stubPaneTransport{
+		hostStatusByName: map[string]proto.ConnState{"builder": proto.Connected},
+	}, nil)
+
+	_, err := sess.queryPaneRef("builder")
+	if err == nil {
+		t.Fatal("queryPaneRef(builder) error = nil, want ambiguity error")
+	}
+	if got := err.Error(); got != `ambiguous pane ref "builder": matches both a remote host and a local pane; use host/pane or rename the local pane` {
+		t.Fatalf("queryPaneRef(builder) error = %q", got)
+	}
+}
+
+func TestQueryPaneRefLeavesUnknownNamesLocal(t *testing.T) {
+	t.Parallel()
+
+	_, sess, cleanup := newCommandTestSession(t)
+	defer cleanup()
+
+	got, err := sess.queryPaneRef("pane-1")
+	if err != nil {
+		t.Fatalf("queryPaneRef(pane-1) error = %v", err)
+	}
+	if got != (proto.PaneRef{Pane: "pane-1"}) {
+		t.Fatalf("queryPaneRef(pane-1) = %#v, want local pane ref", got)
+	}
+}

--- a/internal/server/pane_transport.go
+++ b/internal/server/pane_transport.go
@@ -14,6 +14,7 @@ type PaneTransportHooks struct {
 	OnPaneOutput  func(localPaneID uint32, data []byte)
 	OnPaneExit    func(localPaneID uint32, reason string)
 	OnStateChange func(hostName string, state proto.ConnState)
+	OnLayout      func(hostName string, layout *proto.LayoutSnapshot)
 }
 
 // PaneTransportFactory builds one transport for a session using the session's
@@ -50,6 +51,9 @@ func (s *Session) paneTransportHooks() PaneTransportHooks {
 		},
 		OnStateChange: func(hostName string, state proto.ConnState) {
 			s.enqueueRemoteStateChange(hostName, state)
+		},
+		OnLayout: func(hostName string, layout *proto.LayoutSnapshot) {
+			s.enqueueRemoteLayout(hostName, layout)
 		},
 	}
 }

--- a/internal/server/pane_transport_test.go
+++ b/internal/server/pane_transport_test.go
@@ -37,8 +37,9 @@ func TestPrepareRemotePaneUsesConfiguredTransportHostColor(t *testing.T) {
 		t.Fatalf("CreatePane calls = %d, want 1", len(transport.createPaneCalls))
 	}
 	call := transport.createPaneCalls[0]
-	if call.hostName != "dev" || call.sessionName != sess.Name {
-		t.Fatalf("CreatePane call = %+v, want host dev and session %q", call, sess.Name)
+	wantSession := managedSessionName(sess.Name)
+	if call.hostName != "dev" || call.sessionName != wantSession {
+		t.Fatalf("CreatePane call = %+v, want host dev and session %q", call, wantSession)
 	}
 }
 

--- a/internal/server/pane_transport_test_helpers_test.go
+++ b/internal/server/pane_transport_test_helpers_test.go
@@ -11,6 +11,9 @@ type stubPaneTransport struct {
 	createPaneErr    error
 	createPaneRemote uint32
 	createPaneCalls  []createPaneCall
+	runHostOutput    string
+	runHostErr       error
+	runHostCalls     []runHostCommandCall
 	sendInputCalls   []sendInputCall
 	sendInputErr     error
 	sendResizeErr    error
@@ -35,6 +38,13 @@ type createPaneCall struct {
 type sendInputCall struct {
 	localPaneID uint32
 	data        []byte
+}
+
+type runHostCommandCall struct {
+	hostName    string
+	sessionName string
+	cmdName     string
+	cmdArgs     []string
 }
 
 type attachForTakeoverCall struct {
@@ -78,6 +88,13 @@ func (s *stubPaneTransport) RemovePane(localPaneID uint32) {
 	s.removedPanes = append(s.removedPanes, localPaneID)
 }
 
+func (s *stubPaneTransport) RegisterPane(hostName string, localPaneID uint32, remotePaneID uint32) error {
+	if err := s.lookupHostErr(s.disconnectErrs, hostName); err != nil {
+		return err
+	}
+	return nil
+}
+
 func (s *stubPaneTransport) CreatePane(hostName string, localPaneID uint32, sessionName string) (uint32, error) {
 	s.createPaneCalls = append(s.createPaneCalls, createPaneCall{
 		hostName:    hostName,
@@ -91,6 +108,28 @@ func (s *stubPaneTransport) CreatePane(hostName string, localPaneID uint32, sess
 		return s.createPaneRemote, nil
 	}
 	return 1, nil
+}
+
+func (s *stubPaneTransport) ConnectHost(hostName string, sessionName string) (*proto.LayoutSnapshot, error) {
+	if err := s.lookupHostErr(s.reconnectErrs, hostName); err != nil {
+		return nil, err
+	}
+	return &proto.LayoutSnapshot{
+		ActiveWindowID: 1,
+		Windows: []proto.WindowSnapshot{{
+			ID:           1,
+			Name:         hostName,
+			ActivePaneID: 1,
+			Root: proto.CellSnapshot{
+				X: 0, Y: 0, W: 80, H: 24, IsLeaf: true, Dir: -1, PaneID: 1,
+			},
+			Panes: []proto.PaneSnapshot{{
+				ID:   1,
+				Name: "pane-1",
+				Host: hostName,
+			}},
+		}},
+	}, nil
 }
 
 func (s *stubPaneTransport) ConnStatusForPane(localPaneID uint32) string {
@@ -119,6 +158,25 @@ func (s *stubPaneTransport) AllHostStatus() map[string]proto.ConnState {
 		out[hostName] = status
 	}
 	return out
+}
+
+func (s *stubPaneTransport) RunHostCommand(hostName string, sessionName string, cmdName string, cmdArgs []string) (string, error) {
+	s.runHostCalls = append(s.runHostCalls, runHostCommandCall{
+		hostName:    hostName,
+		sessionName: sessionName,
+		cmdName:     cmdName,
+		cmdArgs:     append([]string(nil), cmdArgs...),
+	})
+	if err := s.lookupHostErr(s.reconnectErrs, hostName); err != nil {
+		return "", err
+	}
+	if sessionName == "" || cmdName == "" {
+		return "", fmt.Errorf("missing remote command")
+	}
+	if s.runHostErr != nil {
+		return "", s.runHostErr
+	}
+	return s.runHostOutput, nil
 }
 
 func (s *stubPaneTransport) DisconnectHost(hostName string) error {

--- a/internal/server/remote_command_forward.go
+++ b/internal/server/remote_command_forward.go
@@ -1,0 +1,34 @@
+package server
+
+import (
+	"fmt"
+
+	commandpkg "github.com/weill-labs/amux/internal/server/commands"
+)
+
+func (s *Session) runRemoteCommand(hostName string, cmdName string, cmdArgs []string) (string, error) {
+	if s == nil || s.RemoteManager == nil {
+		return "", fmt.Errorf("no remote hosts configured")
+	}
+	return s.RemoteManager.RunHostCommand(hostName, managedSessionName(s.Name), cmdName, cmdArgs)
+}
+
+func remoteCommandResult(sess *Session, hostName string, cmdName string, cmdArgs []string) commandpkg.Result {
+	output, err := sess.runRemoteCommand(hostName, cmdName, cmdArgs)
+	return commandpkg.Result{
+		Output: output,
+		Err:    err,
+	}
+}
+
+func rewritePaneRefArg(args []string, index int, pane string) []string {
+	rewritten := append([]string(nil), args...)
+	if index < 0 || index >= len(rewritten) {
+		return rewritten
+	}
+	if pane == "" {
+		return append(rewritten[:index], rewritten[index+1:]...)
+	}
+	rewritten[index] = pane
+	return rewritten
+}

--- a/internal/server/remote_command_forward_test.go
+++ b/internal/server/remote_command_forward_test.go
@@ -1,0 +1,104 @@
+package server
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/weill-labs/amux/internal/proto"
+)
+
+func TestRemotePaneRefCommandsForwardToHostCommand(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		command    string
+		args       []string
+		wantArgs   []string
+		wantOutput string
+	}{
+		{
+			name:       "capture pane ref",
+			command:    "capture",
+			args:       []string{"gpu/pane-7", "--format", "json"},
+			wantArgs:   []string{"--format", "json", "pane-7"},
+			wantOutput: "{\n  \"name\": \"pane-7\"\n}\n",
+		},
+		{
+			name:       "capture host-only ref drops pane argument",
+			command:    "capture",
+			args:       []string{"gpu", "--format", "json"},
+			wantArgs:   []string{"--format", "json"},
+			wantOutput: "{\n  \"panes\": []\n}\n",
+		},
+		{
+			name:       "send-keys pane ref",
+			command:    "send-keys",
+			args:       []string{"gpu/pane-7", "echo hi", "Enter"},
+			wantArgs:   []string{"pane-7", "echo hi", "Enter"},
+			wantOutput: "Sent 8 bytes to pane-7\n",
+		},
+		{
+			name:       "wait content pane ref",
+			command:    "wait",
+			args:       []string{"content", "gpu/pane-7", "READY", "--timeout", "3s"},
+			wantArgs:   []string{"content", "pane-7", "READY", "--timeout", "3s"},
+			wantOutput: "matched\n",
+		},
+		{
+			name:       "resize-pane pane ref",
+			command:    "resize-pane",
+			args:       []string{"gpu/pane-7", "right", "2"},
+			wantArgs:   []string{"pane-7", "right", "2"},
+			wantOutput: "Resized pane-7 right by 2\n",
+		},
+		{
+			name:       "kill pane ref",
+			command:    "kill",
+			args:       []string{"--cleanup", "--timeout", "250ms", "gpu/pane-7"},
+			wantArgs:   []string{"--cleanup", "--timeout", "250ms", "pane-7"},
+			wantOutput: "Cleaning up pane-7\n",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv, sess, cleanup := newCommandTestSession(t)
+			defer cleanup()
+
+			transport := &stubPaneTransport{
+				hostStatusByName: map[string]proto.ConnState{"gpu": proto.Connected},
+				runHostOutput:    tt.wantOutput,
+			}
+			installTestPaneTransport(t, sess, transport, nil)
+
+			res := runTestCommand(t, srv, sess, tt.command, tt.args...)
+			if res.cmdErr != "" {
+				t.Fatalf("%s error = %q", tt.command, res.cmdErr)
+			}
+			if res.output != tt.wantOutput {
+				t.Fatalf("%s output = %q, want %q", tt.command, res.output, tt.wantOutput)
+			}
+			if len(transport.runHostCalls) != 1 {
+				t.Fatalf("RunHostCommand calls = %d, want 1", len(transport.runHostCalls))
+			}
+			call := transport.runHostCalls[0]
+			if call.hostName != "gpu" {
+				t.Fatalf("RunHostCommand host = %q, want %q", call.hostName, "gpu")
+			}
+			wantSession := managedSessionName(sess.Name)
+			if call.sessionName != wantSession {
+				t.Fatalf("RunHostCommand session = %q, want %q", call.sessionName, wantSession)
+			}
+			if call.cmdName != tt.command {
+				t.Fatalf("RunHostCommand cmd = %q, want %q", call.cmdName, tt.command)
+			}
+			if !reflect.DeepEqual(call.cmdArgs, tt.wantArgs) {
+				t.Fatalf("RunHostCommand args = %#v, want %#v", call.cmdArgs, tt.wantArgs)
+			}
+		})
+	}
+}

--- a/internal/server/remote_session.go
+++ b/internal/server/remote_session.go
@@ -1,0 +1,439 @@
+package server
+
+import (
+	"fmt"
+	"slices"
+
+	"github.com/weill-labs/amux/internal/mux"
+	"github.com/weill-labs/amux/internal/proto"
+)
+
+type RemoteSessionMode string
+
+const (
+	RemoteSessionConnect  RemoteSessionMode = "connect"
+	RemoteSessionTakeover RemoteSessionMode = "takeover"
+)
+
+type RemoteSession struct {
+	Host            string
+	Mode            RemoteSessionMode
+	State           proto.ConnState
+	PlaceholderPane uint32
+	RemoteToLocal   map[uint32]uint32
+	LocalToRemote   map[uint32]uint32
+	WindowByRemote  map[uint32]uint32
+}
+
+func NewRemoteSession(host string, mode RemoteSessionMode) *RemoteSession {
+	return &RemoteSession{
+		Host:           host,
+		Mode:           mode,
+		State:          proto.Connected,
+		RemoteToLocal:  make(map[uint32]uint32),
+		LocalToRemote:  make(map[uint32]uint32),
+		WindowByRemote: make(map[uint32]uint32),
+	}
+}
+
+func (rs *RemoteSession) ApplyLayout(s *Session, layout *proto.LayoutSnapshot, activate bool) error {
+	if rs == nil {
+		return fmt.Errorf("missing remote session")
+	}
+	if s == nil || layout == nil {
+		return fmt.Errorf("missing layout")
+	}
+
+	remoteWindows, activeRemoteWindowID := remoteLayoutWindows(layout)
+	if len(remoteWindows) == 0 {
+		return fmt.Errorf("remote layout for %s has no windows", rs.Host)
+	}
+
+	if err := rs.syncProxyPanes(s, remoteWindows); err != nil {
+		return err
+	}
+
+	switch rs.Mode {
+	case RemoteSessionTakeover:
+		return rs.applyTakeoverLayout(s, remoteWindows, activeRemoteWindowID)
+	default:
+		return rs.applyConnectedLayout(s, remoteWindows, activeRemoteWindowID, activate)
+	}
+}
+
+func (rs *RemoteSession) Remove(s *Session) error {
+	if rs == nil || s == nil {
+		return nil
+	}
+
+	switch rs.Mode {
+	case RemoteSessionTakeover:
+		if err := rs.removeTakeover(s); err != nil {
+			return err
+		}
+	default:
+		rs.removeConnectedWindows(s)
+	}
+
+	for _, localPaneID := range rs.sortedLocalPaneIDs() {
+		removeRemoteProxyPane(s, localPaneID, "remote disconnect")
+	}
+	clear(rs.RemoteToLocal)
+	clear(rs.LocalToRemote)
+	clear(rs.WindowByRemote)
+	return nil
+}
+
+func (rs *RemoteSession) applyConnectedLayout(s *Session, remoteWindows []proto.WindowSnapshot, activeRemoteWindowID uint32, activate bool) error {
+	width, height := remoteLayoutSize(s)
+
+	presentWindows := make(map[uint32]struct{}, len(remoteWindows))
+	for _, remoteWin := range remoteWindows {
+		presentWindows[remoteWin.ID] = struct{}{}
+
+		paneMap := rs.windowPaneMap(s, remoteWin)
+		if len(paneMap) == 0 {
+			continue
+		}
+
+		rebuilt := mux.RebuildWindowFromSnapshot(remoteWin, width, height, paneMap)
+		localWindowID, ok := rs.WindowByRemote[remoteWin.ID]
+		var localWindow *mux.Window
+		if ok {
+			localWindow = s.windowByID(localWindowID)
+		}
+		if localWindow == nil {
+			localWindow = rebuilt
+			localWindow.ID = s.windowCounter.Add(1)
+			localWindow.Name = remoteWindowName(rs.Host, remoteWin.Name)
+			if err := localWindow.ApplyLayout(rebuilt.Root, rebuilt.ActivePane, width, height, remoteWin.ZoomedPaneID, remoteWin.LeadPaneID); err != nil {
+				return err
+			}
+			s.Windows = append(s.Windows, localWindow)
+			rs.WindowByRemote[remoteWin.ID] = localWindow.ID
+		} else {
+			localWindow.Name = remoteWindowName(rs.Host, remoteWin.Name)
+			if err := localWindow.ApplyLayout(rebuilt.Root, rebuilt.ActivePane, width, height, remoteWin.ZoomedPaneID, remoteWin.LeadPaneID); err != nil {
+				return err
+			}
+		}
+	}
+
+	for remoteWindowID, localWindowID := range rs.WindowByRemote {
+		if _, ok := presentWindows[remoteWindowID]; ok {
+			continue
+		}
+		s.removeWindow(localWindowID)
+		delete(rs.WindowByRemote, remoteWindowID)
+	}
+
+	if activate {
+		localWindowID := rs.WindowByRemote[activeRemoteWindowID]
+		if localWindow := s.windowByID(localWindowID); localWindow != nil {
+			s.activateWindow(localWindow)
+		}
+	}
+	return nil
+}
+
+func (rs *RemoteSession) applyTakeoverLayout(s *Session, remoteWindows []proto.WindowSnapshot, activeRemoteWindowID uint32) error {
+	sshPane := s.findPaneByID(rs.PlaceholderPane)
+	if sshPane == nil {
+		return fmt.Errorf("takeover pane %d not found", rs.PlaceholderPane)
+	}
+
+	activeWindow := remoteWindows[0]
+	for _, remoteWin := range remoteWindows {
+		if remoteWin.ID == activeRemoteWindowID {
+			activeWindow = remoteWin
+			break
+		}
+	}
+
+	window := s.findWindowByPaneID(rs.PlaceholderPane)
+	if window == nil {
+		for _, candidate := range s.Windows {
+			if candidate == nil {
+				continue
+			}
+			found := false
+			for _, pane := range candidate.Panes() {
+				if pane != nil && pane.Meta.Host == rs.Host && pane.IsProxy() {
+					found = true
+					break
+				}
+			}
+			if found {
+				window = candidate
+				break
+			}
+		}
+	}
+	if window == nil {
+		return fmt.Errorf("takeover host %s not in any window", rs.Host)
+	}
+
+	if paneCell := window.Root.FindPane(rs.PlaceholderPane); paneCell == nil {
+		if err := window.UnsplicePane(rs.Host, sshPane); err != nil {
+			return err
+		}
+	}
+
+	subtree, activePane := rs.remoteSubtree(s, activeWindow)
+	if subtree == nil {
+		return fmt.Errorf("remote host %s active window has no mapped panes", rs.Host)
+	}
+
+	if err := window.SplicePaneWithLayout(rs.PlaceholderPane, subtree, activePane); err != nil {
+		return err
+	}
+	sshPane.Meta.Dormant = true
+	return nil
+}
+
+func (rs *RemoteSession) removeConnectedWindows(s *Session) {
+	for _, localWindowID := range rs.sortedLocalWindowIDs() {
+		s.removeWindow(localWindowID)
+	}
+	clear(rs.WindowByRemote)
+}
+
+func (rs *RemoteSession) removeTakeover(s *Session) error {
+	sshPane := s.findPaneByID(rs.PlaceholderPane)
+	if sshPane == nil {
+		return nil
+	}
+	window := s.findWindowByPaneID(rs.PlaceholderPane)
+	if window == nil {
+		for _, candidate := range s.Windows {
+			if candidate != nil {
+				if err := candidate.UnsplicePane(rs.Host, sshPane); err == nil {
+					sshPane.Meta.Dormant = false
+					return nil
+				}
+			}
+		}
+		return nil
+	}
+	if err := window.UnsplicePane(rs.Host, sshPane); err != nil {
+		return err
+	}
+	sshPane.Meta.Dormant = false
+	return nil
+}
+
+func (rs *RemoteSession) syncProxyPanes(s *Session, remoteWindows []proto.WindowSnapshot) error {
+	presentRemote := make(map[uint32]proto.PaneSnapshot)
+	for _, remoteWin := range remoteWindows {
+		for _, pane := range remoteWin.Panes {
+			presentRemote[pane.ID] = pane
+		}
+	}
+
+	for remotePaneID, pane := range presentRemote {
+		localPaneID, ok := rs.RemoteToLocal[remotePaneID]
+		if !ok {
+			localPane, err := rs.newProxyPane(s, pane)
+			if err != nil {
+				return err
+			}
+			s.Panes = append(s.Panes, localPane)
+			s.appendPaneLog(paneLogEventCreate, localPane, "")
+			s.logPaneCreate(localPane, "remote-session")
+			localPaneID = localPane.ID
+			rs.RemoteToLocal[remotePaneID] = localPaneID
+			rs.LocalToRemote[localPaneID] = remotePaneID
+			if s.RemoteManager != nil {
+				if err := s.RemoteManager.RegisterPane(rs.Host, localPaneID, remotePaneID); err != nil {
+					return err
+				}
+			}
+		}
+		if localPane := s.findPaneByID(localPaneID); localPane != nil {
+			rs.applyPaneSnapshot(localPane, pane)
+		}
+	}
+
+	for remotePaneID, localPaneID := range rs.RemoteToLocal {
+		if _, ok := presentRemote[remotePaneID]; ok {
+			continue
+		}
+		removeRemoteProxyPane(s, localPaneID, "remote layout changed")
+		delete(rs.RemoteToLocal, remotePaneID)
+		delete(rs.LocalToRemote, localPaneID)
+	}
+	return nil
+}
+
+func (rs *RemoteSession) newProxyPane(s *Session, pane proto.PaneSnapshot) (*mux.Pane, error) {
+	localPaneID := s.counter.Add(1)
+	meta := mux.PaneMeta{
+		Name:   pane.Name,
+		Host:   rs.Host,
+		Task:   pane.Task,
+		Color:  s.remotePaneColor(rs.Host),
+		Remote: string(rs.State),
+	}
+	proxy := s.ownPane(mux.NewProxyPaneWithScrollback(
+		localPaneID,
+		meta,
+		DefaultTermCols,
+		mux.PaneContentHeight(DefaultTermRows),
+		s.scrollbackLines,
+		s.paneOutputCallback(),
+		s.paneExitCallback(),
+		s.remoteWriteOverride(localPaneID),
+	))
+	rs.applyPaneSnapshot(proxy, pane)
+	return proxy, nil
+}
+
+func (rs *RemoteSession) applyPaneSnapshot(localPane *mux.Pane, remotePane proto.PaneSnapshot) {
+	if localPane == nil {
+		return
+	}
+	localPane.Meta.Name = remotePane.Name
+	localPane.Meta.Host = rs.Host
+	localPane.Meta.Task = remotePane.Task
+	localPane.Meta.GitBranch = remotePane.GitBranch
+	localPane.Meta.PR = remotePane.PR
+	localPane.Meta.TrackedPRs = proto.CloneTrackedPRs(remotePane.TrackedPRs)
+	localPane.Meta.TrackedIssues = proto.CloneTrackedIssues(remotePane.TrackedIssues)
+	localPane.Meta.KV = mux.CloneMetaKV(remotePane.KV)
+	localPane.Meta.Remote = string(rs.State)
+}
+
+func (rs *RemoteSession) remoteSubtree(s *Session, remoteWin proto.WindowSnapshot) (*mux.LayoutCell, *mux.Pane) {
+	paneMap := rs.windowPaneMap(s, remoteWin)
+	if len(paneMap) == 0 {
+		return nil, nil
+	}
+	rebuilt := mux.RebuildWindowFromSnapshot(remoteWin, remoteWin.Root.W, remoteWin.Root.H, paneMap)
+	return rebuilt.Root, rebuilt.ActivePane
+}
+
+func (rs *RemoteSession) windowPaneMap(s *Session, remoteWin proto.WindowSnapshot) map[uint32]*mux.Pane {
+	paneMap := make(map[uint32]*mux.Pane, len(remoteWin.Panes))
+	for _, pane := range remoteWin.Panes {
+		localPaneID, ok := rs.RemoteToLocal[pane.ID]
+		if !ok {
+			continue
+		}
+		if localPane := s.findPaneByID(localPaneID); localPane != nil {
+			paneMap[pane.ID] = localPane
+		}
+	}
+	return paneMap
+}
+
+func (rs *RemoteSession) sortedLocalPaneIDs() []uint32 {
+	ids := make([]uint32, 0, len(rs.LocalToRemote))
+	for localPaneID := range rs.LocalToRemote {
+		ids = append(ids, localPaneID)
+	}
+	slices.Sort(ids)
+	return ids
+}
+
+func (rs *RemoteSession) sortedLocalWindowIDs() []uint32 {
+	ids := make([]uint32, 0, len(rs.WindowByRemote))
+	for _, localWindowID := range rs.WindowByRemote {
+		ids = append(ids, localWindowID)
+	}
+	slices.Sort(ids)
+	return ids
+}
+
+func remoteLayoutWindows(layout *proto.LayoutSnapshot) ([]proto.WindowSnapshot, uint32) {
+	if layout == nil {
+		return nil, 0
+	}
+	if len(layout.Windows) > 0 {
+		return append([]proto.WindowSnapshot(nil), layout.Windows...), layout.ActiveWindowID
+	}
+	windowID := layout.ActiveWindowID
+	if windowID == 0 {
+		windowID = 1
+	}
+	return []proto.WindowSnapshot{{
+		ID:           windowID,
+		Name:         "window-1",
+		Index:        1,
+		ActivePaneID: layout.ActivePaneID,
+		ZoomedPaneID: layout.ZoomedPaneID,
+		LeadPaneID:   layout.LeadPaneID,
+		Root:         layout.Root,
+		Panes:        append([]proto.PaneSnapshot(nil), layout.Panes...),
+	}}, windowID
+}
+
+func remoteLayoutSize(s *Session) (int, int) {
+	if s == nil {
+		return DefaultTermCols, DefaultTermRows
+	}
+	if w := s.activeWindow(); w != nil {
+		return w.Width, w.Height
+	}
+	return DefaultTermCols, DefaultTermRows
+}
+
+func remoteWindowName(hostName, windowName string) string {
+	if windowName == "" {
+		return hostName
+	}
+	return fmt.Sprintf("%s@%s", windowName, hostName)
+}
+
+func removeRemoteProxyPane(s *Session, localPaneID uint32, reason string) {
+	if s == nil {
+		return
+	}
+	removed := s.finalizePaneRemoval(localPaneID)
+	if removed.pane == nil {
+		return
+	}
+	s.appendPaneLog(paneLogEventExit, removed.pane, reason)
+	s.emitEvent(Event{
+		Type:     EventPaneExit,
+		PaneID:   localPaneID,
+		PaneName: removed.paneName,
+		Host:     removed.pane.Meta.Host,
+		Reason:   reason,
+	})
+	s.logPaneExit(removed.pane, reason)
+	s.closePaneAsync(removed.pane)
+}
+
+func (s *Session) connectRemoteSession(hostName string, layout *proto.LayoutSnapshot, mode RemoteSessionMode, placeholderPaneID uint32, activate bool) error {
+	if s == nil {
+		return fmt.Errorf("no session")
+	}
+	rs := s.remoteSessions[hostName]
+	if rs == nil {
+		rs = NewRemoteSession(hostName, mode)
+		s.remoteSessions[hostName] = rs
+	}
+	rs.Mode = mode
+	if placeholderPaneID != 0 {
+		rs.PlaceholderPane = placeholderPaneID
+	}
+	if s.RemoteManager != nil {
+		rs.State = s.RemoteManager.HostStatus(hostName)
+	}
+	return rs.ApplyLayout(s, layout, activate)
+}
+
+func (s *Session) disconnectRemoteSession(hostName string) error {
+	if s == nil {
+		return fmt.Errorf("no session")
+	}
+	rs := s.remoteSessions[hostName]
+	if rs == nil {
+		return nil
+	}
+	if err := rs.Remove(s); err != nil {
+		return err
+	}
+	delete(s.remoteSessions, hostName)
+	return nil
+}

--- a/internal/server/remote_session.go
+++ b/internal/server/remote_session.go
@@ -412,6 +412,8 @@ func (s *Session) connectRemoteSession(hostName string, layout *proto.LayoutSnap
 	if rs == nil {
 		rs = NewRemoteSession(hostName, mode)
 		s.remoteSessions[hostName] = rs
+	} else if rs.Mode != mode {
+		return fmt.Errorf("remote host %q already uses %s mode", hostName, rs.Mode)
 	}
 	rs.Mode = mode
 	if placeholderPaneID != 0 {

--- a/internal/server/remote_session_test.go
+++ b/internal/server/remote_session_test.go
@@ -1,0 +1,182 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/weill-labs/amux/internal/mux"
+	"github.com/weill-labs/amux/internal/proto"
+)
+
+func TestRemoteStateChangeEventUpdatesRemoteSessionAndProxyPanes(t *testing.T) {
+	t.Parallel()
+
+	for _, state := range []proto.ConnState{
+		proto.Connecting,
+		proto.Connected,
+		proto.Reconnecting,
+		proto.Disconnected,
+	} {
+		state := state
+		t.Run(string(state), func(t *testing.T) {
+			t.Parallel()
+
+			_, sess, cleanup := newCommandTestSession(t)
+			defer cleanup()
+
+			proxy := newProxyPane(2, mux.PaneMeta{
+				Name:   "pane-2",
+				Host:   "gpu",
+				Remote: string(proto.Connected),
+			}, 80, 23, sess.paneOutputCallback(), sess.paneExitCallback(), func(data []byte) (int, error) {
+				return len(data), nil
+			})
+			window := newTestWindowWithPanes(t, sess, 1, "main", proxy)
+			setSessionLayoutForTest(t, sess, window.ID, []*mux.Window{window}, proxy)
+
+			mustSessionMutation(t, sess, func(sess *Session) {
+				sess.remoteSessions["gpu"] = NewRemoteSession("gpu", RemoteSessionConnect)
+			})
+
+			mustSessionMutation(t, sess, func(sess *Session) {
+				remoteStateChangeEvent{hostName: "gpu", state: state}.handle(sess)
+			})
+
+			snap := mustSessionQuery(t, sess, func(sess *Session) struct {
+				sessionState string
+				proxyState   string
+			} {
+				return struct {
+					sessionState string
+					proxyState   string
+				}{
+					sessionState: string(sess.remoteSessions["gpu"].State),
+					proxyState:   sess.findPaneByID(proxy.ID).Meta.Remote,
+				}
+			})
+			if snap.sessionState != string(state) {
+				t.Fatalf("remote session state = %q, want %q", snap.sessionState, state)
+			}
+			if snap.proxyState != string(state) {
+				t.Fatalf("proxy pane state = %q, want %q", snap.proxyState, state)
+			}
+		})
+	}
+}
+
+func TestConnectAndDisconnectRemoteSessionLifecycle(t *testing.T) {
+	t.Parallel()
+
+	_, sess, cleanup := newCommandTestSession(t)
+	defer cleanup()
+
+	localPane := newTestPane(sess, 1, "pane-1")
+	localWindow := newTestWindowWithPanes(t, sess, 1, "local", localPane)
+	setSessionLayoutForTest(t, sess, localWindow.ID, []*mux.Window{localWindow}, localPane)
+	mustSessionMutation(t, sess, func(sess *Session) {
+		sess.windowCounter.Store(localWindow.ID)
+		sess.counter.Store(localPane.ID)
+	})
+	installTestPaneTransport(t, sess, &stubPaneTransport{
+		hostStatusByName: map[string]proto.ConnState{"gpu": proto.Connected},
+	}, nil)
+
+	layout := &proto.LayoutSnapshot{
+		ActiveWindowID: 5,
+		Windows: []proto.WindowSnapshot{{
+			ID:           5,
+			Name:         "remote",
+			ActivePaneID: 7,
+			Root: proto.CellSnapshot{
+				X: 0, Y: 0, W: 80, H: 24, IsLeaf: true, Dir: -1, PaneID: 7,
+			},
+			Panes: []proto.PaneSnapshot{{
+				ID:   7,
+				Name: "pane-7",
+				Task: "shell",
+			}},
+		}},
+	}
+
+	mustSessionMutation(t, sess, func(sess *Session) {
+		if err := sess.connectRemoteSession("gpu", layout, RemoteSessionConnect, 0, false); err != nil {
+			t.Fatalf("connectRemoteSession() error = %v", err)
+		}
+	})
+
+	connected := mustSessionQuery(t, sess, func(sess *Session) struct {
+		paneCount    int
+		windowCount  int
+		hostPaneName string
+		state        string
+	} {
+		var hostPaneName string
+		for _, pane := range sess.Panes {
+			if pane.Meta.Host == "gpu" {
+				hostPaneName = pane.Meta.Name
+				break
+			}
+		}
+		return struct {
+			paneCount    int
+			windowCount  int
+			hostPaneName string
+			state        string
+		}{
+			paneCount:    len(sess.Panes),
+			windowCount:  len(sess.Windows),
+			hostPaneName: hostPaneName,
+			state:        string(sess.remoteSessions["gpu"].State),
+		}
+	})
+	if connected.paneCount != 2 {
+		t.Fatalf("pane count after connect = %d, want 2", connected.paneCount)
+	}
+	if connected.windowCount != 2 {
+		t.Fatalf("window count after connect = %d, want 2", connected.windowCount)
+	}
+	if connected.hostPaneName != "pane-7" {
+		t.Fatalf("remote proxy pane name = %q, want %q", connected.hostPaneName, "pane-7")
+	}
+	if connected.state != string(proto.Connected) {
+		t.Fatalf("remote session state = %q, want %q", connected.state, proto.Connected)
+	}
+
+	mustSessionMutation(t, sess, func(sess *Session) {
+		if err := sess.disconnectRemoteSession("gpu"); err != nil {
+			t.Fatalf("disconnectRemoteSession() error = %v", err)
+		}
+	})
+
+	disconnected := mustSessionQuery(t, sess, func(sess *Session) struct {
+		paneCount   int
+		windowCount int
+		hasRemote   bool
+	} {
+		hasRemote := false
+		for _, pane := range sess.Panes {
+			if pane.Meta.Host == "gpu" {
+				hasRemote = true
+				break
+			}
+		}
+		_, stillConnected := sess.remoteSessions["gpu"]
+		return struct {
+			paneCount   int
+			windowCount int
+			hasRemote   bool
+		}{
+			paneCount:   len(sess.Panes),
+			windowCount: len(sess.Windows),
+			hasRemote:   hasRemote || stillConnected,
+		}
+	})
+	if disconnected.paneCount != 1 {
+		t.Fatalf("pane count after disconnect = %d, want 1", disconnected.paneCount)
+	}
+	if disconnected.windowCount != 1 {
+		t.Fatalf("window count after disconnect = %d, want 1", disconnected.windowCount)
+	}
+	if disconnected.hasRemote {
+		t.Fatal("remote session state should be removed after disconnect")
+	}
+}

--- a/internal/server/remote_session_test.go
+++ b/internal/server/remote_session_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/weill-labs/amux/internal/mux"
@@ -178,5 +179,109 @@ func TestConnectAndDisconnectRemoteSessionLifecycle(t *testing.T) {
 	}
 	if disconnected.hasRemote {
 		t.Fatal("remote session state should be removed after disconnect")
+	}
+}
+
+func TestConnectRemoteSessionRejectsModeMismatch(t *testing.T) {
+	t.Parallel()
+
+	_, sess, cleanup := newCommandTestSession(t)
+	defer cleanup()
+
+	mustSessionMutation(t, sess, func(sess *Session) {
+		rs := NewRemoteSession("gpu", RemoteSessionTakeover)
+		rs.PlaceholderPane = 42
+		sess.remoteSessions["gpu"] = rs
+	})
+
+	layout := &proto.LayoutSnapshot{
+		ActiveWindowID: 1,
+		Windows: []proto.WindowSnapshot{{
+			ID:           1,
+			Name:         "remote",
+			ActivePaneID: 7,
+			Root: proto.CellSnapshot{
+				X: 0, Y: 0, W: 80, H: 24, IsLeaf: true, Dir: -1, PaneID: 7,
+			},
+			Panes: []proto.PaneSnapshot{{
+				ID:   7,
+				Name: "pane-7",
+			}},
+		}},
+	}
+
+	var err error
+	mustSessionMutation(t, sess, func(sess *Session) {
+		err = sess.connectRemoteSession("gpu", layout, RemoteSessionConnect, 0, false)
+	})
+	if err == nil || !strings.Contains(err.Error(), `remote host "gpu" already uses takeover mode`) {
+		t.Fatalf("connectRemoteSession() error = %v, want mode mismatch", err)
+	}
+
+	snap := mustSessionQuery(t, sess, func(sess *Session) struct {
+		mode        RemoteSessionMode
+		placeholder uint32
+	} {
+		rs := sess.remoteSessions["gpu"]
+		return struct {
+			mode        RemoteSessionMode
+			placeholder uint32
+		}{
+			mode:        rs.Mode,
+			placeholder: rs.PlaceholderPane,
+		}
+	})
+	if snap.mode != RemoteSessionTakeover {
+		t.Fatalf("remote session mode = %q, want %q", snap.mode, RemoteSessionTakeover)
+	}
+	if snap.placeholder != 42 {
+		t.Fatalf("placeholder pane = %d, want 42", snap.placeholder)
+	}
+}
+
+func TestRemoteLayoutEventLogsApplyErrors(t *testing.T) {
+	t.Parallel()
+
+	logger, buf := newAuditTestLogger()
+	_, sess, cleanup := newCommandTestSession(t)
+	defer cleanup()
+	sess.logger = logger
+
+	mustSessionMutation(t, sess, func(sess *Session) {
+		rs := NewRemoteSession("gpu", RemoteSessionTakeover)
+		rs.PlaceholderPane = 99
+		sess.remoteSessions["gpu"] = rs
+	})
+
+	mustSessionMutation(t, sess, func(sess *Session) {
+		remoteLayoutEvent{
+			hostName: "gpu",
+			layout: &proto.LayoutSnapshot{
+				ActiveWindowID: 1,
+				Windows: []proto.WindowSnapshot{{
+					ID:           1,
+					Name:         "remote",
+					ActivePaneID: 7,
+					Root: proto.CellSnapshot{
+						X: 0, Y: 0, W: 80, H: 24, IsLeaf: true, Dir: -1, PaneID: 7,
+					},
+					Panes: []proto.PaneSnapshot{{
+						ID:   7,
+						Name: "pane-7",
+					}},
+				}},
+			},
+		}.handle(sess)
+	})
+
+	logOutput := buf.String()
+	if !strings.Contains(logOutput, "remote layout apply failed") {
+		t.Fatalf("warn log = %q, want remote layout apply failed", logOutput)
+	}
+	if !strings.Contains(logOutput, "remote_layout_apply") {
+		t.Fatalf("warn log = %q, want remote_layout_apply event", logOutput)
+	}
+	if !strings.Contains(logOutput, "takeover pane 99 not found") {
+		t.Fatalf("warn log = %q, want apply error text", logOutput)
 	}
 }

--- a/internal/server/respawn_command_test.go
+++ b/internal/server/respawn_command_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/weill-labs/amux/internal/mux"
 )
 
+const respawnWaitTimeout = 10 * time.Second
+
 func TestRespawnCommandRestartsLocalPaneInPlace(t *testing.T) {
 	t.Parallel()
 
@@ -304,7 +306,7 @@ func withShellForTest(t *testing.T, shellPath string) func() {
 func waitForMarkerCount(t *testing.T, path string, want int) {
 	t.Helper()
 
-	waitUntilRespawn(t, 5*time.Second, func() bool {
+	waitUntilRespawn(t, respawnWaitTimeout, func() bool {
 		data, err := os.ReadFile(path)
 		return err == nil && len(bytes.TrimSpace(data)) >= want
 	})
@@ -313,7 +315,7 @@ func waitForMarkerCount(t *testing.T, path string, want int) {
 func waitForFileString(t *testing.T, path, want string) {
 	t.Helper()
 
-	waitUntilRespawn(t, 5*time.Second, func() bool {
+	waitUntilRespawn(t, respawnWaitTimeout, func() bool {
 		data, err := os.ReadFile(path)
 		return err == nil && strings.TrimSpace(string(data)) == want
 	}, func() string {
@@ -328,7 +330,7 @@ func waitForFileString(t *testing.T, path, want string) {
 func waitForProcessExit(t *testing.T, pid int) {
 	t.Helper()
 
-	waitUntilRespawn(t, 5*time.Second, func() bool {
+	waitUntilRespawn(t, respawnWaitTimeout, func() bool {
 		return syscall.Kill(pid, 0) != nil
 	})
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -87,6 +87,7 @@ type Session struct {
 	RemoteManager   proto.PaneTransport
 	remoteTakeover  PaneTakeoverTransport
 	remoteHostColor func(string) string
+	remoteSessions  map[string]*RemoteSession
 
 	// SSH takeover tracking — pane IDs that have already been taken over.
 	// Prevents duplicate takeover if the remote emits the sequence twice.
@@ -447,6 +448,7 @@ func newSessionWithLogger(name string, scrollbackLines int, logger *charmlog.Log
 	}
 	sess.idle = NewIdleTracker(sess.clock)
 	sess.takenOverPanes = make(map[uint32]bool)
+	sess.remoteSessions = make(map[string]*RemoteSession)
 	sess.terminalEventState = make(map[uint32]paneTerminalEventState)
 	sess.waiters = newWaiterManager()
 	sess.capture = newCaptureForwarder()

--- a/internal/server/session_events_pane.go
+++ b/internal/server/session_events_pane.go
@@ -241,6 +241,8 @@ func (e remoteLayoutEvent) handle(s *Session) {
 	}
 	if err := rs.ApplyLayout(s, e.layout, false); err == nil {
 		s.broadcastLayoutNow()
+	} else {
+		s.logger.Warn("remote layout apply failed", "event", "remote_layout_apply", "host", e.hostName, "error", err)
 	}
 }
 

--- a/internal/server/session_events_pane.go
+++ b/internal/server/session_events_pane.go
@@ -218,12 +218,30 @@ type remoteStateChangeEvent struct {
 }
 
 func (e remoteStateChangeEvent) handle(s *Session) {
+	if rs := s.remoteSessions[e.hostName]; rs != nil {
+		rs.State = e.state
+	}
 	for _, p := range s.Panes {
 		if p.Meta.Host == e.hostName && p.IsProxy() {
 			p.Meta.Remote = string(e.state)
 		}
 	}
 	s.broadcastLayoutNow()
+}
+
+type remoteLayoutEvent struct {
+	hostName string
+	layout   *proto.LayoutSnapshot
+}
+
+func (e remoteLayoutEvent) handle(s *Session) {
+	rs := s.remoteSessions[e.hostName]
+	if rs == nil || e.layout == nil {
+		return
+	}
+	if err := rs.ApplyLayout(s, e.layout, false); err == nil {
+		s.broadcastLayoutNow()
+	}
 }
 
 type localPaneBuildResultEvent struct {
@@ -326,6 +344,10 @@ func (s *Session) enqueueRemotePaneExit(paneID uint32, reason string) {
 
 func (s *Session) enqueueRemoteStateChange(hostName string, state proto.ConnState) {
 	s.enqueueEvent(remoteStateChangeEvent{hostName: hostName, state: state})
+}
+
+func (s *Session) enqueueRemoteLayout(hostName string, layout *proto.LayoutSnapshot) {
+	s.enqueueEvent(remoteLayoutEvent{hostName: hostName, layout: layout})
 }
 
 // --- Pane output subscribe/unsubscribe through the event loop ---

--- a/internal/server/session_pane.go
+++ b/internal/server/session_pane.go
@@ -519,7 +519,7 @@ func (s *Session) prepareRemotePane(hostName string, cols, rows int) (*mux.Pane,
 	))
 
 	// Create the corresponding pane on the remote server
-	_, err := s.RemoteManager.CreatePane(hostName, id, s.Name)
+	_, err := s.RemoteManager.CreatePane(hostName, id, managedSessionName(s.Name))
 	if err != nil {
 		s.RemoteManager.RemovePane(id)
 		return nil, err

--- a/internal/server/session_queries.go
+++ b/internal/server/session_queries.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/weill-labs/amux/internal/mux"
@@ -10,10 +11,10 @@ import (
 
 type activeWindowSnapshot struct {
 	activePane *mux.Pane
-	activePID int
-	width     int
-	height    int
-	proxyHost string
+	activePID  int
+	width      int
+	height     int
+	proxyHost  string
 }
 
 type resolvedPaneRef struct {
@@ -325,6 +326,33 @@ func (s *Session) queryPaneList() ([]paneListEntry, error) {
 			}
 			entries = append(entries, entry)
 		}
+		slices.SortFunc(entries, func(a, b paneListEntry) int {
+			aGroup, bGroup := a.host, b.host
+			if aGroup == "" {
+				aGroup = "\x00"
+			}
+			if bGroup == "" {
+				bGroup = "\x00"
+			}
+			switch {
+			case aGroup < bGroup:
+				return -1
+			case aGroup > bGroup:
+				return 1
+			}
+			switch {
+			case a.name < b.name:
+				return -1
+			case a.name > b.name:
+				return 1
+			case a.paneID < b.paneID:
+				return -1
+			case a.paneID > b.paneID:
+				return 1
+			default:
+				return 0
+			}
+		})
 		return entries, nil
 	})
 }

--- a/internal/server/session_queries.go
+++ b/internal/server/session_queries.go
@@ -328,10 +328,10 @@ func (s *Session) queryPaneList() ([]paneListEntry, error) {
 		}
 		slices.SortFunc(entries, func(a, b paneListEntry) int {
 			aGroup, bGroup := a.host, b.host
-			if aGroup == "" {
+			if aGroup == "" || aGroup == mux.DefaultHost {
 				aGroup = "\x00"
 			}
-			if bGroup == "" {
+			if bGroup == "" || bGroup == mux.DefaultHost {
 				bGroup = "\x00"
 			}
 			switch {

--- a/internal/server/session_queries_test.go
+++ b/internal/server/session_queries_test.go
@@ -169,6 +169,44 @@ func TestResolvePaneAcrossWindowsForActorPrefersActorWindowForDuplicateNames(t *
 	}
 }
 
+func TestQueryPaneListSortsLocalFirstThenHost(t *testing.T) {
+	t.Parallel()
+
+	sess := newSession("test-query-pane-list-sort")
+	stopCrashCheckpointLoop(t, sess)
+	defer stopSessionBackgroundLoops(t, sess)
+
+	local := newProxyPane(1, mux.PaneMeta{Name: "local", Host: ""}, 80, 23, sess.paneOutputCallback(), sess.paneExitCallback(), func(data []byte) (int, error) {
+		return len(data), nil
+	})
+	alpha := newProxyPane(2, mux.PaneMeta{Name: "alpha-pane", Host: "alpha"}, 80, 23, sess.paneOutputCallback(), sess.paneExitCallback(), func(data []byte) (int, error) {
+		return len(data), nil
+	})
+	zulu := newProxyPane(3, mux.PaneMeta{Name: "zulu-pane", Host: "zulu"}, 80, 23, sess.paneOutputCallback(), sess.paneExitCallback(), func(data []byte) (int, error) {
+		return len(data), nil
+	})
+	window := newTestWindowWithPanes(t, sess, 1, "main", local, alpha, zulu)
+	setSessionLayoutForTest(t, sess, window.ID, []*mux.Window{window}, zulu, local, alpha)
+
+	entries, err := sess.queryPaneList()
+	if err != nil {
+		t.Fatalf("queryPaneList() error = %v", err)
+	}
+	if len(entries) != 3 {
+		t.Fatalf("queryPaneList() entries = %d, want 3", len(entries))
+	}
+
+	got := []string{
+		entries[0].host + "/" + entries[0].name,
+		entries[1].host + "/" + entries[1].name,
+		entries[2].host + "/" + entries[2].name,
+	}
+	want := []string{"/local", "alpha/alpha-pane", "zulu/zulu-pane"}
+	if got[0] != want[0] || got[1] != want[1] || got[2] != want[2] {
+		t.Fatalf("queryPaneList() order = %v, want %v", got, want)
+	}
+}
+
 func TestEnqueueUIWaitSubscribeErrors(t *testing.T) {
 	t.Parallel()
 

--- a/internal/server/session_queries_test.go
+++ b/internal/server/session_queries_test.go
@@ -176,7 +176,7 @@ func TestQueryPaneListSortsLocalFirstThenHost(t *testing.T) {
 	stopCrashCheckpointLoop(t, sess)
 	defer stopSessionBackgroundLoops(t, sess)
 
-	local := newProxyPane(1, mux.PaneMeta{Name: "local", Host: ""}, 80, 23, sess.paneOutputCallback(), sess.paneExitCallback(), func(data []byte) (int, error) {
+	local := newProxyPane(1, mux.PaneMeta{Name: "local", Host: mux.DefaultHost}, 80, 23, sess.paneOutputCallback(), sess.paneExitCallback(), func(data []byte) (int, error) {
 		return len(data), nil
 	})
 	alpha := newProxyPane(2, mux.PaneMeta{Name: "alpha-pane", Host: "alpha"}, 80, 23, sess.paneOutputCallback(), sess.paneExitCallback(), func(data []byte) (int, error) {
@@ -201,7 +201,7 @@ func TestQueryPaneListSortsLocalFirstThenHost(t *testing.T) {
 		entries[1].host + "/" + entries[1].name,
 		entries[2].host + "/" + entries[2].name,
 	}
-	want := []string{"/local", "alpha/alpha-pane", "zulu/zulu-pane"}
+	want := []string{"local/local", "alpha/alpha-pane", "zulu/zulu-pane"}
 	if got[0] != want[0] || got[1] != want[1] || got[2] != want[2] {
 		t.Fatalf("queryPaneList() order = %v, want %v", got, want)
 	}

--- a/internal/server/session_remote.go
+++ b/internal/server/session_remote.go
@@ -180,6 +180,15 @@ func (s *Session) handleTakeover(sshPaneID uint32, req mux.TakeoverRequest) {
 		if sshPane := s.findPaneByID(sshPaneID); sshPane != nil {
 			sshPane.Meta.Dormant = true
 		}
+		rs := NewRemoteSession(start.hostname, RemoteSessionTakeover)
+		rs.PlaceholderPane = sshPaneID
+		rs.State = proto.Connected
+		for i, pp := range proxyPanes {
+			remotePaneID := remotePanes[i].ID
+			rs.RemoteToLocal[remotePaneID] = pp.ID
+			rs.LocalToRemote[pp.ID] = remotePaneID
+		}
+		s.sess.remoteSessions[start.hostname] = rs
 		return commandMutationResult{broadcastLayout: true}
 	})
 	if res.err != nil {

--- a/internal/server/session_window.go
+++ b/internal/server/session_window.go
@@ -69,11 +69,18 @@ func (s *Session) removeWindow(windowID uint32) {
 		if w.ID == windowID {
 			s.Windows = append(s.Windows[:i], s.Windows[i+1:]...)
 			if s.ActiveWindowID == windowID {
-				s.ActiveWindowID = 0
+				if prev := s.previousWindow(); prev != nil && prev.ID != windowID {
+					s.ActiveWindowID = prev.ID
+				} else if len(s.Windows) > 0 {
+					s.ActiveWindowID = s.Windows[0].ID
+				} else {
+					s.ActiveWindowID = 0
+				}
 			}
 			if s.PreviousWindowID == windowID {
 				s.PreviousWindowID = 0
 			}
+			s.refreshInputTarget()
 			return
 		}
 	}

--- a/test/remote_management_test.go
+++ b/test/remote_management_test.go
@@ -1,8 +1,11 @@
 package test
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
+
+	"github.com/weill-labs/amux/internal/proto"
 )
 
 // remoteHarness bundles a ServerHarness with SSH test infrastructure.
@@ -21,6 +24,16 @@ func splitRemotePane(t *testing.T, h *ServerHarness) {
 	out := h.runCmd("split", "pane-1", "--host", "test-remote")
 	if strings.Contains(out, "error") || strings.Contains(out, "Error") {
 		t.Fatalf("remote split failed: %s", out)
+	}
+	h.waitLayout(gen)
+}
+
+func connectRemoteSession(t *testing.T, h *ServerHarness) {
+	t.Helper()
+	gen := h.generation()
+	out := h.runCmd("connect", "test-remote")
+	if strings.Contains(out, "error") || strings.Contains(out, "Error") {
+		t.Fatalf("remote connect failed: %s", out)
 	}
 	h.waitLayout(gen)
 }
@@ -133,6 +146,63 @@ func TestDisconnectAndReconnect(t *testing.T) {
 	out = h.runCmd("hosts")
 	if !hostsShowsState(out, "connected") {
 		t.Errorf("hosts should show connected after reconnect, got:\n%s", out)
+	}
+}
+
+func TestConnectCaptureAndDisconnect(t *testing.T) {
+	t.Parallel()
+
+	h := newRemoteHarness(t)
+	connectRemoteSession(t, h)
+
+	c := h.captureJSON()
+	assertCaptureConsistent(t, c)
+	if len(c.Panes) == 0 {
+		t.Fatal("connect should leave at least one visible pane in capture")
+	}
+
+	listOut := h.runCmd("list")
+	if !strings.Contains(listOut, "HOST") {
+		t.Fatalf("list output missing HOST column:\n%s", listOut)
+	}
+	if !strings.Contains(listOut, "test-remote") {
+		t.Fatalf("list output missing remote host entry:\n%s", listOut)
+	}
+	if !strings.Contains(listOut, "pane-1") {
+		t.Fatalf("list output missing mirrored remote pane name:\n%s", listOut)
+	}
+
+	h.sendKeys("test-remote/pane-1", "echo CONNECT_REMOTE_OK", "Enter")
+	h.waitForTimeout("test-remote/pane-1", "CONNECT_REMOTE_OK", "5s")
+
+	rawCapture := h.runCmd("capture", "test-remote/pane-1", "--format", "json")
+	var paneCapture proto.CapturePane
+	if err := json.Unmarshal([]byte(rawCapture), &paneCapture); err != nil {
+		t.Fatalf("capture remote pane json: %v\nraw: %s", err, rawCapture)
+	}
+	if joined := strings.Join(append(append([]string(nil), paneCapture.History...), paneCapture.Content...), "\n"); !strings.Contains(joined, "CONNECT_REMOTE_OK") {
+		t.Fatalf("remote pane capture missing command output:\n%s", rawCapture)
+	}
+
+	gen := h.generation()
+	out := h.runCmd("disconnect", "test-remote")
+	if !strings.Contains(out, "Disconnected from test-remote") {
+		t.Fatalf("disconnect should confirm, got: %s", out)
+	}
+	h.waitLayout(gen)
+
+	c = h.captureJSON()
+	assertCaptureConsistent(t, c)
+	listOut = h.runCmd("list")
+	for _, line := range strings.Split(listOut, "\n") {
+		if strings.Contains(line, "test-remote") {
+			t.Fatalf("disconnect should remove remote panes from list, still found:\n%s", listOut)
+		}
+	}
+
+	out = h.runCmd("hosts")
+	if !hostsShowsState(out, "disconnected") {
+		t.Fatalf("hosts should show disconnected after connect/disconnect, got:\n%s", out)
 	}
 }
 

--- a/test/server_harness_test.go
+++ b/test/server_harness_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/weill-labs/amux/internal/mux"
 	"github.com/weill-labs/amux/internal/proto"
 	"github.com/weill-labs/amux/internal/server"
 )
@@ -571,12 +572,63 @@ func (h *ServerHarness) attachedClientKnowsPane(ref string) bool {
 	return false
 }
 
+func (h *ServerHarness) attachedClientTargetsRemotePane(ref string) bool {
+	if ref == "" {
+		return false
+	}
+	if strings.Contains(ref, "/") {
+		return true
+	}
+	if h == nil || h.client == nil {
+		return false
+	}
+
+	var capture proto.CaptureJSON
+	if err := json.Unmarshal([]byte(h.client.renderer.CaptureJSON(nil)), &capture); err != nil {
+		return false
+	}
+	for _, pane := range capture.Panes {
+		if pane.Name != ref && !strings.HasPrefix(pane.Name, ref) && strconv.FormatUint(uint64(pane.ID), 10) != ref {
+			continue
+		}
+		return pane.Host != "" && pane.Host != mux.DefaultHost
+	}
+	return false
+}
+
+func (h *ServerHarness) attachedClientCommandTargetsRemotePane(args []string) bool {
+	if len(args) == 0 {
+		return false
+	}
+
+	switch args[0] {
+	case "focus", "send-keys":
+		if len(args) < 2 {
+			return false
+		}
+		return h.attachedClientTargetsRemotePane(args[1])
+	case "wait":
+		if len(args) < 3 {
+			return false
+		}
+		switch args[1] {
+		case "content", "ready", "idle", "exited", "busy":
+			return h.attachedClientTargetsRemotePane(args[2])
+		}
+	}
+
+	return false
+}
+
 func (h *ServerHarness) canUseAttachedClient(args []string) bool {
 	if len(args) == 0 {
 		return false
 	}
 	cmdName := args[0]
 	if !attachedClientCommands[cmdName] {
+		return false
+	}
+	if h.attachedClientCommandTargetsRemotePane(args) {
 		return false
 	}
 	h.commandConnMu.Lock()


### PR DESCRIPTION
## Motivation
Remote amux sessions were still treated as client-side tunnels, so the local server couldn't own connection state, couldn't mirror remote panes as first-class entities, and couldn't resolve host-qualified pane refs across existing commands. Takeover and connect were also maintaining separate connection flows despite sharing the same proxy-pane model.

## Summary
- add server-owned `RemoteSession` state with remote layout reconciliation, proxy pane mapping, and connect/takeover unification hooks
- add `amux connect` and teach `disconnect`, `hosts`, `list`, and host-qualified pane refs to route through managed remote sessions
- route `capture`, `send-keys`, `wait`, `resize-pane`, and `kill` through host-aware remote command forwarding
- move `amux ssh` onto the local-server-managed remote session path and use managed remote session names to avoid localhost socket collisions
- add unit and integration coverage for pane-ref parsing, remote command routing, connect/disconnect lifecycle, ssh attach routing, and HOST-aware listing

## Testing
- `go test ./internal/proto -run '^TestParsePaneRef$' -count=100`
- `go test ./internal/server -run 'Test(QueryPaneRefResolvesKnownHostOnlyRef|QueryPaneRefRejectsHostPaneNameCollision|QueryPaneRefLeavesUnknownNamesLocal|RemotePaneRefCommandsForwardToHostCommand|RemoteStateChangeEventUpdatesRemoteSessionAndProxyPanes|ConnectAndDisconnectRemoteSessionLifecycle|QueryPaneListSortsLocalFirstThenHost|RemoveWindowFallsBackToRemainingActiveWindow|PrepareRemotePaneUsesConfiguredTransportHostColor)' -count=100`
- `go test ./internal/client -run 'TestRunSSHSessionViaLocalServer|TestRunSSHSessionViaLocalServerWrapsConnectError' -count=100`
- `go test ./test -run '^TestConnectCaptureAndDisconnect$' -count=100 -timeout 30m`
- `go test ./test -timeout 120s -count=1`
- `go test ./... -timeout 120s`

## Review Focus
- managed remote session naming and the places where local commands now intentionally target `managedSessionName(...)`
- `RemoteSession` layout reconciliation for connect vs takeover, especially proxy-pane/window cleanup on disconnect
- transport error handling: fast-fail SSH/setup errors vs retrying remote-socket availability

Closes LAB-1334
