### PR TITLE
LAB-1621: Add ResolvePane fuzz harness

### DIFF
--- a/internal/mux/pane_ref_test.go
+++ b/internal/mux/pane_ref_test.go
@@ -1,0 +1,115 @@
+package mux
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// FuzzWindowResolvePane seeds the documented pane reference forms plus their
+// boundary cases: exact names, duplicate names, decimal IDs with leading
+// zeroes, uint32 limits, prefix-shaped misses, whitespace, signs, embedded
+// NULs, and raw non-UTF-8 bytes. Those cases keep the CI seed run focused on
+// the parser's public contract while opt-in fuzzing mutates arbitrary user
+// refs around them.
+func FuzzWindowResolvePane(f *testing.F) {
+	for _, seed := range []string{
+		"",
+		"1",
+		"01",
+		"0000000001",
+		"2",
+		"3",
+		"4",
+		"0000000004",
+		"5",
+		"0000000005",
+		"4294967295",
+		"004294967295",
+		"4294967296",
+		"004294967296",
+		"18446744073709551615",
+		"-1",
+		"+1",
+		"1\n",
+		"pane-1",
+		"pane-1\x00",
+		"pane-2",
+		"pane-",
+		"pane-10",
+		"shared",
+		"shared\x00",
+		"sh",
+		" ",
+		"\t1",
+		string([]byte{'p', 'a', 'n', 'e', '-', 0, '1'}),
+		string([]byte{0xff, '1'}),
+	} {
+		f.Add(seed)
+	}
+
+	w, byID, byName := resolvePaneFuzzWindow()
+	f.Fuzz(func(t *testing.T, ref string) {
+		got, err := w.ResolvePane(ref)
+		if parsed, parseErr := strconv.ParseUint(ref, 10, 32); parseErr == nil {
+			want := byID[uint32(parsed)]
+			if want == nil {
+				assertResolvePaneCleanError(t, got, err, "not found")
+				return
+			}
+			if err != nil || got != want {
+				t.Fatalf("ResolvePane(%q) = (%v, %v), want pane %d with nil error", ref, got, err, want.ID)
+			}
+			return
+		}
+
+		matches := byName[ref]
+		switch len(matches) {
+		case 0:
+			assertResolvePaneCleanError(t, got, err, "not found")
+		case 1:
+			if err != nil || got != matches[0] {
+				t.Fatalf("ResolvePane(%q) = (%v, %v), want pane %d with nil error", ref, got, err, matches[0].ID)
+			}
+		default:
+			assertResolvePaneCleanError(t, got, err, "ambiguous")
+		}
+	})
+}
+
+func resolvePaneFuzzWindow() (*Window, map[uint32]*Pane, map[string][]*Pane) {
+	panes := []*Pane{
+		{ID: 1, Meta: PaneMeta{Name: "pane-1"}},
+		{ID: 2, Meta: PaneMeta{Name: "pane-2"}},
+		{ID: 3, Meta: PaneMeta{Name: "shared"}},
+		{ID: 4, Meta: PaneMeta{Name: "shared"}},
+	}
+
+	w := NewWindow(panes[0], 120, 40)
+	for _, pane := range panes[1:] {
+		if _, err := w.SplitRoot(SplitVertical, pane); err != nil {
+			panic(err)
+		}
+	}
+
+	byID := make(map[uint32]*Pane, len(panes))
+	byName := make(map[string][]*Pane, len(panes))
+	for _, pane := range panes {
+		byID[pane.ID] = pane
+		byName[pane.Meta.Name] = append(byName[pane.Meta.Name], pane)
+	}
+	return w, byID, byName
+}
+
+func assertResolvePaneCleanError(t *testing.T, got *Pane, err error, wantReason string) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("ResolvePane returned pane %v with nil error, want %s error", got, wantReason)
+	}
+	if got != nil {
+		t.Fatalf("ResolvePane returned pane %v with error %v, want nil pane on error", got, err)
+	}
+	if !strings.Contains(err.Error(), wantReason) {
+		t.Fatalf("ResolvePane error = %q, want reason containing %q", err.Error(), wantReason)
+	}
+}


### PR DESCRIPTION
## Motivation

LAB-1621 asks for fuzz coverage over parsers and untrusted input handlers. This PR covers target #1: `Window.ResolvePane(ref)`, which is the shared pane reference resolver used by server and client command paths.

## Summary

- Add `FuzzWindowResolvePane` next to the mux pane reference tests.
- Seed exact names, duplicate names, decimal ID normalization, uint32 boundaries, prefix-shaped misses, whitespace/sign cases, embedded NULs, and raw non-UTF-8 bytes.
- Assert this invariant: `Window.ResolvePane(ref)` must never panic; decimal `uint32` strings resolve only by pane ID; non-numeric strings resolve by exact pane name; duplicate exact names return an ambiguity error; misses return a clean not-found error; successful results are panes in the window.
- CI runs the seed corpus in normal `go test` mode. Full fuzzing remains opt-in with the operator command below.

## Testing

- `go test ./internal/mux -run=FuzzWindowResolvePane -count=1`
- `go test ./internal/mux -run=FuzzWindowResolvePane -fuzz=FuzzWindowResolvePane -fuzztime=5m`
- `go test ./internal/mux -run=FuzzWindowResolvePane -fuzz=FuzzWindowResolvePane -fuzztime=10m`
- `go test ./internal/mux -run=FuzzWindowResolvePane -count=100`
- `go test ./internal/mux -count=1`
- `go test ./internal/mux -run TestAgentStatusTreatsPromptTimeBashSelfForkAsIdle -count=1`
- `go test ./test -run TestCapturePreservesTruncatedStatusPaddingBeforeBorder -count=1 -timeout 30s`
- `go test ./test -run TestHotReloadRebuildConvergesFromOutsideRepoWithMismatchedInstallMetadata -count=1 -timeout 60s`

Local full-suite attempts with `go test ./... -timeout 120s` and `go test ./... -timeout 240s` failed in unrelated integration/process tests after the target package passed. I forwarded the observed protocol/concurrency-looking failure signature to LAB-1620 and did not change that code in this PR.

## Review focus

- Check that the fuzz invariant matches the current `ResolvePaneRef` contract rather than older architecture text. Current production code and tests treat `pane-` as not found, so this harness seeds prefix-shaped misses instead of introducing prefix matching.
- Check that the seed corpus is broad enough for CI seed execution while keeping full `-fuzz` operation manual.

Part of LAB-1621.