### PR TITLE
LAB-1593: Cap pane scrollback by host

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ amux capture --history --format json pane-1
 amux capture --history --rewrap 120 --format json pane-1
 ```
 
-`capture pane-1` returns the pane's current visible screen. `capture --history pane-1` returns the full browsable buffer for that pane: retained scrollback followed by the current screen. `capture --history --rewrap WIDTH pane-1` best-effort reconstructs narrow-pane rows at a wider width, which is useful when agent output was captured in dense layouts. The JSON form keeps history and visible content separate as `history` and `content`, and `--rewrap` applies there too. By default amux retains up to `10000` scrollback lines per pane; override that with `scrollback_lines` in `config.toml`. After crash recovery, `history` includes any archived pre-crash visible screen from panes whose foreground process was lost.
+`capture pane-1` returns the pane's current visible screen. `capture --history pane-1` returns the full browsable buffer for that pane: retained scrollback followed by the current screen. `capture --history --rewrap WIDTH pane-1` best-effort reconstructs narrow-pane rows at a wider width, which is useful when agent output was captured in dense layouts. The JSON form keeps history and visible content separate as `history` and `content`, and `--rewrap` applies there too. By default amux retains up to `5000` scrollback lines per pane; override that with `scrollback_lines` in `config.toml` or on a specific host. After crash recovery, `history` includes any archived pre-crash visible screen from panes whose foreground process was lost.
 
 `--rewrap` is exact for live rows captured in the current process lifetime, where amux tracks the width each scrollback row was wrapped at. Restored/base history from attach bootstrap, reload checkpoints, and crash checkpoints is still stored as raw text rows, so rewrap can only improve live rows and current visible content. Hard newlines that happened exactly at pane width remain ambiguous without tmux-style wrapped-line metadata.
 
@@ -429,7 +429,7 @@ with `AMUX_CLIENT_CAPABILITIES`. Use a comma-separated list of capability names:
 ### Session
 
 ```toml
-scrollback_lines = 10000   # optional: retained history per pane (default: 10000, must be >= 1)
+scrollback_lines = 5000    # optional: retained history per pane (default: 5000, must be >= 1)
 ```
 
 ### Debugging
@@ -474,10 +474,12 @@ identity_file = "~/.ssh/id_ed25519"
 project_dir = "~/Project"
 gpu = "A100"
 color = "f38ba8"            # Catppuccin Red — optional, auto-assigned if omitted
+scrollback_lines = 2000     # optional: retained history for panes on this host
 
 [hosts.macbook]
 type = "local"
 color = "a6e3a1"            # Catppuccin Green
+scrollback_lines = 10000    # optional: override the session default for this host
 ```
 
 ### Remote Transports

--- a/internal/cli/server_bootstrap.go
+++ b/internal/cli/server_bootstrap.go
@@ -70,9 +70,13 @@ func RestoreServerFromReloadCheckpoint(sessionName, cpPath string, scrollbackLin
 }
 
 func restoreServerFromReloadCheckpointLogger(sessionName, cpPath string, scrollbackLines int, logger *charmlog.Logger) (*server.Server, error) {
+	return restoreServerFromReloadCheckpointWithScrollbackConfigLogger(sessionName, cpPath, server.NewScrollbackConfig(scrollbackLines, nil), logger)
+}
+
+func restoreServerFromReloadCheckpointWithScrollbackConfigLogger(sessionName, cpPath string, scrollback server.ScrollbackConfig, logger *charmlog.Logger) (*server.Server, error) {
 	cp, err := checkpoint.Read(cpPath)
 	if err == nil {
-		return server.NewServerFromCheckpointWithScrollbackLogger(cp, scrollbackLines, logger)
+		return server.NewServerFromCheckpointWithScrollbackConfigLogger(cp, scrollback, logger)
 	}
 
 	var versionErr checkpoint.UnsupportedServerCheckpointVersionError
@@ -107,7 +111,7 @@ func restoreServerFromReloadCheckpointLogger(sessionName, cpPath string, scrollb
 		"path", crashPath,
 		"error", err,
 	)
-	return server.NewServerFromCrashCheckpointWithListenerAndLockFdLogger(restoreSessionName, cp.ListenerFd, cp.SessionLockFd, crashCP, crashPath, scrollbackLines, logger)
+	return server.NewServerFromCrashCheckpointWithScrollbackConfigListenerAndLockFdLogger(restoreSessionName, cp.ListenerFd, cp.SessionLockFd, crashCP, crashPath, scrollback, logger)
 }
 
 func RunServer(sessionName string, managedTakeover bool, buildVersion string) {
@@ -130,11 +134,11 @@ func RunServer(sessionName string, managedTakeover bool, buildVersion string) {
 		)
 		cfg = &config.Config{Hosts: make(map[string]config.Host)}
 	}
-	scrollbackLines := cfg.EffectiveScrollbackLines()
+	scrollback := server.NewScrollbackConfig(cfg.EffectiveScrollbackLines(), cfg.EffectiveHostScrollbackLines())
 
 	if cpPath := os.Getenv("AMUX_CHECKPOINT"); cpPath != "" {
 		os.Unsetenv("AMUX_CHECKPOINT")
-		s, err = restoreServerFromReloadCheckpointLogger(sessionName, cpPath, scrollbackLines, logger)
+		s, err = restoreServerFromReloadCheckpointWithScrollbackConfigLogger(sessionName, cpPath, scrollback, logger)
 		if err != nil {
 			logger.Error("reading reload checkpoint failed",
 				"event", "checkpoint_restore",
@@ -156,7 +160,7 @@ func RunServer(sessionName string, managedTakeover bool, buildVersion string) {
 				"error", readErr,
 			)
 			_ = checkpoint.RemoveCrashFile(crashPath)
-			s, err = server.NewServerWithScrollbackLogger(sessionName, scrollbackLines, logger)
+			s, err = server.NewServerWithScrollbackConfigLogger(sessionName, scrollback, logger)
 			if err != nil {
 				exitBootstrapError(logger, sessionName, "creating server failed", err)
 			}
@@ -167,7 +171,7 @@ func RunServer(sessionName string, managedTakeover bool, buildVersion string) {
 				"checkpoint_kind", "crash",
 				"path", crashPath,
 			)
-			s, err = server.NewServerFromCrashCheckpointWithScrollbackLogger(sessionName, crashCP, crashPath, scrollbackLines, logger)
+			s, err = server.NewServerFromCrashCheckpointWithScrollbackConfigLogger(sessionName, crashCP, crashPath, scrollback, logger)
 			if err != nil {
 				logger.Error("crash recovery failed",
 					"event", "checkpoint_restore",
@@ -180,7 +184,7 @@ func RunServer(sessionName string, managedTakeover bool, buildVersion string) {
 			}
 		}
 	} else {
-		s, err = server.NewServerWithScrollbackLogger(sessionName, scrollbackLines, logger)
+		s, err = server.NewServerWithScrollbackConfigLogger(sessionName, scrollback, logger)
 		if err != nil {
 			exitBootstrapError(logger, sessionName, "creating server failed", err)
 		}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -97,6 +97,7 @@ type Host struct {
 	GPU                 string   `toml:"gpu"`
 	Color               string   `toml:"color"`  // hex color, auto-assigned if empty
 	Deploy              *bool    `toml:"deploy"` // auto-deploy binary; nil = true (opt-out with false)
+	ScrollbackLines     *int     `toml:"scrollback_lines"`
 }
 
 type DebugConfig struct {
@@ -167,6 +168,11 @@ func Load(path string) (*Config, error) {
 	if _, err := ResolveScrollbackLines(cfg.ScrollbackLines); err != nil {
 		return nil, err
 	}
+	for name, host := range cfg.Hosts {
+		if _, err := resolveScrollbackLinesField("hosts."+name+".scrollback_lines", host.ScrollbackLines); err != nil {
+			return nil, err
+		}
+	}
 	if _, err := ResolveLocalEchoMode(cfg.Client.LocalEcho); err != nil {
 		return nil, err
 	}
@@ -199,11 +205,15 @@ func hasLegacyKeysConfig(undecoded []toml.Key) bool {
 // ResolveScrollbackLines validates a configured scrollback limit and returns
 // the effective value. Zero means "use the built-in default".
 func ResolveScrollbackLines(lines *int) (int, error) {
+	return resolveScrollbackLinesField("scrollback_lines", lines)
+}
+
+func resolveScrollbackLinesField(field string, lines *int) (int, error) {
 	switch {
 	case lines == nil:
 		return proto.DefaultScrollbackLines, nil
 	case *lines < 1:
-		return 0, fmt.Errorf("scrollback_lines must be >= 1")
+		return 0, fmt.Errorf("%s must be >= 1", field)
 	default:
 		return *lines, nil
 	}
@@ -220,6 +230,40 @@ func (c *Config) EffectiveScrollbackLines() int {
 		return proto.DefaultScrollbackLines
 	}
 	return lines
+}
+
+func (c *Config) EffectiveScrollbackLinesForHost(hostname string) int {
+	if c == nil {
+		return proto.DefaultScrollbackLines
+	}
+	if host, ok := c.Hosts[hostname]; ok && host.ScrollbackLines != nil {
+		lines, err := ResolveScrollbackLines(host.ScrollbackLines)
+		if err == nil {
+			return lines
+		}
+	}
+	return c.EffectiveScrollbackLines()
+}
+
+func (c *Config) EffectiveHostScrollbackLines() map[string]int {
+	if c == nil {
+		return nil
+	}
+	out := make(map[string]int)
+	for name, host := range c.Hosts {
+		if host.ScrollbackLines == nil {
+			continue
+		}
+		lines, err := ResolveScrollbackLines(host.ScrollbackLines)
+		if err != nil {
+			continue
+		}
+		out[name] = lines
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 func (c *Config) PprofEnabled() bool {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -262,6 +262,51 @@ func TestLoadScrollbackLines(t *testing.T) {
 	}
 }
 
+func TestLoadHostScrollbackLines(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	content := `
+scrollback_lines = 2048
+
+[hosts.local]
+type = "local"
+scrollback_lines = 1024
+
+[hosts.builder]
+type = "remote"
+address = "builder.example"
+`
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	local := cfg.Hosts["local"]
+	if local.ScrollbackLines == nil || *local.ScrollbackLines != 1024 {
+		t.Fatalf("local.ScrollbackLines = %v, want 1024", local.ScrollbackLines)
+	}
+	if got := cfg.EffectiveScrollbackLinesForHost("local"); got != 1024 {
+		t.Fatalf("EffectiveScrollbackLinesForHost(local) = %d, want 1024", got)
+	}
+	if got := cfg.EffectiveScrollbackLinesForHost("builder"); got != 2048 {
+		t.Fatalf("EffectiveScrollbackLinesForHost(builder) = %d, want global 2048", got)
+	}
+
+	hostLines := cfg.EffectiveHostScrollbackLines()
+	if got, ok := hostLines["local"]; !ok || got != 1024 {
+		t.Fatalf("EffectiveHostScrollbackLines()[local] = %d, %v; want 1024, true", got, ok)
+	}
+	if _, ok := hostLines["builder"]; ok {
+		t.Fatalf("EffectiveHostScrollbackLines()[builder] present, want omitted")
+	}
+}
+
 func TestLoadDebugPprof(t *testing.T) {
 	t.Parallel()
 
@@ -365,6 +410,15 @@ func TestLoadRejectsZeroScrollbackLines(t *testing.T) {
 			name:    "zero scrollback",
 			content: "scrollback_lines = 0\n",
 			wantErr: "scrollback_lines must be >= 1",
+		},
+		{
+			name: "zero host scrollback",
+			content: `
+[hosts.local]
+type = "local"
+scrollback_lines = 0
+`,
+			wantErr: "hosts.local.scrollback_lines must be >= 1",
 		},
 		{
 			name: "keys section",

--- a/internal/mux/emulator_test.go
+++ b/internal/mux/emulator_test.go
@@ -74,6 +74,26 @@ func TestVTEmulatorCloseResponsePipeNilReceiver(t *testing.T) {
 	}
 }
 
+func TestVTEmulatorRespectsScrollbackLimitUnderFlood(t *testing.T) {
+	t.Parallel()
+
+	emu := NewVTEmulatorWithDrainAndScrollback(20, 2, 3)
+	for i := 1; i <= 12; i++ {
+		mustWrite(t, emu, []byte(fmt.Sprintf("flood-%02d\r\n", i)))
+	}
+
+	got := EmulatorScrollbackLines(emu)
+	want := []string{"flood-09", "flood-10", "flood-11"}
+	if len(got) != len(want) {
+		t.Fatalf("scrollback len = %d, want %d: %#v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("scrollback[%d] = %q, want %q; full scrollback=%#v", i, got[i], want[i], got)
+		}
+	}
+}
+
 func TestVTEmulatorResizeWiderReflowsVisibleRows(t *testing.T) {
 	t.Parallel()
 

--- a/internal/proto/pane.go
+++ b/internal/proto/pane.go
@@ -4,7 +4,7 @@ import "image/color"
 
 // DefaultScrollbackLines is the retained history limit used by amux for pane
 // scrollback on both server and client emulators.
-const DefaultScrollbackLines = 10000
+const DefaultScrollbackLines = 5000
 
 // MouseTrackingMode is the pane's current application mouse-tracking mode.
 type MouseTrackingMode int

--- a/internal/server/checkpoint.go
+++ b/internal/server/checkpoint.go
@@ -210,6 +210,10 @@ func NewServerFromCheckpointWithScrollback(cp *checkpoint.ServerCheckpoint, scro
 }
 
 func NewServerFromCheckpointWithScrollbackLogger(cp *checkpoint.ServerCheckpoint, scrollbackLines int, logger *charmlog.Logger) (*Server, error) {
+	return NewServerFromCheckpointWithScrollbackConfigLogger(cp, NewScrollbackConfig(scrollbackLines, nil), logger)
+}
+
+func NewServerFromCheckpointWithScrollbackConfigLogger(cp *checkpoint.ServerCheckpoint, scrollback ScrollbackConfig, logger *charmlog.Logger) (*Server, error) {
 	if logger == nil {
 		logger = auditlog.Discard()
 	}
@@ -225,7 +229,7 @@ func NewServerFromCheckpointWithScrollbackLogger(cp *checkpoint.ServerCheckpoint
 		return nil, err
 	}
 
-	sess := newSessionWithLogger(cp.SessionName, scrollbackLines, logger.With("session", cp.SessionName))
+	sess := newSessionWithScrollbackConfigLogger(cp.SessionName, scrollback, logger.With("session", cp.SessionName))
 	if !cp.StartedAt.IsZero() {
 		sess.startedAt = cp.StartedAt
 	}
@@ -256,13 +260,13 @@ func NewServerFromCheckpointWithScrollbackLogger(cp *checkpoint.ServerCheckpoint
 			// The remote manager will re-establish the SSH connection.
 			meta := pc.Meta
 			meta.Remote = string(proto.Reconnecting)
-			pane = sess.ownPane(mux.NewProxyPaneWithScrollback(pc.ID, meta, pc.Cols, pc.Rows, sess.scrollbackLines,
+			pane = sess.ownPane(mux.NewProxyPaneWithScrollback(pc.ID, meta, pc.Cols, pc.Rows, sess.scrollbackLinesForHost(meta.Host),
 				onOutput, onExit,
 				sess.remoteWriteOverride(pc.ID),
 			))
 		} else {
 			var restoreErr error
-			pane, restoreErr = mux.RestorePaneWithScrollback(pc.ID, pc.Meta, pc.PtmxFd, pc.PID, pc.Cols, pc.Rows, sess.scrollbackLines,
+			pane, restoreErr = mux.RestorePaneWithScrollback(pc.ID, pc.Meta, pc.PtmxFd, pc.PID, pc.Cols, pc.Rows, sess.scrollbackLinesForHost(pc.Meta.Host),
 				onOutput, onExit,
 			)
 			if restoreErr != nil {

--- a/internal/server/commands_remote.go
+++ b/internal/server/commands_remote.go
@@ -131,7 +131,7 @@ func (ctx remoteCommandContext) InjectProxy(hostName string) commandpkg.Result {
 		Host:  hostName,
 		Color: config.AccentColor(0),
 	}
-	proxyPane := ctx.Sess.ownPane(mux.NewProxyPaneWithScrollback(id, meta, w.Width/2, mux.PaneContentHeight(w.Height), ctx.Sess.scrollbackLines,
+	proxyPane := ctx.Sess.ownPane(mux.NewProxyPaneWithScrollback(id, meta, w.Width/2, mux.PaneContentHeight(w.Height), ctx.Sess.scrollbackLinesForHost(meta.Host),
 		ctx.Sess.paneOutputCallback(),
 		ctx.Sess.paneExitCallback(),
 		func(data []byte) (int, error) { return len(data), nil },

--- a/internal/server/remote_session.go
+++ b/internal/server/remote_session.go
@@ -279,7 +279,7 @@ func (rs *RemoteSession) newProxyPane(s *Session, pane proto.PaneSnapshot) (*mux
 		meta,
 		DefaultTermCols,
 		mux.PaneContentHeight(DefaultTermRows),
-		s.scrollbackLines,
+		s.scrollbackLinesForHost(meta.Host),
 		s.paneOutputCallback(),
 		s.paneExitCallback(),
 		s.remoteWriteOverride(localPaneID),

--- a/internal/server/scrollback.go
+++ b/internal/server/scrollback.go
@@ -1,0 +1,46 @@
+package server
+
+import "github.com/weill-labs/amux/internal/mux"
+
+// ScrollbackConfig resolves retained history limits for panes in a session.
+type ScrollbackConfig struct {
+	DefaultLines int
+	HostLines    map[string]int
+}
+
+// NewScrollbackConfig returns a normalized scrollback config. Non-positive
+// values fall back to the built-in default.
+func NewScrollbackConfig(defaultLines int, hostLines map[string]int) ScrollbackConfig {
+	cfg := ScrollbackConfig{
+		DefaultLines: defaultScrollbackLines(defaultLines),
+	}
+	if len(hostLines) > 0 {
+		cfg.HostLines = make(map[string]int, len(hostLines))
+		for host, lines := range hostLines {
+			if host == "" || lines <= 0 {
+				continue
+			}
+			cfg.HostLines[host] = lines
+		}
+	}
+	return cfg
+}
+
+func defaultScrollbackLines(lines int) int {
+	if lines <= 0 {
+		return mux.DefaultScrollbackLines
+	}
+	return lines
+}
+
+func (c ScrollbackConfig) LinesForHost(host string) int {
+	if host == "" {
+		host = mux.DefaultHost
+	}
+	if c.HostLines != nil {
+		if lines, ok := c.HostLines[host]; ok && lines > 0 {
+			return lines
+		}
+	}
+	return defaultScrollbackLines(c.DefaultLines)
+}

--- a/internal/server/scrollback_test.go
+++ b/internal/server/scrollback_test.go
@@ -1,0 +1,48 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/weill-labs/amux/internal/mux"
+)
+
+func TestScrollbackConfigLinesForHost(t *testing.T) {
+	t.Parallel()
+
+	cfg := NewScrollbackConfig(2000, map[string]int{
+		"local":   1000,
+		"builder": 3000,
+		"ignored": 0,
+	})
+
+	tests := []struct {
+		name string
+		host string
+		want int
+	}{
+		{name: "local override", host: "local", want: 1000},
+		{name: "remote override", host: "builder", want: 3000},
+		{name: "missing host uses default", host: "unknown", want: 2000},
+		{name: "empty host resolves local", host: "", want: 1000},
+		{name: "invalid override omitted", host: "ignored", want: 2000},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := cfg.LinesForHost(tt.host); got != tt.want {
+				t.Fatalf("LinesForHost(%q) = %d, want %d", tt.host, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestScrollbackConfigFallsBackToBuiltInDefault(t *testing.T) {
+	t.Parallel()
+
+	cfg := NewScrollbackConfig(0, nil)
+	if got := cfg.LinesForHost("local"); got != mux.DefaultScrollbackLines {
+		t.Fatalf("LinesForHost(local) = %d, want %d", got, mux.DefaultScrollbackLines)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -131,8 +131,8 @@ type Session struct {
 	// (last client disconnected, last pane exited). The event loop checks
 	// this after each event and triggers shutdown asynchronously — never
 	// from inside the handler, which would deadlock.
-	wantShutdown    bool
-	scrollbackLines int
+	wantShutdown bool
+	scrollback   ScrollbackConfig
 }
 
 type processEnviron struct{}
@@ -470,13 +470,18 @@ func listenForSession(sessionName string) (net.Listener, string, *os.File, error
 }
 
 func newSessionWithLogger(name string, scrollbackLines int, logger *charmlog.Logger) *Session {
+	return newSessionWithScrollbackConfigLogger(name, NewScrollbackConfig(scrollbackLines, nil), logger)
+}
+
+func newSessionWithScrollbackConfigLogger(name string, scrollback ScrollbackConfig, logger *charmlog.Logger) *Session {
 	if logger == nil {
 		logger = auditlog.Discard()
 	}
+	scrollback = NewScrollbackConfig(scrollback.DefaultLines, scrollback.HostLines)
 	sess := &Session{
 		Name:               name,
 		startedAt:          time.Now(),
-		scrollbackLines:    scrollbackLines,
+		scrollback:         scrollback,
 		logger:             logger,
 		launchColorProfile: defaultSessionLaunchColorProfile(),
 		clientState:        newClientManager(),
@@ -495,6 +500,13 @@ func newSessionWithLogger(name string, scrollbackLines int, logger *charmlog.Log
 	return sess
 }
 
+func (s *Session) scrollbackLinesForHost(host string) int {
+	if s == nil {
+		return mux.DefaultScrollbackLines
+	}
+	return s.scrollback.LinesForHost(host)
+}
+
 func newSessionWithScrollback(name string, scrollbackLines int) *Session {
 	return newSessionWithLogger(name, scrollbackLines, nil)
 }
@@ -502,6 +514,10 @@ func newSessionWithScrollback(name string, scrollbackLines int) *Session {
 // NewServerWithScrollback creates a new server with an explicit retained
 // scrollback limit for all panes in the session.
 func newServerWithScrollbackLogger(sessionName string, scrollbackLines int, logger *charmlog.Logger) (*Server, error) {
+	return newServerWithScrollbackConfigLogger(sessionName, NewScrollbackConfig(scrollbackLines, nil), logger)
+}
+
+func newServerWithScrollbackConfigLogger(sessionName string, scrollback ScrollbackConfig, logger *charmlog.Logger) (*Server, error) {
 	if logger == nil {
 		logger = auditlog.Discard()
 	}
@@ -511,7 +527,7 @@ func newServerWithScrollbackLogger(sessionName string, scrollbackLines int, logg
 		return nil, err
 	}
 
-	sess := newSessionWithLogger(sessionName, scrollbackLines, logger.With("session", sessionName))
+	sess := newSessionWithScrollbackConfigLogger(sessionName, scrollback, logger.With("session", sessionName))
 
 	s := &Server{
 		listener:     listener,
@@ -534,12 +550,20 @@ func NewServerWithScrollbackLogger(sessionName string, scrollbackLines int, logg
 	return newServerWithScrollbackLogger(sessionName, scrollbackLines, logger)
 }
 
+func NewServerWithScrollbackConfigLogger(sessionName string, scrollback ScrollbackConfig, logger *charmlog.Logger) (*Server, error) {
+	return newServerWithScrollbackConfigLogger(sessionName, scrollback, logger)
+}
+
 func newServerFromCrashCheckpointWithListenerLogger(sessionName string, listener net.Listener, sockPath string, sessionLock *os.File, cp *checkpoint.CrashCheckpoint, crashPath string, scrollbackLines int, logger *charmlog.Logger) (*Server, error) {
+	return newServerFromCrashCheckpointWithScrollbackConfigListenerLogger(sessionName, listener, sockPath, sessionLock, cp, crashPath, NewScrollbackConfig(scrollbackLines, nil), logger)
+}
+
+func newServerFromCrashCheckpointWithScrollbackConfigListenerLogger(sessionName string, listener net.Listener, sockPath string, sessionLock *os.File, cp *checkpoint.CrashCheckpoint, crashPath string, scrollback ScrollbackConfig, logger *charmlog.Logger) (*Server, error) {
 	if logger == nil {
 		logger = auditlog.Discard()
 	}
 	restoreStarted := time.Now()
-	sess := newSessionWithLogger(sessionName, scrollbackLines, logger.With("session", sessionName))
+	sess := newSessionWithScrollbackConfigLogger(sessionName, scrollback, logger.With("session", sessionName))
 	sess.startedAt = cp.Timestamp
 	sess.counter.Store(cp.Counter)
 	sess.windowCounter.Store(cp.WindowCounter)
@@ -568,7 +592,7 @@ func newServerFromCrashCheckpointWithListenerLogger(sessionName string, listener
 			// The remote manager will re-establish the SSH connection.
 			meta := ps.Meta
 			meta.Remote = string(proto.Reconnecting)
-			pane = sess.ownPane(mux.NewProxyPaneWithScrollback(ps.ID, meta, ps.Cols, ps.Rows, sess.scrollbackLines,
+			pane = sess.ownPane(mux.NewProxyPaneWithScrollback(ps.ID, meta, ps.Cols, ps.Rows, sess.scrollbackLinesForHost(meta.Host),
 				onOutput, onExit,
 				sess.remoteWriteOverride(ps.ID),
 			))
@@ -577,7 +601,7 @@ func newServerFromCrashCheckpointWithListenerLogger(sessionName string, listener
 			meta := ps.Meta
 			meta.Dir = ps.Cwd // set cwd for the new shell
 			var newErr error
-			pane, newErr = mux.NewPaneWithScrollback(ps.ID, meta, ps.Cols, ps.Rows, sessionName, sess.scrollbackLines,
+			pane, newErr = mux.NewPaneWithScrollback(ps.ID, meta, ps.Cols, ps.Rows, sessionName, sess.scrollbackLinesForHost(meta.Host),
 				onOutput, onExit,
 			)
 			if newErr != nil {
@@ -659,12 +683,16 @@ func NewServerFromCrashCheckpointWithScrollback(sessionName string, cp *checkpoi
 }
 
 func NewServerFromCrashCheckpointWithScrollbackLogger(sessionName string, cp *checkpoint.CrashCheckpoint, crashPath string, scrollbackLines int, logger *charmlog.Logger) (*Server, error) {
+	return NewServerFromCrashCheckpointWithScrollbackConfigLogger(sessionName, cp, crashPath, NewScrollbackConfig(scrollbackLines, nil), logger)
+}
+
+func NewServerFromCrashCheckpointWithScrollbackConfigLogger(sessionName string, cp *checkpoint.CrashCheckpoint, crashPath string, scrollback ScrollbackConfig, logger *charmlog.Logger) (*Server, error) {
 	listener, sockPath, sessionLock, err := listenForSession(sessionName)
 	if err != nil {
 		return nil, err
 	}
 
-	return newServerFromCrashCheckpointWithListenerLogger(sessionName, listener, sockPath, sessionLock, cp, crashPath, scrollbackLines, logger)
+	return newServerFromCrashCheckpointWithScrollbackConfigListenerLogger(sessionName, listener, sockPath, sessionLock, cp, crashPath, scrollback, logger)
 }
 
 func NewServerFromCrashCheckpointWithListenerFdLogger(sessionName string, listenerFd int, cp *checkpoint.CrashCheckpoint, crashPath string, scrollbackLines int, logger *charmlog.Logger) (*Server, error) {
@@ -672,6 +700,10 @@ func NewServerFromCrashCheckpointWithListenerFdLogger(sessionName string, listen
 }
 
 func NewServerFromCrashCheckpointWithListenerAndLockFdLogger(sessionName string, listenerFd, sessionLockFd int, cp *checkpoint.CrashCheckpoint, crashPath string, scrollbackLines int, logger *charmlog.Logger) (*Server, error) {
+	return NewServerFromCrashCheckpointWithScrollbackConfigListenerAndLockFdLogger(sessionName, listenerFd, sessionLockFd, cp, crashPath, NewScrollbackConfig(scrollbackLines, nil), logger)
+}
+
+func NewServerFromCrashCheckpointWithScrollbackConfigListenerAndLockFdLogger(sessionName string, listenerFd, sessionLockFd int, cp *checkpoint.CrashCheckpoint, crashPath string, scrollback ScrollbackConfig, logger *charmlog.Logger) (*Server, error) {
 	listener, err := restoreListenerFromFD(listenerFd)
 	if err != nil {
 		return nil, fmt.Errorf("restoring listener: %w", err)
@@ -681,7 +713,7 @@ func NewServerFromCrashCheckpointWithListenerAndLockFdLogger(sessionName string,
 		listener.Close()
 		return nil, err
 	}
-	return newServerFromCrashCheckpointWithListenerLogger(sessionName, listener, SocketPath(sessionName), sessionLock, cp, crashPath, scrollbackLines, logger)
+	return newServerFromCrashCheckpointWithScrollbackConfigListenerLogger(sessionName, listener, SocketPath(sessionName), sessionLock, cp, crashPath, scrollback, logger)
 }
 
 // Run accepts client connections in a loop.

--- a/internal/server/session_pane.go
+++ b/internal/server/session_pane.go
@@ -132,7 +132,7 @@ func (s *Session) newLocalPaneBuildRequest(id uint32, meta mux.PaneMeta, cols, r
 		cols:            cols,
 		rows:            rows,
 		sessionName:     s.Name,
-		scrollbackLines: s.scrollbackLines,
+		scrollbackLines: s.scrollbackLinesForHost(meta.Host),
 		colorProfile:    colorProfile,
 		onOutput:        s.paneOutputCallback(),
 		onExit:          s.paneExitCallback(),
@@ -153,7 +153,7 @@ func (s *Session) preparePendingLocalPane(srv *Server, meta mux.PaneMeta, cols, 
 		colorProfile = s.paneLaunchColorProfile(nil)
 	}
 
-	pane, err := mux.NewPendingPaneWithScrollback(id, meta, cols, rows, s.scrollbackLines, s.paneOutputCallback(), s.paneExitCallback())
+	pane, err := mux.NewPendingPaneWithScrollback(id, meta, cols, rows, s.scrollbackLinesForHost(meta.Host), s.paneOutputCallback(), s.paneExitCallback())
 	if err != nil {
 		return nil, localPaneBuildRequest{}, err
 	}
@@ -513,7 +513,7 @@ func (s *Session) prepareRemotePane(hostName string, cols, rows int) (*mux.Pane,
 	}
 
 	// Create the proxy pane with a writeOverride that routes to the remote manager
-	pane := s.ownPane(mux.NewProxyPaneWithScrollback(id, meta, cols, rows, s.scrollbackLines,
+	pane := s.ownPane(mux.NewProxyPaneWithScrollback(id, meta, cols, rows, s.scrollbackLinesForHost(meta.Host),
 		s.paneOutputCallback(),
 		s.paneExitCallback(),
 		s.remoteWriteOverride(id),

--- a/internal/server/session_remote.go
+++ b/internal/server/session_remote.go
@@ -112,7 +112,7 @@ func (s *Session) handleTakeover(sshPaneID uint32, req mux.TakeoverRequest) {
 		}
 
 		// writeOverride routes input through the RemoteManager → SSH → remote amux.
-		proxyPane := s.ownPane(mux.NewProxyPaneWithScrollback(id, meta, layout.cols, mux.PaneContentHeight(layout.cellH), s.scrollbackLines,
+		proxyPane := s.ownPane(mux.NewProxyPaneWithScrollback(id, meta, layout.cols, mux.PaneContentHeight(layout.cellH), s.scrollbackLinesForHost(meta.Host),
 			s.paneOutputCallback(),
 			s.paneExitCallback(),
 			s.remoteWriteOverride(id),

--- a/test/capture_test.go
+++ b/test/capture_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -97,6 +98,40 @@ func TestCapturePaneHistoryJSON(t *testing.T) {
 	}
 	if strings.Join(pane.Content, "\n") == "" {
 		t.Fatal("content should not be empty")
+	}
+}
+
+func TestCaptureHistoryUsesLocalHostScrollbackOverride(t *testing.T) {
+	t.Parallel()
+
+	h := newServerHarnessWithConfig(t, 80, 8, `
+scrollback_lines = 20
+
+[hosts.local]
+type = "local"
+scrollback_lines = 3
+`)
+
+	scriptPath := filepath.Join(os.TempDir(), fmt.Sprintf("amux-local-history-limit-%s.sh", h.session))
+	if err := os.WriteFile(scriptPath, []byte("#!/bin/bash\nfor i in $(seq -w 1 20); do echo \"LOCALHIST-$i\"; done\n"), 0755); err != nil {
+		t.Fatalf("writing history script: %v", err)
+	}
+	t.Cleanup(func() { os.Remove(scriptPath) })
+
+	h.sendKeys("pane-1", scriptPath, "Enter")
+	h.waitFor("pane-1", "LOCALHIST-20")
+
+	out := h.runCmd("capture", "--history", "--format", "json", "pane-1")
+	var pane proto.CapturePane
+	if err := json.Unmarshal([]byte(out), &pane); err != nil {
+		t.Fatalf("json.Unmarshal: %v\noutput:\n%s", err, out)
+	}
+	got := linesWithPrefix(pane.History, "LOCALHIST-")
+	if len(got) != 3 {
+		t.Fatalf("history markers = %#v, want exactly 3 retained host-local lines\nfull history=%#v\ncontent=%#v", got, pane.History, pane.Content)
+	}
+	if slices.Contains(got, "LOCALHIST-01") {
+		t.Fatalf("oldest marker should be trimmed by host-local cap, got %#v", got)
 	}
 }
 


### PR DESCRIPTION
## Motivation

LAB-1593 showed amux at 1.68 GB RSS under host memory pressure, with retained pane history called out as a likely contributor. This PR bounds the per-pane scrollback buffer first so long-running sessions have a configurable memory ceiling before the log rotation and systemd mitigations land.

## Summary

- Lower the built-in retained scrollback default from 10000 to 5000 lines per pane.
- Add `scrollback_lines` to `[hosts.<name>]`, while keeping the top-level `scrollback_lines` as the session default.
- Add a server-side scrollback resolver and use it for local panes, proxy panes, reload restore, and crash restore.
- Update README config examples for global and per-host scrollback limits.
- File LAB-1594 for the out-of-scope missing-shell-binary skipped-pane recovery bug.

Design: the config package resolves global and host-specific limits once at server bootstrap, then passes a normalized `server.ScrollbackConfig` into session construction. Pane creation asks the session for the effective limit using `PaneMeta.Host`; missing or empty hosts fall back to `local`, and unconfigured hosts use the session default.

Recommended landing order for the remaining LAB-1593 mitigations:

1. This PR: cap per-pane scrollback in config.
2. Next PR: rotate `/tmp/amux-${UID}/${session}.log` with a bounded default.
3. Final PR: add the `systemd --user` unit and the operator playbook.

## Testing

Passed:

- `go test -run TestVTEmulatorRespectsScrollbackLimitUnderFlood ./internal/mux -count=100`
- `go test -run 'TestLoadHostScrollbackLines|TestLoadRejectsZeroScrollbackLines|TestEffectiveScrollbackLinesDefaultsWhenUnset' ./internal/config -count=100`
- `go test -run 'TestScrollbackConfig|TestCaptureHistoryUsesLocalHostScrollbackOverride' ./internal/server ./test -timeout 120s -count=100`
- `go test ./internal/server -timeout 120s`
- `go test ./test -timeout 240s`
- `go test -run TestAgentStatusTreatsPromptTimeBashSelfForkAsIdle ./internal/mux -count=5 -timeout 30s -v`

Local verification gaps:

- `go test ./... -timeout 120s` timed out in the large `./test` integration package after 120s; rerunning that package with `-timeout 240s` passed in 164.871s.
- `go test ./... -timeout 240s` later failed once in `internal/mux` on `TestAgentStatusTreatsPromptTimeBashSelfForkAsIdle`; the same test passed 5/5 in isolation.
- `make coverage` did not complete locally. It reported unrelated flakes in `internal/client`, `internal/mux`, and `internal/server`, then the integration package timed out under coverage. It still reached the merge step and reported total statement coverage of 88.4%.

## Review focus

- Confirm the host-specific resolver is threaded through every pane creation/restore path that should respect `PaneMeta.Host`.
- Check whether lowering the default from 10000 to 5000 is the right memory/ergonomics tradeoff.
- Confirm this PR is appropriately scoped as mitigation 1 only, with LAB-1594 left out of scope.

Part of LAB-1593.
