### PR TITLE
LAB-1593: Add systemd unit and operations playbook

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1,0 +1,129 @@
+# amux Operations
+
+This guide covers the Linux operating procedures for keeping long-running amux
+servers recoverable under host memory pressure.
+
+## systemd User Service
+
+The user-scoped unit in `packaging/systemd/amux@.service` runs one amux server
+per named session. The instance name becomes the amux session name, so
+`amux@main.service` starts `amux _server main`.
+
+Install it for the current user:
+
+```bash
+mkdir -p ~/.config/systemd/user
+cp packaging/systemd/amux@.service ~/.config/systemd/user/
+systemctl --user daemon-reload
+systemctl --user enable --now amux@main.service
+systemctl --user status amux@main.service
+```
+
+The unit sets `OOMScoreAdjust=-500`, `MemoryHigh=2G`, `MemoryMax=4G`,
+`Restart=on-failure`, and `RestartSec=2s`. It uses `/usr/bin/env amux` with a
+PATH that includes `~/.local/bin`, which matches the default `make install` and
+release installer location. If amux is installed somewhere else, add a user
+drop-in that adjusts `PATH` or `ExecStart`.
+
+Useful commands:
+
+```bash
+journalctl --user -u amux@main.service -f
+systemctl --user restart amux@main.service
+systemctl --user disable --now amux@main.service
+loginctl enable-linger "$USER"
+```
+
+Only enable linger when the server should keep running after the user logs out.
+
+## Diagnose An OOM Outage
+
+When amux disappears under host memory pressure, start with the kernel log:
+
+```bash
+sudo grep -E 'Out of memory|oom-reaper|oom-invocation' /var/log/kern.log
+```
+
+If the distro does not write `/var/log/kern.log`, use the kernel journal:
+
+```bash
+sudo journalctl -k -g 'Out of memory|oom-reaper|oom-invocation'
+```
+
+Look for a sequence that names `amux` in the killed process line and then an
+`oom-reaper` line for the same pid. Useful surrounding evidence includes the
+server log and the newest crash checkpoint:
+
+```bash
+ls -lh /tmp/amux-$(id -u)/main.log*
+ls -lt ~/.local/state/amux/*_main.json
+```
+
+The server log should include `checkpoint_kind:"crash"` records for successful
+crash checkpoint writes and restore attempts. If the systemd unit is installed,
+also check the unit restart and memory status:
+
+```bash
+systemctl --user status amux@main.service
+journalctl --user -u amux@main.service --since '1 hour ago'
+```
+
+## Crash Checkpoint Recovery
+
+amux maintains two recovery paths:
+
+- Hot reload uses `internal/reload/reload.go` to watch the installed binary.
+  When the binary changes, the server writes a durable crash checkpoint, writes
+  a reload checkpoint with live file descriptors, clears close-on-exec on those
+  descriptors, and execs the new binary.
+- Crash recovery uses JSON checkpoints under `~/.local/state/amux/`. The
+  checkpoint coordinator writes them on a debounce, periodically, and during
+  shutdown. The audit log records these writes as `checkpoint_kind:"crash"`.
+
+After an OOM kill, the next `amux` attach or `systemd --user` restart checks for
+a stale or missing socket plus a crash checkpoint. Local panes cannot keep their
+old process ids or PTY file descriptors after the server process dies, so crash
+recovery starts fresh shells, restores pane metadata, retained history, and the
+last visible screen. If a pane had a foreground process at crash time, amux adds
+an `amux: previous process lost during crash recovery` notice and archives the
+pre-crash screen in history. Proxy panes are restored in reconnecting state so
+the remote transport can re-establish the connection.
+
+For a manual recovery check:
+
+```bash
+amux wait checkpoint
+amux capture --format json
+grep -E '"event":"checkpoint_(write|restore)"|"checkpoint_kind":"crash"' /tmp/amux-$(id -u)/main.log*
+```
+
+## Stale Pane References
+
+LAB-1593 included a pane like `pane-481` that was skipped during crash recovery
+because the saved shell path was `/bin/bash` and that binary was missing on the
+host. The current behavior logs the skipped pane and continues restoring the
+rest of the session. LAB-1594 tracks the follow-up fix so a missing saved shell
+binary can fall back instead of dropping the pane.
+
+Diagnose skipped panes from the server log:
+
+```bash
+grep -E 'crash recovery skipped pane|/bin/bash|pane_id' /tmp/amux-$(id -u)/main.log*
+amux list --no-cwd
+amux capture --format json
+```
+
+If the skipped pane no longer appears in `amux list`, clean up any external
+references to that pane in orchestration metadata and spawn a replacement pane
+with a valid shell. If a stale or exited pane still appears in amux, capture the
+session first, confirm no useful process remains, and then use the normal pane
+cleanup path:
+
+```bash
+amux capture --format json pane-481
+amux kill --cleanup pane-481
+amux spawn --name pane-481-recovered
+```
+
+Do not restart orca or kill worker processes just to clear metadata. Preserve
+the log and checkpoint evidence first, then replace only the missing pane.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -25,6 +25,17 @@ PATH that includes `~/.local/bin`, which matches the default `make install` and
 release installer location. If amux is installed somewhere else, add a user
 drop-in that adjusts `PATH` or `ExecStart`.
 
+On a standard Linux install, the cgroup memory controls are the enforceable
+protection in this user unit. `MemoryHigh=2G` and `MemoryMax=4G` are applied by
+systemd through the user slice on cgroup v2 systems. `OOMScoreAdjust=-500` is
+included as the preferred process-level protection, but setting a negative
+`oom_score_adj` requires `CAP_SYS_RESOURCE`. Most `systemd --user` managers do
+not have that capability, so systemd may log `Failed to set OOM score adjust`
+and continue starting amux without applying the negative score. If that setting
+must be enforced, run amux from a system-scope unit or delegate the capability
+through site-specific policy; otherwise rely on the documented user-unit memory
+limits and restart behavior.
+
 Useful commands:
 
 ```bash
@@ -58,6 +69,9 @@ server log and the newest crash checkpoint:
 ls -lh /tmp/amux-$(id -u)/main.log*
 ls -lt ~/.local/state/amux/*_main.json
 ```
+
+If `XDG_STATE_HOME` is set, crash checkpoints live under
+`$XDG_STATE_HOME/amux/` instead of `~/.local/state/amux/`.
 
 The server log should include `checkpoint_kind:"crash"` records for successful
 crash checkpoint writes and restore attempts. If the systemd unit is installed,

--- a/packaging/systemd/amux@.service
+++ b/packaging/systemd/amux@.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=amux server for session %i
+Documentation=https://github.com/weill-labs/amux/blob/main/docs/operations.md
+
+[Service]
+Type=simple
+Environment=PATH=%h/.local/bin:/usr/local/bin:/usr/bin:/bin
+ExecStart=/usr/bin/env amux _server %i
+OOMScoreAdjust=-500
+MemoryHigh=2G
+MemoryMax=4G
+Restart=on-failure
+RestartSec=2s
+
+[Install]
+WantedBy=default.target

--- a/test/operations_docs_test.go
+++ b/test/operations_docs_test.go
@@ -12,6 +12,7 @@ func TestSystemdUnitAndOperationsPlaybook(t *testing.T) {
 	service := readRepoFile(t, "packaging/systemd/amux@.service")
 	for _, want := range []string{
 		"[Service]",
+		"Environment=PATH=%h/.local/bin:",
 		"ExecStart=/usr/bin/env amux _server %i",
 		"OOMScoreAdjust=-500",
 		"MemoryHigh=2G",
@@ -31,6 +32,7 @@ func TestSystemdUnitAndOperationsPlaybook(t *testing.T) {
 		"systemctl --user enable --now amux@main.service",
 		"grep -E 'Out of memory|oom-reaper|oom-invocation' /var/log/kern.log",
 		`checkpoint_kind:"crash"`,
+		"CAP_SYS_RESOURCE",
 		"internal/reload/reload.go",
 		"LAB-1594",
 		"/bin/bash",

--- a/test/operations_docs_test.go
+++ b/test/operations_docs_test.go
@@ -1,0 +1,52 @@
+package test
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestSystemdUnitAndOperationsPlaybook(t *testing.T) {
+	t.Parallel()
+
+	service := readRepoFile(t, "packaging/systemd/amux@.service")
+	for _, want := range []string{
+		"[Service]",
+		"ExecStart=/usr/bin/env amux _server %i",
+		"OOMScoreAdjust=-500",
+		"MemoryHigh=2G",
+		"MemoryMax=4G",
+		"Restart=on-failure",
+		"RestartSec=2s",
+		"[Install]",
+		"WantedBy=default.target",
+	} {
+		if !strings.Contains(service, want) {
+			t.Fatalf("packaging/systemd/amux@.service missing %q", want)
+		}
+	}
+
+	operations := readRepoFile(t, "docs/operations.md")
+	for _, want := range []string{
+		"systemctl --user enable --now amux@main.service",
+		"grep -E 'Out of memory|oom-reaper|oom-invocation' /var/log/kern.log",
+		`checkpoint_kind:"crash"`,
+		"internal/reload/reload.go",
+		"LAB-1594",
+		"/bin/bash",
+	} {
+		if !strings.Contains(operations, want) {
+			t.Fatalf("docs/operations.md missing %q", want)
+		}
+	}
+}
+
+func readRepoFile(t *testing.T, rel string) string {
+	t.Helper()
+
+	data, err := os.ReadFile(repoPath(t, rel))
+	if err != nil {
+		t.Fatalf("os.ReadFile(%q): %v", rel, err)
+	}
+	return string(data)
+}


### PR DESCRIPTION
## Motivation

LAB-1593 identified two operational gaps after the scrollback and log-size mitigations: Linux should supervise long-running amux servers under memory pressure, and operators need one place to diagnose OOM kills, understand crash recovery, and clean up stale panes like the missing `/bin/bash` case from the incident evidence.

Recommended landing order:
1. #744 - cap per-pane scrollback by host.
2. #745 - rotate server logs by size.
3. This PR - add the systemd unit and operations playbook.

## Summary

- Add an instanced user-scope `packaging/systemd/amux@.service` so `amux@main.service` runs `amux _server main`.
- Set the requested unit guardrails: `OOMScoreAdjust=-500`, `MemoryHigh=2G`, `MemoryMax=4G`, `Restart=on-failure`, and `RestartSec=2s`.
- Document the important user-unit caveat: `MemoryHigh`/`MemoryMax` are the enforceable default protection on cgroup v2, while a negative `OOMScoreAdjust` requires `CAP_SYS_RESOURCE` and may not apply in a standard `systemd --user` manager.
- Document install, status, and journald commands in `docs/operations.md`.
- Document OOM diagnosis using `/var/log/kern.log`, crash-checkpoint recovery via `checkpoint_kind:"crash"` records and `internal/reload/reload.go`, and cleanup steps for stale panes such as the skipped `/bin/bash` pane.
- Add a static regression test that keeps the required unit settings, PATH setup, and playbook commands present.

The unit is instanced because amux already treats the session name as the daemon boundary. It uses `/usr/bin/env amux _server %i` with a PATH that includes `~/.local/bin`, matching the default dev and release installer location while still allowing users to override PATH or ExecStart with a systemd drop-in.

Follow-up issue for the out-of-scope missing-shell recovery bug: https://linear.app/weill-labs/issue/LAB-1594/amux-crash-recovery-skips-pane-when-saved-shell-path-is-missing

## Testing

- `go test ./test -run TestSystemdUnitAndOperationsPlaybook -count=100`
- `go test ./test -run TestParallelAudit -count=1`
- `systemd-analyze verify --user packaging/systemd/amux@.service`
- `go test ./... -timeout 120s` locally did not complete cleanly: unrelated `./test` integration failures in `TestMouseDragWindowTabDwellSwitchesWindowAndKeepsDrag` and `TestMetaSetAllowsGenericKeys`, followed by the package timeout. Unit packages completed before the integration timeout.
- `make coverage` locally did not complete cleanly: unrelated `internal/client` timing failure in `TestRenderCoalescedPrioritizesActivePaneCursorOnlyOutputAfterLocalInput`, then `./test` timed out after 5m. The script still reported merged coverage at 86.8%.

## Review focus

- Whether the documented user-unit caveat around `OOMScoreAdjust=-500` is clear enough while preserving the LAB-1593 requested setting.
- Whether `/usr/bin/env amux _server %i` is the right default ExecStart for the packaged user unit, given the documented PATH and drop-in escape hatch.
- Whether the playbook gives enough concrete evidence-gathering steps without turning the missing `/bin/bash` behavior into part of this fix.
- Whether this should be landed after #744 and #745 as the final LAB-1593 mitigation PR.

Closes LAB-1593.
