### PR TITLE
LAB-1432: Prevent DSR reply deadlocks from wedging panes

### DIFF
--- a/internal/mux/emulator.go
+++ b/internal/mux/emulator.go
@@ -3,6 +3,7 @@ package mux
 import (
 	"fmt"
 	"image/color"
+	"io"
 	"strings"
 	"sync/atomic"
 
@@ -120,6 +121,10 @@ type vtEmulator struct {
 	scrollbackLimit   int
 }
 
+type responsePipeWriteCloser interface {
+	CloseWithError(error) error
+}
+
 // NewVTEmulatorWithScrollback creates a terminal emulator with an explicit
 // retained scrollback limit.
 func NewVTEmulatorWithScrollback(width, height, scrollbackLines int) TerminalEmulator {
@@ -209,6 +214,20 @@ func (p *touchedScreenProbe) WidthMethod() uv.WidthMethod {
 
 func (v *vtEmulator) Close() error {
 	return v.emu.Close()
+}
+
+func (v *vtEmulator) closeResponsePipe(err error) error {
+	if err == nil {
+		err = io.ErrClosedPipe
+	}
+	if v == nil || v.emu == nil {
+		return nil
+	}
+	pw, ok := v.emu.InputPipe().(responsePipeWriteCloser)
+	if !ok {
+		return nil
+	}
+	return pw.CloseWithError(err)
 }
 
 func (v *vtEmulator) Render() string {

--- a/internal/mux/emulator.go
+++ b/internal/mux/emulator.go
@@ -1,6 +1,7 @@
 package mux
 
 import (
+	"errors"
 	"fmt"
 	"image/color"
 	"io"
@@ -213,7 +214,11 @@ func (p *touchedScreenProbe) WidthMethod() uv.WidthMethod {
 }
 
 func (v *vtEmulator) Close() error {
-	return v.emu.Close()
+	err := v.emu.Close()
+	if errors.Is(err, io.ErrClosedPipe) {
+		return nil
+	}
+	return err
 }
 
 func (v *vtEmulator) closeResponsePipe(err error) error {

--- a/internal/mux/emulator_test.go
+++ b/internal/mux/emulator_test.go
@@ -49,6 +49,31 @@ func TestVTEmulatorSize(t *testing.T) {
 	}
 }
 
+func TestVTEmulatorCloseIgnoresClosedResponsePipe(t *testing.T) {
+	t.Parallel()
+
+	emu, ok := NewVTEmulatorWithScrollback(10, 4, DefaultScrollbackLines).(*vtEmulator)
+	if !ok {
+		t.Fatal("NewVTEmulatorWithScrollback() did not return *vtEmulator")
+	}
+
+	if err := emu.closeResponsePipe(nil); err != nil {
+		t.Fatalf("closeResponsePipe(nil) = %v, want nil", err)
+	}
+	if err := emu.Close(); err != nil {
+		t.Fatalf("Close() after response pipe close = %v, want nil", err)
+	}
+}
+
+func TestVTEmulatorCloseResponsePipeNilReceiver(t *testing.T) {
+	t.Parallel()
+
+	var emu *vtEmulator
+	if err := emu.closeResponsePipe(nil); err != nil {
+		t.Fatalf("nil closeResponsePipe(nil) = %v, want nil", err)
+	}
+}
+
 func TestVTEmulatorResizeWiderReflowsVisibleRows(t *testing.T) {
 	t.Parallel()
 

--- a/internal/mux/pane_emulator.go
+++ b/internal/mux/pane_emulator.go
@@ -1,6 +1,7 @@
 package mux
 
 import (
+	"io"
 	"os"
 	"strings"
 
@@ -35,6 +36,7 @@ func (p *Pane) drainResponses(emulator TerminalEmulator, ptmx *os.File, done cha
 	if done != nil {
 		defer close(done)
 	}
+	defer closeTerminalResponsePipe(emulator)
 	buf := make([]byte, 1024)
 	for {
 		n, err := emulator.Read(buf)
@@ -359,6 +361,7 @@ func (p *Pane) drainResponsesDiscard(emulator TerminalEmulator, done chan struct
 	if done != nil {
 		defer close(done)
 	}
+	defer closeTerminalResponsePipe(emulator)
 	buf := make([]byte, 1024)
 	for {
 		_, err := emulator.Read(buf)
@@ -366,6 +369,18 @@ func (p *Pane) drainResponsesDiscard(emulator TerminalEmulator, done chan struct
 			return
 		}
 	}
+}
+
+type terminalResponsePipeCloser interface {
+	closeResponsePipe(error) error
+}
+
+func closeTerminalResponsePipe(emulator TerminalEmulator) {
+	closer, ok := emulator.(terminalResponsePipeCloser)
+	if !ok {
+		return
+	}
+	_ = closer.closeResponsePipe(io.ErrClosedPipe)
 }
 
 // FeedOutput feeds remote PTY output into this proxy pane's local emulator

--- a/internal/mux/pane_window_process_test.go
+++ b/internal/mux/pane_window_process_test.go
@@ -531,7 +531,9 @@ func TestPaneActorDoesNotDeadlockAfterDrainResponsesExit(t *testing.T) {
 	p.baseHistory.Store(&paneBaseHistory{})
 	p.startActor()
 	defer func() {
-		_ = emu.Close()
+		if err := emu.Close(); err != nil {
+			t.Fatalf("emu.Close() during cleanup = %v, want nil", err)
+		}
 		stopDone := make(chan struct{})
 		go func() {
 			p.stopActor()

--- a/internal/mux/pane_window_process_test.go
+++ b/internal/mux/pane_window_process_test.go
@@ -519,6 +519,78 @@ func TestStopActorDrainsBlockedSendersBeforeClose(t *testing.T) {
 	}
 }
 
+func TestPaneActorDoesNotDeadlockAfterDrainResponsesExit(t *testing.T) {
+	t.Parallel()
+
+	emu := NewVTEmulatorWithScrollback(20, 5, DefaultScrollbackLines)
+	p := &Pane{
+		ID:              1,
+		emulator:        emu,
+		scrollbackLines: DefaultScrollbackLines,
+	}
+	p.baseHistory.Store(&paneBaseHistory{})
+	p.startActor()
+	defer func() {
+		_ = emu.Close()
+		stopDone := make(chan struct{})
+		go func() {
+			p.stopActor()
+			close(stopDone)
+		}()
+		select {
+		case <-stopDone:
+		case <-time.After(time.Second):
+			t.Fatal("timed out stopping pane actor during cleanup")
+		}
+	}()
+
+	ptmx, err := os.OpenFile("/dev/null", os.O_WRONLY, 0)
+	if err != nil {
+		t.Fatalf("open /dev/null: %v", err)
+	}
+	if err := ptmx.Close(); err != nil {
+		t.Fatalf("close /dev/null writer: %v", err)
+	}
+
+	drainDone := make(chan struct{})
+	go p.drainResponses(emu, ptmx, drainDone)
+
+	if _, err := emu.Write([]byte("\x1b[5n")); err != nil {
+		t.Fatalf("initial emulator.Write(DSR) error = %v", err)
+	}
+
+	select {
+	case <-drainDone:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for drainResponses to exit")
+	}
+
+	applyDone := make(chan struct{})
+	go func() {
+		_ = p.applyOutput([]byte("\x1b[5n"))
+		close(applyDone)
+	}()
+
+	select {
+	case <-applyDone:
+	case <-time.After(200 * time.Millisecond):
+		_ = emu.Close()
+		t.Fatal("pane actor deadlocked on DSR after drainResponses exited")
+	}
+
+	unblocked := make(chan struct{})
+	go func() {
+		p.withActor(func() {})
+		close(unblocked)
+	}()
+
+	select {
+	case <-unblocked:
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("pane actor stayed wedged after DSR write returned")
+	}
+}
+
 func TestRestorePaneWithScrollbackUsesExistingPTYAndProcess(t *testing.T) {
 	t.Parallel()
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -726,6 +726,7 @@ func (s *Server) shutdown() {
 
 	for _, sess := range s.sessions {
 		sess.shutdown.Store(true)
+		timeout := s.shutdownCrashCheckpointTimeout()
 
 		// Persist one final snapshot before the checkpoint coordinator stops so
 		// the next start can restore the latest clean-shutdown state.
@@ -736,11 +737,11 @@ func (s *Server) shutdown() {
 		}()
 		select {
 		case <-checkpointDone:
-		case <-time.After(s.shutdownCrashCheckpointTimeout()):
+		case <-time.After(timeout):
 			if s.logger != nil {
 				s.logger.Warn("timed out waiting for crash checkpoint during shutdown",
 					"session", sess.Name,
-					"timeout", s.shutdownCrashCheckpointTimeout())
+					"timeout", timeout)
 			}
 		}
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -404,7 +404,13 @@ type Server struct {
 	// commands overrides the default commandRegistry for handler lookup.
 	// When nil, handleCommand falls back to the package-level registry.
 	commands map[string]CommandHandler
+
+	// shutdownCheckpointTimeout bounds the final crash checkpoint write during
+	// shutdown. Zero uses the default timeout.
+	shutdownCheckpointTimeout time.Duration
 }
+
+const defaultShutdownCheckpointTimeout = 2 * time.Second
 
 // lookupCommand returns the handler for the given command name, consulting the
 // server-level override first, then the package-level commandRegistry.
@@ -723,7 +729,20 @@ func (s *Server) shutdown() {
 
 		// Persist one final snapshot before the checkpoint coordinator stops so
 		// the next start can restore the latest clean-shutdown state.
-		_, _ = sess.writeCrashCheckpointNow()
+		checkpointDone := make(chan struct{})
+		go func() {
+			_, _ = sess.writeCrashCheckpointNow()
+			close(checkpointDone)
+		}()
+		select {
+		case <-checkpointDone:
+		case <-time.After(s.shutdownCrashCheckpointTimeout()):
+			if s.logger != nil {
+				s.logger.Warn("timed out waiting for crash checkpoint during shutdown",
+					"session", sess.Name,
+					"timeout", s.shutdownCrashCheckpointTimeout())
+			}
+		}
 
 		sess.stopEventLoop()
 
@@ -747,6 +766,13 @@ func (s *Server) shutdown() {
 		}
 		wg.Wait()
 	}
+}
+
+func (s *Server) shutdownCrashCheckpointTimeout() time.Duration {
+	if s == nil || s.shutdownCheckpointTimeout <= 0 {
+		return defaultShutdownCheckpointTimeout
+	}
+	return s.shutdownCheckpointTimeout
 }
 
 func (s *Server) handleConn(conn net.Conn) {

--- a/internal/server/server_shutdown_test.go
+++ b/internal/server/server_shutdown_test.go
@@ -149,3 +149,75 @@ func (l *notifyListener) Close() error {
 func (l *notifyListener) Addr() net.Addr {
 	return trackingAddr("notify")
 }
+
+func TestShutdownTimesOutBlockedCrashCheckpointWrite(t *testing.T) {
+	t.Parallel()
+
+	srv, sess, cleanup := newCommandTestSession(t)
+	defer cleanup()
+
+	coord := &blockingCrashCheckpointCoordinator{
+		writeStarted: make(chan struct{}),
+		releaseWrite: make(chan struct{}),
+		stopCalled:   make(chan struct{}),
+	}
+	sess.checkpointCoordinator = coord
+
+	shutdownDone := make(chan struct{})
+	go func() {
+		srv.shutdown()
+		close(shutdownDone)
+	}()
+
+	select {
+	case <-coord.writeStarted:
+	case <-time.After(time.Second):
+		t.Fatal("shutdown did not start crash checkpoint write")
+	}
+
+	select {
+	case <-shutdownDone:
+		t.Fatal("shutdown returned before checkpoint timeout elapsed")
+	case <-time.After(500 * time.Millisecond):
+	}
+
+	select {
+	case <-shutdownDone:
+	case <-time.After(3 * time.Second):
+		coord.Stop()
+		t.Fatal("shutdown hung on blocked crash checkpoint write")
+	}
+
+	select {
+	case <-coord.stopCalled:
+	case <-time.After(time.Second):
+		t.Fatal("shutdown did not stop the crash checkpoint coordinator")
+	}
+}
+
+type blockingCrashCheckpointCoordinator struct {
+	writeStarted chan struct{}
+	releaseWrite chan struct{}
+	stopCalled   chan struct{}
+	writeOnce    sync.Once
+	stopOnce     sync.Once
+}
+
+func (c *blockingCrashCheckpointCoordinator) Trigger() {}
+
+func (c *blockingCrashCheckpointCoordinator) Stop() {
+	c.stopOnce.Do(func() {
+		close(c.stopCalled)
+		close(c.releaseWrite)
+	})
+}
+
+func (c *blockingCrashCheckpointCoordinator) Write() {}
+
+func (c *blockingCrashCheckpointCoordinator) WriteNow() (string, error) {
+	c.writeOnce.Do(func() {
+		close(c.writeStarted)
+	})
+	<-c.releaseWrite
+	return "", nil
+}

--- a/internal/server/server_shutdown_test.go
+++ b/internal/server/server_shutdown_test.go
@@ -155,6 +155,7 @@ func TestShutdownTimesOutBlockedCrashCheckpointWrite(t *testing.T) {
 
 	srv, sess, cleanup := newCommandTestSession(t)
 	defer cleanup()
+	srv.shutdownCheckpointTimeout = 50 * time.Millisecond
 
 	coord := &blockingCrashCheckpointCoordinator{
 		writeStarted: make(chan struct{}),
@@ -178,12 +179,12 @@ func TestShutdownTimesOutBlockedCrashCheckpointWrite(t *testing.T) {
 	select {
 	case <-shutdownDone:
 		t.Fatal("shutdown returned before checkpoint timeout elapsed")
-	case <-time.After(500 * time.Millisecond):
+	case <-time.After(20 * time.Millisecond):
 	}
 
 	select {
 	case <-shutdownDone:
-	case <-time.After(3 * time.Second):
+	case <-time.After(time.Second):
 		coord.Stop()
 		t.Fatal("shutdown hung on blocked crash checkpoint write")
 	}

--- a/internal/server/server_shutdown_test.go
+++ b/internal/server/server_shutdown_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"net"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -156,6 +157,8 @@ func TestShutdownTimesOutBlockedCrashCheckpointWrite(t *testing.T) {
 	srv, sess, cleanup := newCommandTestSession(t)
 	defer cleanup()
 	srv.shutdownCheckpointTimeout = 50 * time.Millisecond
+	logger, logBuf := newAuditTestLogger()
+	srv.logger = logger
 
 	coord := &blockingCrashCheckpointCoordinator{
 		writeStarted: make(chan struct{}),
@@ -193,6 +196,10 @@ func TestShutdownTimesOutBlockedCrashCheckpointWrite(t *testing.T) {
 	case <-coord.stopCalled:
 	case <-time.After(time.Second):
 		t.Fatal("shutdown did not stop the crash checkpoint coordinator")
+	}
+
+	if !strings.Contains(logBuf.String(), "timed out waiting for crash checkpoint during shutdown") {
+		t.Fatalf("shutdown log = %q, want timeout warning", logBuf.String())
 	}
 }
 


### PR DESCRIPTION
Motivation

The pane actor could block forever in the x/vt DSR reply path after `drainResponses` exited, which in turn wedged the session event loop. Shutdown could also hang indefinitely on the final crash checkpoint write even when the underlying wedge came from another path.

Summary

- Close the emulator response pipe whenever `drainResponses` or `drainResponsesDiscard` exit so later CSI `n` replies fail fast with `io.ErrClosedPipe` instead of blocking the pane actor.
- Normalize emulator shutdown after an already-closed response pipe and add a regression test that reproduces the pane-actor DSR wedge.
- Bound the final `writeCrashCheckpointNow()` call in `Server.shutdown()` and add a regression test that verifies shutdown continues past a blocked checkpoint write.

Testing

- `go test ./internal/mux -run TestPaneActorDoesNotDeadlockAfterDrainResponsesExit -count=100`
- `go test ./internal/server -run TestShutdownTimesOutBlockedCrashCheckpointWrite -count=100`
- `go test ./internal/mux ./internal/server -count=1`

Review focus

- Whether closing the emulator response pipe on every drain-loop exit is the right ownership boundary for preventing late DSR replies from wedging the actor.
- Whether bounding the final crash checkpoint write inside `Server.shutdown()` is the right fallback when the session event loop is already stuck.

Closes LAB-1432
