### PR TITLE
LAB-1402: Default amux connect to remote main session

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,11 +377,13 @@ Remote host commands are also available under `amux remote ...`.
 | Command | Description |
 |---------|-------------|
 | `amux remote hosts` | List configured remote hosts and connection status |
-| `amux remote connect <host>` | Connect to a remote amux session and mirror its panes locally |
+| `amux remote connect <host> [--session <name> \| --session-per-client]` | Connect to a remote amux session and mirror its panes locally |
 | `amux spawn --at <pane> [--root] [--vertical\|--horizontal] [--name NAME] --host HOST` | Create a remote split pane on HOST |
 | `amux remote disconnect <host>` | Drop a remote host connection |
 | `amux remote reconnect <host>` | Reconnect to a remote host |
 | `amux remote unsplice <host>` | Revert remote takeover, replace remote panes with local |
+
+`amux remote connect <host>` attaches to the remote `main` session by default. Use `--session <name>` to mirror a different remote session, or `--session-per-client` to keep the older per-local-machine managed-session behavior.
 
 ## Keybindings
 

--- a/internal/cli/cli_commands_remote.go
+++ b/internal/cli/cli_commands_remote.go
@@ -8,10 +8,10 @@ func remoteCLICommands() map[string]commandHandler {
 	return map[string]commandHandler{
 		"connect": func(inv invocation, args []string) int {
 			if len(args) < 1 {
-				fmt.Fprintln(inv.runtime.Stderr, "usage: amux connect <host>")
+				fmt.Fprintln(inv.runtime.Stderr, connectUsage)
 				return 1
 			}
-			return inv.runSessionCommand("connect", []string{args[0]})
+			return inv.runSessionCommand("connect", args)
 		},
 		"hosts": func(inv invocation, args []string) int {
 			return inv.runSessionCommand("hosts", nil)

--- a/internal/cli/cli_parse.go
+++ b/internal/cli/cli_parse.go
@@ -33,7 +33,7 @@ var canonicalSessionCommands = map[string]sessionCommandSpec{
 	"_inject-proxy": {connectName: "_inject-proxy", argMode: sessionCommandForwardArgs},
 	"_layout-json":  {connectName: "_layout-json", argMode: sessionCommandNoArgs},
 	"capture":       {connectName: "capture", argMode: sessionCommandForwardArgs},
-	"connect":       {connectName: "connect", minArgs: 1, usage: connectUsage, argMode: sessionCommandFirstArg},
+	"connect":       {connectName: "connect", minArgs: 1, usage: connectUsage, argMode: sessionCommandForwardArgs},
 	"copy-mode":     {connectName: "copy-mode", argMode: sessionCommandForwardArgs},
 	"cursor":        {connectName: "cursor", minArgs: 1, usage: cursorUsage, argMode: sessionCommandForwardArgs},
 	"disconnect":    {connectName: "disconnect", minArgs: 1, usage: disconnectUsage, argMode: sessionCommandFirstArg},

--- a/internal/cli/cli_usage.go
+++ b/internal/cli/cli_usage.go
@@ -17,7 +17,7 @@ const (
 	spawnUsage        = "usage: amux spawn [--auto] [--at <pane>] [--window <name|id>] [--vertical|--horizontal] [--root] [--focus] [--name NAME] [--host HOST] [--task TASK] [--color COLOR]"
 	swapUsage         = "usage: amux swap <pane1> <pane2> [--tree] | amux swap forward | amux swap backward"
 	cursorUsage       = "usage: amux cursor <layout|clipboard|ui> [--client <id>]"
-	connectUsage      = "usage: amux connect <host>"
+	connectUsage      = "usage: amux connect <host> [--session <name> | --session-per-client]"
 	disconnectUsage   = "usage: amux disconnect <host>"
 	focusUsage        = "usage: amux focus <pane>"
 	listClientsUsage  = "usage: amux list-clients"
@@ -169,7 +169,8 @@ Usage:
                                        Capture a pane's retained history + visible screen
   amux [-s session] capture --ansi     Capture with ANSI escape codes
   amux [-s session] capture --colors   Capture border color map
-  amux [-s session] connect <host>     Connect to a remote amux session and mirror its panes locally
+  amux [-s session] connect <host> [--session <name> | --session-per-client]
+                                       Connect to a remote amux session and mirror its panes locally
   amux [-s session] send-keys <pane> [--via pty|client] [--client <id>] [--wait ready|ui=input-idle] [--timeout <duration>] [--delay-final <duration>] [--hex] <keys>...
                                        Send keystrokes to a pane
   amux [-s session] mouse [--client <id>] [--timeout <duration>] ...

--- a/internal/cli/main_test.go
+++ b/internal/cli/main_test.go
@@ -287,6 +287,20 @@ func TestResolveCanonicalSessionCommand(t *testing.T) {
 			wantHandled: true,
 		},
 		{
+			name:        "connect forwards host and session flags",
+			args:        []string{"connect", "host-a", "--session", "work"},
+			wantCmd:     "connect",
+			wantArgs:    []string{"host-a", "--session", "work"},
+			wantHandled: true,
+		},
+		{
+			name:        "remote connect unwraps to session command with per-client flag",
+			args:        []string{"remote", "connect", "host-a", "--session-per-client"},
+			wantCmd:     "connect",
+			wantArgs:    []string{"host-a", "--session-per-client"},
+			wantHandled: true,
+		},
+		{
 			name:        "respawn narrows to pane arg",
 			args:        []string{"respawn", "pane-1", "ignored"},
 			wantCmd:     "respawn",
@@ -785,6 +799,22 @@ func TestRunMainDispatchesCommands(t *testing.T) {
 			},
 		},
 		{
+			name:     "connect forwards session override through server",
+			args:     []string{"connect", "host-a", "--session", "work"},
+			wantExit: 0,
+			wantCalls: []cliCall{
+				{kind: "server-command", session: resolvedSessionMarker, cmd: "connect", args: []string{"host-a", "--session", "work"}},
+			},
+		},
+		{
+			name:     "remote connect forwards per-client flag through server",
+			args:     []string{"remote", "connect", "host-a", "--session-per-client"},
+			wantExit: 0,
+			wantCalls: []cliCall{
+				{kind: "server-command", session: resolvedSessionMarker, cmd: "connect", args: []string{"host-a", "--session-per-client"}},
+			},
+		},
+		{
 			name:     "remote subcommand dispatches through server",
 			args:     []string{"remote", "disconnect", "host-a"},
 			wantExit: 0,
@@ -927,7 +957,7 @@ func TestRunMainHelpAndUsageErrors(t *testing.T) {
 			name:       "connect usage error stays in dispatch layer",
 			args:       []string{"connect"},
 			wantExit:   1,
-			wantStderr: "usage: amux connect <host>\n",
+			wantStderr: "usage: amux connect <host> [--session <name> | --session-per-client]\n",
 		},
 	}
 

--- a/internal/server/commands_remote.go
+++ b/internal/server/commands_remote.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -164,29 +165,29 @@ func parseConnectTarget(args []string, localSessionName string) (connectTarget, 
 		switch arg := args[i]; arg {
 		case "--session":
 			if perClient || i+1 >= len(args) || args[i+1] == "" || strings.HasPrefix(args[i+1], "-") {
-				return connectTarget{}, fmt.Errorf(connectCommandUsage)
+				return connectTarget{}, errors.New(connectCommandUsage)
 			}
 			target.sessionName = args[i+1]
 			sessionExplicit = true
 			i++
 		case "--session-per-client":
 			if sessionExplicit || perClient {
-				return connectTarget{}, fmt.Errorf(connectCommandUsage)
+				return connectTarget{}, errors.New(connectCommandUsage)
 			}
 			perClient = true
 		default:
 			if strings.HasPrefix(arg, "-") {
-				return connectTarget{}, fmt.Errorf(connectCommandUsage)
+				return connectTarget{}, errors.New(connectCommandUsage)
 			}
 			if target.hostName != "" {
-				return connectTarget{}, fmt.Errorf(connectCommandUsage)
+				return connectTarget{}, errors.New(connectCommandUsage)
 			}
 			target.hostName = arg
 		}
 	}
 
 	if target.hostName == "" {
-		return connectTarget{}, fmt.Errorf(connectCommandUsage)
+		return connectTarget{}, errors.New(connectCommandUsage)
 	}
 	if perClient {
 		target.sessionName = managedSessionName(localSessionName)

--- a/internal/server/commands_remote.go
+++ b/internal/server/commands_remote.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/weill-labs/amux/internal/config"
 	"github.com/weill-labs/amux/internal/mux"
@@ -11,6 +12,8 @@ import (
 )
 
 const ReloadServerExecPathFlag = remotecmd.ReloadServerExecPathFlag
+
+const connectCommandUsage = "usage: connect <host> [--session <name> | --session-per-client]"
 
 type remoteCommandContext struct {
 	*CommandContext
@@ -147,16 +150,61 @@ func cmdHosts(ctx *CommandContext) {
 	ctx.applyCommandResult(remotecmd.Hosts(remoteCommandContext{ctx}, ctx.Args))
 }
 
+type connectTarget struct {
+	hostName    string
+	sessionName string
+}
+
+func parseConnectTarget(args []string, localSessionName string) (connectTarget, error) {
+	target := connectTarget{sessionName: DefaultSessionName}
+	sessionExplicit := false
+	perClient := false
+
+	for i := 0; i < len(args); i++ {
+		switch arg := args[i]; arg {
+		case "--session":
+			if perClient || i+1 >= len(args) || args[i+1] == "" || strings.HasPrefix(args[i+1], "-") {
+				return connectTarget{}, fmt.Errorf(connectCommandUsage)
+			}
+			target.sessionName = args[i+1]
+			sessionExplicit = true
+			i++
+		case "--session-per-client":
+			if sessionExplicit || perClient {
+				return connectTarget{}, fmt.Errorf(connectCommandUsage)
+			}
+			perClient = true
+		default:
+			if strings.HasPrefix(arg, "-") {
+				return connectTarget{}, fmt.Errorf(connectCommandUsage)
+			}
+			if target.hostName != "" {
+				return connectTarget{}, fmt.Errorf(connectCommandUsage)
+			}
+			target.hostName = arg
+		}
+	}
+
+	if target.hostName == "" {
+		return connectTarget{}, fmt.Errorf(connectCommandUsage)
+	}
+	if perClient {
+		target.sessionName = managedSessionName(localSessionName)
+	}
+	return target, nil
+}
+
 func runConnect(ctx *CommandContext) commandpkg.Result {
-	if len(ctx.Args) < 1 {
-		return commandpkg.Result{Err: fmt.Errorf("usage: connect <host>")}
+	target, err := parseConnectTarget(ctx.Args, ctx.Sess.Name)
+	if err != nil {
+		return commandpkg.Result{Err: err}
 	}
 	if ctx.Sess.RemoteManager == nil {
 		return commandpkg.Result{Err: fmt.Errorf("no remote hosts configured")}
 	}
 
-	hostName := ctx.Args[0]
-	layout, err := ctx.Sess.RemoteManager.ConnectHost(hostName, managedSessionName(ctx.Sess.Name))
+	hostName := target.hostName
+	layout, err := ctx.Sess.RemoteManager.ConnectHost(hostName, target.sessionName)
 	if err != nil {
 		return commandpkg.Result{Err: err}
 	}

--- a/internal/server/commands_remote.go
+++ b/internal/server/commands_remote.go
@@ -164,7 +164,7 @@ func parseConnectTarget(args []string, localSessionName string) (connectTarget, 
 	for i := 0; i < len(args); i++ {
 		switch arg := args[i]; arg {
 		case "--session":
-			if perClient || i+1 >= len(args) || args[i+1] == "" || strings.HasPrefix(args[i+1], "-") {
+			if perClient || sessionExplicit || i+1 >= len(args) || args[i+1] == "" || strings.HasPrefix(args[i+1], "-") {
 				return connectTarget{}, errors.New(connectCommandUsage)
 			}
 			target.sessionName = args[i+1]

--- a/internal/server/commands_remote_test.go
+++ b/internal/server/commands_remote_test.go
@@ -120,6 +120,42 @@ func TestRunConnectRejectsConflictingSessionFlags(t *testing.T) {
 	}
 }
 
+func TestRunConnectRejectsInvalidSessionArgs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "duplicate session flag", args: []string{"gpu", "--session", "work", "--session", "logs"}},
+		{name: "missing session value", args: []string{"gpu", "--session"}},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv, sess, cleanup := newCommandTestSession(t)
+			defer cleanup()
+
+			transport := &stubPaneTransport{}
+			installTestPaneTransport(t, sess, transport, nil)
+
+			res := runConnect(&CommandContext{Srv: srv, Sess: sess, Args: tt.args})
+			if res.Err == nil {
+				t.Fatal("runConnect() error = nil, want usage error")
+			}
+			if got := res.Err.Error(); got != "usage: connect <host> [--session <name> | --session-per-client]" {
+				t.Fatalf("runConnect() error = %q, want connect usage", got)
+			}
+			if len(transport.connectHostCalls) != 0 {
+				t.Fatalf("ConnectHost calls = %d, want 0", len(transport.connectHostCalls))
+			}
+		})
+	}
+}
+
 func TestRunConnectMirrorsExistingRemoteMainSessionLayout(t *testing.T) {
 	t.Parallel()
 

--- a/internal/server/commands_remote_test.go
+++ b/internal/server/commands_remote_test.go
@@ -1,6 +1,11 @@
 package server
 
-import "testing"
+import (
+	"slices"
+	"testing"
+
+	"github.com/weill-labs/amux/internal/proto"
+)
 
 func TestRemoteCommandContextFinalizeDisconnect(t *testing.T) {
 	t.Parallel()
@@ -23,5 +28,164 @@ func TestRemoteCommandContextFinalizeDisconnect(t *testing.T) {
 	}
 	if !got.BroadcastLayout {
 		t.Fatal("FinalizeDisconnect() should broadcast layout updates")
+	}
+}
+
+func TestRunConnectDefaultsToRemoteMainSession(t *testing.T) {
+	t.Parallel()
+
+	srv, sess, cleanup := newCommandTestSession(t)
+	defer cleanup()
+
+	transport := &stubPaneTransport{}
+	installTestPaneTransport(t, sess, transport, nil)
+
+	res := runConnect(&CommandContext{Srv: srv, Sess: sess, Args: []string{"gpu"}})
+	if res.Err != nil {
+		t.Fatalf("runConnect() error = %v", res.Err)
+	}
+	if len(transport.connectHostCalls) != 1 {
+		t.Fatalf("ConnectHost calls = %d, want 1", len(transport.connectHostCalls))
+	}
+	call := transport.connectHostCalls[0]
+	if call.hostName != "gpu" {
+		t.Fatalf("ConnectHost host = %q, want gpu", call.hostName)
+	}
+	if call.sessionName != DefaultSessionName {
+		t.Fatalf("ConnectHost session = %q, want %q", call.sessionName, DefaultSessionName)
+	}
+}
+
+func TestRunConnectUsesRequestedRemoteSession(t *testing.T) {
+	t.Parallel()
+
+	srv, sess, cleanup := newCommandTestSession(t)
+	defer cleanup()
+
+	transport := &stubPaneTransport{}
+	installTestPaneTransport(t, sess, transport, nil)
+
+	res := runConnect(&CommandContext{Srv: srv, Sess: sess, Args: []string{"gpu", "--session", "work"}})
+	if res.Err != nil {
+		t.Fatalf("runConnect() error = %v", res.Err)
+	}
+	if len(transport.connectHostCalls) != 1 {
+		t.Fatalf("ConnectHost calls = %d, want 1", len(transport.connectHostCalls))
+	}
+	if got := transport.connectHostCalls[0].sessionName; got != "work" {
+		t.Fatalf("ConnectHost session = %q, want work", got)
+	}
+}
+
+func TestRunConnectUsesManagedSessionWhenRequested(t *testing.T) {
+	t.Parallel()
+
+	srv, sess, cleanup := newCommandTestSession(t)
+	defer cleanup()
+
+	transport := &stubPaneTransport{}
+	installTestPaneTransport(t, sess, transport, nil)
+
+	res := runConnect(&CommandContext{Srv: srv, Sess: sess, Args: []string{"gpu", "--session-per-client"}})
+	if res.Err != nil {
+		t.Fatalf("runConnect() error = %v", res.Err)
+	}
+	if len(transport.connectHostCalls) != 1 {
+		t.Fatalf("ConnectHost calls = %d, want 1", len(transport.connectHostCalls))
+	}
+	wantSession := managedSessionName(sess.Name)
+	if got := transport.connectHostCalls[0].sessionName; got != wantSession {
+		t.Fatalf("ConnectHost session = %q, want %q", got, wantSession)
+	}
+}
+
+func TestRunConnectRejectsConflictingSessionFlags(t *testing.T) {
+	t.Parallel()
+
+	srv, sess, cleanup := newCommandTestSession(t)
+	defer cleanup()
+
+	transport := &stubPaneTransport{}
+	installTestPaneTransport(t, sess, transport, nil)
+
+	res := runConnect(&CommandContext{Srv: srv, Sess: sess, Args: []string{"gpu", "--session", "work", "--session-per-client"}})
+	if res.Err == nil {
+		t.Fatal("runConnect() error = nil, want conflict error")
+	}
+	if got := res.Err.Error(); got != "usage: connect <host> [--session <name> | --session-per-client]" {
+		t.Fatalf("runConnect() error = %q, want connect usage", got)
+	}
+	if len(transport.connectHostCalls) != 0 {
+		t.Fatalf("ConnectHost calls = %d, want 0", len(transport.connectHostCalls))
+	}
+}
+
+func TestRunConnectMirrorsExistingRemoteMainSessionLayout(t *testing.T) {
+	t.Parallel()
+
+	srv, sess, cleanup := newCommandTestSession(t)
+	defer cleanup()
+
+	transport := &stubPaneTransport{
+		hostStatusByName: map[string]proto.ConnState{"gpu": proto.Connected},
+		connectLayout: &proto.LayoutSnapshot{
+			ActiveWindowID: 7,
+			Windows: []proto.WindowSnapshot{{
+				ID:           7,
+				Name:         "remote-main",
+				ActivePaneID: 11,
+				Root: proto.CellSnapshot{
+					X: 0, Y: 0, W: 80, H: 24, IsLeaf: false, Dir: 0,
+					Children: []proto.CellSnapshot{
+						{X: 0, Y: 0, W: 40, H: 24, IsLeaf: true, Dir: -1, PaneID: 11},
+						{X: 40, Y: 0, W: 40, H: 24, IsLeaf: true, Dir: -1, PaneID: 12},
+					},
+				},
+				Panes: []proto.PaneSnapshot{
+					{ID: 11, Name: "pane-11"},
+					{ID: 12, Name: "remote-main-2"},
+				},
+			}},
+		},
+	}
+	installTestPaneTransport(t, sess, transport, nil)
+
+	res := runConnect(&CommandContext{Srv: srv, Sess: sess, Args: []string{"gpu"}})
+	if res.Err != nil {
+		t.Fatalf("runConnect() error = %v", res.Err)
+	}
+
+	state := mustSessionQuery(t, sess, func(sess *Session) struct {
+		remoteNames []string
+		windowNames []string
+	} {
+		remoteNames := make([]string, 0, len(sess.Panes))
+		for _, pane := range sess.Panes {
+			if pane.Meta.Host == "gpu" {
+				remoteNames = append(remoteNames, pane.Meta.Name)
+			}
+		}
+		slices.Sort(remoteNames)
+		windowNames := make([]string, 0, len(sess.Windows))
+		for _, window := range sess.Windows {
+			windowNames = append(windowNames, window.Name)
+		}
+		return struct {
+			remoteNames []string
+			windowNames []string
+		}{
+			remoteNames: remoteNames,
+			windowNames: windowNames,
+		}
+	})
+
+	if len(state.remoteNames) != 2 {
+		t.Fatalf("remote pane count = %d, want 2", len(state.remoteNames))
+	}
+	if state.remoteNames[0] != "pane-11" || state.remoteNames[1] != "remote-main-2" {
+		t.Fatalf("remote pane names = %v, want [pane-11 remote-main-2]", state.remoteNames)
+	}
+	if len(state.windowNames) != 1 || state.windowNames[0] != "remote-main@gpu" {
+		t.Fatalf("window names = %v, want [remote-main@gpu]", state.windowNames)
 	}
 }

--- a/internal/server/pane_transport_test_helpers_test.go
+++ b/internal/server/pane_transport_test_helpers_test.go
@@ -11,6 +11,8 @@ type stubPaneTransport struct {
 	createPaneErr    error
 	createPaneRemote uint32
 	createPaneCalls  []createPaneCall
+	connectLayout    *proto.LayoutSnapshot
+	connectHostCalls []connectHostCall
 	runHostOutput    string
 	runHostErr       error
 	runHostCalls     []runHostCommandCall
@@ -32,6 +34,11 @@ type stubPaneTransport struct {
 type createPaneCall struct {
 	hostName    string
 	localPaneID uint32
+	sessionName string
+}
+
+type connectHostCall struct {
+	hostName    string
 	sessionName string
 }
 
@@ -111,8 +118,15 @@ func (s *stubPaneTransport) CreatePane(hostName string, localPaneID uint32, sess
 }
 
 func (s *stubPaneTransport) ConnectHost(hostName string, sessionName string) (*proto.LayoutSnapshot, error) {
+	s.connectHostCalls = append(s.connectHostCalls, connectHostCall{
+		hostName:    hostName,
+		sessionName: sessionName,
+	})
 	if err := s.lookupHostErr(s.reconnectErrs, hostName); err != nil {
 		return nil, err
+	}
+	if s.connectLayout != nil {
+		return s.connectLayout, nil
 	}
 	return &proto.LayoutSnapshot{
 		ActiveWindowID: 1,

--- a/test/remote_management_test.go
+++ b/test/remote_management_test.go
@@ -34,7 +34,10 @@ func splitRemotePane(t *testing.T, h *ServerHarness) {
 func connectRemoteSessionViaRemoteCLI(t *testing.T, h *ServerHarness) {
 	t.Helper()
 	gen := h.generation()
-	out := h.runCmd("remote", "connect", "test-remote")
+	// These integration tests exercise the remote mirroring/disconnect mechanics.
+	// Use the explicit per-client session flag so the SSH fixture stays hermetic
+	// even if another test left a stale "main" socket behind for the same UID.
+	out := h.runCmd("remote", "connect", "test-remote", "--session-per-client")
 	if strings.Contains(out, "error") || strings.Contains(out, "Error") {
 		t.Fatalf("remote connect failed: %s", out)
 	}


### PR DESCRIPTION
## Motivation

`amux connect <host>` was always forcing a per-client managed session on the remote host, which meant it would miss the remote `main` session users already had open. This change restores the expected default while keeping the older machine-scoped workflow available behind an explicit flag.

## Summary

- default `amux connect <host>` to the remote `main` session instead of `managedSessionName(...)`
- add `--session <name>` to target a specific remote session and `--session-per-client` to keep the old per-client session naming
- preserve the mirrored remote layout by regression-testing the pane set returned from the existing remote session
- document the new default and both override flags in CLI help and README

## Testing

- `go test ./internal/cli -run 'TestResolveCanonicalSessionCommand|TestRunWithRuntimeDispatchesCommands|TestRunMainHelpAndUsageErrors' -count=100`
- `go test ./internal/server -run 'TestRunConnect|TestRemoteCommandContextFinalizeDisconnect' -count=100`
- `go test ./test -run 'TestConnectCaptureAndDisconnect'`
- `go test ./... -timeout 120s`

## Review focus

- confirm the `connect` flag parsing matches the intended contract: default remote `main`, explicit `--session`, explicit `--session-per-client`
- check that only `connect` changes session targeting; remote split/managed-pane flows still use managed session names
- review the new regression coverage for the mirrored remote layout behavior

Closes LAB-1402
