### PR TITLE
LAB-1418: Parallelize per-pane work in client JSON capture

### DIFF
--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -78,6 +78,39 @@ func threePane80x23() *proto.LayoutSnapshot {
 	}
 }
 
+func fourPane80x23OutOfOrder() *proto.LayoutSnapshot {
+	root := proto.CellSnapshot{
+		X: 0, Y: 0, W: 80, H: 23,
+		Dir: int(mux.SplitVertical),
+		Children: []proto.CellSnapshot{
+			{X: 0, Y: 0, W: 19, H: 23, IsLeaf: true, Dir: -1, PaneID: 3},
+			{X: 20, Y: 0, W: 19, H: 23, IsLeaf: true, Dir: -1, PaneID: 1},
+			{X: 40, Y: 0, W: 19, H: 23, IsLeaf: true, Dir: -1, PaneID: 4},
+			{X: 60, Y: 0, W: 19, H: 23, IsLeaf: true, Dir: -1, PaneID: 2},
+		},
+	}
+	panes := []proto.PaneSnapshot{
+		{ID: 1, Name: "pane-1", Host: "local", Color: "f5e0dc", ColumnIndex: 0},
+		{ID: 2, Name: "pane-2", Host: "local", Color: "f2cdcd", ColumnIndex: 1},
+		{ID: 3, Name: "pane-3", Host: "local", Color: "cba6f7", ColumnIndex: 2},
+		{ID: 4, Name: "pane-4", Host: "local", Color: "89dceb", ColumnIndex: 3},
+	}
+	return &proto.LayoutSnapshot{
+		SessionName:  "test",
+		ActivePaneID: 3,
+		Width:        80,
+		Height:       23,
+		Root:         root,
+		Panes:        panes,
+		Windows: []proto.WindowSnapshot{{
+			ID: 1, Name: "window-1", Index: 1, ActivePaneID: 3,
+			Root:  root,
+			Panes: panes,
+		}},
+		ActiveWindowID: 1,
+	}
+}
+
 func duplicateNameTwoPane80x23(name string) *proto.LayoutSnapshot {
 	snap := twoPane80x23()
 	for i := range snap.Panes {
@@ -514,6 +547,34 @@ func TestRendererCaptureJSONValueMatchesCaptureJSON(t *testing.T) {
 
 	if got, want := marshalIndented(capture), cr.renderer.CaptureJSON(status); got != want {
 		t.Fatalf("captureJSONValue output mismatch\n got: %s\nwant: %s", got, want)
+	}
+}
+
+func TestRendererCaptureJSONPreservesLayoutWalkOrder(t *testing.T) {
+	t.Parallel()
+
+	r := NewWithScrollback(80, 24, mux.DefaultScrollbackLines)
+	defer r.Close()
+	r.HandleLayout(fourPane80x23OutOfOrder())
+	for _, paneID := range []uint32{1, 2, 3, 4} {
+		r.HandlePaneOutput(paneID, []byte(fmt.Sprintf("pane-%d output", paneID)))
+	}
+
+	capture, ok := r.captureJSONValue(nil)
+	if !ok {
+		t.Fatal("captureJSONValue returned no layout")
+	}
+	if got, want := len(capture.Panes), 4; got != want {
+		t.Fatalf("panes = %d, want %d", got, want)
+	}
+
+	gotIDs := make([]uint32, 0, len(capture.Panes))
+	for _, pane := range capture.Panes {
+		gotIDs = append(gotIDs, pane.ID)
+	}
+	wantIDs := []uint32{3, 1, 4, 2}
+	if !reflect.DeepEqual(gotIDs, wantIDs) {
+		t.Fatalf("pane order = %#v, want %#v", gotIDs, wantIDs)
 	}
 }
 

--- a/internal/client/renderer.go
+++ b/internal/client/renderer.go
@@ -430,20 +430,71 @@ func (r *Renderer) captureJSONValueWithHistory(agentStatus map[uint32]proto.Pane
 			}
 		}
 
+		type capturePaneWork struct {
+			paneID      uint32
+			position    proto.CapturePos
+			baseHistory []proto.StyledLine
+		}
+
+		paneWork := make([]capturePaneWork, 0)
 		root.Walk(func(c *mux.LayoutCell) {
 			paneID := c.CellPaneID()
 			if paneID == 0 {
 				return
 			}
-			cp, ok := r.buildCapturePane(st, snap, paneID, agentStatus, includeHistory, baseHistory[paneID])
-			if !ok {
-				return
-			}
-			cp.Position = &proto.CapturePos{
-				X: c.X, Y: c.Y, Width: c.W, Height: c.H,
-			}
-			capture.Panes = append(capture.Panes, cp)
+			paneWork = append(paneWork, capturePaneWork{
+				paneID:      paneID,
+				position:    proto.CapturePos{X: c.X, Y: c.Y, Width: c.W, Height: c.H},
+				baseHistory: baseHistory[paneID],
+			})
 		})
+
+		emulators := make([]mux.TerminalEmulator, len(paneWork))
+		// Pre-warm serially so the fan-out only performs read-only access across
+		// the emulator and snapshot maps.
+		for i, work := range paneWork {
+			emulators[i] = st.ensurePaneEmulator(work.paneID)
+			if emulators[i] == nil {
+				continue
+			}
+			st.warmPaneOutput(work.paneID, st.emulators)
+		}
+
+		ordered := make([]proto.CapturePane, len(paneWork))
+		orderedOK := make([]bool, len(paneWork))
+		var wg sync.WaitGroup
+		for i, work := range paneWork {
+			emu := emulators[i]
+			if emu == nil {
+				continue
+			}
+			wg.Add(1)
+			go func(i int, work capturePaneWork, emu mux.TerminalEmulator) {
+				defer wg.Done()
+
+				cp, ok := r.buildCapturePaneFromEmulator(emu, snap, work.paneID, agentStatus, includeHistory, work.baseHistory)
+				if !ok {
+					return
+				}
+				cp.Position = &proto.CapturePos{
+					X:      work.position.X,
+					Y:      work.position.Y,
+					Width:  work.position.Width,
+					Height: work.position.Height,
+				}
+				ordered[i] = cp
+				orderedOK[i] = true
+			}(i, work, emu)
+		}
+		wg.Wait()
+
+		capture.Panes = make([]proto.CapturePane, 0, len(ordered))
+		for i := range ordered {
+			if !orderedOK[i] {
+				continue
+			}
+			capture.Panes = append(capture.Panes, ordered[i])
+		}
 
 		ok = true
 	})
@@ -558,6 +609,10 @@ func (r *Renderer) buildCapturePane(st *rendererActorState, snap *rendererSnapsh
 		return proto.CapturePane{}, false
 	}
 	st.warmPaneOutput(paneID, st.emulators)
+	return r.buildCapturePaneFromEmulator(emu, snap, paneID, agentStatus, includeHistory, baseHistory)
+}
+
+func (r *Renderer) buildCapturePaneFromEmulator(emu mux.TerminalEmulator, snap *rendererSnapshot, paneID uint32, agentStatus map[uint32]proto.PaneAgentStatus, includeHistory bool, baseHistory []proto.StyledLine) (proto.CapturePane, bool) {
 	info, ok := snap.paneInfo[paneID]
 	if !ok {
 		return proto.CapturePane{}, false

--- a/internal/client/renderer_bench_test.go
+++ b/internal/client/renderer_bench_test.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/weill-labs/amux/internal/config"
@@ -108,6 +109,49 @@ func benchRendererWithContent(n int) (*Renderer, map[uint32]proto.PaneAgentStatu
 	}
 
 	return r, status
+}
+
+func benchScrollbackPayload(paneID uint32, lines int) []byte {
+	var b strings.Builder
+	for line := 0; line < lines; line++ {
+		fmt.Fprintf(&b, "\x1b[3%dm pane-%d live line %03d %s\x1b[0m\r\n", (int(paneID)+line)%8, paneID, line, "scrollback payload")
+	}
+	return []byte(b.String())
+}
+
+func benchStyledHistory(paneID uint32, lines int) []proto.StyledLine {
+	history := make([]proto.StyledLine, lines)
+	for line := 0; line < lines; line++ {
+		history[line] = proto.StyledLine{
+			Text: fmt.Sprintf("pane-%d history line %03d", paneID, line),
+		}
+	}
+	return history
+}
+
+func benchRendererWithScrollback(n int) (*Renderer, map[uint32]proto.PaneAgentStatus, map[uint32][]proto.StyledLine) {
+	const (
+		width           = 240
+		layoutHeight    = 31
+		scrollbackLines = 256
+	)
+
+	r := NewWithScrollback(width, layoutHeight+1, scrollbackLines)
+	snap := benchLayoutSnapshot(n, width, layoutHeight)
+	r.HandleLayout(snap)
+
+	status := make(map[uint32]proto.PaneAgentStatus, n)
+	baseHistory := make(map[uint32][]proto.StyledLine, n)
+	for _, pane := range snap.Panes {
+		r.HandlePaneOutput(pane.ID, benchScrollbackPayload(pane.ID, 128))
+		status[pane.ID] = proto.PaneAgentStatus{
+			Idle:           true,
+			CurrentCommand: "bash",
+		}
+		baseHistory[pane.ID] = benchStyledHistory(pane.ID, 96)
+	}
+
+	return r, status, baseHistory
 }
 
 func BenchmarkRendererHandlePaneOutput(b *testing.B) {
@@ -234,6 +278,23 @@ func BenchmarkRendererHandlePaneOutputVisibility(b *testing.B) {
 			r.HandlePaneOutput(paneID, payload)
 		}
 	})
+}
+
+func BenchmarkCaptureJSON(b *testing.B) {
+	for _, panes := range []int{2, 4, 8, 16} {
+		b.Run(fmt.Sprintf("panes_%d", panes), func(b *testing.B) {
+			r, status, baseHistory := benchRendererWithScrollback(panes)
+			defer r.Close()
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				if _, ok := r.captureJSONValueWithHistory(status, baseHistory, true); !ok {
+					b.Fatal("captureJSONValueWithHistory returned no layout")
+				}
+			}
+		})
+	}
 }
 
 func BenchmarkRendererCaptureJSON(b *testing.B) {


### PR DESCRIPTION
## Motivation

Client-side JSON capture built each visible pane sequentially, so capture latency scaled with pane count even though each pane render is independent. LAB-1418 asks us to parallelize that pane-local work without changing output order or introducing shared-map races around emulator allocation.

## Summary

- collect visible pane work during the layout walk, then serially pre-warm `ensurePaneEmulator` and `warmPaneOutput` before any goroutines start
- render panes in parallel via a new `buildCapturePaneFromEmulator` helper and write each result into a fixed slot so `capture.Panes` preserves layout-walk order
- add regression coverage for layout-walk ordering and a scrollback-heavy `BenchmarkCaptureJSON` over 2/4/8/16 panes

## Baseline numbers

Hardware: Linux amd64, AMD EPYC-Milan Processor

Command:

```bash
go test ./internal/client -run '^$' -bench '^BenchmarkCaptureJSON$' -benchmem
```

| Benchmark | Before | After | Delta |
| --- | ---: | ---: | ---: |
| `BenchmarkCaptureJSON/panes_2-8` | 1.012 ms/op | 0.820 ms/op | -19.0% |
| `BenchmarkCaptureJSON/panes_4-8` | 1.325 ms/op | 0.676 ms/op | -49.0% |
| `BenchmarkCaptureJSON/panes_8-8` | 2.883 ms/op | 1.328 ms/op | -53.9% |
| `BenchmarkCaptureJSON/panes_16-8` | 4.714 ms/op | 1.634 ms/op | -65.3% |

## Testing

```bash
go test ./internal/client -run 'Test(RendererCaptureJSONPreservesLayoutWalkOrder|RendererCaptureJSONValueMatchesCaptureJSON|RendererHandleCaptureRequestHistoryJSONWithoutBootstrapHistory)$' -count=100
go test ./internal/client -run 'Test(RendererCaptureJSONPreservesLayoutWalkOrder|RendererCaptureJSONValueMatchesCaptureJSON|RendererHandleCaptureRequestHistoryJSONWithoutBootstrapHistory)$' -count=100 -race
go test ./internal/client -run '^$' -bench '^BenchmarkCaptureJSON$' -benchmem
go vet ./...
go test ./internal/client/... -count=100 -race
go test ./... -timeout 120s
go test ./test -run '^TestMouseCommandDragAutomaticallyCopiesSelection$' -count=1 -v
go test ./test -run '^TestCopyModeEnterExit$' -count=1 -v
```

Notes:
- `go test ./internal/client/... -count=100 -race` hit unrelated timeout-sensitive failures in existing render/input tests rather than the capture JSON slice.
- `go test ./... -timeout 120s` flaked twice in `github.com/weill-labs/amux/test`; the isolated failing tests (`TestMouseCommandDragAutomaticallyCopiesSelection` and `TestCopyModeEnterExit`) both passed immediately on rerun.

## Review focus

- confirm the serial pre-pass is the right minimal fix for the `ensurePaneEmulator` / `warmPaneOutput` shared-map mutation risk
- confirm the indexed fan-out + ordered compaction keeps `capture.Panes` in layout-walk order and still drops failed pane builds the same way as before
- sanity-check the benchmark setup so it reflects the scrollback-heavy capture path we care about

Closes LAB-1418
