### PR TITLE
LAB-1423: Bound install.sh session-probe with timeout

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -105,9 +105,11 @@ discover_live_sessions() {
 		return 0
 	fi
 
+	# Bound each probe so a stale socket with a wedged server doesn't hang
+	# install. Dev machines accumulate these from crashed test harnesses.
 	while IFS= read -r sock; do
 		session="${sock##*/}"
-		if out="$("$dest" -s "$session" status 2>/dev/null)"; then
+		if out="$(timeout 2s "$dest" -s "$session" status 2>/dev/null)"; then
 			printf '%s\t%s\n' "$session" "$out"
 		fi
 	done < <(find "$socket_dir" -maxdepth 1 -type s -print 2>/dev/null | sort)


### PR DESCRIPTION
## Motivation

`scripts/install.sh` hangs indefinitely when probing stale sockets in `/tmp/amux-\$UID/`. Observed on a dev machine with 1,322 leftover `t-*` test-harness sockets and 94 zombie `amux _server` processes — a single probe was stuck for 4+ minutes with 1,321 more to go, so `make install` could not complete.

Root cause at `scripts/install.sh:108-113`: `amux -s \$session status` uses `net.Dial("unix", ...)` (fast, fails with ECONNREFUSED on a truly dead socket), then writes a command and blocks reading the reply. When a socket is held by a zombie server, `Dial` succeeds but the server never responds, so the read blocks forever.

## Summary

- Wrap the `amux status` probe in `timeout 2s` so a wedged socket falls through without blocking install.
- 2s is generous for a healthy local server (status normally completes in well under 100ms).
- Worst-case install walltime is bounded by `2s × (stale-socket count)` in the serial path.

## Testing

- `time make install` on the affected machine:
  - **Before:** hangs 4m+ on the first stale socket.
  - **After:** completes in ~10s across 1,322 sockets.
- Probe behavior preserved on healthy sockets (still captures `status` output for checkpoint-version comparison).

## Review focus

- `timeout` is in coreutils on Linux and macOS. Not a new dependency but worth a quick grep for other repo scripts that might already assume it, and whether a detection shim is needed.
- 2s threshold — could be bumped to 3s or 5s if reviewers are worried about genuinely-slow healthy servers under GC/load. I chose 2s because status is near-instant on the happy path and the worst-case walltime is linear in stale-socket count.
- Parallelism intentionally out of scope for this PR — `xargs -P` would help but the timeout alone fixes the unbounded-hang case.

## Follow-up work (separate issues worth filing)

- **Zombie `amux _server` cleanup.** 94 orphaned servers accumulated on this machine from test-harness fixtures that didn't tear down. A client-side timeout doesn't stop the leak — it just makes install resilient to it.
- **Socket-directory GC.** Nothing prunes `/tmp/amux-\$UID/`. Consider a prune step at server startup (only remove sockets older than N days with no live listener).

Closes LAB-1423.