### PR TITLE
LAB-1398: Restore ConnState constant coverage

### DIFF
--- a/internal/proto/conn_state_test.go
+++ b/internal/proto/conn_state_test.go
@@ -1,0 +1,28 @@
+package proto
+
+import "testing"
+
+func TestConnStateConstants(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		got  ConnState
+		want string
+	}{
+		{name: "disconnected", got: Disconnected, want: "disconnected"},
+		{name: "connecting", got: Connecting, want: "connecting"},
+		{name: "connected", got: Connected, want: "connected"},
+		{name: "reconnecting", got: Reconnecting, want: "reconnecting"},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := string(tt.got); got != tt.want {
+				t.Fatalf("string(%s) = %q, want %q", tt.name, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Motivation

PR #728 removed `internal/proto/pane_transport_test.go` to delete the dead `testPaneTransport` stub, but that file also contained `TestConnStateConstants`. This follow-up restores the lost specification for the serialized `ConnState` values without bringing back the dead transport stub.

## Summary

- add `internal/proto/conn_state_test.go`
- restore `TestConnStateConstants` for `Disconnected`, `Connecting`, `Connected`, and `Reconnecting`
- keep the dead `testPaneTransport` removal from #728 intact

## Testing

- `go test ./internal/proto -run TestConnStateConstants -count=100`
- `go test ./internal/proto -timeout 120s -count=3`

## Review Focus

- confirm this restores only the lost `ConnState` value coverage and does not reintroduce the deleted `PaneTransport` compile-check stub
- confirm a dedicated `conn_state_test.go` is the right long-term home for this spec
