### PR TITLE
LAB-1472: Add timeouts to daemon Unix dials

### DIFF
--- a/internal/cli/cli_server_client.go
+++ b/internal/cli/cli_server_client.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/weill-labs/amux/internal/dialutil"
 	"github.com/weill-labs/amux/internal/reload"
 	"github.com/weill-labs/amux/internal/server"
 )
@@ -137,7 +138,7 @@ type serverSocket struct {
 }
 
 func dialServer(sessionName string) (*serverSocket, error) {
-	conn, err := net.Dial("unix", server.SocketPath(sessionName))
+	conn, err := dialutil.DialUnix(server.SocketPath(sessionName))
 	if err != nil {
 		return nil, fmt.Errorf("connecting to server: %w", err)
 	}

--- a/internal/client/pprof.go
+++ b/internal/client/pprof.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/weill-labs/amux/internal/dialutil"
 	"github.com/weill-labs/amux/internal/proto"
 )
 
@@ -66,7 +67,7 @@ func newPprofEndpoint(session string, pid int) (*pprofEndpoint, error) {
 
 	sockPath := PprofProcessSocketPath(session, pid)
 	if _, err := os.Stat(sockPath); err == nil {
-		conn, dialErr := net.Dial("unix", sockPath)
+		conn, dialErr := dialutil.DialUnixStaleProbe(sockPath)
 		if dialErr == nil {
 			conn.Close()
 			return nil, fmt.Errorf("pprof debug endpoint already running at %s", sockPath)
@@ -155,7 +156,7 @@ func promoteFallbackPprofAlias(session, aliasPath, skipPath string) {
 	})
 
 	for _, candidate := range candidates {
-		conn, err := net.Dial("unix", candidate.path)
+		conn, err := dialutil.DialUnixStaleProbe(candidate.path)
 		if err != nil {
 			_ = os.Remove(candidate.path)
 			continue

--- a/internal/client/ssh_attach.go
+++ b/internal/client/ssh_attach.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/weill-labs/amux/internal/config"
+	"github.com/weill-labs/amux/internal/dialutil"
 	"github.com/weill-labs/amux/internal/proto"
 	"github.com/weill-labs/amux/internal/transport"
 	_ "github.com/weill-labs/amux/internal/transport/mosh"
@@ -189,7 +190,7 @@ func (s *sshSessionState) set(tr transport.Transport) {
 }
 
 func runLocalServerCommand(sessionName, cmdName string, args []string) error {
-	conn, err := net.Dial("unix", proto.SocketPath(sessionName))
+	conn, err := dialutil.DialUnix(proto.SocketPath(sessionName))
 	if err != nil {
 		return err
 	}

--- a/internal/dialutil/dial.go
+++ b/internal/dialutil/dial.go
@@ -1,0 +1,64 @@
+package dialutil
+
+import (
+	"context"
+	"log"
+	"net"
+	"os"
+	"time"
+)
+
+const (
+	EnvDialTimeout        = "AMUX_DIAL_TIMEOUT"
+	DefaultDialTimeout    = 2 * time.Second
+	StaleProbeDialTimeout = 500 * time.Millisecond
+)
+
+func TimeoutFromEnv(defaultTimeout time.Duration) time.Duration {
+	return TimeoutFromEnvWithLogger(defaultTimeout, log.Printf)
+}
+
+func TimeoutFromEnvWithLogger(defaultTimeout time.Duration, warnf func(string, ...any)) time.Duration {
+	value := os.Getenv(EnvDialTimeout)
+	if value == "" {
+		return defaultTimeout
+	}
+	timeout, err := time.ParseDuration(value)
+	if err != nil {
+		warnInvalidTimeout(warnf, value, defaultTimeout, err.Error())
+		return defaultTimeout
+	}
+	if timeout <= 0 {
+		warnInvalidTimeout(warnf, value, defaultTimeout, "duration must be positive")
+		return defaultTimeout
+	}
+	return timeout
+}
+
+func DialUnix(path string) (net.Conn, error) {
+	return DialUnixWithDefault(path, DefaultDialTimeout)
+}
+
+func DialUnixStaleProbe(path string) (net.Conn, error) {
+	return DialUnixWithDefault(path, StaleProbeDialTimeout)
+}
+
+func DialUnixWithDefault(path string, defaultTimeout time.Duration) (net.Conn, error) {
+	return net.DialTimeout("unix", path, TimeoutFromEnv(defaultTimeout))
+}
+
+func DialUnixContext(ctx context.Context, path string) (net.Conn, error) {
+	return DialUnixContextWithDefault(ctx, path, DefaultDialTimeout)
+}
+
+func DialUnixContextWithDefault(ctx context.Context, path string, defaultTimeout time.Duration) (net.Conn, error) {
+	dialer := &net.Dialer{Timeout: TimeoutFromEnv(defaultTimeout)}
+	return dialer.DialContext(ctx, "unix", path)
+}
+
+func warnInvalidTimeout(warnf func(string, ...any), value string, defaultTimeout time.Duration, reason string) {
+	if warnf == nil {
+		return
+	}
+	warnf("invalid %s=%q (%s); using default %s", EnvDialTimeout, value, reason, defaultTimeout)
+}

--- a/internal/dialutil/dial_test.go
+++ b/internal/dialutil/dial_test.go
@@ -14,31 +14,45 @@ import (
 )
 
 func TestDialUnixHelpersTimeoutOnWedgedSocket(t *testing.T) {
+	t.Parallel()
+
 	sockPath := newWedgedUnixSocket(t)
 	timeout := 40 * time.Millisecond
 
 	tests := []struct {
-		name string
-		dial func(context.Context, string, time.Duration) (net.Conn, error)
+		name    string
+		timeout time.Duration
+		dial    func(context.Context, string) (net.Conn, error)
 	}{
 		{
-			name: "dial",
-			dial: func(_ context.Context, path string, timeout time.Duration) (net.Conn, error) {
+			name:    "dial",
+			timeout: timeout,
+			dial: func(_ context.Context, path string) (net.Conn, error) {
 				return DialUnixWithDefault(path, timeout)
 			},
 		},
 		{
-			name: "dial context",
-			dial: func(ctx context.Context, path string, timeout time.Duration) (net.Conn, error) {
+			name:    "dial context",
+			timeout: timeout,
+			dial: func(ctx context.Context, path string) (net.Conn, error) {
 				return DialUnixContextWithDefault(ctx, path, timeout)
+			},
+		},
+		{
+			name:    "stale probe",
+			timeout: StaleProbeDialTimeout,
+			dial: func(_ context.Context, path string) (net.Conn, error) {
+				return DialUnixStaleProbe(path)
 			},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			start := time.Now()
-			conn, err := tt.dial(context.Background(), sockPath, timeout)
+			conn, err := tt.dial(context.Background(), sockPath)
 			elapsed := time.Since(start)
 			if conn != nil {
 				conn.Close()
@@ -46,14 +60,27 @@ func TestDialUnixHelpersTimeoutOnWedgedSocket(t *testing.T) {
 			if !isTimeoutError(err) {
 				t.Fatalf("dial error = %v, want timeout", err)
 			}
-			if elapsed > timeout+220*time.Millisecond {
-				t.Fatalf("dial returned in %v, want within configured timeout %v", elapsed, timeout)
+			if elapsed > tt.timeout+220*time.Millisecond {
+				t.Fatalf("dial returned in %v, want within configured timeout %v", elapsed, tt.timeout)
 			}
 		})
 	}
 }
 
+func TestDialTimeoutDefaults(t *testing.T) {
+	t.Parallel()
+
+	if DefaultDialTimeout != 2*time.Second {
+		t.Fatalf("DefaultDialTimeout = %v, want 2s", DefaultDialTimeout)
+	}
+	if StaleProbeDialTimeout != 500*time.Millisecond {
+		t.Fatalf("StaleProbeDialTimeout = %v, want 500ms", StaleProbeDialTimeout)
+	}
+}
+
 func TestDialUnixMissingSocketReturnsBeforeTimeout(t *testing.T) {
+	t.Parallel()
+
 	missingPath := filepath.Join(t.TempDir(), "missing.sock")
 	timeout := 80 * time.Millisecond
 
@@ -77,6 +104,10 @@ func TestDialUnixMissingSocketReturnsBeforeTimeout(t *testing.T) {
 func TestDialTimeoutFromEnvOverridesDefault(t *testing.T) {
 	t.Setenv(EnvDialTimeout, "500ms")
 	sockPath := newWedgedUnixSocket(t)
+
+	if got := TimeoutFromEnv(DefaultDialTimeout); got != 500*time.Millisecond {
+		t.Fatalf("TimeoutFromEnv() = %v, want env override", got)
+	}
 
 	start := time.Now()
 	conn, err := DialUnix(sockPath)

--- a/internal/dialutil/dial_test.go
+++ b/internal/dialutil/dial_test.go
@@ -1,0 +1,157 @@
+package dialutil
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestDialUnixHelpersTimeoutOnWedgedSocket(t *testing.T) {
+	sockPath := newWedgedUnixSocket(t)
+	timeout := 40 * time.Millisecond
+
+	tests := []struct {
+		name string
+		dial func(context.Context, string, time.Duration) (net.Conn, error)
+	}{
+		{
+			name: "dial",
+			dial: func(_ context.Context, path string, timeout time.Duration) (net.Conn, error) {
+				return DialUnixWithDefault(path, timeout)
+			},
+		},
+		{
+			name: "dial context",
+			dial: func(ctx context.Context, path string, timeout time.Duration) (net.Conn, error) {
+				return DialUnixContextWithDefault(ctx, path, timeout)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			start := time.Now()
+			conn, err := tt.dial(context.Background(), sockPath, timeout)
+			elapsed := time.Since(start)
+			if conn != nil {
+				conn.Close()
+			}
+			if !isTimeoutError(err) {
+				t.Fatalf("dial error = %v, want timeout", err)
+			}
+			if elapsed > timeout+220*time.Millisecond {
+				t.Fatalf("dial returned in %v, want within configured timeout %v", elapsed, timeout)
+			}
+		})
+	}
+}
+
+func TestDialUnixMissingSocketReturnsBeforeTimeout(t *testing.T) {
+	missingPath := filepath.Join(t.TempDir(), "missing.sock")
+	timeout := 80 * time.Millisecond
+
+	start := time.Now()
+	conn, err := DialUnixWithDefault(missingPath, timeout)
+	elapsed := time.Since(start)
+	if conn != nil {
+		conn.Close()
+	}
+	if err == nil {
+		t.Fatal("DialUnixWithDefault() error = nil, want missing-socket error")
+	}
+	if isTimeoutError(err) {
+		t.Fatalf("DialUnixWithDefault() error = %v, want non-timeout missing-socket error", err)
+	}
+	if elapsed > timeout {
+		t.Fatalf("DialUnixWithDefault() returned in %v, want before timeout %v", elapsed, timeout)
+	}
+}
+
+func TestDialTimeoutFromEnvOverridesDefault(t *testing.T) {
+	t.Setenv(EnvDialTimeout, "500ms")
+	sockPath := newWedgedUnixSocket(t)
+
+	start := time.Now()
+	conn, err := DialUnix(sockPath)
+	elapsed := time.Since(start)
+	if conn != nil {
+		conn.Close()
+	}
+	if !isTimeoutError(err) {
+		t.Fatalf("DialUnix() error = %v, want timeout", err)
+	}
+	if elapsed > 700*time.Millisecond {
+		t.Fatalf("DialUnix() returned in %v, want within env timeout budget", elapsed)
+	}
+}
+
+func TestDialTimeoutFromEnvWarnsAndUsesDefaultOnParseError(t *testing.T) {
+	t.Setenv(EnvDialTimeout, "garbage")
+	var warnings []string
+
+	got := TimeoutFromEnvWithLogger(75*time.Millisecond, func(format string, args ...any) {
+		warnings = append(warnings, fmt.Sprintf(format, args...))
+	})
+
+	if got != 75*time.Millisecond {
+		t.Fatalf("TimeoutFromEnvWithLogger() = %v, want default", got)
+	}
+	if len(warnings) != 1 {
+		t.Fatalf("warnings = %d, want 1", len(warnings))
+	}
+	if !strings.Contains(warnings[0], EnvDialTimeout) || !strings.Contains(warnings[0], "garbage") {
+		t.Fatalf("warning = %q, want env var name and invalid value", warnings[0])
+	}
+}
+
+func newWedgedUnixSocket(t *testing.T) string {
+	t.Helper()
+
+	sockPath := filepath.Join(t.TempDir(), "wedged.sock")
+	fd, err := syscall.Socket(syscall.AF_UNIX, syscall.SOCK_STREAM, 0)
+	if err != nil {
+		t.Fatalf("Socket(AF_UNIX): %v", err)
+	}
+	t.Cleanup(func() {
+		_ = syscall.Close(fd)
+		_ = os.Remove(sockPath)
+	})
+
+	if err := syscall.Bind(fd, &syscall.SockaddrUnix{Name: sockPath}); err != nil {
+		t.Fatalf("Bind(%q): %v", sockPath, err)
+	}
+	if err := syscall.Listen(fd, 0); err != nil {
+		t.Fatalf("Listen(%q): %v", sockPath, err)
+	}
+
+	var fillConns []net.Conn
+	t.Cleanup(func() {
+		for _, conn := range fillConns {
+			_ = conn.Close()
+		}
+	})
+	for attempts := 0; attempts < 64; attempts++ {
+		conn, err := net.DialTimeout("unix", sockPath, 5*time.Millisecond)
+		if err != nil {
+			if !isTimeoutError(err) {
+				t.Fatalf("filling wedged socket queue: %v", err)
+			}
+			return sockPath
+		}
+		fillConns = append(fillConns, conn)
+	}
+	t.Fatal("wedged socket accept queue did not fill")
+	return ""
+}
+
+func isTimeoutError(err error) bool {
+	var netErr net.Error
+	return errors.As(err, &netErr) && netErr.Timeout()
+}

--- a/internal/proto/daemon.go
+++ b/internal/proto/daemon.go
@@ -3,12 +3,13 @@ package proto
 import (
 	"fmt"
 	"io"
-	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"syscall"
 	"time"
+
+	"github.com/weill-labs/amux/internal/dialutil"
 )
 
 type daemonFns struct {
@@ -141,7 +142,7 @@ func EnsureDaemon(sessionName string, timeout time.Duration) error {
 
 // SocketAlive checks if a socket exists and a server is listening on it.
 func SocketAlive(sockPath string) bool {
-	conn, err := net.Dial("unix", sockPath)
+	conn, err := dialutil.DialUnix(sockPath)
 	if err != nil {
 		return false
 	}

--- a/internal/server/pprof.go
+++ b/internal/server/pprof.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	charmlog "github.com/charmbracelet/log"
+	"github.com/weill-labs/amux/internal/dialutil"
 )
 
 type pprofEndpoint struct {
@@ -44,7 +45,7 @@ func newPprofMux() *http.ServeMux {
 
 func newPprofEndpoint(sockPath string, logger *charmlog.Logger) (*pprofEndpoint, error) {
 	if _, err := os.Stat(sockPath); err == nil {
-		conn, dialErr := net.Dial("unix", sockPath)
+		conn, dialErr := dialutil.DialUnixStaleProbe(sockPath)
 		if dialErr == nil {
 			conn.Close()
 			return nil, fmt.Errorf("pprof debug endpoint already running at %s", sockPath)

--- a/internal/transport/ssh/ssh.go
+++ b/internal/transport/ssh/ssh.go
@@ -10,6 +10,7 @@ import (
 
 	charmlog "github.com/charmbracelet/log"
 	"github.com/weill-labs/amux/internal/auditlog"
+	"github.com/weill-labs/amux/internal/dialutil"
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/agent"
 	"golang.org/x/crypto/ssh/knownhosts"
@@ -38,7 +39,7 @@ func BuildSSHConfig(user, identityFile string) (*ssh.ClientConfig, error) {
 	}
 
 	if sock := os.Getenv("SSH_AUTH_SOCK"); sock != "" {
-		conn, err := net.Dial("unix", sock)
+		conn, err := dialutil.DialUnix(sock)
 		if err == nil {
 			agentClient := agent.NewClient(conn)
 			authMethods = append(authMethods, ssh.PublicKeysCallback(agentClient.Signers))


### PR DESCRIPTION
## Motivation
Multiple CLI and helper paths dial the amux Unix socket to discover or contact the daemon. A wedged accept loop can make bare Unix dials stall the caller, so these paths need bounded dial behavior with an override for operators who need a different budget.

## Summary
- Add `internal/dialutil` with a 2s default Unix dial timeout and `AMUX_DIAL_TIMEOUT` parsing via `time.ParseDuration`.
- Log a warning and keep the default when `AMUX_DIAL_TIMEOUT` is invalid.
- Replace production bare Unix dials in the requested daemon/client/SSH paths with timed helpers.
- Use the 500ms stale-detect timeout for server and client pprof socket probes.
- Add regression coverage for wedged Unix sockets, missing socket paths, env overrides, invalid-env warnings, and timeout defaults.

## Testing
- `go test ./internal/dialutil -run 'TestDial' -count=100`
- `go test ./internal/dialutil ./internal/proto ./internal/cli ./internal/client ./internal/server ./internal/transport/ssh -count=1`
- `go test ./... -timeout 120s`

## Review focus
- Confirm the shared timeout helper is the right package boundary for daemon, client, server pprof, and SSH auth socket dials.
- Confirm the pprof stale-detect probes should use the 500ms default while the regular daemon/client dials use 2s.
- Confirm the LAB-1434 coordination decision: `internal/server/server.go:488` was deliberately untouched. In this base, LAB-1434 has already removed the old stat/dial/remove block, and this PR intentionally leaves that area owned by LAB-1434.

Closes LAB-1472
