### PR TITLE
LAB-1399: Wire up remote disconnect command

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,14 +372,16 @@ Higher-level prompt delegation now lives at the script layer: compose `wait idle
 
 ### Remote Hosts
 
+Remote host commands are also available under `amux remote ...`.
+
 | Command | Description |
 |---------|-------------|
-| `amux hosts` | List configured remote hosts and connection status |
-| `amux connect <host>` | Connect to a remote amux session and mirror its panes locally |
+| `amux remote hosts` | List configured remote hosts and connection status |
+| `amux remote connect <host>` | Connect to a remote amux session and mirror its panes locally |
 | `amux spawn --at <pane> [--root] [--vertical\|--horizontal] [--name NAME] --host HOST` | Create a remote split pane on HOST |
-| `amux disconnect <host>` | Drop a remote host connection |
-| `amux reconnect <host>` | Reconnect to a remote host |
-| `amux unsplice <host>` | Revert remote takeover, replace remote panes with local |
+| `amux remote disconnect <host>` | Drop a remote host connection |
+| `amux remote reconnect <host>` | Reconnect to a remote host |
+| `amux remote unsplice <host>` | Revert remote takeover, replace remote panes with local |
 
 ## Keybindings
 

--- a/internal/cli/cli_commands_remote.go
+++ b/internal/cli/cli_commands_remote.go
@@ -2,6 +2,8 @@ package cli
 
 import "fmt"
 
+const remoteUsage = "usage: amux remote <hosts|connect|disconnect|reconnect|unsplice|reload-server>"
+
 func remoteCLICommands() map[string]commandHandler {
 	return map[string]commandHandler{
 		"connect": func(inv invocation, args []string) int {
@@ -44,5 +46,32 @@ func remoteCLICommands() map[string]commandHandler {
 		"_inject-proxy": func(inv invocation, args []string) int {
 			return inv.runSessionCommand("_inject-proxy", args)
 		},
+	}
+}
+
+func remoteCLICommandGroup() commandHandler {
+	subcommands := remoteCLICommands()
+	return func(inv invocation, args []string) int {
+		switch {
+		case len(args) == 0:
+			fmt.Fprintln(inv.runtime.Stderr, remoteUsage)
+			return 1
+		case isHelpFlag(args[0]):
+			fmt.Fprintln(inv.runtime.Stdout, remoteUsage)
+			return 0
+		case len(args) > 1 && isHelpFlag(args[1]):
+			if usage, ok := commandUsageByName[args[0]]; ok {
+				fmt.Fprintln(inv.runtime.Stdout, usage)
+				return 0
+			}
+		}
+
+		handler, ok := subcommands[args[0]]
+		if !ok {
+			fmt.Fprintf(inv.runtime.Stderr, "amux: unknown remote command %q\n", args[0])
+			fmt.Fprintln(inv.runtime.Stderr, remoteUsage)
+			return 1
+		}
+		return handler(inv, args[1:])
 	}
 }

--- a/internal/cli/cli_dispatch.go
+++ b/internal/cli/cli_dispatch.go
@@ -44,6 +44,7 @@ func buildCLICommands() map[string]commandHandler {
 	addCLICommands(commands, layoutCLICommands())
 	addCLICommands(commands, windowCLICommands())
 	addCLICommands(commands, remoteCLICommands())
+	commands["remote"] = remoteCLICommandGroup()
 	return commands
 }
 

--- a/internal/cli/cli_parse.go
+++ b/internal/cli/cli_parse.go
@@ -89,6 +89,12 @@ func ResolveCanonicalSessionCommand(args []string) (cmdName string, cmdArgs []st
 	if len(args) == 0 {
 		return "", nil, false, nil
 	}
+	if args[0] == "remote" {
+		if len(args) == 1 {
+			return "", nil, true, errors.New(remoteUsage)
+		}
+		return ResolveCanonicalSessionCommand(args[1:])
+	}
 
 	spec, ok := canonicalSessionCommands[args[0]]
 	if !ok {

--- a/internal/cli/cli_usage.go
+++ b/internal/cli/cli_usage.go
@@ -74,6 +74,7 @@ var commandUsageByName = map[string]string{
 	"prev-window":      prevWindowUsage,
 	"last-window":      lastWindowUsage,
 	"rename":           renameUsage,
+	"remote":           remoteUsage,
 	"reconnect":        reconnectUsage,
 	"reload-server":    reloadServerUsage,
 	"rename-window":    renameWindowUsage,
@@ -220,11 +221,15 @@ Usage:
                                        Resize window to cols x rows
   amux [-s session] events [--filter type1,type2] [--pane <ref>] [--host <name>] [--client <id>] [--no-reconnect]
                                        Stream events as NDJSON (layout, output, idle, busy, exited, client-connect, client-disconnect, display-panes-*, choose-*, copy-mode-*, input-*, reconnect)
-  amux [-s session] hosts              List configured remote hosts + status
-  amux [-s session] disconnect <host>  Drop a remote host connection
-  amux [-s session] reconnect <host>   Reconnect to a remote host
-  amux [-s session] unsplice <host>    Revert remote takeover for a host
-  amux [-s session] reload-server      Hot-reload the server (preserves panes)
+  amux [-s session] remote hosts       List configured remote hosts + status
+  amux [-s session] remote disconnect <host>
+                                       Drop a remote host connection
+  amux [-s session] remote reconnect <host>
+                                       Reconnect to a remote host
+  amux [-s session] remote unsplice <host>
+                                       Revert remote takeover for a host
+  amux [-s session] remote reload-server
+                                       Hot-reload the server (preserves panes)
   amux [-s session] cursor layout      Show current layout cursor
   amux [-s session] cursor clipboard   Show current clipboard cursor
   amux [-s session] cursor ui [--client <id>]

--- a/internal/cli/main_test.go
+++ b/internal/cli/main_test.go
@@ -778,6 +778,14 @@ func TestRunMainDispatchesCommands(t *testing.T) {
 			},
 		},
 		{
+			name:     "remote subcommand dispatches through server",
+			args:     []string{"remote", "disconnect", "host-a"},
+			wantExit: 0,
+			wantCalls: []cliCall{
+				{kind: "server-command", session: resolvedSessionMarker, cmd: "disconnect", args: []string{"host-a"}},
+			},
+		},
+		{
 			name:       "removed ssh command prints migration hint",
 			args:       []string{"ssh", "builder:work"},
 			wantExit:   1,

--- a/internal/cli/main_test.go
+++ b/internal/cli/main_test.go
@@ -826,6 +826,61 @@ func TestRunMainDispatchesCommands(t *testing.T) {
 	}
 }
 
+func TestRemoteCLICommandGroupUsageAndErrors(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		args       []string
+		wantExit   int
+		wantStdout string
+		wantStderr string
+	}{
+		{
+			name:       "missing subcommand prints usage",
+			wantExit:   1,
+			wantStderr: remoteUsage + "\n",
+		},
+		{
+			name:       "group help prints usage",
+			args:       []string{"--help"},
+			wantExit:   0,
+			wantStdout: remoteUsage + "\n",
+		},
+		{
+			name:       "nested help prints subcommand usage",
+			args:       []string{"disconnect", "--help"},
+			wantExit:   0,
+			wantStdout: disconnectUsage + "\n",
+		},
+		{
+			name:       "unknown subcommand prints error",
+			args:       []string{"unknown"},
+			wantExit:   1,
+			wantStderr: "amux: unknown remote command \"unknown\"\n" + remoteUsage + "\n",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newCLIRuntimeHarness()
+			exitCode := remoteCLICommandGroup()(invocation{runtime: h.runtime(), sessionName: resolvedSessionMarker}, tt.args)
+			if exitCode != tt.wantExit {
+				t.Fatalf("exit = %d, want %d", exitCode, tt.wantExit)
+			}
+			if got := h.stdout.String(); got != tt.wantStdout {
+				t.Fatalf("stdout = %q, want %q", got, tt.wantStdout)
+			}
+			if got := h.stderr.String(); got != tt.wantStderr {
+				t.Fatalf("stderr = %q, want %q", got, tt.wantStderr)
+			}
+		})
+	}
+}
+
 func TestRunMainHelpAndUsageErrors(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cli/main_test.go
+++ b/internal/cli/main_test.go
@@ -280,6 +280,13 @@ func TestResolveCanonicalSessionCommand(t *testing.T) {
 			wantHandled: true,
 		},
 		{
+			name:        "remote disconnect unwraps to session command",
+			args:        []string{"remote", "disconnect", "host-a"},
+			wantCmd:     "disconnect",
+			wantArgs:    []string{"host-a"},
+			wantHandled: true,
+		},
+		{
 			name:        "respawn narrows to pane arg",
 			args:        []string{"respawn", "pane-1", "ignored"},
 			wantCmd:     "respawn",

--- a/internal/server/commands/remote/reload_test.go
+++ b/internal/server/commands/remote/reload_test.go
@@ -128,6 +128,10 @@ func (ctx reloadTestContext) HostStatuses() map[string]string { return nil }
 
 func (ctx reloadTestContext) DisconnectHost(string) error { return nil }
 
+func (ctx reloadTestContext) FinalizeDisconnect(host string) commandpkg.Result {
+	return commandpkg.Result{Output: fmt.Sprintf("Disconnected from %s\n", host)}
+}
+
 func (ctx reloadTestContext) ReconnectHost(string) error { return nil }
 
 func (ctx reloadTestContext) ResolveReloadExecPath() (string, error) {

--- a/internal/server/commands/remote/remote.go
+++ b/internal/server/commands/remote/remote.go
@@ -12,6 +12,7 @@ import (
 type Context interface {
 	HostStatuses() map[string]string
 	DisconnectHost(host string) error
+	FinalizeDisconnect(host string) commandpkg.Result
 	ReconnectHost(host string) error
 	ResolveReloadExecPath() (string, error)
 	ReloadServer(execPath string) error
@@ -47,7 +48,7 @@ func Disconnect(ctx Context, args []string) commandpkg.Result {
 	if err := ctx.DisconnectHost(host); err != nil {
 		return commandpkg.Result{Err: err}
 	}
-	return commandpkg.Result{Output: fmt.Sprintf("Disconnected from %s\n", host)}
+	return ctx.FinalizeDisconnect(host)
 }
 
 func Reconnect(ctx Context, args []string) commandpkg.Result {

--- a/internal/server/commands/remote/remote_test.go
+++ b/internal/server/commands/remote/remote_test.go
@@ -1,0 +1,121 @@
+package remote
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	commandpkg "github.com/weill-labs/amux/internal/server/commands"
+)
+
+type commandTestContext struct {
+	disconnectErr error
+	reconnectErr  error
+	finalizeRes   commandpkg.Result
+	disconnects   []string
+	reconnects    []string
+	finalized     []string
+}
+
+func (ctx *commandTestContext) HostStatuses() map[string]string { return nil }
+
+func (ctx *commandTestContext) DisconnectHost(host string) error {
+	ctx.disconnects = append(ctx.disconnects, host)
+	return ctx.disconnectErr
+}
+
+func (ctx *commandTestContext) FinalizeDisconnect(host string) commandpkg.Result {
+	ctx.finalized = append(ctx.finalized, host)
+	if ctx.finalizeRes.Output == "" && ctx.finalizeRes.Err == nil && ctx.finalizeRes.Mutate == nil && ctx.finalizeRes.Stream == nil && ctx.finalizeRes.Message == nil {
+		return commandpkg.Result{Output: fmt.Sprintf("Disconnected from %s\n", host)}
+	}
+	return ctx.finalizeRes
+}
+
+func (ctx *commandTestContext) ReconnectHost(host string) error {
+	ctx.reconnects = append(ctx.reconnects, host)
+	return ctx.reconnectErr
+}
+
+func (ctx *commandTestContext) ResolveReloadExecPath() (string, error) { return "", nil }
+
+func (ctx *commandTestContext) ReloadServer(string) error { return nil }
+
+func (ctx *commandTestContext) UnspliceHost(string) commandpkg.Result { return commandpkg.Result{} }
+
+func (ctx *commandTestContext) InjectProxy(string) commandpkg.Result { return commandpkg.Result{} }
+
+func TestDisconnectRequiresHost(t *testing.T) {
+	t.Parallel()
+
+	res := Disconnect(&commandTestContext{}, nil)
+	if res.Err == nil || res.Err.Error() != "usage: disconnect <host>" {
+		t.Fatalf("Disconnect() error = %v, want usage", res.Err)
+	}
+}
+
+func TestDisconnectDelegatesToContextAndFinalizer(t *testing.T) {
+	t.Parallel()
+
+	ctx := &commandTestContext{
+		finalizeRes: commandpkg.Result{Output: "done\n"},
+	}
+
+	res := Disconnect(ctx, []string{"gpu"})
+	if res.Output != "done\n" {
+		t.Fatalf("Disconnect() output = %q, want %q", res.Output, "done\n")
+	}
+	if len(ctx.disconnects) != 1 || ctx.disconnects[0] != "gpu" {
+		t.Fatalf("disconnects = %v, want [gpu]", ctx.disconnects)
+	}
+	if len(ctx.finalized) != 1 || ctx.finalized[0] != "gpu" {
+		t.Fatalf("finalized = %v, want [gpu]", ctx.finalized)
+	}
+}
+
+func TestDisconnectReturnsDisconnectError(t *testing.T) {
+	t.Parallel()
+
+	wantErr := errors.New("boom")
+	ctx := &commandTestContext{disconnectErr: wantErr}
+	res := Disconnect(ctx, []string{"gpu"})
+	if !errors.Is(res.Err, wantErr) {
+		t.Fatalf("Disconnect() error = %v, want %v", res.Err, wantErr)
+	}
+	if len(ctx.finalized) != 0 {
+		t.Fatalf("FinalizeDisconnect should not run on error, got %v", ctx.finalized)
+	}
+}
+
+func TestReconnectRequiresHost(t *testing.T) {
+	t.Parallel()
+
+	res := Reconnect(&commandTestContext{}, nil)
+	if res.Err == nil || res.Err.Error() != "usage: reconnect <host>" {
+		t.Fatalf("Reconnect() error = %v, want usage", res.Err)
+	}
+}
+
+func TestReconnectDelegatesToContext(t *testing.T) {
+	t.Parallel()
+
+	ctx := &commandTestContext{}
+	res := Reconnect(ctx, []string{"gpu"})
+	if res.Output != "Reconnected to gpu\n" {
+		t.Fatalf("Reconnect() output = %q, want %q", res.Output, "Reconnected to gpu\n")
+	}
+	if len(ctx.reconnects) != 1 || ctx.reconnects[0] != "gpu" {
+		t.Fatalf("reconnects = %v, want [gpu]", ctx.reconnects)
+	}
+}
+
+func TestReconnectReturnsReconnectError(t *testing.T) {
+	t.Parallel()
+
+	wantErr := errors.New("boom")
+	ctx := &commandTestContext{reconnectErr: wantErr}
+	res := Reconnect(ctx, []string{"gpu"})
+	if !errors.Is(res.Err, wantErr) {
+		t.Fatalf("Reconnect() error = %v, want %v", res.Err, wantErr)
+	}
+}

--- a/internal/server/commands_remote.go
+++ b/internal/server/commands_remote.go
@@ -35,6 +35,20 @@ func (ctx remoteCommandContext) DisconnectHost(host string) error {
 	return ctx.Sess.RemoteManager.DisconnectHost(host)
 }
 
+func (ctx remoteCommandContext) FinalizeDisconnect(hostName string) commandpkg.Result {
+	return commandpkg.Result{
+		Mutate: func() commandpkg.Result {
+			if err := ctx.Sess.disconnectRemoteSession(hostName); err != nil {
+				return commandpkg.Result{Err: err}
+			}
+			return commandpkg.Result{
+				Output:          fmt.Sprintf("Disconnected from %s\n", hostName),
+				BroadcastLayout: true,
+			}
+		},
+	}
+}
+
 func (ctx remoteCommandContext) ReconnectHost(host string) error {
 	if ctx.Sess.RemoteManager == nil {
 		return fmt.Errorf("no remote hosts configured")
@@ -164,34 +178,8 @@ func cmdConnect(ctx *CommandContext) {
 	ctx.applyCommandResult(runConnect(ctx))
 }
 
-func runDisconnect(ctx *CommandContext) commandpkg.Result {
-	if len(ctx.Args) < 1 {
-		return commandpkg.Result{Err: fmt.Errorf("usage: disconnect <host>")}
-	}
-	if ctx.Sess.RemoteManager == nil {
-		return commandpkg.Result{Err: fmt.Errorf("no remote hosts configured")}
-	}
-
-	hostName := ctx.Args[0]
-	if err := ctx.Sess.RemoteManager.DisconnectHost(hostName); err != nil {
-		return commandpkg.Result{Err: err}
-	}
-
-	return toCommandResult(ctx.Sess.enqueueCommandMutation(func(mctx *MutationContext) commandMutationResult {
-		if err := mutationContextDo(mctx, func(sess *Session) error {
-			return sess.disconnectRemoteSession(hostName)
-		}); err != nil {
-			return commandMutationResult{err: err}
-		}
-		return commandMutationResult{
-			output:          fmt.Sprintf("Disconnected from %s\n", hostName),
-			broadcastLayout: true,
-		}
-	}))
-}
-
 func cmdDisconnect(ctx *CommandContext) {
-	ctx.applyCommandResult(runDisconnect(ctx))
+	ctx.applyCommandResult(remotecmd.Disconnect(remoteCommandContext{ctx}, ctx.Args))
 }
 
 func cmdReconnect(ctx *CommandContext) {

--- a/internal/server/commands_remote_test.go
+++ b/internal/server/commands_remote_test.go
@@ -1,0 +1,27 @@
+package server
+
+import "testing"
+
+func TestRemoteCommandContextFinalizeDisconnect(t *testing.T) {
+	t.Parallel()
+
+	_, sess, cleanup := newCommandTestSession(t)
+	defer cleanup()
+
+	ctx := remoteCommandContext{&CommandContext{Sess: sess}}
+	res := ctx.FinalizeDisconnect("gpu")
+	if res.Mutate == nil {
+		t.Fatal("FinalizeDisconnect() should return a mutation result")
+	}
+
+	got := res.Mutate()
+	if got.Err != nil {
+		t.Fatalf("FinalizeDisconnect() mutate error = %v", got.Err)
+	}
+	if got.Output != "Disconnected from gpu\n" {
+		t.Fatalf("FinalizeDisconnect() output = %q, want %q", got.Output, "Disconnected from gpu\n")
+	}
+	if !got.BroadcastLayout {
+		t.Fatal("FinalizeDisconnect() should broadcast layout updates")
+	}
+}

--- a/test/remote_management_test.go
+++ b/test/remote_management_test.go
@@ -16,6 +16,12 @@ func newRemoteHarness(t *testing.T) *ServerHarness {
 	return newServerHarnessWithConfig(t, 80, 24, remoteTestConfig(addr, keyFile))
 }
 
+func newPersistentRemoteHarness(t *testing.T) *ServerHarness {
+	t.Helper()
+	addr, keyFile := setupTestSSH(t)
+	return newServerHarnessWithOptions(t, 80, 24, remoteTestConfig(addr, keyFile), false, false)
+}
+
 // splitRemotePane creates a remote pane on "test-remote" and waits for the
 // layout to update. Fails the test if the split command errors.
 func splitRemotePane(t *testing.T, h *ServerHarness) {
@@ -32,6 +38,16 @@ func connectRemoteSession(t *testing.T, h *ServerHarness) {
 	t.Helper()
 	gen := h.generation()
 	out := h.runCmd("connect", "test-remote")
+	if strings.Contains(out, "error") || strings.Contains(out, "Error") {
+		t.Fatalf("remote connect failed: %s", out)
+	}
+	h.waitLayout(gen)
+}
+
+func connectRemoteSessionViaRemoteCLI(t *testing.T, h *ServerHarness) {
+	t.Helper()
+	gen := h.generation()
+	out := h.runCmd("remote", "connect", "test-remote")
 	if strings.Contains(out, "error") || strings.Contains(out, "Error") {
 		t.Fatalf("remote connect failed: %s", out)
 	}
@@ -203,6 +219,37 @@ func TestConnectCaptureAndDisconnect(t *testing.T) {
 	out = h.runCmd("hosts")
 	if !hostsShowsState(out, "disconnected") {
 		t.Fatalf("hosts should show disconnected after connect/disconnect, got:\n%s", out)
+	}
+}
+
+func TestRemoteCommandDisconnectUpdatesHostStatusAndLayout(t *testing.T) {
+	t.Parallel()
+
+	h := newPersistentRemoteHarness(t)
+	connectRemoteSessionViaRemoteCLI(t, h)
+
+	out := h.runCmd("remote", "hosts")
+	if !hostsShowsState(out, "connected") {
+		t.Fatalf("remote hosts should show connected after connect, got:\n%s", out)
+	}
+
+	gen := h.generation()
+	out = h.runCmd("remote", "disconnect", "test-remote")
+	if !strings.Contains(out, "Disconnected from test-remote") {
+		t.Fatalf("remote disconnect should confirm, got: %s", out)
+	}
+	h.waitLayout(gen)
+
+	listOut := h.runCmd("list")
+	for _, line := range strings.Split(listOut, "\n") {
+		if strings.Contains(line, "test-remote") {
+			t.Fatalf("remote disconnect should remove remote panes from list, still found:\n%s", listOut)
+		}
+	}
+
+	out = h.runCmd("remote", "hosts")
+	if !hostsShowsState(out, "disconnected") {
+		t.Fatalf("remote hosts should show disconnected after disconnect, got:\n%s", out)
 	}
 }
 

--- a/test/remote_management_test.go
+++ b/test/remote_management_test.go
@@ -1,11 +1,8 @@
 package test
 
 import (
-	"encoding/json"
 	"strings"
 	"testing"
-
-	"github.com/weill-labs/amux/internal/proto"
 )
 
 // remoteHarness bundles a ServerHarness with SSH test infrastructure.
@@ -30,16 +27,6 @@ func splitRemotePane(t *testing.T, h *ServerHarness) {
 	out := h.runCmd("split", "pane-1", "--host", "test-remote")
 	if strings.Contains(out, "error") || strings.Contains(out, "Error") {
 		t.Fatalf("remote split failed: %s", out)
-	}
-	h.waitLayout(gen)
-}
-
-func connectRemoteSession(t *testing.T, h *ServerHarness) {
-	t.Helper()
-	gen := h.generation()
-	out := h.runCmd("connect", "test-remote")
-	if strings.Contains(out, "error") || strings.Contains(out, "Error") {
-		t.Fatalf("remote connect failed: %s", out)
 	}
 	h.waitLayout(gen)
 }
@@ -168,8 +155,8 @@ func TestDisconnectAndReconnect(t *testing.T) {
 func TestConnectCaptureAndDisconnect(t *testing.T) {
 	t.Parallel()
 
-	h := newRemoteHarness(t)
-	connectRemoteSession(t, h)
+	h := newPersistentRemoteHarness(t)
+	connectRemoteSessionViaRemoteCLI(t, h)
 
 	c := h.captureJSON()
 	assertCaptureConsistent(t, c)
@@ -188,20 +175,8 @@ func TestConnectCaptureAndDisconnect(t *testing.T) {
 		t.Fatalf("list output missing mirrored remote pane name:\n%s", listOut)
 	}
 
-	h.sendKeys("test-remote/pane-1", "echo CONNECT_REMOTE_OK", "Enter")
-	h.waitForTimeout("test-remote/pane-1", "CONNECT_REMOTE_OK", "5s")
-
-	rawCapture := h.runCmd("capture", "test-remote/pane-1", "--format", "json")
-	var paneCapture proto.CapturePane
-	if err := json.Unmarshal([]byte(rawCapture), &paneCapture); err != nil {
-		t.Fatalf("capture remote pane json: %v\nraw: %s", err, rawCapture)
-	}
-	if joined := strings.Join(append(append([]string(nil), paneCapture.History...), paneCapture.Content...), "\n"); !strings.Contains(joined, "CONNECT_REMOTE_OK") {
-		t.Fatalf("remote pane capture missing command output:\n%s", rawCapture)
-	}
-
 	gen := h.generation()
-	out := h.runCmd("disconnect", "test-remote")
+	out := h.runCmd("remote", "disconnect", "test-remote")
 	if !strings.Contains(out, "Disconnected from test-remote") {
 		t.Fatalf("disconnect should confirm, got: %s", out)
 	}
@@ -216,40 +191,9 @@ func TestConnectCaptureAndDisconnect(t *testing.T) {
 		}
 	}
 
-	out = h.runCmd("hosts")
-	if !hostsShowsState(out, "disconnected") {
-		t.Fatalf("hosts should show disconnected after connect/disconnect, got:\n%s", out)
-	}
-}
-
-func TestRemoteCommandDisconnectUpdatesHostStatusAndLayout(t *testing.T) {
-	t.Parallel()
-
-	h := newPersistentRemoteHarness(t)
-	connectRemoteSessionViaRemoteCLI(t, h)
-
-	out := h.runCmd("remote", "hosts")
-	if !hostsShowsState(out, "connected") {
-		t.Fatalf("remote hosts should show connected after connect, got:\n%s", out)
-	}
-
-	gen := h.generation()
-	out = h.runCmd("remote", "disconnect", "test-remote")
-	if !strings.Contains(out, "Disconnected from test-remote") {
-		t.Fatalf("remote disconnect should confirm, got: %s", out)
-	}
-	h.waitLayout(gen)
-
-	listOut := h.runCmd("list")
-	for _, line := range strings.Split(listOut, "\n") {
-		if strings.Contains(line, "test-remote") {
-			t.Fatalf("remote disconnect should remove remote panes from list, still found:\n%s", listOut)
-		}
-	}
-
 	out = h.runCmd("remote", "hosts")
 	if !hostsShowsState(out, "disconnected") {
-		t.Fatalf("remote hosts should show disconnected after disconnect, got:\n%s", out)
+		t.Fatalf("hosts should show disconnected after connect/disconnect, got:\n%s", out)
 	}
 }
 


### PR DESCRIPTION
## Motivation

`internal/server/commands/remote/remote.go` already had `Disconnect`, but the live disconnect path still bypassed it and `deadcode -test ./...` reported that helper as unreachable. LAB-1399 finishes that extraction and exposes the `amux remote ...` CLI path that pairs with the existing remote command helpers.

## Summary

- add an `amux remote ...` CLI group alias for remote host commands and wire `disconnect` through the same extracted remote command package as `reconnect`
- teach `remote.Disconnect` to finalize server-side remote-session teardown so disconnect still removes mirrored remote panes and broadcasts layout updates
- update the remote CLI/docs/tests so the persistent-harness integration coverage exercises `remote connect`, `remote disconnect`, and `remote hosts`

## Testing

- `deadcode -test ./...`
- `go vet ./...`
- `go test ./internal/cli -run 'TestResolveCanonicalSessionCommand|TestRunMainDispatchesCommands' -count=100`
- `go test ./test -run 'TestConnectCaptureAndDisconnect' -count=100 -timeout 30m`
- `go test ./... -timeout 10m -count=3`
- `go test ./... -timeout 120s -count=3`  
  On this machine, this command still times out in the pre-existing `./test` SSH/takeover package before any assertion failure; the same suite passes with the higher timeout above.

## Review focus

- confirm `cmdDisconnect` now delegates through `remote.Disconnect` while preserving the existing `disconnectRemoteSession` layout cleanup
- confirm the new `amux remote disconnect` / `amux remote hosts` aliasing is the intended public CLI surface and the README wording matches it
- confirm the lighter integration test still covers the LAB-1399 happy path without keeping the redundant remote capture round-trip

Closes LAB-1399
