### PR TITLE
LAB-1417: Parallelize per-pane HistoryScreenSnapshot in checkpoint loops

### DIFF
--- a/internal/server/checkpoint.go
+++ b/internal/server/checkpoint.go
@@ -63,14 +63,16 @@ func (s *Server) Reload(execPath string) error {
 			Layout:        *snap,
 		}
 
-		for _, p := range sess.Panes {
-			history, screen, _ := p.HistoryScreenSnapshot()
+		paneSnapshots := snapshotPaneHistoryScreens(sess.Panes, (*mux.Pane).HistoryScreenSnapshot)
+		cp.Panes = make([]checkpoint.PaneCheckpoint, len(sess.Panes))
+		for i, p := range sess.Panes {
+			snapshot := paneSnapshots[i]
 			pc := checkpoint.PaneCheckpoint{
 				ID:           p.ID,
 				Meta:         p.Meta,
 				ManualBranch: p.MetaManualBranch(),
-				History:      history,
-				Screen:       screen,
+				History:      snapshot.history,
+				Screen:       snapshot.screen,
 				CreatedAt:    p.CreatedAt(),
 				IsProxy:      p.IsProxy(),
 			}
@@ -88,7 +90,7 @@ func (s *Server) Reload(execPath string) error {
 					break
 				}
 			}
-			cp.Panes = append(cp.Panes, pc)
+			cp.Panes[i] = pc
 		}
 
 		return cp, nil

--- a/internal/server/checkpoint_snapshots.go
+++ b/internal/server/checkpoint_snapshots.go
@@ -1,0 +1,45 @@
+package server
+
+import "github.com/weill-labs/amux/internal/mux"
+
+type paneHistoryScreenSnapshot struct {
+	history []string
+	screen  string
+}
+
+// snapshotPaneHistoryScreens fans out per-pane snapshot work and writes the
+// results back into a pre-sized slice by pane index so callers keep sess.Panes
+// ordering even when snapshots complete out of order. Production callers pass
+// mux.Pane.HistoryScreenSnapshot, which is safe to run concurrently across
+// distinct panes because each pane serializes emulator access through its own
+// actor goroutine.
+func snapshotPaneHistoryScreens(panes []*mux.Pane, snapshot func(*mux.Pane) ([]string, string, uint64)) []paneHistoryScreenSnapshot {
+	if len(panes) == 0 {
+		return nil
+	}
+
+	type paneSnapshotResult struct {
+		index   int
+		history []string
+		screen  string
+	}
+
+	ch := make(chan paneSnapshotResult, len(panes))
+	for i, p := range panes {
+		go func(index int, pane *mux.Pane) {
+			history, screen, _ := snapshot(pane)
+			ch <- paneSnapshotResult{index: index, history: history, screen: screen}
+		}(i, p)
+	}
+
+	snapshots := make([]paneHistoryScreenSnapshot, len(panes))
+	for range panes {
+		r := <-ch
+		snapshots[r.index] = paneHistoryScreenSnapshot{
+			history: r.history,
+			screen:  r.screen,
+		}
+	}
+
+	return snapshots
+}

--- a/internal/server/checkpoint_snapshots_test.go
+++ b/internal/server/checkpoint_snapshots_test.go
@@ -1,0 +1,42 @@
+package server
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/weill-labs/amux/internal/mux"
+)
+
+func TestSnapshotPaneHistoryScreensPreservesInputOrder(t *testing.T) {
+	t.Parallel()
+
+	panes := []*mux.Pane{
+		{ID: 1},
+		{ID: 2},
+		{ID: 3},
+	}
+	delays := map[uint32]time.Duration{
+		1: 40 * time.Millisecond,
+		2: 0,
+		3: 10 * time.Millisecond,
+	}
+
+	snapshots := snapshotPaneHistoryScreens(panes, func(p *mux.Pane) ([]string, string, uint64) {
+		time.Sleep(delays[p.ID])
+		return []string{fmt.Sprintf("history-%d", p.ID)}, fmt.Sprintf("screen-%d", p.ID), uint64(p.ID)
+	})
+
+	if len(snapshots) != len(panes) {
+		t.Fatalf("len(snapshotPaneHistoryScreens(...)) = %d, want %d", len(snapshots), len(panes))
+	}
+
+	for i, p := range panes {
+		if got := snapshots[i].history; len(got) != 1 || got[0] != fmt.Sprintf("history-%d", p.ID) {
+			t.Fatalf("snapshots[%d].history = %v, want [history-%d]", i, got, p.ID)
+		}
+		if got := snapshots[i].screen; got != fmt.Sprintf("screen-%d", p.ID) {
+			t.Fatalf("snapshots[%d].screen = %q, want screen-%d", i, got, p.ID)
+		}
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -270,15 +270,17 @@ func (s *Session) buildCrashCheckpoint() *checkpoint.CrashCheckpoint {
 			Timestamp:     time.Now(),
 		}
 
+		paneSnapshots := snapshotPaneHistoryScreens(s.Panes, (*mux.Pane).HistoryScreenSnapshot)
+		cp.PaneStates = make([]checkpoint.CrashPaneState, len(s.Panes))
 		var cwdWork []pidEntry
-		for _, p := range s.Panes {
-			history, screen, _ := p.HistoryScreenSnapshot()
+		for i, p := range s.Panes {
+			snapshot := paneSnapshots[i]
 			ps := checkpoint.CrashPaneState{
 				ID:           p.ID,
 				Meta:         p.Meta,
 				ManualBranch: p.MetaManualBranch(),
-				History:      history,
-				Screen:       screen,
+				History:      snapshot.history,
+				Screen:       snapshot.screen,
 				CreatedAt:    p.CreatedAt(),
 				IsProxy:      p.IsProxy(),
 			}
@@ -292,10 +294,10 @@ func (s *Session) buildCrashCheckpoint() *checkpoint.CrashCheckpoint {
 			}
 
 			if !p.IsProxy() {
-				cwdWork = append(cwdWork, pidEntry{index: len(cp.PaneStates), pane: p, pid: p.ProcessPid()})
+				cwdWork = append(cwdWork, pidEntry{index: i, pane: p, pid: p.ProcessPid()})
 			}
 
-			cp.PaneStates = append(cp.PaneStates, ps)
+			cp.PaneStates[i] = ps
 		}
 
 		return crashSnapshot{cp: cp, cwdWork: cwdWork}, nil


### PR DESCRIPTION
## Motivation

Two checkpoint paths were still serializing `HistoryScreenSnapshot()` across every pane, which stretched both hot-reload checkpoint time and crash-checkpoint time on sessions with heavy scrollback. The capture path already fixed the same shape of work by fanning out per-pane subprocess-heavy calls, so this change applies the same approach here without changing checkpoint ordering.

## Summary

- add a shared `snapshotPaneHistoryScreens` helper that fans out per-pane snapshot work and writes results back into a pre-sized slice by pane index
- use that helper in both the reload checkpoint loop and the crash checkpoint loop, preserving `sess.Panes` order with indexed writes instead of append order
- add a focused ordering test that forces out-of-order completions and verifies the collected slice still matches the input pane order

## Testing

- `go test ./internal/server/... -run 'TestSnapshotPaneHistoryScreensPreservesInputOrder|TestCrashCheckpointBuildAndWrite|TestServerReloadWritesCrashCheckpointBeforeExec'`
- `go test ./internal/server/... -run 'TestSnapshotPaneHistoryScreensPreservesInputOrder|TestCrashCheckpointBuildAndWrite|TestServerReloadWritesCrashCheckpointBeforeExec' -count=100 -race`
- `go test ./internal/server/... -count=100 -race`  
  Currently reports a pre-existing unrelated race rooted in `TestCommandSpawnAtLeadPaneSucceeds` / `session_pane.go` and the session event loop; the race trace does not include the checkpoint code touched here.
- `go test ./test -run TestEventsIdleBusyTransition -count=5`
- `go test ./... -timeout 120s`

## Baseline numbers

Measured on `AMD EPYC-Milan Processor`, Linux, with a temporary `BenchmarkLAB1417ReloadCheckpoint` harness run via `go test ./internal/server -run '^$' -bench BenchmarkLAB1417ReloadCheckpoint -benchtime=1x -count=1`.

| Pane count | Before | After | Delta |
| --- | ---: | ---: | ---: |
| 2 | 28.99 ms | 23.36 ms | -19.4% |
| 6 | 84.27 ms | 48.60 ms | -42.3% |
| 12 | 160.30 ms | 78.46 ms | -51.1% |
| 20 | 266.77 ms | 116.73 ms | -56.2% |

## Review focus

- ordering: both checkpoint structs still preserve `sess.Panes` order because the parallel phase only fills a pre-sized results slice by index
- concurrency safety: `HistoryScreenSnapshot` is safe to fan out across panes because each pane serializes emulator access through its own actor goroutine
- phase separation: the reload `clearCloexec` pass still begins only after snapshot collection finishes, so there is no new FD ordering dependency to reason about

Closes LAB-1417
