### PR TITLE
LAB-1619: Add mux layout invariant tests

### DIFF
--- a/internal/mux/invariants_test.go
+++ b/internal/mux/invariants_test.go
@@ -1,0 +1,520 @@
+package mux
+
+import (
+	"fmt"
+	"math/rand"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+const (
+	invariantSequenceSteps = 80
+	invariantMaxPanes      = 12
+)
+
+var invariantSeeds = []int64{1, 2, 3, 5, 8, 13, 21, 34}
+
+func TestSplitRootRejectsLayoutsBelowMinimumSize(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		window     func(t *testing.T) *Window
+		dir        SplitDir
+		wantPanes  int
+		wantErr    string
+		wantTrace  string
+		nextPaneID uint32
+	}{
+		{
+			name: "leaf root too narrow for vertical split",
+			window: func(t *testing.T) *Window {
+				t.Helper()
+				return NewWindow(invariantPane(1), 4, 10)
+			},
+			dir:        SplitVertical,
+			wantPanes:  1,
+			wantErr:    "not enough space to split",
+			wantTrace:  "4 < 5",
+			nextPaneID: 2,
+		},
+		{
+			name: "same direction root append would overflow columns",
+			window: func(t *testing.T) *Window {
+				t.Helper()
+				w := NewWindow(invariantPane(1), 8, 10)
+				if _, err := w.SplitRoot(SplitVertical, invariantPane(2)); err != nil {
+					t.Fatalf("SplitRoot pane-2: %v", err)
+				}
+				if _, err := w.SplitRoot(SplitVertical, invariantPane(3)); err != nil {
+					t.Fatalf("SplitRoot pane-3: %v", err)
+				}
+				return w
+			},
+			dir:        SplitVertical,
+			wantPanes:  3,
+			wantErr:    "not enough space to split",
+			wantTrace:  "8 < 11",
+			nextPaneID: 4,
+		},
+		{
+			name: "wrapped root split would overflow existing subtree",
+			window: func(t *testing.T) *Window {
+				t.Helper()
+				w := NewWindow(invariantPane(1), 10, 12)
+				if _, err := w.SplitRoot(SplitVertical, invariantPane(2)); err != nil {
+					t.Fatalf("SplitRoot pane-2: %v", err)
+				}
+				if _, err := w.SplitRoot(SplitVertical, invariantPane(3)); err != nil {
+					t.Fatalf("SplitRoot pane-3: %v", err)
+				}
+				if _, err := w.SplitRoot(SplitHorizontal, invariantPane(4)); err != nil {
+					t.Fatalf("SplitRoot pane-4: %v", err)
+				}
+				return w
+			},
+			dir:        SplitVertical,
+			wantPanes:  4,
+			wantErr:    "not enough space to split",
+			wantTrace:  "10 < 11",
+			nextPaneID: 5,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			w := tt.window(t)
+			before := snapshotLeafGeometry(w.Root)
+			_, err := w.SplitRoot(tt.dir, invariantPane(tt.nextPaneID))
+			if err == nil {
+				t.Fatal("SplitRoot error = nil, want not enough space")
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) || !strings.Contains(err.Error(), tt.wantTrace) {
+				t.Fatalf("SplitRoot error = %q, want %q with %q", err.Error(), tt.wantErr, tt.wantTrace)
+			}
+			if got := w.PaneCount(); got != tt.wantPanes {
+				t.Fatalf("PaneCount after failed SplitRoot = %d, want %d", got, tt.wantPanes)
+			}
+			if diff := diffLeafGeometry(before, snapshotLeafGeometry(w.Root)); diff != "" {
+				t.Fatalf("failed SplitRoot mutated layout:\n%s", diff)
+			}
+			assertGeometryInvariant(t, w, []string{tt.name})
+		})
+	}
+}
+
+func TestWindowLayoutInvariants(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		check func(t *testing.T, w *Window, trace []string)
+	}{
+		{
+			name:  "geometry_covers_parent_rectangles",
+			check: assertGeometryInvariant,
+		},
+		{
+			name:  "walk_visits_each_leaf_once",
+			check: assertWalkInvariant,
+		},
+		{
+			name:  "pane_collections_match_tree",
+			check: assertPaneCollectionInvariant,
+		},
+		{
+			name:  "resolve_name_and_id_match",
+			check: assertResolvePaneInvariant,
+		},
+		{
+			name:  "active_pane_survives",
+			check: assertActivePaneInvariant,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			for _, seed := range invariantSeeds {
+				runInvariantSequence(t, seed, tt.check)
+			}
+		})
+	}
+}
+
+func runInvariantSequence(t *testing.T, seed int64, check func(t *testing.T, w *Window, trace []string)) {
+	t.Helper()
+
+	rng := rand.New(rand.NewSource(seed))
+	w := NewWindow(invariantPane(1), 80, 24)
+	nextPaneID := uint32(2)
+	trace := []string{fmt.Sprintf("seed=%d new-window 80x24 pane-1", seed)}
+
+	check(t, w, trace)
+	for step := 0; step < invariantSequenceSteps; step++ {
+		op := applyInvariantOperation(t, rng, w, &nextPaneID)
+		trace = append(trace, fmt.Sprintf("%02d %s", step, op))
+		check(t, w, trace)
+	}
+}
+
+func applyInvariantOperation(t *testing.T, rng *rand.Rand, w *Window, nextPaneID *uint32) string {
+	t.Helper()
+
+	switch rng.Intn(6) {
+	case 0:
+		dir := randomSplitDir(rng)
+		if w.PaneCount() >= invariantMaxPanes {
+			return fmt.Sprintf("split-active %s skipped at pane limit", splitDirName(dir))
+		}
+		pane := invariantPane(*nextPaneID)
+		*nextPaneID++
+		_, err := w.Split(dir, pane)
+		if err != nil {
+			return fmt.Sprintf("split-active %s pane-%d error=%q", splitDirName(dir), pane.ID, err.Error())
+		}
+		return fmt.Sprintf("split-active %s pane-%d", splitDirName(dir), pane.ID)
+	case 1:
+		dir := randomSplitDir(rng)
+		if w.PaneCount() >= invariantMaxPanes {
+			return fmt.Sprintf("split-root %s skipped at pane limit", splitDirName(dir))
+		}
+		pane := invariantPane(*nextPaneID)
+		*nextPaneID++
+		_, err := w.SplitRoot(dir, pane)
+		if err != nil {
+			return fmt.Sprintf("split-root %s pane-%d error=%q", splitDirName(dir), pane.ID, err.Error())
+		}
+		return fmt.Sprintf("split-root %s pane-%d", splitDirName(dir), pane.ID)
+	case 2:
+		panes := w.Panes()
+		if len(panes) <= 1 {
+			return "close skipped at one pane"
+		}
+		pane := panes[rng.Intn(len(panes))]
+		if err := w.ClosePane(pane.ID); err != nil {
+			t.Fatalf("ClosePane(%d): %v\ntrace:\n%s", pane.ID, err, strings.Join([]string{fmt.Sprintf("close pane-%d", pane.ID)}, "\n"))
+		}
+		return fmt.Sprintf("close pane-%d", pane.ID)
+	case 3:
+		directions := []string{"next", "left", "right", "up", "down"}
+		dir := directions[rng.Intn(len(directions))]
+		before := uint32(0)
+		if w.ActivePane != nil {
+			before = w.ActivePane.ID
+		}
+		w.Focus(dir)
+		after := uint32(0)
+		if w.ActivePane != nil {
+			after = w.ActivePane.ID
+		}
+		return fmt.Sprintf("focus %s pane-%d->pane-%d", dir, before, after)
+	case 4:
+		minW := w.Root.minSubtreeSize(SplitVertical)
+		minH := w.Root.minSubtreeSize(SplitHorizontal)
+		width := minW + rng.Intn(90)
+		height := minH + rng.Intn(36)
+		w.Resize(width, height)
+		return fmt.Sprintf("resize-window %dx%d", width, height)
+	default:
+		panes := w.Panes()
+		pane := panes[rng.Intn(len(panes))]
+		directions := []string{"left", "right", "up", "down"}
+		dir := directions[rng.Intn(len(directions))]
+		delta := 1 + rng.Intn(8)
+		ok := w.ResizePane(pane.ID, dir, delta)
+		return fmt.Sprintf("resize-pane pane-%d %s %d ok=%t", pane.ID, dir, delta, ok)
+	}
+}
+
+func invariantPane(id uint32) *Pane {
+	return &Pane{
+		ID: id,
+		Meta: PaneMeta{
+			Name: fmt.Sprintf("pane-%d", id),
+			Host: DefaultHost,
+		},
+	}
+}
+
+func randomSplitDir(rng *rand.Rand) SplitDir {
+	if rng.Intn(2) == 0 {
+		return SplitVertical
+	}
+	return SplitHorizontal
+}
+
+func splitDirName(dir SplitDir) string {
+	if dir == SplitVertical {
+		return "vertical"
+	}
+	return "horizontal"
+}
+
+func assertGeometryInvariant(t *testing.T, w *Window, trace []string) {
+	t.Helper()
+
+	if w.Root == nil {
+		invariantFatalf(t, trace, "window root is nil")
+	}
+	if w.Root.Parent != nil {
+		invariantFatalf(t, trace, "root parent = %p, want nil", w.Root.Parent)
+	}
+	if w.Root.X != 0 || w.Root.Y != 0 {
+		invariantFatalf(t, trace, "root offset = (%d,%d), want (0,0)", w.Root.X, w.Root.Y)
+	}
+	if w.Root.W != w.Width || w.Root.H != w.Height {
+		invariantFatalf(t, trace, "root size = %dx%d, want window size %dx%d", w.Root.W, w.Root.H, w.Width, w.Height)
+	}
+
+	assertCellGeometryInvariant(t, w.Root, trace)
+
+	leaves := collectLeavesByWalk(w.Root)
+	for i := 0; i < len(leaves); i++ {
+		for j := i + 1; j < len(leaves); j++ {
+			if cellsOverlap(leaves[i], leaves[j]) {
+				invariantFatalf(t, trace, "pane-%d overlaps pane-%d: %s vs %s",
+					leaves[i].CellPaneID(), leaves[j].CellPaneID(),
+					cellRect(leaves[i]), cellRect(leaves[j]))
+			}
+		}
+	}
+}
+
+func assertCellGeometryInvariant(t *testing.T, cell *LayoutCell, trace []string) {
+	t.Helper()
+
+	if cell.W <= 0 || cell.H <= 0 {
+		invariantFatalf(t, trace, "cell %s has non-positive size", cellRect(cell))
+	}
+	if cell.IsLeaf() {
+		if len(cell.Children) != 0 {
+			invariantFatalf(t, trace, "leaf pane-%d has %d children", cell.CellPaneID(), len(cell.Children))
+		}
+		if cell.CellPaneID() == 0 {
+			invariantFatalf(t, trace, "leaf %s has no pane identity", cellRect(cell))
+		}
+		if cell.W < PaneMinSize || cell.H < PaneMinSize {
+			invariantFatalf(t, trace, "leaf pane-%d size = %dx%d, want each dimension >= %d",
+				cell.CellPaneID(), cell.W, cell.H, PaneMinSize)
+		}
+		return
+	}
+
+	if cell.Pane != nil || cell.PaneID != 0 {
+		invariantFatalf(t, trace, "internal cell %s has pane identity pane=%v paneID=%d", cellRect(cell), cell.Pane, cell.PaneID)
+	}
+	if len(cell.Children) < 2 {
+		invariantFatalf(t, trace, "internal cell %s has %d children, want at least 2", cellRect(cell), len(cell.Children))
+	}
+	if cell.Dir != SplitVertical && cell.Dir != SplitHorizontal {
+		invariantFatalf(t, trace, "internal cell %s dir = %d, want split direction", cellRect(cell), cell.Dir)
+	}
+	if cell.W < cell.minSubtreeSize(SplitVertical) {
+		invariantFatalf(t, trace, "cell %s width below subtree minimum %d", cellRect(cell), cell.minSubtreeSize(SplitVertical))
+	}
+	if cell.H < cell.minSubtreeSize(SplitHorizontal) {
+		invariantFatalf(t, trace, "cell %s height below subtree minimum %d", cellRect(cell), cell.minSubtreeSize(SplitHorizontal))
+	}
+
+	total := len(cell.Children) - 1
+	if cell.Dir == SplitVertical {
+		x := cell.X
+		for i, child := range cell.Children {
+			if child.Parent != cell {
+				invariantFatalf(t, trace, "child[%d] parent = %p, want %p", i, child.Parent, cell)
+			}
+			if child.X != x || child.Y != cell.Y {
+				invariantFatalf(t, trace, "child[%d] offset = (%d,%d), want (%d,%d)", i, child.X, child.Y, x, cell.Y)
+			}
+			if child.H != cell.H {
+				invariantFatalf(t, trace, "child[%d] height = %d, want parent height %d", i, child.H, cell.H)
+			}
+			total += child.W
+			x += child.W + 1
+			assertCellGeometryInvariant(t, child, trace)
+		}
+		if total != cell.W {
+			invariantFatalf(t, trace, "vertical children total = %d, want parent width %d for %s", total, cell.W, cellRect(cell))
+		}
+		return
+	}
+
+	y := cell.Y
+	for i, child := range cell.Children {
+		if child.Parent != cell {
+			invariantFatalf(t, trace, "child[%d] parent = %p, want %p", i, child.Parent, cell)
+		}
+		if child.X != cell.X || child.Y != y {
+			invariantFatalf(t, trace, "child[%d] offset = (%d,%d), want (%d,%d)", i, child.X, child.Y, cell.X, y)
+		}
+		if child.W != cell.W {
+			invariantFatalf(t, trace, "child[%d] width = %d, want parent width %d", i, child.W, cell.W)
+		}
+		total += child.H
+		y += child.H + 1
+		assertCellGeometryInvariant(t, child, trace)
+	}
+	if total != cell.H {
+		invariantFatalf(t, trace, "horizontal children total = %d, want parent height %d for %s", total, cell.H, cellRect(cell))
+	}
+}
+
+func assertWalkInvariant(t *testing.T, w *Window, trace []string) {
+	t.Helper()
+
+	recursive := collectLeavesRecursive(w.Root)
+	walked := collectLeavesByWalk(w.Root)
+	if len(walked) != len(recursive) {
+		invariantFatalf(t, trace, "Walk visited %d leaves, recursive traversal found %d", len(walked), len(recursive))
+	}
+
+	seen := make(map[*LayoutCell]bool, len(walked))
+	for _, leaf := range walked {
+		if seen[leaf] {
+			invariantFatalf(t, trace, "Walk visited pane-%d leaf more than once", leaf.CellPaneID())
+		}
+		seen[leaf] = true
+	}
+	for _, leaf := range recursive {
+		if !seen[leaf] {
+			invariantFatalf(t, trace, "Walk skipped pane-%d leaf", leaf.CellPaneID())
+		}
+	}
+	for _, leaf := range walked {
+		if got := w.Root.FindByPaneID(leaf.CellPaneID()); got != leaf {
+			invariantFatalf(t, trace, "FindByPaneID(%d) = %p, want %p", leaf.CellPaneID(), got, leaf)
+		}
+		if leaf.Pane != nil {
+			if got := w.Root.FindPane(leaf.Pane.ID); got != leaf {
+				invariantFatalf(t, trace, "FindPane(%d) = %p, want %p", leaf.Pane.ID, got, leaf)
+			}
+		}
+	}
+}
+
+func assertPaneCollectionInvariant(t *testing.T, w *Window, trace []string) {
+	t.Helper()
+
+	panes := w.Panes()
+	if got := w.PaneCount(); got != len(panes) {
+		invariantFatalf(t, trace, "PaneCount() = %d, len(Panes()) = %d", got, len(panes))
+	}
+
+	leaves := collectLeavesByWalk(w.Root)
+	if len(leaves) != len(panes) {
+		invariantFatalf(t, trace, "layout leaves = %d, Panes() = %d", len(leaves), len(panes))
+	}
+
+	paneByID := make(map[uint32]*Pane, len(panes))
+	for _, pane := range panes {
+		if pane == nil {
+			invariantFatalf(t, trace, "Panes() returned nil pane")
+		}
+		if existing := paneByID[pane.ID]; existing != nil {
+			invariantFatalf(t, trace, "duplicate pane ID %d in Panes(): %p and %p", pane.ID, existing, pane)
+		}
+		paneByID[pane.ID] = pane
+		cell := w.Root.FindPane(pane.ID)
+		if cell == nil {
+			invariantFatalf(t, trace, "Panes() included pane-%d but FindPane returned nil", pane.ID)
+		}
+		if cell.Pane != pane {
+			invariantFatalf(t, trace, "FindPane(%d).Pane = %p, want %p", pane.ID, cell.Pane, pane)
+		}
+	}
+
+	for _, leaf := range leaves {
+		if leaf.Pane == nil {
+			invariantFatalf(t, trace, "server-side layout leaf has no Pane pointer: %s", cellRect(leaf))
+		}
+		if paneByID[leaf.Pane.ID] != leaf.Pane {
+			invariantFatalf(t, trace, "leaf pane-%d missing from Panes()", leaf.Pane.ID)
+		}
+	}
+}
+
+func assertResolvePaneInvariant(t *testing.T, w *Window, trace []string) {
+	t.Helper()
+
+	for _, pane := range w.Panes() {
+		byID, err := w.ResolvePane(strconv.FormatUint(uint64(pane.ID), 10))
+		if err != nil {
+			invariantFatalf(t, trace, "ResolvePane(%d): %v", pane.ID, err)
+		}
+		if byID != pane {
+			invariantFatalf(t, trace, "ResolvePane(%d) = %p, want %p", pane.ID, byID, pane)
+		}
+		if pane.Meta.Name == "" {
+			continue
+		}
+		byName, err := w.ResolvePane(pane.Meta.Name)
+		if err != nil {
+			invariantFatalf(t, trace, "ResolvePane(%q): %v", pane.Meta.Name, err)
+		}
+		if byName != pane {
+			invariantFatalf(t, trace, "ResolvePane(%q) = %p, want %p", pane.Meta.Name, byName, pane)
+		}
+	}
+}
+
+func assertActivePaneInvariant(t *testing.T, w *Window, trace []string) {
+	t.Helper()
+
+	if w.ActivePane == nil {
+		invariantFatalf(t, trace, "ActivePane is nil")
+	}
+	if got := w.Root.FindPane(w.ActivePane.ID); got == nil {
+		invariantFatalf(t, trace, "ActivePane pane-%d is not in the layout", w.ActivePane.ID)
+	}
+	if w.ZoomedPaneID != 0 && w.Root.FindPane(w.ZoomedPaneID) == nil {
+		invariantFatalf(t, trace, "ZoomedPaneID pane-%d is not in the layout", w.ZoomedPaneID)
+	}
+	if w.LeadPaneID != 0 && w.Root.FindPane(w.LeadPaneID) == nil {
+		invariantFatalf(t, trace, "LeadPaneID pane-%d is not in the layout", w.LeadPaneID)
+	}
+}
+
+func collectLeavesByWalk(root *LayoutCell) []*LayoutCell {
+	var leaves []*LayoutCell
+	root.Walk(func(cell *LayoutCell) {
+		leaves = append(leaves, cell)
+	})
+	return leaves
+}
+
+func collectLeavesRecursive(root *LayoutCell) []*LayoutCell {
+	if root == nil {
+		return nil
+	}
+	if root.IsLeaf() {
+		return []*LayoutCell{root}
+	}
+	var leaves []*LayoutCell
+	for _, child := range root.Children {
+		leaves = append(leaves, collectLeavesRecursive(child)...)
+	}
+	return leaves
+}
+
+func cellsOverlap(a, b *LayoutCell) bool {
+	return a.X < b.X+b.W &&
+		b.X < a.X+a.W &&
+		a.Y < b.Y+b.H &&
+		b.Y < a.Y+a.H
+}
+
+func cellRect(cell *LayoutCell) string {
+	return fmt.Sprintf("(x=%d y=%d w=%d h=%d)", cell.X, cell.Y, cell.W, cell.H)
+}
+
+func invariantFatalf(t *testing.T, trace []string, format string, args ...any) {
+	t.Helper()
+	t.Fatalf(format+"\ntrace:\n%s", append(args, strings.Join(trace, "\n"))...)
+}

--- a/internal/mux/invariants_test.go
+++ b/internal/mux/invariants_test.go
@@ -107,6 +107,83 @@ func TestSplitRootRejectsLayoutsBelowMinimumSize(t *testing.T) {
 	}
 }
 
+func TestResizeAllPreservesNestedSubtreeMinimums(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		build      func(t *testing.T) *Window
+		width      int
+		height     int
+		violatedID uint32
+		axis       SplitDir
+	}{
+		{
+			name: "vertical shrink keeps nested column wide enough",
+			build: func(t *testing.T) *Window {
+				t.Helper()
+
+				w := NewWindow(invariantPane(1), 20, 12)
+				if _, err := w.SplitRoot(SplitVertical, invariantPane(2)); err != nil {
+					t.Fatalf("SplitRoot pane-2: %v", err)
+				}
+				if _, err := w.SplitPaneWithOptions(2, SplitHorizontal, invariantPane(3), SplitOptions{}); err != nil {
+					t.Fatalf("SplitPaneWithOptions pane-3: %v", err)
+				}
+				if _, err := w.SplitPaneWithOptions(2, SplitVertical, invariantPane(4), SplitOptions{}); err != nil {
+					t.Fatalf("SplitPaneWithOptions pane-4: %v", err)
+				}
+				return w
+			},
+			width:      8,
+			height:     12,
+			violatedID: 2,
+			axis:       SplitVertical,
+		},
+		{
+			name: "horizontal shrink keeps nested row tall enough",
+			build: func(t *testing.T) *Window {
+				t.Helper()
+
+				w := NewWindow(invariantPane(1), 12, 20)
+				if _, err := w.SplitRoot(SplitHorizontal, invariantPane(2)); err != nil {
+					t.Fatalf("SplitRoot pane-2: %v", err)
+				}
+				if _, err := w.SplitPaneWithOptions(2, SplitVertical, invariantPane(3), SplitOptions{}); err != nil {
+					t.Fatalf("SplitPaneWithOptions pane-3: %v", err)
+				}
+				if _, err := w.SplitPaneWithOptions(2, SplitHorizontal, invariantPane(4), SplitOptions{}); err != nil {
+					t.Fatalf("SplitPaneWithOptions pane-4: %v", err)
+				}
+				return w
+			},
+			width:      12,
+			height:     8,
+			violatedID: 2,
+			axis:       SplitHorizontal,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			w := tt.build(t)
+			w.Resize(tt.width, tt.height)
+			cell := w.Root.FindPane(tt.violatedID)
+			if cell == nil || cell.Parent == nil {
+				t.Fatalf("nested pane-%d cell = %v, want nested cell", tt.violatedID, cell)
+			}
+			parent := cell.Parent
+			if got, want := parent.axisSize(tt.axis), parent.minSubtreeSize(tt.axis); got < want {
+				t.Fatalf("nested subtree %s size = %d, want at least %d", splitDirName(tt.axis), got, want)
+			}
+			assertGeometryInvariant(t, w, []string{tt.name})
+		})
+	}
+}
+
 func TestWindowLayoutInvariants(t *testing.T) {
 	t.Parallel()
 

--- a/internal/mux/invariants_test.go
+++ b/internal/mux/invariants_test.go
@@ -184,6 +184,69 @@ func TestResizeAllPreservesNestedSubtreeMinimums(t *testing.T) {
 	}
 }
 
+func TestSplitSiblingInsertionPreservesNestedSubtreeMinimums(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		build func(t *testing.T) (*Window, *Pane, SplitDir)
+	}{
+		{
+			name: "vertical sibling insertion keeps nested column wide enough",
+			build: func(t *testing.T) (*Window, *Pane, SplitDir) {
+				t.Helper()
+
+				p1 := invariantPane(1)
+				w := NewWindow(p1, 14, 12)
+				if _, err := w.SplitRoot(SplitVertical, invariantPane(2)); err != nil {
+					t.Fatalf("SplitRoot pane-2: %v", err)
+				}
+				if _, err := w.SplitPaneWithOptions(2, SplitHorizontal, invariantPane(3), SplitOptions{}); err != nil {
+					t.Fatalf("SplitPaneWithOptions pane-3: %v", err)
+				}
+				if _, err := w.SplitPaneWithOptions(2, SplitVertical, invariantPane(4), SplitOptions{}); err != nil {
+					t.Fatalf("SplitPaneWithOptions pane-4: %v", err)
+				}
+				w.FocusPane(p1)
+				return w, invariantPane(5), SplitVertical
+			},
+		},
+		{
+			name: "horizontal sibling insertion keeps nested row tall enough",
+			build: func(t *testing.T) (*Window, *Pane, SplitDir) {
+				t.Helper()
+
+				p1 := invariantPane(1)
+				w := NewWindow(p1, 12, 14)
+				if _, err := w.SplitRoot(SplitHorizontal, invariantPane(2)); err != nil {
+					t.Fatalf("SplitRoot pane-2: %v", err)
+				}
+				if _, err := w.SplitPaneWithOptions(2, SplitVertical, invariantPane(3), SplitOptions{}); err != nil {
+					t.Fatalf("SplitPaneWithOptions pane-3: %v", err)
+				}
+				if _, err := w.SplitPaneWithOptions(2, SplitHorizontal, invariantPane(4), SplitOptions{}); err != nil {
+					t.Fatalf("SplitPaneWithOptions pane-4: %v", err)
+				}
+				w.FocusPane(p1)
+				return w, invariantPane(5), SplitHorizontal
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			w, pane, dir := tt.build(t)
+			if _, err := w.Split(dir, pane); err != nil {
+				t.Fatalf("Split(%s): %v", splitDirName(dir), err)
+			}
+			assertGeometryInvariant(t, w, []string{tt.name})
+		})
+	}
+}
+
 func TestWindowLayoutInvariants(t *testing.T) {
 	t.Parallel()
 

--- a/internal/mux/layout.go
+++ b/internal/mux/layout.go
@@ -339,28 +339,7 @@ func proportionalSubtreeChildSizes(children []*LayoutCell, axis SplitDir, target
 	}
 
 	sizes := proportionalChildSizes(children, axis, target+n-1)
-	deficit := 0
-	for i := range sizes {
-		if sizes[i] < minimums[i] {
-			deficit += minimums[i] - sizes[i]
-			sizes[i] = minimums[i]
-		}
-	}
-	if deficit == 0 {
-		return sizes
-	}
-
-	for i := len(sizes) - 1; i >= 0 && deficit > 0; i-- {
-		available := sizes[i] - minimums[i]
-		if available <= 0 {
-			continue
-		}
-		if available > deficit {
-			available = deficit
-		}
-		sizes[i] -= available
-		deficit -= available
-	}
+	_ = raiseSizesToMinimums(sizes, minimums)
 	return sizes
 }
 
@@ -384,17 +363,26 @@ func equalSubtreeSplitSizes(children []*LayoutCell, axis SplitDir, total int) ([
 		return nil, false
 	}
 
-	deficit := 0
 	minimums := make([]int, len(children))
 	for i, child := range children {
 		minimums[i] = child.minSubtreeSize(axis)
+	}
+	if !raiseSizesToMinimums(sizes, minimums) {
+		return nil, false
+	}
+	return sizes, true
+}
+
+func raiseSizesToMinimums(sizes, minimums []int) bool {
+	deficit := 0
+	for i := range sizes {
 		if sizes[i] < minimums[i] {
 			deficit += minimums[i] - sizes[i]
 			sizes[i] = minimums[i]
 		}
 	}
 	if deficit == 0 {
-		return sizes, true
+		return true
 	}
 
 	for i := len(sizes) - 1; i >= 0 && deficit > 0; i-- {
@@ -408,10 +396,7 @@ func equalSubtreeSplitSizes(children []*LayoutCell, axis SplitDir, total int) ([
 		sizes[i] -= available
 		deficit -= available
 	}
-	if deficit > 0 {
-		return nil, false
-	}
-	return sizes, true
+	return deficit == 0
 }
 
 func (c *LayoutCell) resizeCheck(axis SplitDir) int {

--- a/internal/mux/layout.go
+++ b/internal/mux/layout.go
@@ -338,64 +338,29 @@ func proportionalSubtreeChildSizes(children []*LayoutCell, axis SplitDir, target
 		target = minimumTotal
 	}
 
-	sizes := make([]int, n)
-	extra := target - minimumTotal
-	if extra == 0 {
-		copy(sizes, minimums)
+	sizes := proportionalChildSizes(children, axis, target+n-1)
+	deficit := 0
+	for i := range sizes {
+		if sizes[i] < minimums[i] {
+			deficit += minimums[i] - sizes[i]
+			sizes[i] = minimums[i]
+		}
+	}
+	if deficit == 0 {
 		return sizes
 	}
 
-	weights := make([]int, n)
-	totalWeight := 0
-	for i, child := range children {
-		weight := child.axisSize(axis) - minimums[i]
-		if weight < 0 {
-			weight = 0
+	for i := len(sizes) - 1; i >= 0 && deficit > 0; i-- {
+		available := sizes[i] - minimums[i]
+		if available <= 0 {
+			continue
 		}
-		weights[i] = weight
-		totalWeight += weight
-	}
-
-	if totalWeight == 0 {
-		base := extra / n
-		leftover := extra % n
-		for i := range sizes {
-			sizes[i] = minimums[i] + base
-			if i >= n-leftover {
-				sizes[i]++
-			}
+		if available > deficit {
+			available = deficit
 		}
-		return sizes
+		sizes[i] -= available
+		deficit -= available
 	}
-
-	type remainder struct {
-		idx int
-		rem int64
-	}
-	remainders := make([]remainder, 0, n)
-	assignedExtra := 0
-	for i, weight := range weights {
-		numerator := int64(extra) * int64(weight)
-		share := int(numerator / int64(totalWeight))
-		sizes[i] = minimums[i] + share
-		assignedExtra += share
-		remainders = append(remainders, remainder{
-			idx: i,
-			rem: numerator % int64(totalWeight),
-		})
-	}
-
-	leftover := extra - assignedExtra
-	sort.SliceStable(remainders, func(i, j int) bool {
-		if remainders[i].rem == remainders[j].rem {
-			return remainders[i].idx > remainders[j].idx
-		}
-		return remainders[i].rem > remainders[j].rem
-	})
-	for i := 0; i < leftover; i++ {
-		sizes[remainders[i].idx]++
-	}
-
 	return sizes
 }
 
@@ -411,6 +376,42 @@ func equalSplitSizes(total, count int) []int {
 	}
 	sizes[count-1] = total - seps - each*(count-1)
 	return sizes
+}
+
+func equalSubtreeSplitSizes(children []*LayoutCell, axis SplitDir, total int) ([]int, bool) {
+	sizes := equalSplitSizes(total, len(children))
+	if len(sizes) == 0 {
+		return nil, false
+	}
+
+	deficit := 0
+	minimums := make([]int, len(children))
+	for i, child := range children {
+		minimums[i] = child.minSubtreeSize(axis)
+		if sizes[i] < minimums[i] {
+			deficit += minimums[i] - sizes[i]
+			sizes[i] = minimums[i]
+		}
+	}
+	if deficit == 0 {
+		return sizes, true
+	}
+
+	for i := len(sizes) - 1; i >= 0 && deficit > 0; i-- {
+		available := sizes[i] - minimums[i]
+		if available <= 0 {
+			continue
+		}
+		if available > deficit {
+			available = deficit
+		}
+		sizes[i] -= available
+		deficit -= available
+	}
+	if deficit > 0 {
+		return nil, false
+	}
+	return sizes, true
 }
 
 func (c *LayoutCell) resizeCheck(axis SplitDir) int {
@@ -492,7 +493,7 @@ func (c *LayoutCell) resizeAxis(axis SplitDir, target int) {
 		return
 	}
 
-	sizes := proportionalChildSizes(c.Children, axis, target)
+	sizes := proportionalSubtreeChildSizes(c.Children, axis, target-(len(c.Children)-1))
 	for i, child := range c.Children {
 		child.resizeAxis(axis, sizes[i])
 	}
@@ -758,7 +759,10 @@ func (c *LayoutCell) equalizeChildren() {
 		return
 	}
 
-	sizes := equalSplitSizes(c.axisSize(c.Dir), len(c.Children))
+	sizes, ok := equalSubtreeSplitSizes(c.Children, c.Dir, c.axisSize(c.Dir))
+	if !ok {
+		return
+	}
 	for i, child := range c.Children {
 		if c.Dir == SplitVertical {
 			child.ResizeSubtree(sizes[i], c.H)
@@ -775,7 +779,10 @@ func (c *LayoutCell) equalizeChildrenNeeded() bool {
 		return false
 	}
 
-	sizes := equalSplitSizes(c.axisSize(c.Dir), len(c.Children))
+	sizes, ok := equalSubtreeSplitSizes(c.Children, c.Dir, c.axisSize(c.Dir))
+	if !ok {
+		return false
+	}
 	for i, child := range c.Children {
 		if child.axisSize(c.Dir) != sizes[i] {
 			return true

--- a/internal/mux/layout.go
+++ b/internal/mux/layout.go
@@ -373,6 +373,39 @@ func equalSubtreeSplitSizes(children []*LayoutCell, axis SplitDir, total int) ([
 	return sizes, true
 }
 
+func frontLoadedSubtreeSplitSizes(children []*LayoutCell, axis SplitDir, total int) ([]int, bool) {
+	sizes := frontLoadedSplitSizes(total, len(children))
+	if len(sizes) == 0 {
+		return nil, false
+	}
+
+	minimums := make([]int, len(children))
+	for i, child := range children {
+		minimums[i] = child.minSubtreeSize(axis)
+	}
+	if !raiseSizesToMinimums(sizes, minimums) {
+		return nil, false
+	}
+	return sizes, true
+}
+
+func frontLoadedSplitSizes(total, count int) []int {
+	if count <= 0 {
+		return nil
+	}
+	seps := count - 1
+	available := total - seps
+	each := available / count
+	sizes := make([]int, count)
+	for i := range sizes {
+		sizes[i] = each
+	}
+	for i := 0; i < available-each*count; i++ {
+		sizes[i]++
+	}
+	return sizes
+}
+
 func raiseSizesToMinimums(sizes, minimums []int) bool {
 	deficit := 0
 	for i := range sizes {

--- a/internal/mux/layout_test.go
+++ b/internal/mux/layout_test.go
@@ -119,6 +119,61 @@ func TestSplitHorizontal(t *testing.T) {
 	}
 }
 
+func TestSubtreeSplitSizeHelpersRespectMinimumsAndEmptyInputs(t *testing.T) {
+	t.Parallel()
+
+	left := NewLeaf(fakePaneID(1), 0, 0, PaneMinSize, 10)
+	right := NewLeaf(fakePaneID(2), 0, 0, PaneMinSize, 10)
+	nested := &LayoutCell{
+		W:        5,
+		H:        10,
+		Dir:      SplitVertical,
+		Children: []*LayoutCell{left, right},
+	}
+	left.Parent = nested
+	right.Parent = nested
+	newLeaf := NewLeaf(fakePaneID(3), 0, 0, PaneMinSize, 10)
+	children := []*LayoutCell{nested, newLeaf}
+
+	for _, tt := range []struct {
+		name string
+		fn   func([]*LayoutCell, SplitDir, int) ([]int, bool)
+	}{
+		{name: "equal", fn: equalSubtreeSplitSizes},
+		{name: "front loaded", fn: frontLoadedSubtreeSplitSizes},
+	} {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			sizes, ok := tt.fn(children, SplitVertical, 8)
+			if !ok {
+				t.Fatal("split size helper returned ok=false, want true")
+			}
+			if want := []int{5, 2}; !reflect.DeepEqual(sizes, want) {
+				t.Fatalf("split sizes = %v, want %v", sizes, want)
+			}
+
+			if sizes, ok := tt.fn(children, SplitVertical, 7); ok || sizes != nil {
+				t.Fatalf("impossible split sizes = (%v, %t), want (nil, false)", sizes, ok)
+			}
+			if sizes, ok := tt.fn(nil, SplitVertical, 8); ok || sizes != nil {
+				t.Fatalf("empty split sizes = (%v, %t), want (nil, false)", sizes, ok)
+			}
+		})
+	}
+
+	if sizes := frontLoadedSplitSizes(8, 2); !reflect.DeepEqual(sizes, []int{4, 3}) {
+		t.Fatalf("frontLoadedSplitSizes(8, 2) = %v, want [4 3]", sizes)
+	}
+	if sizes := frontLoadedSplitSizes(8, 0); sizes != nil {
+		t.Fatalf("frontLoadedSplitSizes(8, 0) = %v, want nil", sizes)
+	}
+	if got, want := splitRootRequiredSize(nil, SplitVertical), 2*PaneMinSize+1; got != want {
+		t.Fatalf("splitRootRequiredSize(nil) = %d, want %d", got, want)
+	}
+}
+
 func TestSplitWithOrderInsertFirst(t *testing.T) {
 	t.Parallel()
 

--- a/internal/mux/lead_test.go
+++ b/internal/mux/lead_test.go
@@ -539,6 +539,36 @@ func TestSplitRootHorizontalWithAnchoredLeadPreservesWidths(t *testing.T) {
 	}
 }
 
+func TestSplitRootHorizontalWithAnchoredLeadPreservesOddLeadWidth(t *testing.T) {
+	t.Parallel()
+
+	p1 := fakePaneID(1)
+	p2 := fakePaneID(2)
+	p3 := fakePaneID(3)
+	w := NewWindow(p1, 80, 24)
+	if _, err := w.SplitRoot(SplitVertical, p2); err != nil {
+		t.Fatalf("SplitRoot p2: %v", err)
+	}
+	if err := w.SetLead(p1.ID); err != nil {
+		t.Fatalf("SetLead: %v", err)
+	}
+
+	widthsBefore := anchoredLeadColumnWidths(t, w)
+	want := []int{40, 39}
+	if !reflect.DeepEqual(widthsBefore, want) {
+		t.Fatalf("anchored lead column widths before horizontal SplitRoot = %v, want %v", widthsBefore, want)
+	}
+
+	if _, err := w.SplitRoot(SplitHorizontal, p3); err != nil {
+		t.Fatalf("SplitRoot p3: %v", err)
+	}
+
+	got := anchoredLeadColumnWidths(t, w)
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("anchored lead column widths after horizontal SplitRoot = %v, want %v", got, want)
+	}
+}
+
 func TestMovePaneToRootEdgeWithAnchoredLeadEqualizesWrappedColumns(t *testing.T) {
 	t.Parallel()
 

--- a/internal/mux/window.go
+++ b/internal/mux/window.go
@@ -82,49 +82,51 @@ func (w *Window) splitRootTargetWithOptions(targetRoot, parent *LayoutCell, pare
 	if targetRoot == nil {
 		return nil, fmt.Errorf("window has no layout root")
 	}
+	required := splitRootRequiredSize(targetRoot, dir)
+	if available := splitAvailable(targetRoot, dir); available < required {
+		return nil, fmt.Errorf("not enough space to split (%d < %d)", available, required)
+	}
 	newLeaf := NewLeaf(newPane, 0, 0, 0, 0)
 	equalizeAnchoredLeadAfterSplit := false
 
 	if !targetRoot.IsLeaf() && targetRoot.Dir == dir {
 		equalizeAnchoredLeadAfterSplit = w.shouldEqualizeAnchoredLeadAfterRootSplit(parent, parentIdx, dir)
 		// Same direction: add as sibling, redistribute equally
+		children := append(append([]*LayoutCell{}, targetRoot.Children...), newLeaf)
+		sizes, ok := equalSubtreeSplitSizes(children, dir, targetRoot.axisSize(dir))
+		if !ok {
+			return nil, fmt.Errorf("not enough space to split (%d < %d)", splitAvailable(targetRoot, dir), required)
+		}
 		newLeaf.Parent = targetRoot
 		targetRoot.Children = append(targetRoot.Children, newLeaf)
-		// Give all children equal sizes so ResizeAll distributes fairly
-		n := len(targetRoot.Children)
-		seps := n - 1
 		if dir == SplitVertical {
-			each := (targetRoot.W - seps) / n
-			for _, child := range targetRoot.Children {
-				child.ResizeSubtree(each, targetRoot.H)
+			for i, child := range targetRoot.Children {
+				child.ResizeSubtree(sizes[i], targetRoot.H)
 			}
-			// Give remainder to last child
-			targetRoot.Children[n-1].ResizeSubtree(targetRoot.W-seps-each*(n-1), targetRoot.H)
 		} else {
-			each := (targetRoot.H - seps) / n
-			for _, child := range targetRoot.Children {
-				child.ResizeSubtree(targetRoot.W, each)
+			for i, child := range targetRoot.Children {
+				child.ResizeSubtree(targetRoot.W, sizes[i])
 			}
-			targetRoot.Children[n-1].ResizeSubtree(targetRoot.W, targetRoot.H-seps-each*(n-1))
 		}
 	} else {
 		// Different direction or root is a leaf: wrap
 		oldRoot := targetRoot
 		oldX, oldY := oldRoot.X, oldRoot.Y
 		oldW, oldH := oldRoot.W, oldRoot.H
+		children := []*LayoutCell{oldRoot, newLeaf}
+		sizes, ok := equalSubtreeSplitSizes(children, dir, oldRoot.axisSize(dir))
+		if !ok {
+			return nil, fmt.Errorf("not enough space to split (%d < %d)", splitAvailable(targetRoot, dir), required)
+		}
 
 		if dir == SplitVertical {
-			size2 := (oldW - 1) / 2
-			size1 := oldW - 1 - size2
-			newLeaf.W = size2
+			newLeaf.W = sizes[1]
 			newLeaf.H = oldH
-			oldRoot.ResizeSubtree(size1, oldH)
+			oldRoot.ResizeSubtree(sizes[0], oldH)
 		} else {
-			size2 := (oldH - 1) / 2
-			size1 := oldH - 1 - size2
 			newLeaf.W = oldW
-			newLeaf.H = size2
-			oldRoot.ResizeSubtree(oldW, size1)
+			newLeaf.H = sizes[1]
+			oldRoot.ResizeSubtree(oldW, sizes[0])
 		}
 
 		newRoot := &LayoutCell{
@@ -254,6 +256,13 @@ func splitAvailable(cell *LayoutCell, dir SplitDir) int {
 	return cell.W
 }
 
+func splitRootRequiredSize(cell *LayoutCell, dir SplitDir) int {
+	if cell == nil {
+		return 2*PaneMinSize + 1
+	}
+	return cell.minSubtreeSize(dir) + 1 + PaneMinSize
+}
+
 func (w *Window) restoreActivePaneByID(activePaneID uint32, preferred *Pane) {
 	if preferred != nil && activePaneID == preferred.ID {
 		w.setActive(preferred)
@@ -349,8 +358,9 @@ func (w *Window) MovePaneToRootEdge(paneID uint32, dir SplitDir, insertFirst boo
 	}
 
 	root := w.logicalRoot()
-	if !canSplitCell(root, dir) {
-		return fmt.Errorf("not enough space to split (%d < %d)", splitAvailable(root, dir), 2*PaneMinSize+1)
+	required := splitRootRequiredSize(root, dir)
+	if available := splitAvailable(root, dir); available < required {
+		return fmt.Errorf("not enough space to split (%d < %d)", available, required)
 	}
 
 	sourceCell, err := w.mustFindPane(paneID)

--- a/internal/mux/window.go
+++ b/internal/mux/window.go
@@ -114,7 +114,7 @@ func (w *Window) splitRootTargetWithOptions(targetRoot, parent *LayoutCell, pare
 		oldX, oldY := oldRoot.X, oldRoot.Y
 		oldW, oldH := oldRoot.W, oldRoot.H
 		children := []*LayoutCell{oldRoot, newLeaf}
-		sizes, ok := equalSubtreeSplitSizes(children, dir, oldRoot.axisSize(dir))
+		sizes, ok := frontLoadedSubtreeSplitSizes(children, dir, oldRoot.axisSize(dir))
 		if !ok {
 			return nil, fmt.Errorf("not enough space to split (%d < %d)", splitAvailable(targetRoot, dir), required)
 		}

--- a/internal/mux/window_spiral.go
+++ b/internal/mux/window_spiral.go
@@ -211,6 +211,10 @@ func (w *Window) splitSubtreeRootWithOptions(root *LayoutCell, dir SplitDir, new
 			return nil, err
 		}
 	}
+	required := splitRootRequiredSize(root, dir)
+	if available := splitAvailable(root, dir); available < required {
+		return nil, fmt.Errorf("not enough space to split (%d < %d)", available, required)
+	}
 
 	newLeaf := NewLeaf(newPane, 0, 0, 0, 0)
 	parent := root.Parent
@@ -220,50 +224,64 @@ func (w *Window) splitSubtreeRootWithOptions(root *LayoutCell, dir SplitDir, new
 	if !root.IsLeaf() && root.Dir == dir {
 		equalizeAnchoredLeadAfterSplit = w.shouldEqualizeAnchoredLeadAfterRootSplit(parent, parentIdx, dir)
 		newLeaf.Parent = root
+		children := append([]*LayoutCell{}, root.Children...)
 		if insertFirst {
-			root.Children = append([]*LayoutCell{newLeaf}, root.Children...)
+			children = append([]*LayoutCell{newLeaf}, children...)
 		} else {
-			root.Children = append(root.Children, newLeaf)
+			children = append(children, newLeaf)
 		}
-		root.distributeEqual()
+		sizes, ok := equalSubtreeSplitSizes(children, dir, root.axisSize(dir))
+		if !ok {
+			return nil, fmt.Errorf("not enough space to split (%d < %d)", splitAvailable(root, dir), required)
+		}
+		root.Children = children
+		if dir == SplitVertical {
+			for i, child := range root.Children {
+				child.ResizeSubtree(sizes[i], root.H)
+			}
+		} else {
+			for i, child := range root.Children {
+				child.ResizeSubtree(root.W, sizes[i])
+			}
+		}
 	} else {
 		oldRoot := root
+		children := []*LayoutCell{oldRoot, newLeaf}
+		if insertFirst {
+			children = []*LayoutCell{newLeaf, oldRoot}
+		}
+		sizes, ok := equalSubtreeSplitSizes(children, dir, oldRoot.axisSize(dir))
+		if !ok {
+			return nil, fmt.Errorf("not enough space to split (%d < %d)", splitAvailable(root, dir), required)
+		}
 
 		newRoot := &LayoutCell{
 			X: oldRoot.X, Y: oldRoot.Y, W: oldRoot.W, H: oldRoot.H,
-			Dir: dir,
-		}
-		if insertFirst {
-			newRoot.Children = []*LayoutCell{newLeaf, oldRoot}
-		} else {
-			newRoot.Children = []*LayoutCell{oldRoot, newLeaf}
+			Dir:      dir,
+			Children: children,
 		}
 		newLeaf.Parent = newRoot
 		oldRoot.Parent = newRoot
 
 		if dir == SplitVertical {
-			secondW := (oldRoot.W - 1) / 2
-			firstW := oldRoot.W - 1 - secondW
 			if insertFirst {
-				newLeaf.W = firstW
+				newLeaf.W = sizes[0]
 				newLeaf.H = oldRoot.H
-				oldRoot.ResizeSubtree(secondW, oldRoot.H)
+				oldRoot.ResizeSubtree(sizes[1], oldRoot.H)
 			} else {
-				newLeaf.W = secondW
+				newLeaf.W = sizes[1]
 				newLeaf.H = oldRoot.H
-				oldRoot.ResizeSubtree(firstW, oldRoot.H)
+				oldRoot.ResizeSubtree(sizes[0], oldRoot.H)
 			}
 		} else {
-			secondH := (oldRoot.H - 1) / 2
-			firstH := oldRoot.H - 1 - secondH
 			if insertFirst {
 				newLeaf.W = oldRoot.W
-				newLeaf.H = firstH
-				oldRoot.ResizeSubtree(oldRoot.W, secondH)
+				newLeaf.H = sizes[0]
+				oldRoot.ResizeSubtree(oldRoot.W, sizes[1])
 			} else {
 				newLeaf.W = oldRoot.W
-				newLeaf.H = secondH
-				oldRoot.ResizeSubtree(oldRoot.W, firstH)
+				newLeaf.H = sizes[1]
+				oldRoot.ResizeSubtree(oldRoot.W, sizes[0])
 			}
 		}
 

--- a/internal/mux/window_spiral.go
+++ b/internal/mux/window_spiral.go
@@ -250,7 +250,7 @@ func (w *Window) splitSubtreeRootWithOptions(root *LayoutCell, dir SplitDir, new
 		if insertFirst {
 			children = []*LayoutCell{newLeaf, oldRoot}
 		}
-		sizes, ok := equalSubtreeSplitSizes(children, dir, oldRoot.axisSize(dir))
+		sizes, ok := frontLoadedSubtreeSplitSizes(children, dir, oldRoot.axisSize(dir))
 		if !ok {
 			return nil, fmt.Errorf("not enough space to split (%d < %d)", splitAvailable(root, dir), required)
 		}


### PR DESCRIPTION
## Motivation

`internal/mux` layout mutations sit under pane splitting, closing, focus, resizing, snapshots, and rendering. This adds invariant coverage so layout bugs surface as small deterministic failures instead of visual corruption or dropped panes later in the stack.

## Summary

- Add randomized invariant tests for `Window` and `LayoutCell` sequences over split, root split, close, focus, window resize, and pane resize.
- Add table-driven regressions for root splits, `ResizeAll`, same-axis sibling insertion, and anchored lead width preservation when root wrap splits have an odd cell.
- Fix root-level split and resize redistribution to respect subtree minimums while preserving existing proportional resize behavior and legacy wrap-split remainder placement.

| Invariant tested | Why it matters | Existing coverage relationship |
| --- | --- | --- |
| Layout geometry covers parent rectangles exactly: child sizes plus 1-cell separators equal the parent split axis, cross-axis offsets/sizes match, and leaves stay within the root | Render, mouse hit testing, directional focus, and resize all depend on this geometry | Extends example assertions in `layout_test.go`, `window_test.go`, and lead resize regressions across generated operation sequences |
| Tree shape is internally consistent: root has no parent, child parent pointers are correct, leaves have pane identity, internal cells have children | Mutation helpers use parent/index lookups and assume leaves are the only pane holders | Extends targeted split/close/move tests with post-operation checks after every generated step |
| `Walk`, `FindPane`, `FindByPaneID`, `Panes`, and `PaneCount` agree and visit each surviving pane exactly once | Close/move/split must not duplicate or drop panes | Supersets the single-shape `TestWalkAndFindPane` coverage over many shapes |
| `ResolvePane(id)` and `ResolvePane(name)` return the same surviving pane for unique pane names | CLI/server pane commands route through pane refs | Extends existing exact name/id tests; prefix resolution remains intentionally unsupported by current tests |
| `ActivePane`, `ZoomedPaneID`, and `LeadPaneID` always reference surviving panes when set | Later commands and rendering assume active/zoom/lead state points into the layout | Extends close/focus/lead examples with checks after every generated mutation |

No `test/testdata` golden changed because the failures were internal layout-tree invariants, not renderer output snapshots.

## Testing

- `go test ./internal/mux -run 'TestSubtreeSplitSizeHelpersRespectMinimumsAndEmptyInputs|TestSplitRootHorizontalWithAnchoredLeadPreservesOddLeadWidth|TestSplitRootHorizontalWithAnchoredLeadPreservesWidths|TestSplitRootVerticalWithAnchoredLeadEqualizesWrappedColumns|TestSplitRootVerticalWithAnchoredLeadKeepsEqualColumnsInSameDirection|TestSplitRootRejectsLayoutsBelowMinimumSize|TestResizeAllPreservesNestedSubtreeMinimums|TestSplitSiblingInsertionPreservesNestedSubtreeMinimums|TestWindowLayoutInvariants' -count=100 -timeout 120s`
- `go test ./test -run '^TestRootHorizontalBindingWhileLeadFocused$' -count=1 -timeout 120s`
- `go test ./internal/mux -skip '^TestAgentStatusTreatsPromptTimeBashSelfForkAsIdle$' -timeout 120s`

Local gaps:

- `go test ./internal/mux -run '^TestAgentStatusTreatsPromptTimeBashSelfForkAsIdle$' -count=3 -timeout 120s` times out locally waiting for prompt-time bash self-fork process state; this test is outside the layout changes and fails by itself in this environment.
- `go test ./... -skip '^TestAgentStatusTreatsPromptTimeBashSelfForkAsIdle$' -timeout 120s` reached `github.com/weill-labs/amux/test` and timed out at the command-level 120s limit with long-running takeover/SSH integration tests still active; earlier packages completed green.

## Review focus

- Check that `equalSubtreeSplitSizes`, `frontLoadedSubtreeSplitSizes`, and `proportionalSubtreeChildSizes` preserve existing roomy-layout behavior and only pin children when a subtree minimum would be violated.
- Check the `SplitRoot` and `MovePaneToRootEdge` preflight guards, since they now account for existing subtree minimums rather than only leaf minimums.
- Check whether the invariant operation mix should include additional mux-only mutations in a follow-up, such as swap/move/lead-specific sequences.

Closes LAB-1619
