### PR TITLE
LAB-1633: Stop ANSI captures from clearing screens

### DIFF
--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -359,6 +359,29 @@ func TestClientRendererCapture(t *testing.T) {
 	}
 }
 
+func TestClientRendererCaptureDoesNotClearScreen(t *testing.T) {
+	t.Parallel()
+	cr := buildTestRenderer(t)
+
+	const clearScreen = "\x1b[2J"
+	for _, tt := range []struct {
+		name string
+		out  string
+	}{
+		{name: "ansi", out: cr.Capture(false)},
+		{name: "colors", out: cr.CaptureColorMap()},
+	} {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if strings.Contains(tt.out, clearScreen) {
+				prefixLen := min(len(tt.out), len("\x1b[?25l\x1b[2J\x1b[H\x1b[m"))
+				t.Fatalf("%s capture contains clear-screen escape; prefix %q", tt.name, tt.out[:prefixLen])
+			}
+		})
+	}
+}
+
 func TestClientRendererCaptureJSON(t *testing.T) {
 	t.Parallel()
 	cr := buildTestRenderer(t)

--- a/internal/client/renderer.go
+++ b/internal/client/renderer.go
@@ -359,7 +359,7 @@ func (r *Renderer) Capture(stripANSI bool) string {
 		root, activePaneID := snap.captureRoot(st.compositor.LayoutHeight())
 		raw := st.compositor.RenderFullWithOverlay(root, activePaneID, func(paneID uint32) render.PaneData {
 			return r.paneLookupSnapshot(st, snap, paneID)
-		}, r.mergeOverlay(snap, render.OverlayState{}), true)
+		}, r.mergeOverlay(snap, render.OverlayState{}), false)
 		if stripANSI {
 			return render.MaterializeGrid(raw, snap.width, snap.height)
 		}
@@ -387,7 +387,7 @@ func (r *Renderer) CaptureColorMap() string {
 		root, activePaneID := snap.captureRoot(st.compositor.LayoutHeight())
 		raw := st.compositor.RenderFullWithOverlay(root, activePaneID, func(paneID uint32) render.PaneData {
 			return r.paneLookupSnapshot(st, snap, paneID)
-		}, r.mergeOverlay(snap, render.OverlayState{}), true)
+		}, r.mergeOverlay(snap, render.OverlayState{}), false)
 		return render.ExtractColorMap(raw, snap.width, snap.height) + "\n"
 	})
 }


### PR DESCRIPTION
## Motivation

ANSI full-screen captures were emitted with the live-render clear-screen prefix, so printing or cat-ing a capture could blank the terminal before drawing the captured content.

## Summary

- Add a focused internal/client renderer regression test for Capture(false) and CaptureColorMap() so capture output cannot contain the clear-screen CSI sequence.
- Pass clearScreen=false for the two capture-only RenderFullWithOverlay calls.
- Keep the PR scoped to the surgical fix; no compose/emit split or broader renderer refactor.

## Testing

- `go test ./internal/client -run TestClientRendererCaptureDoesNotClearScreen -count=100`
- `go test ./test -run 'TestCapture|TestCaptureJSON' -count=1 -timeout 60s`
- `make install`
- `amux capture --ansi | xxd | head -1` now starts `00000000: 1b5b 3f32 356c 1b5b 481b 5b6d ...`, with no `1b5b 324a` clear-screen bytes. The exact `amux capture --ansi 1` form could not run in this live session because pane `1` does not exist.

Local full-suite note: `go test ./... -timeout 120s` hit an unrelated `internal/mux` prompt-time timeout and then the integration package timed out. The named mux test passed in isolation with `go test ./internal/mux -run TestAgentStatusTreatsPromptTimeBashSelfForkAsIdle -count=1 -v`; `go test ./test -timeout 180s` later hit unrelated `TestMouseCommandDragAutomaticallyCopiesSelection`, which passed in isolation with `go test ./test -run TestMouseCommandDragAutomaticallyCopiesSelection -count=1 -v -timeout 30s`.

## Review focus

- Confirm capture paths should suppress `ClearAll` while the live terminal render path remains unchanged.
- Confirm the regression belongs in internal/client: the failure is local to the renderer capture API and the existing renderer helper exercises the path without a socket harness.

Closes LAB-1633