### PR TITLE
LAB-1593: Rotate server logs by size

### DIFF
--- a/internal/auditlog/rotation.go
+++ b/internal/auditlog/rotation.go
@@ -49,9 +49,10 @@ func NewRotatingFileWriter(path string, opts RotationOptions) (io.WriteCloser, e
 }
 
 // InstallProcessLogRotation redirects stdout and stderr through a rotating
-// writer and also returns that writer for synchronous logger writes. It is
-// intended for daemon/server process bootstrap.
-func InstallProcessLogRotation(path string, opts RotationOptions) (io.WriteCloser, func(), error) {
+// writer and also returns a synchronous logger writer. Foreground invocations
+// keep receiving stderr output, but inherited regular log files are not teed
+// because that would recreate the unbounded file this rotation avoids.
+func InstallProcessLogRotation(path string, opts RotationOptions) (io.Writer, func(), error) {
 	writer, err := NewRotatingFileWriter(path, opts)
 	if err != nil {
 		return nil, nil, err
@@ -78,10 +79,16 @@ func InstallProcessLogRotation(path string, opts RotationOptions) (io.WriteClose
 		_ = writer.Close()
 		return nil, nil, err
 	}
+	teeFile := teeFileForFD(oldStderr)
+	logWriter := &lockedWriter{w: writer}
+	if teeFile != nil {
+		logWriter.w = io.MultiWriter(writer, teeFile)
+	}
 
 	if err := unix.Dup2(int(writePipe.Fd()), int(os.Stdout.Fd())); err != nil {
 		_ = unix.Close(oldStdout)
 		_ = unix.Close(oldStderr)
+		closeTeeFile(teeFile)
 		_ = readPipe.Close()
 		_ = writePipe.Close()
 		_ = writer.Close()
@@ -91,6 +98,7 @@ func InstallProcessLogRotation(path string, opts RotationOptions) (io.WriteClose
 		_ = unix.Dup2(oldStdout, int(os.Stdout.Fd()))
 		_ = unix.Close(oldStdout)
 		_ = unix.Close(oldStderr)
+		closeTeeFile(teeFile)
 		_ = readPipe.Close()
 		_ = writePipe.Close()
 		_ = writer.Close()
@@ -99,7 +107,7 @@ func InstallProcessLogRotation(path string, opts RotationOptions) (io.WriteClose
 
 	done := make(chan struct{})
 	go func() {
-		_, _ = io.Copy(writer, readPipe)
+		_, _ = io.Copy(logWriter, readPipe)
 		_ = readPipe.Close()
 		close(done)
 	}()
@@ -114,9 +122,42 @@ func InstallProcessLogRotation(path string, opts RotationOptions) (io.WriteClose
 			_ = writePipe.Close()
 			<-done
 			_ = writer.Close()
+			closeTeeFile(teeFile)
 		})
 	}
-	return writer, cleanup, nil
+	return logWriter, cleanup, nil
+}
+
+type lockedWriter struct {
+	mu sync.Mutex
+	w  io.Writer
+}
+
+func (w *lockedWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.w.Write(p)
+}
+
+func teeFileForFD(fd int) *os.File {
+	var stat unix.Stat_t
+	if err := unix.Fstat(fd, &stat); err != nil {
+		return nil
+	}
+	if stat.Mode&unix.S_IFMT == unix.S_IFREG {
+		return nil
+	}
+	teeFD, err := unix.Dup(fd)
+	if err != nil {
+		return nil
+	}
+	return os.NewFile(uintptr(teeFD), "amux-log-stderr")
+}
+
+func closeTeeFile(file *os.File) {
+	if file != nil {
+		_ = file.Close()
+	}
 }
 
 type rotatingFileWriter struct {

--- a/internal/auditlog/rotation.go
+++ b/internal/auditlog/rotation.go
@@ -1,0 +1,258 @@
+package auditlog
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"golang.org/x/sys/unix"
+)
+
+const (
+	defaultMaxLogBytes = 20 << 20
+	defaultLogBackups  = 4
+)
+
+// RotationOptions controls size-based log rotation.
+type RotationOptions struct {
+	MaxBytes   int64
+	MaxBackups int
+}
+
+// DefaultRotationOptions keeps the active log plus four backups bounded to
+// roughly 100 MiB total.
+func DefaultRotationOptions() RotationOptions {
+	return RotationOptions{
+		MaxBytes:   defaultMaxLogBytes,
+		MaxBackups: defaultLogBackups,
+	}
+}
+
+// NewRotatingFileWriter opens path for append and rotates it by size.
+func NewRotatingFileWriter(path string, opts RotationOptions) (io.WriteCloser, error) {
+	opts = normalizeRotationOptions(opts)
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return nil, err
+	}
+
+	w := &rotatingFileWriter{
+		path:       path,
+		maxBytes:   opts.MaxBytes,
+		maxBackups: opts.MaxBackups,
+	}
+	if err := w.open(); err != nil {
+		return nil, err
+	}
+	return w, nil
+}
+
+// InstallProcessLogRotation redirects stdout and stderr through a rotating
+// writer and also returns that writer for synchronous logger writes. It is
+// intended for daemon/server process bootstrap.
+func InstallProcessLogRotation(path string, opts RotationOptions) (io.WriteCloser, func(), error) {
+	writer, err := NewRotatingFileWriter(path, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	readPipe, writePipe, err := os.Pipe()
+	if err != nil {
+		_ = writer.Close()
+		return nil, nil, err
+	}
+
+	oldStdout, err := unix.Dup(int(os.Stdout.Fd()))
+	if err != nil {
+		_ = readPipe.Close()
+		_ = writePipe.Close()
+		_ = writer.Close()
+		return nil, nil, err
+	}
+	oldStderr, err := unix.Dup(int(os.Stderr.Fd()))
+	if err != nil {
+		_ = unix.Close(oldStdout)
+		_ = readPipe.Close()
+		_ = writePipe.Close()
+		_ = writer.Close()
+		return nil, nil, err
+	}
+
+	if err := unix.Dup2(int(writePipe.Fd()), int(os.Stdout.Fd())); err != nil {
+		_ = unix.Close(oldStdout)
+		_ = unix.Close(oldStderr)
+		_ = readPipe.Close()
+		_ = writePipe.Close()
+		_ = writer.Close()
+		return nil, nil, err
+	}
+	if err := unix.Dup2(int(writePipe.Fd()), int(os.Stderr.Fd())); err != nil {
+		_ = unix.Dup2(oldStdout, int(os.Stdout.Fd()))
+		_ = unix.Close(oldStdout)
+		_ = unix.Close(oldStderr)
+		_ = readPipe.Close()
+		_ = writePipe.Close()
+		_ = writer.Close()
+		return nil, nil, err
+	}
+
+	done := make(chan struct{})
+	go func() {
+		_, _ = io.Copy(writer, readPipe)
+		_ = readPipe.Close()
+		close(done)
+	}()
+
+	var once sync.Once
+	cleanup := func() {
+		once.Do(func() {
+			_ = unix.Dup2(oldStdout, int(os.Stdout.Fd()))
+			_ = unix.Dup2(oldStderr, int(os.Stderr.Fd()))
+			_ = unix.Close(oldStdout)
+			_ = unix.Close(oldStderr)
+			_ = writePipe.Close()
+			<-done
+			_ = writer.Close()
+		})
+	}
+	return writer, cleanup, nil
+}
+
+type rotatingFileWriter struct {
+	mu         sync.Mutex
+	path       string
+	maxBytes   int64
+	maxBackups int
+	file       *os.File
+	size       int64
+}
+
+func normalizeRotationOptions(opts RotationOptions) RotationOptions {
+	if opts.MaxBytes <= 0 {
+		opts.MaxBytes = defaultMaxLogBytes
+	}
+	if opts.MaxBackups < 0 {
+		opts.MaxBackups = defaultLogBackups
+	}
+	return opts
+}
+
+func (w *rotatingFileWriter) open() error {
+	file, err := os.OpenFile(w.path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		return err
+	}
+	info, err := file.Stat()
+	if err != nil {
+		_ = file.Close()
+		return err
+	}
+	w.file = file
+	w.size = info.Size()
+	if w.size >= w.maxBytes {
+		return w.rotate()
+	}
+	return nil
+}
+
+func (w *rotatingFileWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	written := 0
+	for len(p) > 0 {
+		if w.file == nil {
+			return written, os.ErrClosed
+		}
+		if w.size >= w.maxBytes {
+			if err := w.rotate(); err != nil {
+				return written, err
+			}
+		}
+		space := w.maxBytes - w.size
+		if space <= 0 {
+			if err := w.rotate(); err != nil {
+				return written, err
+			}
+			space = w.maxBytes
+		}
+
+		chunk := len(p)
+		if int64(chunk) > space {
+			chunk = int(space)
+		}
+		n, err := w.file.Write(p[:chunk])
+		w.size += int64(n)
+		written += n
+		p = p[n:]
+		if err != nil {
+			return written, err
+		}
+		if n == 0 {
+			return written, io.ErrShortWrite
+		}
+	}
+	return written, nil
+}
+
+func (w *rotatingFileWriter) Close() error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if w.file == nil {
+		return nil
+	}
+	err := w.file.Close()
+	w.file = nil
+	return err
+}
+
+func (w *rotatingFileWriter) rotate() error {
+	if w.file != nil {
+		if err := w.file.Close(); err != nil {
+			return err
+		}
+		w.file = nil
+	}
+
+	if w.maxBackups <= 0 {
+		if err := os.Remove(w.path); err != nil && !os.IsNotExist(err) {
+			return err
+		}
+	} else {
+		oldest := backupPath(w.path, w.maxBackups)
+		if err := os.Remove(oldest); err != nil && !os.IsNotExist(err) {
+			return err
+		}
+		for i := w.maxBackups - 1; i >= 1; i-- {
+			src := backupPath(w.path, i)
+			dst := backupPath(w.path, i+1)
+			if err := renameIfExists(src, dst); err != nil {
+				return err
+			}
+		}
+		if err := renameIfExists(w.path, backupPath(w.path, 1)); err != nil {
+			return err
+		}
+	}
+
+	file, err := os.OpenFile(w.path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
+	if err != nil {
+		return err
+	}
+	w.file = file
+	w.size = 0
+	return nil
+}
+
+func backupPath(path string, n int) string {
+	return fmt.Sprintf("%s.%d", path, n)
+}
+
+func renameIfExists(src, dst string) error {
+	if err := os.Rename(src, dst); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}

--- a/internal/auditlog/rotation.go
+++ b/internal/auditlog/rotation.go
@@ -48,79 +48,25 @@ func NewRotatingFileWriter(path string, opts RotationOptions) (io.WriteCloser, e
 	return w, nil
 }
 
-// InstallProcessLogRotation redirects stdout and stderr through a rotating
-// writer and also returns a synchronous logger writer. Foreground invocations
-// keep receiving stderr output, but inherited regular log files are not teed
-// because that would recreate the unbounded file this rotation avoids.
+// InstallProcessLogRotation returns a synchronous logger writer backed by a
+// rotating file. Foreground invocations keep receiving stderr output, but
+// inherited regular log files are not teed because that would recreate the
+// unbounded file this rotation avoids.
 func InstallProcessLogRotation(path string, opts RotationOptions) (io.Writer, func(), error) {
 	writer, err := NewRotatingFileWriter(path, opts)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	readPipe, writePipe, err := os.Pipe()
-	if err != nil {
-		_ = writer.Close()
-		return nil, nil, err
-	}
-
-	oldStdout, err := unix.Dup(int(os.Stdout.Fd()))
-	if err != nil {
-		_ = readPipe.Close()
-		_ = writePipe.Close()
-		_ = writer.Close()
-		return nil, nil, err
-	}
-	oldStderr, err := unix.Dup(int(os.Stderr.Fd()))
-	if err != nil {
-		_ = unix.Close(oldStdout)
-		_ = readPipe.Close()
-		_ = writePipe.Close()
-		_ = writer.Close()
-		return nil, nil, err
-	}
-	teeFile := teeFileForFD(oldStderr)
+	teeFile := teeFileForFD(int(os.Stderr.Fd()))
 	logWriter := &lockedWriter{w: writer}
 	if teeFile != nil {
 		logWriter.w = io.MultiWriter(writer, teeFile)
 	}
 
-	if err := unix.Dup2(int(writePipe.Fd()), int(os.Stdout.Fd())); err != nil {
-		_ = unix.Close(oldStdout)
-		_ = unix.Close(oldStderr)
-		closeTeeFile(teeFile)
-		_ = readPipe.Close()
-		_ = writePipe.Close()
-		_ = writer.Close()
-		return nil, nil, err
-	}
-	if err := unix.Dup2(int(writePipe.Fd()), int(os.Stderr.Fd())); err != nil {
-		_ = unix.Dup2(oldStdout, int(os.Stdout.Fd()))
-		_ = unix.Close(oldStdout)
-		_ = unix.Close(oldStderr)
-		closeTeeFile(teeFile)
-		_ = readPipe.Close()
-		_ = writePipe.Close()
-		_ = writer.Close()
-		return nil, nil, err
-	}
-
-	done := make(chan struct{})
-	go func() {
-		_, _ = io.Copy(logWriter, readPipe)
-		_ = readPipe.Close()
-		close(done)
-	}()
-
 	var once sync.Once
 	cleanup := func() {
 		once.Do(func() {
-			_ = unix.Dup2(oldStdout, int(os.Stdout.Fd()))
-			_ = unix.Dup2(oldStderr, int(os.Stderr.Fd()))
-			_ = unix.Close(oldStdout)
-			_ = unix.Close(oldStderr)
-			_ = writePipe.Close()
-			<-done
 			_ = writer.Close()
 			closeTeeFile(teeFile)
 		})

--- a/internal/auditlog/rotation_test.go
+++ b/internal/auditlog/rotation_test.go
@@ -21,6 +21,34 @@ func TestDefaultRotationOptionsBoundsTotalToHundredMiB(t *testing.T) {
 	}
 }
 
+func TestRotationOptionsNormalizeDefaults(t *testing.T) {
+	t.Parallel()
+
+	opts := normalizeRotationOptions(RotationOptions{MaxBackups: -1})
+	if opts.MaxBytes != defaultMaxLogBytes {
+		t.Fatalf("MaxBytes = %d, want default %d", opts.MaxBytes, defaultMaxLogBytes)
+	}
+	if opts.MaxBackups != defaultLogBackups {
+		t.Fatalf("MaxBackups = %d, want default %d", opts.MaxBackups, defaultLogBackups)
+	}
+}
+
+func TestNewRotatingFileWriterReportsPathErrors(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	parentFile := filepath.Join(dir, "not-a-dir")
+	if err := os.WriteFile(parentFile, []byte("x"), 0o600); err != nil {
+		t.Fatalf("WriteFile parent: %v", err)
+	}
+	if _, err := NewRotatingFileWriter(filepath.Join(parentFile, "main.log"), RotationOptions{MaxBytes: 8}); err == nil {
+		t.Fatal("NewRotatingFileWriter with file parent error = nil, want error")
+	}
+	if _, err := NewRotatingFileWriter(dir, RotationOptions{MaxBytes: 8}); err == nil {
+		t.Fatal("NewRotatingFileWriter with directory path error = nil, want error")
+	}
+}
+
 func TestRotatingFileWriterBoundsTotalLogBytes(t *testing.T) {
 	t.Parallel()
 
@@ -49,6 +77,63 @@ func TestRotatingFileWriterBoundsTotalLogBytes(t *testing.T) {
 	}
 	if _, err := os.Stat(logPath + ".3"); !os.IsNotExist(err) {
 		t.Fatalf("unexpected third backup stat error = %v", err)
+	}
+}
+
+func TestRotatingFileWriterReportsBackupRemoveError(t *testing.T) {
+	t.Parallel()
+
+	logPath := filepath.Join(t.TempDir(), "main.log")
+	w, err := NewRotatingFileWriter(logPath, RotationOptions{
+		MaxBytes:   4,
+		MaxBackups: 1,
+	})
+	if err != nil {
+		t.Fatalf("NewRotatingFileWriter: %v", err)
+	}
+	backupDir := logPath + ".1"
+	if err := os.Mkdir(backupDir, 0o700); err != nil {
+		t.Fatalf("Mkdir backup dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(backupDir, "child"), []byte("x"), 0o600); err != nil {
+		t.Fatalf("WriteFile backup child: %v", err)
+	}
+
+	if _, err := w.Write([]byte("12345")); err == nil {
+		t.Fatal("Write rotating over non-empty backup dir error = nil, want error")
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+}
+
+func TestRotatingFileWriterReportsRenameError(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "main.log")
+	w, err := NewRotatingFileWriter(logPath, RotationOptions{
+		MaxBytes:   4,
+		MaxBackups: 2,
+	})
+	if err != nil {
+		t.Fatalf("NewRotatingFileWriter: %v", err)
+	}
+	if err := os.WriteFile(logPath+".1", []byte("old"), 0o600); err != nil {
+		t.Fatalf("WriteFile backup: %v", err)
+	}
+	if err := os.Chmod(dir, 0o500); err != nil {
+		t.Fatalf("Chmod read-only dir: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chmod(dir, 0o700)
+	})
+
+	if _, err := w.Write([]byte("12345")); err == nil {
+		t.Fatal("Write rotating in read-only dir error = nil, want error")
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
 	}
 }
 
@@ -176,6 +261,16 @@ func TestInstallProcessLogRotationDoesNotTeeRegularStderr(t *testing.T) {
 	if len(data) != 0 {
 		t.Fatalf("regular stderr duplicate = %q, want empty", data)
 	}
+}
+
+func TestTeeFileForFDInvalidFD(t *testing.T) {
+	t.Parallel()
+
+	if file := teeFileForFD(-1); file != nil {
+		_ = file.Close()
+		t.Fatalf("teeFileForFD(-1) = %v, want nil", file)
+	}
+	closeTeeFile(nil)
 }
 
 func totalRegularFileSize(t *testing.T, paths ...string) int64 {

--- a/internal/auditlog/rotation_test.go
+++ b/internal/auditlog/rotation_test.go
@@ -1,0 +1,59 @@
+package auditlog
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRotatingFileWriterBoundsTotalLogBytes(t *testing.T) {
+	t.Parallel()
+
+	logPath := filepath.Join(t.TempDir(), "main.log")
+	const maxBytes int64 = 12
+	w, err := NewRotatingFileWriter(logPath, RotationOptions{
+		MaxBytes:   maxBytes,
+		MaxBackups: 2,
+	})
+	if err != nil {
+		t.Fatalf("NewRotatingFileWriter: %v", err)
+	}
+
+	for i := 0; i < 8; i++ {
+		if _, err := fmt.Fprintf(w, "entry-%02d\n", i); err != nil {
+			t.Fatalf("Write entry %d: %v", i, err)
+		}
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	total := totalRegularFileSize(t, logPath, logPath+".1", logPath+".2")
+	if total > maxBytes*3 {
+		t.Fatalf("total rotated log size = %d, want <= %d", total, maxBytes*3)
+	}
+	if _, err := os.Stat(logPath + ".3"); !os.IsNotExist(err) {
+		t.Fatalf("unexpected third backup stat error = %v", err)
+	}
+}
+
+func totalRegularFileSize(t *testing.T, paths ...string) int64 {
+	t.Helper()
+
+	var total int64
+	for _, path := range paths {
+		info, err := os.Stat(path)
+		if os.IsNotExist(err) {
+			continue
+		}
+		if err != nil {
+			t.Fatalf("Stat(%q): %v", path, err)
+		}
+		if !info.Mode().IsRegular() {
+			t.Fatalf("%q mode = %s, want regular file", path, info.Mode())
+		}
+		total += info.Size()
+	}
+	return total
+}

--- a/internal/auditlog/rotation_test.go
+++ b/internal/auditlog/rotation_test.go
@@ -2,10 +2,23 @@ package auditlog
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+
+	"golang.org/x/sys/unix"
 )
+
+func TestDefaultRotationOptionsBoundsTotalToHundredMiB(t *testing.T) {
+	t.Parallel()
+
+	opts := DefaultRotationOptions()
+	if got, want := opts.MaxBytes*int64(opts.MaxBackups+1), int64(100<<20); got != want {
+		t.Fatalf("default total log budget = %d, want %d", got, want)
+	}
+}
 
 func TestRotatingFileWriterBoundsTotalLogBytes(t *testing.T) {
 	t.Parallel()
@@ -38,6 +51,130 @@ func TestRotatingFileWriterBoundsTotalLogBytes(t *testing.T) {
 	}
 }
 
+func TestRotatingFileWriterRotatesExistingOversizedLog(t *testing.T) {
+	t.Parallel()
+
+	logPath := filepath.Join(t.TempDir(), "main.log")
+	if err := os.WriteFile(logPath, []byte("existing-log"), 0o600); err != nil {
+		t.Fatalf("WriteFile existing log: %v", err)
+	}
+
+	w, err := NewRotatingFileWriter(logPath, RotationOptions{
+		MaxBytes:   8,
+		MaxBackups: 1,
+	})
+	if err != nil {
+		t.Fatalf("NewRotatingFileWriter: %v", err)
+	}
+	if _, err := w.Write([]byte("new\n")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	assertFileContains(t, logPath, "new\n")
+	assertFileContains(t, logPath+".1", "existing-log")
+}
+
+func TestRotatingFileWriterWithNoBackupsKeepsOnlyActiveLog(t *testing.T) {
+	t.Parallel()
+
+	logPath := filepath.Join(t.TempDir(), "main.log")
+	w, err := NewRotatingFileWriter(logPath, RotationOptions{
+		MaxBytes:   5,
+		MaxBackups: 0,
+	})
+	if err != nil {
+		t.Fatalf("NewRotatingFileWriter: %v", err)
+	}
+	if _, err := w.Write([]byte("abcdefghi")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	if total := totalRegularFileSize(t, logPath); total > 5 {
+		t.Fatalf("active log size = %d, want <= 5", total)
+	}
+	if _, err := os.Stat(logPath + ".1"); !os.IsNotExist(err) {
+		t.Fatalf("unexpected backup stat error = %v", err)
+	}
+}
+
+func TestRotatingFileWriterRejectsWriteAfterClose(t *testing.T) {
+	t.Parallel()
+
+	logPath := filepath.Join(t.TempDir(), "main.log")
+	w, err := NewRotatingFileWriter(logPath, RotationOptions{MaxBytes: 8})
+	if err != nil {
+		t.Fatalf("NewRotatingFileWriter: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("second Close: %v", err)
+	}
+	if _, err := w.Write([]byte("after close")); !os.IsNotExist(err) && err != os.ErrClosed {
+		t.Fatalf("Write after Close error = %v, want os.ErrClosed", err)
+	}
+}
+
+func TestInstallProcessLogRotationWritesFileAndForegroundStderr(t *testing.T) {
+	logPath := filepath.Join(t.TempDir(), "main.log")
+	readPipe, writePipe, restore := redirectStderrToPipe(t)
+	defer readPipe.Close()
+	defer writePipe.Close()
+	defer restore()
+
+	writer, cleanup, err := InstallProcessLogRotation(logPath, RotationOptions{MaxBytes: 128, MaxBackups: 1})
+	if err != nil {
+		t.Fatalf("InstallProcessLogRotation: %v", err)
+	}
+	if _, err := writer.Write([]byte("foreground log\n")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	cleanup()
+	restore()
+	writePipe.Close()
+
+	tee, err := io.ReadAll(readPipe)
+	if err != nil {
+		t.Fatalf("ReadAll tee: %v", err)
+	}
+	if !strings.Contains(string(tee), "foreground log") {
+		t.Fatalf("foreground stderr tee = %q, want log line", tee)
+	}
+	assertFileContains(t, logPath, "foreground log")
+}
+
+func TestInstallProcessLogRotationDoesNotTeeRegularStderr(t *testing.T) {
+	logPath := filepath.Join(t.TempDir(), "main.log")
+	stderrPath, restore := redirectStderrToRegularFile(t)
+	defer restore()
+
+	writer, cleanup, err := InstallProcessLogRotation(logPath, RotationOptions{MaxBytes: 128, MaxBackups: 1})
+	if err != nil {
+		t.Fatalf("InstallProcessLogRotation: %v", err)
+	}
+	if _, err := writer.Write([]byte("daemon log\n")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	cleanup()
+	restore()
+
+	assertFileContains(t, logPath, "daemon log")
+	data, err := os.ReadFile(stderrPath)
+	if err != nil {
+		t.Fatalf("ReadFile stderr: %v", err)
+	}
+	if len(data) != 0 {
+		t.Fatalf("regular stderr duplicate = %q, want empty", data)
+	}
+}
+
 func totalRegularFileSize(t *testing.T, paths ...string) int64 {
 	t.Helper()
 
@@ -56,4 +193,77 @@ func totalRegularFileSize(t *testing.T, paths ...string) int64 {
 		total += info.Size()
 	}
 	return total
+}
+
+func assertFileContains(t *testing.T, path, want string) {
+	t.Helper()
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(%q): %v", path, err)
+	}
+	if !strings.Contains(string(data), want) {
+		t.Fatalf("%q = %q, want substring %q", path, data, want)
+	}
+}
+
+func redirectStderrToPipe(t *testing.T) (*os.File, *os.File, func()) {
+	t.Helper()
+
+	readPipe, writePipe, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	restore := redirectStderrToFile(t, writePipe)
+	return readPipe, writePipe, restore
+}
+
+func redirectStderrToRegularFile(t *testing.T) (string, func()) {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "stderr.log")
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR|os.O_TRUNC, 0o600)
+	if err != nil {
+		t.Fatalf("OpenFile stderr: %v", err)
+	}
+	restore := redirectStderrToFile(t, file)
+	var closed bool
+	return path, func() {
+		if closed {
+			return
+		}
+		closed = true
+		restore()
+		if err := file.Close(); err != nil {
+			t.Fatalf("Close stderr file: %v", err)
+		}
+	}
+}
+
+func redirectStderrToFile(t *testing.T, file *os.File) func() {
+	t.Helper()
+
+	oldStderr, err := unix.Dup(int(os.Stderr.Fd()))
+	if err != nil {
+		t.Fatalf("Dup stderr: %v", err)
+	}
+	if err := unix.Dup2(int(file.Fd()), int(os.Stderr.Fd())); err != nil {
+		_ = unix.Close(oldStderr)
+		t.Fatalf("Dup2 stderr: %v", err)
+	}
+
+	var restored bool
+	return func() {
+		if restored {
+			return
+		}
+		restored = true
+		if err := unix.Dup2(oldStderr, int(os.Stderr.Fd())); err != nil {
+			_ = unix.Close(oldStderr)
+			t.Fatalf("restore stderr: %v", err)
+		}
+		if err := unix.Close(oldStderr); err != nil {
+			t.Fatalf("close old stderr: %v", err)
+		}
+	}
 }

--- a/internal/auditlog/rotation_test.go
+++ b/internal/auditlog/rotation_test.go
@@ -1,6 +1,7 @@
 package auditlog
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -117,7 +118,7 @@ func TestRotatingFileWriterRejectsWriteAfterClose(t *testing.T) {
 	if err := w.Close(); err != nil {
 		t.Fatalf("second Close: %v", err)
 	}
-	if _, err := w.Write([]byte("after close")); !os.IsNotExist(err) && err != os.ErrClosed {
+	if _, err := w.Write([]byte("after close")); !errors.Is(err, os.ErrClosed) {
 		t.Fatalf("Write after Close error = %v, want os.ErrClosed", err)
 	}
 }

--- a/internal/auditlog/rotation_test.go
+++ b/internal/auditlog/rotation_test.go
@@ -124,6 +124,7 @@ func TestRotatingFileWriterRejectsWriteAfterClose(t *testing.T) {
 }
 
 func TestInstallProcessLogRotationWritesFileAndForegroundStderr(t *testing.T) {
+	// Not parallel: redirects the process-global stderr file descriptor.
 	logPath := filepath.Join(t.TempDir(), "main.log")
 	readPipe, writePipe, restore := redirectStderrToPipe(t)
 	defer readPipe.Close()
@@ -152,6 +153,7 @@ func TestInstallProcessLogRotationWritesFileAndForegroundStderr(t *testing.T) {
 }
 
 func TestInstallProcessLogRotationDoesNotTeeRegularStderr(t *testing.T) {
+	// Not parallel: redirects the process-global stderr file descriptor.
 	logPath := filepath.Join(t.TempDir(), "main.log")
 	stderrPath, restore := redirectStderrToRegularFile(t)
 	defer restore()

--- a/internal/cli/main_reload_test.go
+++ b/internal/cli/main_reload_test.go
@@ -55,6 +55,12 @@ func TestPrependReloadExecPathArgLeavesArgsUnchangedOnResolverError(t *testing.T
 func TestMainCheckpointReloadStartsServerWithoutSubcommand(t *testing.T) {
 	t.Parallel()
 
+	session := hermeticMainSession(t.Name())
+	logPath := filepath.Join(server.SocketDir(), session+".log")
+	t.Cleanup(func() {
+		_ = os.Remove(logPath)
+	})
+
 	cmd := newHermeticMainCmd(t)
 	cmd.Env = append(cmd.Env, "AMUX_CHECKPOINT=/definitely/missing")
 
@@ -64,7 +70,8 @@ func TestMainCheckpointReloadStartsServerWithoutSubcommand(t *testing.T) {
 		t.Fatalf("exit code = %d, want 1\n%s", exitErr.ExitCode(), out)
 	}
 
-	output := string(out)
+	logData, _ := os.ReadFile(logPath)
+	output := string(out) + string(logData)
 	if !strings.Contains(output, `"event":"checkpoint_restore"`) || !strings.Contains(output, `"msg":"reading reload checkpoint failed"`) {
 		t.Fatalf("expected checkpoint reload to route into server startup, got:\n%s", output)
 	}

--- a/internal/cli/server_bootstrap.go
+++ b/internal/cli/server_bootstrap.go
@@ -3,8 +3,10 @@ package cli
 import (
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"syscall"
@@ -24,12 +26,24 @@ import (
 )
 
 func newBootstrapLogger() *charmlog.Logger {
-	return auditlog.New(os.Stderr, auditlog.Options{
+	return newBootstrapLoggerWithWriter(os.Stderr)
+}
+
+func newBootstrapLoggerWithWriter(w io.Writer) *charmlog.Logger {
+	if w == nil {
+		w = os.Stderr
+	}
+	return auditlog.New(w, auditlog.Options{
 		Format:          auditlog.FormatAuto,
 		Level:           charmlog.InfoLevel,
 		Prefix:          "amux",
 		ReportTimestamp: true,
 	})
+}
+
+func installServerLogRotation(sessionName string) (io.Writer, func(), error) {
+	logPath := filepath.Join(server.SocketDir(), sessionName+".log")
+	return auditlog.InstallProcessLogRotation(logPath, auditlog.DefaultRotationOptions())
 }
 
 func exitBootstrapError(logger *charmlog.Logger, sessionName, msg string, err error) {
@@ -112,7 +126,18 @@ func restoreServerFromReloadCheckpointLogger(sessionName, cpPath string, scrollb
 
 func RunServer(sessionName string, managedTakeover bool, buildVersion string) {
 	server.BuildVersion = buildVersion
-	logger := newBootstrapLogger()
+	logWriter, cleanupLogRotation, logRotationErr := installServerLogRotation(sessionName)
+	if cleanupLogRotation != nil {
+		defer cleanupLogRotation()
+	}
+	logger := newBootstrapLoggerWithWriter(logWriter)
+	if logRotationErr != nil {
+		logger.Warn("log rotation unavailable; using inherited stderr",
+			"event", "log_rotation",
+			"session", sessionName,
+			"error", logRotationErr,
+		)
+	}
 
 	if err := terminfo.Install(); err != nil {
 		exitBootstrapError(logger, sessionName, "server bootstrap failed", err)

--- a/internal/cli/server_bootstrap_audit_test.go
+++ b/internal/cli/server_bootstrap_audit_test.go
@@ -135,7 +135,8 @@ func TestServerBootstrapLogsServerStart(t *testing.T) {
 		t.Fatalf("cmd.Wait(): %v\noutput:\n%s", err, out.String())
 	}
 
-	output := out.String()
+	logData, _ := os.ReadFile(filepath.Join(server.SocketDir(), session+".log"))
+	output := out.String() + string(logData)
 	if !strings.Contains(output, `"event":"server_start"`) {
 		t.Fatalf("output missing server_start event:\n%s", output)
 	}


### PR DESCRIPTION
## Motivation
LAB-1593 showed `/tmp/amux-${UID}/main.log` growing to 1.3 GB during the OOM incident. The server audit log should be bounded by default so host memory or disk pressure is not amplified by unbounded session logs.

## Summary
- Add a built-in size-based rotating writer in `internal/auditlog`.
- Install it during server bootstrap for `/tmp/amux-${UID}/${session}.log`.
- Keep the active log at 20 MiB with four backups, targeting about 100 MiB total.
- Tee foreground `_server` stderr only when stderr is not an inherited regular log file, so tests and manual foreground runs still show structured failures without duplicating daemon logs.

Design / justification: I chose built-in rotation instead of a `logrotate(8)` snippet because amux already owns server bootstrap and this makes the default bounded on every launch path, including systemd user units, shell-started daemons, and integration tests. This PR should land after #744 and before the systemd / operations playbook PR.

## Testing
- `go test ./internal/auditlog -run TestRotatingFileWriterBoundsTotalLogBytes -count=100`
- `go test ./internal/cli -run 'TestMainCheckpointReloadStartsServerWithoutSubcommand|TestServerBootstrapLogsServerStart' -count=100`
- `go test ./internal/cli ./internal/auditlog ./test -run 'TestRotatingFileWriterBoundsTotalLogBytes|TestMainCheckpointReloadStartsServerWithoutSubcommand|TestServerBootstrapLogsServerStart|TestServerBootstrapFailsWithoutTic|TestSessionLockSurvivesHotReload|TestServerReloadPreservesHistoryCapture' -timeout 180s`
- `go test ./test -run TestSwapBackward -count=20 -timeout 120s`
- `go test ./test -run TestEventsIdleBusyTransition -count=20 -timeout 120s`
- `go test ./... -timeout 120s` failed locally only in the large `./test` integration package due a 120s suite timeout; all unit packages passed before the timeout.
- `go test ./test -timeout 240s` failed locally on `TestEventsIdleBusyTransition`; the same test passed 20/20 in isolation.
- `make coverage` failed locally on the pre-existing `TestAgentStatusTreatsPromptTimeBashSelfForkAsIdle` flake and then the integration coverage run timed out at 5m; it still merged coverage and reported 86.9% total.

## Review focus
- Rotation boundary behavior in `internal/auditlog/rotation.go`.
- The choice to avoid pipe-backed stdout/stderr redirection because hot reload exec must not inherit dead pipe FDs.
- Whether 20 MiB active plus four backups is the right default for the 100 MB target.

Part of LAB-1593.
Follow-up for the missing-shell crash-recovery skipped-pane bug: LAB-1594 (https://linear.app/weill-labs/issue/LAB-1594/amux-crash-recovery-skips-pane-when-saved-shell-path-is-missing).