### PR TITLE
LAB-1471: Bound pane shutdown close waits

### DIFF
--- a/internal/mux/pane.go
+++ b/internal/mux/pane.go
@@ -24,6 +24,8 @@ const DefaultHost = "local"
 // PaneNameFormat is the format string for auto-assigned pane names.
 const PaneNameFormat = "pane-%d"
 
+const defaultPaneCloseReadLoopTimeout = 2 * time.Second
+
 func paneShellEnv(id uint32, sessionName string) []string {
 	return paneCommandEnvWithProfile(os.Environ(), id, sessionName, "")
 }
@@ -769,16 +771,7 @@ func (p *Pane) closeBlocking() error {
 		ptmxErr = state.ptmx.Close()
 	}
 	closeTimeout := p.effectiveCloseReadLoopTimeout()
-	if state.readLoopDone != nil {
-		select {
-		case <-state.readLoopDone:
-		case <-time.After(closeTimeout):
-			p.logCloseWarning("pane read loop did not exit before close timeout",
-				"event", "pane_close_read_loop_timeout",
-				"timeout", closeTimeout,
-			)
-		}
-	}
+	p.waitForReadLoopDone(state.readLoopDone, closeTimeout)
 	p.waitForDetachedProcessExit(state, proc, closeTimeout)
 	p.stopActor()
 	emuErr := func() error {
@@ -794,7 +787,24 @@ func (p *Pane) effectiveCloseReadLoopTimeout() time.Duration {
 	if p.closeReadLoopTimeout > 0 {
 		return p.closeReadLoopTimeout
 	}
-	return 2 * time.Second
+	return defaultPaneCloseReadLoopTimeout
+}
+
+func (p *Pane) waitForReadLoopDone(done <-chan struct{}, timeout time.Duration) {
+	if done == nil {
+		return
+	}
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+
+	select {
+	case <-done:
+	case <-timer.C:
+		p.logCloseWarning("pane read loop did not exit before close timeout",
+			"event", "pane_close_read_loop_timeout",
+			"timeout", timeout,
+		)
+	}
 }
 
 func (p *Pane) logCloseWarning(message string, fields ...any) {

--- a/internal/mux/pane.go
+++ b/internal/mux/pane.go
@@ -1,6 +1,7 @@
 package mux
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -103,22 +104,24 @@ type Pane struct {
 	// Used by proxy panes to route input over SSH to a remote amux server.
 	writeOverride func([]byte) (int, error)
 
-	closed              atomic.Bool
-	exitDone            chan struct{} // closed by waitLoop when the shell process exits
-	closeDoneOnce       sync.Once
-	closeDone           chan struct{}
-	closeErr            error
-	closeForbiddenOwner *debugowner.Checker
-	drainStarted        bool
-	onOutput            func(paneID uint32, data []byte, seq uint64)
-	onExit              func(paneID uint32, reason string)
-	onClipboard         func(paneID uint32, data []byte)
-	onTakeover          func(paneID uint32, req TakeoverRequest)
-	onMetaUpdate        func(paneID uint32, update MetaUpdate)
-	osc52Scanner        OSC52Scanner
-	controlScanner      AmuxControlScanner
-	metaScanner         AmuxMetaScanner
-	suppressCallbacks   atomic.Bool
+	closed               atomic.Bool
+	exitDone             chan struct{} // closed by waitLoop when the shell process exits
+	closeDoneOnce        sync.Once
+	closeDone            chan struct{}
+	closeErr             error
+	closeForbiddenOwner  *debugowner.Checker
+	drainStarted         bool
+	onOutput             func(paneID uint32, data []byte, seq uint64)
+	onExit               func(paneID uint32, reason string)
+	onClipboard          func(paneID uint32, data []byte)
+	onTakeover           func(paneID uint32, req TakeoverRequest)
+	onMetaUpdate         func(paneID uint32, update MetaUpdate)
+	onCloseWarning       func(pane *Pane, message string, fields ...any)
+	osc52Scanner         OSC52Scanner
+	controlScanner       AmuxControlScanner
+	metaScanner          AmuxMetaScanner
+	suppressCallbacks    atomic.Bool
+	closeReadLoopTimeout time.Duration
 
 	// Idle tracking (LAB-159)
 	createdAt        time.Time
@@ -551,6 +554,12 @@ func (p *Pane) SetOnMetaUpdate(fn func(paneID uint32, update MetaUpdate)) {
 	p.onMetaUpdate = fn
 }
 
+// SetOnCloseWarning sets the callback invoked when close teardown hits a
+// bounded wait. Must be called before Close().
+func (p *Pane) SetOnCloseWarning(fn func(pane *Pane, message string, fields ...any)) {
+	p.onCloseWarning = fn
+}
+
 // readLoop reads PTY output, feeds the emulator, and notifies the callback.
 func (p *Pane) readLoop(ptmx *os.File, done chan struct{}) {
 	if done != nil {
@@ -728,13 +737,22 @@ func (p *Pane) Close() error {
 }
 
 // WaitClosed waits for the background Close teardown to finish and returns the
-// final close error, if any.
-func (p *Pane) WaitClosed() error {
+// final close error, if any. Passing a context bounds the wait; without one it
+// waits until Close teardown finishes.
+func (p *Pane) WaitClosed(ctxs ...context.Context) error {
 	if !p.closed.Load() {
 		return nil
 	}
-	<-p.ensureCloseDone()
-	return p.closeErr
+	ctx := context.Background()
+	if len(ctxs) > 0 && ctxs[0] != nil {
+		ctx = ctxs[0]
+	}
+	select {
+	case <-p.ensureCloseDone():
+		return p.closeErr
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }
 
 func (p *Pane) closeBlocking() error {
@@ -750,10 +768,18 @@ func (p *Pane) closeBlocking() error {
 	if state.ptmx != nil {
 		ptmxErr = state.ptmx.Close()
 	}
+	closeTimeout := p.effectiveCloseReadLoopTimeout()
 	if state.readLoopDone != nil {
-		<-state.readLoopDone
+		select {
+		case <-state.readLoopDone:
+		case <-time.After(closeTimeout):
+			p.logCloseWarning("pane read loop did not exit before close timeout",
+				"event", "pane_close_read_loop_timeout",
+				"timeout", closeTimeout,
+			)
+		}
 	}
-	p.waitForDetachedProcessExit(state, proc, 2*time.Second)
+	p.waitForDetachedProcessExit(state, proc, closeTimeout)
 	p.stopActor()
 	emuErr := func() error {
 		if state.emulator == nil {
@@ -762,6 +788,20 @@ func (p *Pane) closeBlocking() error {
 		return state.emulator.Close()
 	}()
 	return errors.Join(ptmxErr, emuErr)
+}
+
+func (p *Pane) effectiveCloseReadLoopTimeout() time.Duration {
+	if p.closeReadLoopTimeout > 0 {
+		return p.closeReadLoopTimeout
+	}
+	return 2 * time.Second
+}
+
+func (p *Pane) logCloseWarning(message string, fields ...any) {
+	if p.onCloseWarning == nil {
+		return
+	}
+	p.onCloseWarning(p, message, fields...)
 }
 
 // NewProxyPaneWithScrollback creates a proxy pane with an explicit retained

--- a/internal/mux/pane_window_process_test.go
+++ b/internal/mux/pane_window_process_test.go
@@ -1,6 +1,7 @@
 package mux
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -815,6 +816,98 @@ func TestWaitClosedReturnsNilBeforeClose(t *testing.T) {
 	if err := p.WaitClosed(); err != nil {
 		t.Fatalf("WaitClosed() before Close = %v, want nil", err)
 	}
+}
+
+func TestWaitClosedReturnsContextDeadlineExceeded(t *testing.T) {
+	t.Parallel()
+
+	p := &Pane{}
+	p.closed.Store(true)
+	closeDone := p.ensureCloseDone()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 25*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	err := p.WaitClosed(ctx)
+	elapsed := time.Since(start)
+	close(closeDone)
+
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("WaitClosed(ctx) = %v, want context deadline exceeded", err)
+	}
+	if elapsed > 250*time.Millisecond {
+		t.Fatalf("WaitClosed(ctx) took %v, want bounded by context deadline", elapsed)
+	}
+}
+
+type closeWarningRecord struct {
+	paneID  uint32
+	message string
+	fields  []any
+}
+
+func TestCloseBlockingTimesOutHungReadLoop(t *testing.T) {
+	t.Parallel()
+
+	readLoopDone := make(chan struct{})
+	p := &Pane{
+		ID:                   17,
+		Meta:                 PaneMeta{Name: "pane-17", Host: DefaultHost},
+		readLoopDone:         readLoopDone,
+		closeReadLoopTimeout: 25 * time.Millisecond,
+	}
+	warnings := make(chan closeWarningRecord, 1)
+	p.SetOnCloseWarning(func(pane *Pane, message string, fields ...any) {
+		warnings <- closeWarningRecord{
+			paneID:  pane.ID,
+			message: message,
+			fields:  append([]any(nil), fields...),
+		}
+	})
+
+	done := make(chan error, 1)
+	go func() {
+		done <- p.closeBlocking()
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("closeBlocking() = %v, want nil", err)
+		}
+	case <-time.After(250 * time.Millisecond):
+		close(readLoopDone)
+		<-done
+		t.Fatal("closeBlocking() hung on readLoopDone")
+	}
+
+	select {
+	case warning := <-warnings:
+		if warning.paneID != 17 {
+			t.Fatalf("warning pane ID = %d, want 17", warning.paneID)
+		}
+		if warning.message != "pane read loop did not exit before close timeout" {
+			t.Fatalf("warning message = %q", warning.message)
+		}
+		if got := fieldValue(warning.fields, "event"); got != "pane_close_read_loop_timeout" {
+			t.Fatalf("warning event = %v, want pane_close_read_loop_timeout", got)
+		}
+		if got := fieldValue(warning.fields, "timeout"); got != 25*time.Millisecond {
+			t.Fatalf("warning timeout = %v, want 25ms", got)
+		}
+	default:
+		t.Fatal("closeBlocking() did not log the read loop timeout")
+	}
+}
+
+func fieldValue(fields []any, key string) any {
+	for i := 0; i+1 < len(fields); i += 2 {
+		if fields[i] == key {
+			return fields[i+1]
+		}
+	}
+	return nil
 }
 
 func TestCloseHandlesUnstartedProcessPane(t *testing.T) {

--- a/internal/server/audit.go
+++ b/internal/server/audit.go
@@ -107,6 +107,15 @@ func (s *Session) logPaneExit(pane *mux.Pane, reason string) {
 	}
 }
 
+func (s *Session) logPaneCloseWarning(pane *mux.Pane, message string, fields ...any) {
+	if s == nil || pane == nil {
+		return
+	}
+	closeFields := append([]any(nil), fields...)
+	closeFields = append(closeFields, paneAuditFields(pane)...)
+	auditlog.LogWithLevel(s.logger, charmlog.WarnLevel, message, closeFields...)
+}
+
 func (s *Session) logCheckpointWrite(kind, path string, duration time.Duration, err error) {
 	if s == nil {
 		return

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"os"
@@ -409,9 +410,13 @@ type Server struct {
 	// shutdownCheckpointTimeout bounds the final crash checkpoint write during
 	// shutdown. Zero uses the default timeout.
 	shutdownCheckpointTimeout time.Duration
+	// shutdownPaneCloseTimeout bounds each pane close wait during shutdown.
+	// Zero uses the default timeout.
+	shutdownPaneCloseTimeout time.Duration
 }
 
 const defaultShutdownCheckpointTimeout = 2 * time.Second
+const defaultShutdownPaneCloseTimeout = 3 * time.Second
 
 // lookupCommand returns the handler for the given command name, consulting the
 // server-level override first, then the package-level commandRegistry.
@@ -757,13 +762,20 @@ func (s *Server) shutdown() {
 		}
 		panes := make([]*mux.Pane, len(sess.Panes))
 		copy(panes, sess.Panes)
+		paneCloseTimeout := s.shutdownPaneCloseWaitTimeout()
 		var wg sync.WaitGroup
 		for _, p := range panes {
 			wg.Add(1)
 			go func(p *mux.Pane) {
 				defer wg.Done()
 				_ = p.Close()
-				_ = p.WaitClosed()
+				ctx, cancel := context.WithTimeout(context.Background(), paneCloseTimeout)
+				defer cancel()
+				if err := p.WaitClosed(ctx); err != nil && s.logger != nil {
+					fields := append([]any{"event", "pane_shutdown_close_timeout"}, paneAuditFields(p)...)
+					fields = append(fields, "timeout", paneCloseTimeout, "error", err)
+					s.logger.Warn("timed out waiting for pane close during shutdown", fields...)
+				}
 			}(p)
 		}
 		wg.Wait()
@@ -776,6 +788,13 @@ func (s *Server) shutdownCrashCheckpointTimeout() time.Duration {
 		return defaultShutdownCheckpointTimeout
 	}
 	return s.shutdownCheckpointTimeout
+}
+
+func (s *Server) shutdownPaneCloseWaitTimeout() time.Duration {
+	if s == nil || s.shutdownPaneCloseTimeout <= 0 {
+		return defaultShutdownPaneCloseTimeout
+	}
+	return s.shutdownPaneCloseTimeout
 }
 
 func (s *Server) handleConn(conn net.Conn) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -768,14 +769,7 @@ func (s *Server) shutdown() {
 			wg.Add(1)
 			go func(p *mux.Pane) {
 				defer wg.Done()
-				_ = p.Close()
-				ctx, cancel := context.WithTimeout(context.Background(), paneCloseTimeout)
-				defer cancel()
-				if err := p.WaitClosed(ctx); err != nil && s.logger != nil {
-					fields := append([]any{"event", "pane_shutdown_close_timeout"}, paneAuditFields(p)...)
-					fields = append(fields, "timeout", paneCloseTimeout, "error", err)
-					s.logger.Warn("timed out waiting for pane close during shutdown", fields...)
-				}
+				s.closePaneDuringShutdown(p, paneCloseTimeout)
 			}(p)
 		}
 		wg.Wait()
@@ -795,6 +789,25 @@ func (s *Server) shutdownPaneCloseWaitTimeout() time.Duration {
 		return defaultShutdownPaneCloseTimeout
 	}
 	return s.shutdownPaneCloseTimeout
+}
+
+func (s *Server) closePaneDuringShutdown(p *mux.Pane, timeout time.Duration) {
+	_ = p.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	if err := p.WaitClosed(ctx); errors.Is(err, context.DeadlineExceeded) {
+		s.logPaneShutdownCloseTimeout(p, timeout, err)
+	}
+}
+
+func (s *Server) logPaneShutdownCloseTimeout(p *mux.Pane, timeout time.Duration, err error) {
+	if s == nil || s.logger == nil {
+		return
+	}
+	fields := append([]any{"event", "pane_shutdown_close_timeout"}, paneAuditFields(p)...)
+	fields = append(fields, "timeout", timeout, "error", err)
+	s.logger.Warn("timed out waiting for pane close during shutdown", fields...)
 }
 
 func (s *Server) handleConn(conn net.Conn) {

--- a/internal/server/server_shutdown_test.go
+++ b/internal/server/server_shutdown_test.go
@@ -2,10 +2,14 @@ package server
 
 import (
 	"net"
+	"reflect"
 	"strings"
 	"sync"
 	"testing"
 	"time"
+	"unsafe"
+
+	"github.com/weill-labs/amux/internal/mux"
 )
 
 func TestShutdownCommandFlushesReplyBeforeShutdownStarts(t *testing.T) {
@@ -201,6 +205,73 @@ func TestShutdownTimesOutBlockedCrashCheckpointWrite(t *testing.T) {
 	if !strings.Contains(logBuf.String(), "timed out waiting for crash checkpoint during shutdown") {
 		t.Fatalf("shutdown log = %q, want timeout warning", logBuf.String())
 	}
+}
+
+func TestShutdownExitsWithWedgedPaneReadLoop(t *testing.T) {
+	t.Parallel()
+
+	srv, sess, cleanup := newCommandTestSession(t)
+	defer cleanup()
+
+	logger, logBuf := newAuditTestLogger()
+	srv.SetLogger(logger)
+	srv.shutdownPaneCloseTimeout = 100 * time.Millisecond
+
+	pane1 := newTestPane(sess, 1, "pane-1")
+	wedgedPane := newTestPane(sess, 2, "pane-2")
+	pane3 := newTestPane(sess, 3, "pane-3")
+	releaseReadLoop := wedgePaneReadLoopForShutdownTest(t, wedgedPane, 25*time.Millisecond)
+	defer releaseReadLoop()
+	sess.Panes = []*mux.Pane{pane1, wedgedPane, pane3}
+
+	shutdownDone := make(chan struct{})
+	start := time.Now()
+	go func() {
+		srv.shutdown()
+		close(shutdownDone)
+	}()
+
+	select {
+	case <-shutdownDone:
+	case <-time.After(time.Second):
+		t.Fatal("shutdown hung on wedged pane read loop")
+	}
+	if elapsed := time.Since(start); elapsed > 500*time.Millisecond {
+		t.Fatalf("shutdown took %v, want bounded by pane close timeout", elapsed)
+	}
+
+	logs := logBuf.String()
+	if !strings.Contains(logs, "pane_close_read_loop_timeout") {
+		t.Fatalf("shutdown log = %q, want read loop timeout warning", logs)
+	}
+	if !strings.Contains(logs, "pane-2") {
+		t.Fatalf("shutdown log = %q, want wedged pane name", logs)
+	}
+}
+
+func wedgePaneReadLoopForShutdownTest(t *testing.T, pane *mux.Pane, timeout time.Duration) func() {
+	t.Helper()
+
+	readLoopDone := make(chan struct{})
+	setPaneFieldForShutdownTest(t, pane, "readLoopDone", readLoopDone)
+	setPaneFieldForShutdownTest(t, pane, "closeReadLoopTimeout", timeout)
+
+	var releaseOnce sync.Once
+	return func() {
+		releaseOnce.Do(func() {
+			close(readLoopDone)
+		})
+	}
+}
+
+func setPaneFieldForShutdownTest(t *testing.T, pane *mux.Pane, name string, value any) {
+	t.Helper()
+
+	field := reflect.ValueOf(pane).Elem().FieldByName(name)
+	if !field.IsValid() {
+		t.Fatalf("mux.Pane.%s field not found", name)
+	}
+	reflect.NewAt(field.Type(), unsafe.Pointer(field.UnsafeAddr())).Elem().Set(reflect.ValueOf(value))
 }
 
 type blockingCrashCheckpointCoordinator struct {

--- a/internal/server/session_pane.go
+++ b/internal/server/session_pane.go
@@ -36,6 +36,7 @@ func (s *Session) ownPane(pane *mux.Pane) *mux.Pane {
 		return nil
 	}
 	pane.SetCloseForbiddenOwner(&s.eventLoopOwner)
+	pane.SetOnCloseWarning(s.logPaneCloseWarning)
 	return pane
 }
 


### PR DESCRIPTION
## Motivation

Shutdown can hang indefinitely if a pane close path blocks on a wedged read loop or never-finished close goroutine. LAB-1471 closes the next shutdown-chain gap after LAB-1432 by bounding the pane close waits used during server shutdown.

## Summary

- Add context-bounded `Pane.WaitClosed(ctx)` behavior while keeping existing no-arg callers working.
- Bound `closeBlocking` waits on `readLoopDone` to the same 2s window used for detached process exit, with pane-scoped warning logs.
- Add `shutdownPaneCloseTimeout` with a 3s default and use it for per-pane shutdown wait goroutines.
- Cover hung closeDone, hung readLoopDone, and shutdown with one wedged pane.

## Testing

- `go test ./internal/mux ./internal/server -run 'TestWaitClosedReturnsContextDeadlineExceeded|TestCloseBlockingTimesOutHungReadLoop|TestShutdownExitsWithWedgedPaneReadLoop' -count=100`
- `go test ./... -timeout 120s`

## Review focus

- The optional-context `WaitClosed` API keeps existing callers source-compatible while letting shutdown pass a deadline.
- The read-loop timeout warning is injected through the pane close warning callback so mux does not depend on server logging internals.
- Shutdown only logs the new timeout warning for context deadline expiry, preserving prior behavior for non-timeout close errors.

Closes LAB-1471
