### PR TITLE
LAB-1434: Make session uniqueness atomic

### DIFF
--- a/internal/checkpoint/checkpoint.go
+++ b/internal/checkpoint/checkpoint.go
@@ -49,6 +49,7 @@ type ServerCheckpoint struct {
 	WindowCounter uint32
 	Generation    uint64 // layout generation counter (survives reload)
 	ListenerFd    int
+	SessionLockFd int
 	Layout        proto.LayoutSnapshot
 	Panes         []PaneCheckpoint
 }

--- a/internal/checkpoint/checkpoint_test.go
+++ b/internal/checkpoint/checkpoint_test.go
@@ -15,11 +15,12 @@ func TestRoundTrip(t *testing.T) {
 	t.Parallel()
 
 	cp := &ServerCheckpoint{
-		Version:     ServerCheckpointVersion,
-		SessionName: "test-session",
-		StartedAt:   time.Date(2026, time.March, 27, 12, 0, 0, 0, time.UTC),
-		Counter:     5,
-		ListenerFd:  10,
+		Version:       ServerCheckpointVersion,
+		SessionName:   "test-session",
+		StartedAt:     time.Date(2026, time.March, 27, 12, 0, 0, 0, time.UTC),
+		Counter:       5,
+		ListenerFd:    10,
+		SessionLockFd: 11,
 		Layout: proto.LayoutSnapshot{
 			SessionName:  "test-session",
 			ActivePaneID: 2,
@@ -93,6 +94,9 @@ func TestRoundTrip(t *testing.T) {
 	}
 	if got.ListenerFd != cp.ListenerFd {
 		t.Errorf("ListenerFd = %d, want %d", got.ListenerFd, cp.ListenerFd)
+	}
+	if got.SessionLockFd != cp.SessionLockFd {
+		t.Errorf("SessionLockFd = %d, want %d", got.SessionLockFd, cp.SessionLockFd)
 	}
 	if len(got.Panes) != len(cp.Panes) {
 		t.Fatalf("Panes = %d, want %d", len(got.Panes), len(cp.Panes))

--- a/internal/cli/server_bootstrap.go
+++ b/internal/cli/server_bootstrap.go
@@ -107,7 +107,7 @@ func restoreServerFromReloadCheckpointLogger(sessionName, cpPath string, scrollb
 		"path", crashPath,
 		"error", err,
 	)
-	return server.NewServerFromCrashCheckpointWithListenerFdLogger(restoreSessionName, cp.ListenerFd, crashCP, crashPath, scrollbackLines, logger)
+	return server.NewServerFromCrashCheckpointWithListenerAndLockFdLogger(restoreSessionName, cp.ListenerFd, cp.SessionLockFd, crashCP, crashPath, scrollbackLines, logger)
 }
 
 func RunServer(sessionName string, managedTakeover bool, buildVersion string) {

--- a/internal/server/audit_logging_test.go
+++ b/internal/server/audit_logging_test.go
@@ -288,7 +288,7 @@ func TestCheckpointRestoreAuditLogsRestoreEvent(t *testing.T) {
 	}
 	defer os.Remove(socketPath)
 
-	srv, err := newServerFromCrashCheckpointWithListenerLogger(sessionName, listener, socketPath, cp, "", mux.DefaultScrollbackLines, logger)
+	srv, err := newServerFromCrashCheckpointWithListenerLogger(sessionName, listener, socketPath, nil, cp, "", mux.DefaultScrollbackLines, logger)
 	if err != nil {
 		t.Fatalf("newServerFromCrashCheckpointWithListenerLogger: %v", err)
 	}

--- a/internal/server/checkpoint.go
+++ b/internal/server/checkpoint.go
@@ -107,6 +107,9 @@ func (s *Server) Reload(execPath string) error {
 		return fmt.Errorf("getting listener FD: %w", err)
 	}
 	cp.ListenerFd = lnFd
+	if s.sessionLock != nil {
+		cp.SessionLockFd = int(s.sessionLock.Fd())
+	}
 
 	// Do not exec without a durable crash checkpoint. If the new binary rejects
 	// the reload checkpoint after a version bump, crash recovery is the only
@@ -128,6 +131,12 @@ func (s *Server) Reload(execPath string) error {
 	if err := clearCloexec(uintptr(cp.ListenerFd)); err != nil {
 		sess.shutdown.Store(false)
 		return fmt.Errorf("clearing close-on-exec on listener: %w", err)
+	}
+	if cp.SessionLockFd > 0 {
+		if err := clearCloexec(uintptr(cp.SessionLockFd)); err != nil {
+			sess.shutdown.Store(false)
+			return fmt.Errorf("clearing close-on-exec on session lock: %w", err)
+		}
 	}
 	for _, pc := range cp.Panes {
 		if !pc.IsProxy && pc.PtmxFd >= 0 {
@@ -210,6 +219,11 @@ func NewServerFromCheckpointWithScrollbackLogger(cp *checkpoint.ServerCheckpoint
 	if err != nil {
 		return nil, fmt.Errorf("restoring listener: %w", err)
 	}
+	sessionLock, err := restoreOrAcquireSessionLock(cp.SessionName, cp.SessionLockFd)
+	if err != nil {
+		listener.Close()
+		return nil, err
+	}
 
 	sess := newSessionWithLogger(cp.SessionName, scrollbackLines, logger.With("session", cp.SessionName))
 	if !cp.StartedAt.IsZero() {
@@ -223,6 +237,7 @@ func NewServerFromCheckpointWithScrollbackLogger(cp *checkpoint.ServerCheckpoint
 		listener:     listener,
 		sessions:     map[string]*Session{cp.SessionName: sess},
 		sockPath:     SocketPath(cp.SessionName),
+		sessionLock:  sessionLock,
 		logger:       logger,
 		shutdownDone: make(chan struct{}),
 	}
@@ -272,6 +287,7 @@ func NewServerFromCheckpointWithScrollbackLogger(cp *checkpoint.ServerCheckpoint
 
 	if len(sess.Panes) == 0 {
 		listener.Close()
+		closeSessionLock(sessionLock)
 		return nil, fmt.Errorf("no panes restored from checkpoint")
 	}
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -442,6 +442,27 @@ func SocketPath(session string) string {
 	return proto.SocketPath(session)
 }
 
+func listenForSession(sessionName string) (net.Listener, string, *os.File, error) {
+	sockPath := SocketPath(sessionName)
+	sessionLock, err := acquireSessionLock(sessionName)
+	if err != nil {
+		return nil, "", nil, err
+	}
+
+	_ = os.Remove(sockPath)
+	listener, err := net.Listen("unix", sockPath)
+	if err != nil {
+		closeSessionLock(sessionLock)
+		return nil, "", nil, fmt.Errorf("listening: %w", err)
+	}
+	if err := os.Chmod(sockPath, 0700); err != nil {
+		listener.Close()
+		closeSessionLock(sessionLock)
+		return nil, "", nil, fmt.Errorf("chmod socket: %w", err)
+	}
+	return listener, sockPath, sessionLock, nil
+}
+
 func newSessionWithLogger(name string, scrollbackLines int, logger *charmlog.Logger) *Session {
 	if logger == nil {
 		logger = auditlog.Discard()
@@ -483,23 +504,9 @@ func newServerWithScrollbackLogger(sessionName string, scrollbackLines int, logg
 		return nil, fmt.Errorf("creating socket dir: %w", err)
 	}
 
-	sockPath := SocketPath(sessionName)
-
-	sessionLock, err := acquireSessionLock(sessionName)
+	listener, sockPath, sessionLock, err := listenForSession(sessionName)
 	if err != nil {
 		return nil, err
-	}
-
-	_ = os.Remove(sockPath)
-	listener, err := net.Listen("unix", sockPath)
-	if err != nil {
-		closeSessionLock(sessionLock)
-		return nil, fmt.Errorf("listening: %w", err)
-	}
-	if err := os.Chmod(sockPath, 0700); err != nil {
-		listener.Close()
-		closeSessionLock(sessionLock)
-		return nil, fmt.Errorf("chmod socket: %w", err)
 	}
 
 	sess := newSessionWithLogger(sessionName, scrollbackLines, logger.With("session", sessionName))
@@ -655,23 +662,9 @@ func NewServerFromCrashCheckpointWithScrollbackLogger(sessionName string, cp *ch
 		return nil, fmt.Errorf("creating socket dir: %w", err)
 	}
 
-	sockPath := SocketPath(sessionName)
-	sessionLock, err := acquireSessionLock(sessionName)
+	listener, sockPath, sessionLock, err := listenForSession(sessionName)
 	if err != nil {
 		return nil, err
-	}
-
-	// Clean up any stale socket from the crashed server.
-	_ = os.Remove(sockPath)
-	listener, err := net.Listen("unix", sockPath)
-	if err != nil {
-		closeSessionLock(sessionLock)
-		return nil, fmt.Errorf("listening: %w", err)
-	}
-	if err := os.Chmod(sockPath, 0700); err != nil {
-		listener.Close()
-		closeSessionLock(sessionLock)
-		return nil, fmt.Errorf("chmod socket: %w", err)
 	}
 
 	return newServerFromCrashCheckpointWithListenerLogger(sessionName, listener, sockPath, sessionLock, cp, crashPath, scrollbackLines, logger)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -381,12 +381,13 @@ var BuildVersion string
 
 // Server listens on a Unix socket and manages sessions.
 type Server struct {
-	Env      ServerEnv
-	listener net.Listener
-	sessions map[string]*Session
-	sockPath string
-	pprof    *pprofEndpoint
-	logger   *charmlog.Logger
+	Env         ServerEnv
+	listener    net.Listener
+	sessions    map[string]*Session
+	sockPath    string
+	sessionLock *os.File
+	pprof       *pprofEndpoint
+	logger      *charmlog.Logger
 
 	// Shutdown is serialized with atomics so concurrent callers all observe
 	// one cleanup pass and later callers can wait for completion.
@@ -484,22 +485,20 @@ func newServerWithScrollbackLogger(sessionName string, scrollbackLines int, logg
 
 	sockPath := SocketPath(sessionName)
 
-	if _, err := os.Stat(sockPath); err == nil {
-		conn, err := net.Dial("unix", sockPath)
-		if err != nil {
-			os.Remove(sockPath)
-		} else {
-			conn.Close()
-			return nil, fmt.Errorf("server already running for session %q", sessionName)
-		}
+	sessionLock, err := acquireSessionLock(sessionName)
+	if err != nil {
+		return nil, err
 	}
 
+	_ = os.Remove(sockPath)
 	listener, err := net.Listen("unix", sockPath)
 	if err != nil {
+		closeSessionLock(sessionLock)
 		return nil, fmt.Errorf("listening: %w", err)
 	}
 	if err := os.Chmod(sockPath, 0700); err != nil {
 		listener.Close()
+		closeSessionLock(sessionLock)
 		return nil, fmt.Errorf("chmod socket: %w", err)
 	}
 
@@ -509,6 +508,7 @@ func newServerWithScrollbackLogger(sessionName string, scrollbackLines int, logg
 		listener:     listener,
 		sessions:     map[string]*Session{sessionName: sess},
 		sockPath:     sockPath,
+		sessionLock:  sessionLock,
 		logger:       logger,
 		shutdownDone: make(chan struct{}),
 	}
@@ -525,7 +525,7 @@ func NewServerWithScrollbackLogger(sessionName string, scrollbackLines int, logg
 	return newServerWithScrollbackLogger(sessionName, scrollbackLines, logger)
 }
 
-func newServerFromCrashCheckpointWithListenerLogger(sessionName string, listener net.Listener, sockPath string, cp *checkpoint.CrashCheckpoint, crashPath string, scrollbackLines int, logger *charmlog.Logger) (*Server, error) {
+func newServerFromCrashCheckpointWithListenerLogger(sessionName string, listener net.Listener, sockPath string, sessionLock *os.File, cp *checkpoint.CrashCheckpoint, crashPath string, scrollbackLines int, logger *charmlog.Logger) (*Server, error) {
 	if logger == nil {
 		logger = auditlog.Discard()
 	}
@@ -540,6 +540,7 @@ func newServerFromCrashCheckpointWithListenerLogger(sessionName string, listener
 		listener:     listener,
 		sessions:     map[string]*Session{sessionName: sess},
 		sockPath:     sockPath,
+		sessionLock:  sessionLock,
 		logger:       logger,
 		shutdownDone: make(chan struct{}),
 	}
@@ -599,6 +600,7 @@ func newServerFromCrashCheckpointWithListenerLogger(sessionName string, listener
 
 	if len(sess.Panes) == 0 {
 		listener.Close()
+		closeSessionLock(sessionLock)
 		return nil, fmt.Errorf("no panes restored from crash checkpoint")
 	}
 
@@ -638,7 +640,7 @@ func newServerFromCrashCheckpointWithListenerLogger(sessionName string, listener
 }
 
 func newServerFromCrashCheckpointWithListener(sessionName string, listener net.Listener, sockPath string, cp *checkpoint.CrashCheckpoint, crashPath string, scrollbackLines int) (*Server, error) {
-	return newServerFromCrashCheckpointWithListenerLogger(sessionName, listener, sockPath, cp, crashPath, scrollbackLines, nil)
+	return newServerFromCrashCheckpointWithListenerLogger(sessionName, listener, sockPath, nil, cp, crashPath, scrollbackLines, nil)
 }
 
 // NewServerFromCrashCheckpointWithScrollback restores a server from a crash
@@ -654,27 +656,42 @@ func NewServerFromCrashCheckpointWithScrollbackLogger(sessionName string, cp *ch
 	}
 
 	sockPath := SocketPath(sessionName)
-	// Clean up any stale socket from the crashed server
-	os.Remove(sockPath)
+	sessionLock, err := acquireSessionLock(sessionName)
+	if err != nil {
+		return nil, err
+	}
 
+	// Clean up any stale socket from the crashed server.
+	_ = os.Remove(sockPath)
 	listener, err := net.Listen("unix", sockPath)
 	if err != nil {
+		closeSessionLock(sessionLock)
 		return nil, fmt.Errorf("listening: %w", err)
 	}
 	if err := os.Chmod(sockPath, 0700); err != nil {
 		listener.Close()
+		closeSessionLock(sessionLock)
 		return nil, fmt.Errorf("chmod socket: %w", err)
 	}
 
-	return newServerFromCrashCheckpointWithListenerLogger(sessionName, listener, sockPath, cp, crashPath, scrollbackLines, logger)
+	return newServerFromCrashCheckpointWithListenerLogger(sessionName, listener, sockPath, sessionLock, cp, crashPath, scrollbackLines, logger)
 }
 
 func NewServerFromCrashCheckpointWithListenerFdLogger(sessionName string, listenerFd int, cp *checkpoint.CrashCheckpoint, crashPath string, scrollbackLines int, logger *charmlog.Logger) (*Server, error) {
+	return NewServerFromCrashCheckpointWithListenerAndLockFdLogger(sessionName, listenerFd, 0, cp, crashPath, scrollbackLines, logger)
+}
+
+func NewServerFromCrashCheckpointWithListenerAndLockFdLogger(sessionName string, listenerFd, sessionLockFd int, cp *checkpoint.CrashCheckpoint, crashPath string, scrollbackLines int, logger *charmlog.Logger) (*Server, error) {
 	listener, err := restoreListenerFromFD(listenerFd)
 	if err != nil {
 		return nil, fmt.Errorf("restoring listener: %w", err)
 	}
-	return newServerFromCrashCheckpointWithListenerLogger(sessionName, listener, SocketPath(sessionName), cp, crashPath, scrollbackLines, logger)
+	sessionLock, err := restoreOrAcquireSessionLock(sessionName, sessionLockFd)
+	if err != nil {
+		listener.Close()
+		return nil, err
+	}
+	return newServerFromCrashCheckpointWithListenerLogger(sessionName, listener, SocketPath(sessionName), sessionLock, cp, crashPath, scrollbackLines, logger)
 }
 
 // Run accepts client connections in a loop.
@@ -767,6 +784,7 @@ func (s *Server) shutdown() {
 		}
 		wg.Wait()
 	}
+	closeSessionLock(s.sessionLock)
 }
 
 func (s *Server) shutdownCrashCheckpointTimeout() time.Duration {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -499,10 +499,6 @@ func newServerWithScrollbackLogger(sessionName string, scrollbackLines int, logg
 	if logger == nil {
 		logger = auditlog.Discard()
 	}
-	sockDir := SocketDir()
-	if err := os.MkdirAll(sockDir, 0700); err != nil {
-		return nil, fmt.Errorf("creating socket dir: %w", err)
-	}
 
 	listener, sockPath, sessionLock, err := listenForSession(sessionName)
 	if err != nil {
@@ -657,11 +653,6 @@ func NewServerFromCrashCheckpointWithScrollback(sessionName string, cp *checkpoi
 }
 
 func NewServerFromCrashCheckpointWithScrollbackLogger(sessionName string, cp *checkpoint.CrashCheckpoint, crashPath string, scrollbackLines int, logger *charmlog.Logger) (*Server, error) {
-	sockDir := SocketDir()
-	if err := os.MkdirAll(sockDir, 0700); err != nil {
-		return nil, fmt.Errorf("creating socket dir: %w", err)
-	}
-
 	listener, sockPath, sessionLock, err := listenForSession(sessionName)
 	if err != nil {
 		return nil, err

--- a/internal/server/session_lock.go
+++ b/internal/server/session_lock.go
@@ -1,0 +1,49 @@
+package server
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+)
+
+func sessionLockPath(sessionName string) string {
+	return filepath.Join(SocketDir(), sessionName+".lock")
+}
+
+func acquireSessionLock(sessionName string) (*os.File, error) {
+	if err := os.MkdirAll(SocketDir(), 0700); err != nil {
+		return nil, fmt.Errorf("creating socket dir: %w", err)
+	}
+	lockFile, err := os.OpenFile(sessionLockPath(sessionName), os.O_CREATE|os.O_RDWR, 0600)
+	if err != nil {
+		return nil, fmt.Errorf("opening session lock: %w", err)
+	}
+	if err := syscall.Flock(int(lockFile.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		_ = lockFile.Close()
+		if errors.Is(err, syscall.EWOULDBLOCK) || errors.Is(err, syscall.EAGAIN) {
+			return nil, fmt.Errorf("server already running for session %q", sessionName)
+		}
+		return nil, fmt.Errorf("locking session: %w", err)
+	}
+	return lockFile, nil
+}
+
+func restoreOrAcquireSessionLock(sessionName string, fd int) (*os.File, error) {
+	if fd <= 0 {
+		return acquireSessionLock(sessionName)
+	}
+	lockFile := os.NewFile(uintptr(fd), "session-lock")
+	if lockFile == nil {
+		return nil, fmt.Errorf("invalid session lock fd %d", fd)
+	}
+	syscall.CloseOnExec(fd)
+	return lockFile, nil
+}
+
+func closeSessionLock(lockFile *os.File) {
+	if lockFile != nil {
+		_ = lockFile.Close()
+	}
+}

--- a/internal/server/session_lock_test.go
+++ b/internal/server/session_lock_test.go
@@ -38,9 +38,6 @@ func TestSessionLockSubprocessHelper(t *testing.T) {
 	case "hold":
 		fmt.Fprintln(os.Stdout, "ready")
 		select {}
-	case "probe":
-		srv.Shutdown()
-		fmt.Fprintln(os.Stdout, "started")
 	default:
 		srv.Shutdown()
 		fmt.Fprintf(os.Stderr, "unknown helper mode %q", mode)

--- a/internal/server/session_lock_test.go
+++ b/internal/server/session_lock_test.go
@@ -1,0 +1,205 @@
+package server
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/weill-labs/amux/internal/mux"
+)
+
+const (
+	sessionLockHelperModeEnv    = "AMUX_SESSION_LOCK_HELPER_MODE"
+	sessionLockHelperSessionEnv = "AMUX_SESSION_LOCK_HELPER_SESSION"
+)
+
+func TestSessionLockHelperProcess(t *testing.T) {
+	mode := os.Getenv(sessionLockHelperModeEnv)
+	if mode == "" {
+		return
+	}
+
+	session := os.Getenv(sessionLockHelperSessionEnv)
+	srv, err := newServerWithScrollbackLogger(session, mux.DefaultScrollbackLines, nil)
+	if err != nil {
+		fmt.Fprint(os.Stderr, err.Error())
+		os.Exit(2)
+	}
+
+	switch mode {
+	case "hold":
+		fmt.Fprintln(os.Stdout, "ready")
+		select {}
+	case "probe":
+		srv.Shutdown()
+		fmt.Fprintln(os.Stdout, "started")
+	default:
+		srv.Shutdown()
+		fmt.Fprintf(os.Stderr, "unknown helper mode %q", mode)
+		os.Exit(2)
+	}
+}
+
+func TestNewServerWithScrollbackRejectsDuplicateSessionLockWithoutTouchingLockFile(t *testing.T) {
+	t.Parallel()
+
+	session := fmt.Sprintf("session-lock-duplicate-%d", time.Now().UnixNano())
+	srv, err := newServerWithScrollbackLogger(session, mux.DefaultScrollbackLines, nil)
+	if err != nil {
+		t.Fatalf("first newServerWithScrollbackLogger() error = %v", err)
+	}
+	t.Cleanup(srv.Shutdown)
+
+	lockPath := filepath.Join(SocketDir(), session+".lock")
+	if _, err := os.Stat(lockPath); err != nil {
+		t.Fatalf("expected lock file at %s, err=%v", lockPath, err)
+	}
+
+	marker := []byte("keep-this-marker")
+	if err := os.WriteFile(lockPath, marker, 0600); err != nil {
+		t.Fatalf("WriteFile(%q): %v", lockPath, err)
+	}
+
+	_, err = newServerWithScrollbackLogger(session, mux.DefaultScrollbackLines, nil)
+	if err == nil {
+		t.Fatal("second newServerWithScrollbackLogger() error = nil, want already running")
+	}
+	wantErr := fmt.Sprintf("server already running for session %q", session)
+	if err.Error() != wantErr {
+		t.Fatalf("second newServerWithScrollbackLogger() error = %q, want %q", err.Error(), wantErr)
+	}
+
+	got, err := os.ReadFile(lockPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%q): %v", lockPath, err)
+	}
+	if !bytes.Equal(got, marker) {
+		t.Fatalf("lock file contents changed = %q, want %q", got, marker)
+	}
+}
+
+func TestNewServerWithScrollbackRecoversAfterCrashReleasesLock(t *testing.T) {
+	t.Parallel()
+
+	session := fmt.Sprintf("session-lock-crash-%d", time.Now().UnixNano())
+	cmd, stderr := startSessionLockHelper(t, "hold", session)
+
+	if err := cmd.Process.Signal(syscall.SIGKILL); err != nil {
+		t.Fatalf("killing helper: %v", err)
+	}
+	err := cmd.Wait()
+	if err == nil {
+		t.Fatal("helper exited cleanly, want SIGKILL")
+	}
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("helper wait error = %v, want *exec.ExitError", err)
+	}
+
+	srv, err := newServerWithScrollbackLogger(session, mux.DefaultScrollbackLines, nil)
+	if err != nil {
+		t.Fatalf("newServerWithScrollbackLogger() after SIGKILL error = %v\nhelper stderr:\n%s", err, stderr.String())
+	}
+	srv.Shutdown()
+}
+
+func TestNewServerWithScrollbackConcurrentStartsYieldSingleWinner(t *testing.T) {
+	t.Parallel()
+
+	session := fmt.Sprintf("session-lock-race-%d", time.Now().UnixNano())
+	const attempts = 8
+
+	type result struct {
+		srv *Server
+		err error
+	}
+
+	start := make(chan struct{})
+	results := make(chan result, attempts)
+	for range attempts {
+		go func() {
+			<-start
+			srv, err := newServerWithScrollbackLogger(session, mux.DefaultScrollbackLines, nil)
+			results <- result{srv: srv, err: err}
+		}()
+	}
+	close(start)
+
+	var winners []*Server
+	for range attempts {
+		res := <-results
+		if res.err == nil {
+			winners = append(winners, res.srv)
+			continue
+		}
+		wantErr := fmt.Sprintf("server already running for session %q", session)
+		if res.err.Error() != wantErr {
+			t.Fatalf("concurrent newServerWithScrollbackLogger() error = %q, want %q", res.err.Error(), wantErr)
+		}
+	}
+	for _, srv := range winners {
+		if srv != nil {
+			t.Cleanup(srv.Shutdown)
+		}
+	}
+	if got := len(winners); got != 1 {
+		t.Fatalf("successful starts = %d, want 1", got)
+	}
+}
+
+func startSessionLockHelper(t *testing.T, mode, session string) (*exec.Cmd, *bytes.Buffer) {
+	t.Helper()
+
+	cmd := exec.Command(os.Args[0], "-test.run=^TestSessionLockHelperProcess$")
+	cmd.Env = append(os.Environ(),
+		sessionLockHelperModeEnv+"="+mode,
+		sessionLockHelperSessionEnv+"="+session,
+	)
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		t.Fatalf("StdoutPipe(): %v", err)
+	}
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("starting helper: %v", err)
+	}
+
+	reader := bufio.NewReader(stdout)
+	ready := make(chan error, 1)
+	go func() {
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			ready <- err
+			return
+		}
+		if strings.TrimSpace(line) != "ready" {
+			ready <- fmt.Errorf("ready line = %q, want %q", strings.TrimSpace(line), "ready")
+			return
+		}
+		ready <- nil
+	}()
+
+	select {
+	case err := <-ready:
+		if err != nil {
+			_ = cmd.Process.Kill()
+			_ = cmd.Wait()
+			t.Fatalf("waiting for helper readiness: %v\nstderr:\n%s", err, stderr.String())
+		}
+	case <-time.After(5 * time.Second):
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+		t.Fatalf("timed out waiting for helper readiness\nstderr:\n%s", stderr.String())
+	}
+
+	return cmd, &stderr
+}

--- a/internal/server/session_lock_test.go
+++ b/internal/server/session_lock_test.go
@@ -21,7 +21,7 @@ const (
 	sessionLockHelperSessionEnv = "AMUX_SESSION_LOCK_HELPER_SESSION"
 )
 
-func TestSessionLockHelperProcess(t *testing.T) {
+func TestSessionLockSubprocessHelper(t *testing.T) {
 	mode := os.Getenv(sessionLockHelperModeEnv)
 	if mode == "" {
 		return
@@ -158,7 +158,7 @@ func TestNewServerWithScrollbackConcurrentStartsYieldSingleWinner(t *testing.T) 
 func startSessionLockHelper(t *testing.T, mode, session string) (*exec.Cmd, *bytes.Buffer) {
 	t.Helper()
 
-	cmd := exec.Command(os.Args[0], "-test.run=^TestSessionLockHelperProcess$")
+	cmd := exec.Command(os.Args[0], "-test.run=^TestSessionLockSubprocessHelper$")
 	cmd.Env = append(os.Environ(),
 		sessionLockHelperModeEnv+"="+mode,
 		sessionLockHelperSessionEnv+"="+session,

--- a/test/session_lock_test.go
+++ b/test/session_lock_test.go
@@ -1,0 +1,61 @@
+package test
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/weill-labs/amux/internal/server"
+)
+
+func TestSessionLockSurvivesHotReload(t *testing.T) {
+	t.Parallel()
+
+	h := newPersistentReloadHarness(t, privateAmuxBin(t))
+
+	reloadGen := h.generation()
+	h.runCmd("reload-server")
+	h.waitForReloadedClient(reloadGen, 10*time.Second)
+
+	newServerOut := runDuplicateServerProbe(t, h)
+	if !strings.Contains(newServerOut, "server already running for session") || !strings.Contains(newServerOut, h.inner) {
+		t.Fatalf("duplicate server probe output = %q, want already-running error for %q", strings.TrimSpace(newServerOut), h.inner)
+	}
+
+	lockPath := filepath.Join(server.SocketDir(), h.inner+".lock")
+	if err := exec.Command("flock", "-n", lockPath, "true").Run(); err == nil {
+		t.Fatalf("flock probe acquired %s after hot reload; want lock still held", lockPath)
+	}
+}
+
+func runDuplicateServerProbe(t *testing.T, h *AmuxHarness) string {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, h.innerBin, "_server", h.inner)
+	env := removeEnv(os.Environ(), "AMUX_SESSION")
+	env = removeEnv(env, "TMUX")
+	env = append(env,
+		"HOME="+h.outer.home,
+		"AMUX_NO_WATCH=1",
+		"AMUX_DISABLE_META_REFRESH=1",
+	)
+	if h.outer.coverDir != "" {
+		env = upsertEnv(env, "GOCOVERDIR", h.outer.coverDir)
+	}
+	cmd.Env = env
+	out, err := cmd.CombinedOutput()
+	if ctx.Err() == context.DeadlineExceeded {
+		t.Fatalf("duplicate server probe timed out; process likely started unexpectedly\noutput:\n%s", string(out))
+	}
+	if err == nil {
+		t.Fatalf("duplicate server probe exited successfully, want already-running failure\noutput:\n%s", string(out))
+	}
+	return string(out)
+}


### PR DESCRIPTION
## Motivation
Session startup used a stat/dial/remove/listen sequence on `/tmp/amux-$UID/<session>`, leaving a TOCTOU window where concurrent starts could both pass stale-socket cleanup before binding. LAB-1434 asks for atomic per-user uniqueness without changing the existing per-UID scope.

## Summary
- Acquire `/tmp/amux-$UID/<session>.lock` with `flock(LOCK_EX|LOCK_NB)` before listening, returning the existing already-running error on contention.
- Keep the lock file open on the server, carry its fd through reload checkpoints, clear `FD_CLOEXEC` before `exec`, and wrap the inherited fd after restore.
- Reuse the locked listen setup for fresh starts and crash recovery, while leaving the sentinel file itself for the kernel-managed lock lifecycle.
- Add unit and integration coverage for duplicate starts, process crashes, concurrent starts, and hot-reload lock inheritance.

## Testing
- `go test ./internal/server -count=100 -run 'Test(NewServerWithScrollbackRejectsDuplicateSessionLockWithoutTouchingLockFile|NewServerWithScrollbackRecoversAfterCrashReleasesLock|NewServerWithScrollbackConcurrentStartsYieldSingleWinner|SessionLockSubprocessHelper)$'`
- `go test ./test -count=100 -run 'TestSessionLockSurvivesHotReload$'`
- `go test ./test -count=1 -run '^TestAltHJKLFocus$'`
- `go test ./test -count=1 -run 'TestSessionLockSurvivesHotReload$'`
- `go test ./internal/server ./internal/cli ./internal/checkpoint`
- `go test ./... -timeout 120s` (passed on rerun; first run hit unrelated `TestAltHJKLFocus` inner-client disconnect, which passed alone immediately after)

## Review focus
- Lock fd lifecycle across normal startup, crash recovery, hot reload, and shutdown.
- Whether `SessionLockFd` checkpoint restore should remain backward-compatible by acquiring a lock when older checkpoints lack the field.
- The choice to preserve per-UID scope and not move to per-machine uniqueness.

Closes LAB-1434