### PR TITLE
LAB-1621: Add config parser fuzz harness

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -145,16 +145,20 @@ func DefaultPath() string {
 
 // Load reads the config from the given path. Returns an empty config if the file doesn't exist.
 func Load(path string) (*Config, error) {
-	cfg := &Config{
-		Hosts: make(map[string]Host),
-	}
-
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return cfg, nil
+			return &Config{Hosts: make(map[string]Host)}, nil
 		}
 		return nil, fmt.Errorf("reading config: %w", err)
+	}
+
+	return parseConfig(data)
+}
+
+func parseConfig(data []byte) (*Config, error) {
+	cfg := &Config{
+		Hosts: make(map[string]Host),
 	}
 
 	md, err := toml.Decode(string(data), cfg)

--- a/internal/config/config_fuzz_test.go
+++ b/internal/config/config_fuzz_test.go
@@ -1,0 +1,104 @@
+package config
+
+import (
+	"reflect"
+	"testing"
+)
+
+// FuzzParseConfig seeds the config parser with the accepted top-level tables,
+// host tables, validation failures, legacy keybinding sections, type
+// mismatches, quoted host names, duplicate transport preferences, long
+// comments, and raw bytes. The seed corpus keeps CI focused on the TOML and
+// amux validation branches; opt-in fuzzing mutates arbitrary config bytes
+// around those examples.
+func FuzzParseConfig(f *testing.F) {
+	for _, seed := range [][]byte{
+		nil,
+		[]byte(""),
+		[]byte(`
+[hosts.lambda-a100]
+type = "remote"
+user = "ubuntu"
+address = "150.136.64.231"
+project_dir = "~/Project"
+gpu = "A100"
+color = "f38ba8"
+
+[hosts.macbook]
+type = "local"
+`),
+		[]byte("scrollback_lines = 2048\n"),
+		[]byte(`
+scrollback_lines = 2048
+
+[hosts.local]
+type = "local"
+scrollback_lines = 1024
+
+[hosts.builder]
+type = "remote"
+address = "builder.example"
+`),
+		[]byte("[debug]\npprof = true\n"),
+		[]byte("[client]\nlocal_echo = \"always\"\nlocal_echo_style = \"underline\"\n"),
+		[]byte("[client]\nlocal_echo = \"maybe\"\n"),
+		[]byte("[client]\nlocal_echo_style = \"flashy\"\n"),
+		[]byte("[transport]\npreference = [\" ssh \", \"\", \"ssh\", \"mosh\"]\n"),
+		[]byte("scrollback_lines = 0\n"),
+		[]byte("[hosts.local]\nscrollback_lines = 0\n"),
+		[]byte("[keys]\nprefix = \"C-b\"\n"),
+		[]byte("[keys.bind]\ns = \"split\"\n"),
+		[]byte("scrollback_lines = \"many\"\n"),
+		[]byte("[hosts.\"builder.example\"]\ntype = \"remote\"\naddress = \"127.0.0.1\"\n"),
+		[]byte("[hosts.local]\ntype = \"local\"\ntype = \"remote\"\n"),
+		[]byte("#00000000000000000000000000000000000000000000000000000000000000IIIIIIIIIIIIIIIIIIIIIIII"),
+		[]byte("["),
+		[]byte{0xff, 0x00, 't', 'o', 'm', 'l'},
+	} {
+		f.Add(seed)
+	}
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		cfg, err := parseConfig(data)
+		if err != nil {
+			if cfg != nil {
+				t.Fatalf("parse returned config %+v with error %v, want nil config on error", cfg, err)
+			}
+			return
+		}
+		assertParsedConfigValid(t, cfg)
+	})
+}
+
+func assertParsedConfigValid(t *testing.T, cfg *Config) {
+	t.Helper()
+
+	if cfg == nil {
+		t.Fatal("parse returned nil config with nil error")
+	}
+	if cfg.Hosts == nil {
+		t.Fatal("parse returned nil Hosts map with nil error")
+	}
+	if _, err := ResolveScrollbackLines(cfg.ScrollbackLines); err != nil {
+		t.Fatalf("global scrollback did not validate after parse: %v", err)
+	}
+	if _, err := ResolveLocalEchoMode(cfg.Client.LocalEcho); err != nil {
+		t.Fatalf("local_echo did not validate after parse: %v", err)
+	}
+	if _, err := ResolveLocalEchoStyle(cfg.Client.LocalEchoStyle); err != nil {
+		t.Fatalf("local_echo_style did not validate after parse: %v", err)
+	}
+
+	preferences := cfg.TransportPreferences()
+	for name, host := range cfg.Hosts {
+		if _, err := ResolveScrollbackLines(host.ScrollbackLines); err != nil {
+			t.Fatalf("host %q scrollback did not validate after parse: %v", name, err)
+		}
+		if host.Color == "" {
+			t.Fatalf("host %q color is empty after parse", name)
+		}
+		if !reflect.DeepEqual(host.TransportPreference, preferences) {
+			t.Fatalf("host %q transport preference = %v, want %v", name, host.TransportPreference, preferences)
+		}
+	}
+}


### PR DESCRIPTION
## Motivation

LAB-1621 asks for fuzz harnesses over untrusted parsers. This PR covers target #2: the TOML config parser in `internal/config/config.go`.

## Summary

- Extract the existing post-read config parse/validation path into unexported `parseConfig([]byte)` so fuzzing can exercise the real parser without per-input filesystem writes.
- Add `FuzzParseConfig` for arbitrary config bytes.
- Seed accepted top-level tables, host tables, validation failures, legacy `[keys]` sections, type mismatches, quoted host names, duplicate transport preferences, long comments, and raw bytes.
- Assert this invariant: parsing arbitrary config bytes must not panic; invalid TOML or invalid amux settings return an error; nil-error results have a nonnil config, initialized host map, valid scrollback/local-echo settings, assigned host colors, and copied transport preferences.
- CI runs the seed corpus in normal `go test` mode. Full fuzzing remains opt-in with the operator command below.

## Testing

- `go test ./internal/config -run=FuzzParseConfig -count=1`
- `go test ./internal/config -count=1`
- `go test ./internal/config -run=FuzzParseConfig -fuzz=FuzzParseConfig -fuzztime=5m`
- `go test ./internal/config -run=FuzzParseConfig -fuzz=FuzzParseConfig -fuzztime=10m`
- `go test ./internal/config -run=FuzzParseConfig -count=100`

An earlier 5-minute fuzz attempt reported a worker EOF while minimizing, but the generated seed replayed cleanly and subsequent 1-minute, 5-minute, and 10-minute runs all passed. I kept that long-comment input shape as an explicit seed.

## Review focus

- Check that `parseConfig` preserves `Load(path)` behavior while avoiding fuzz-time temp file churn.
- Check that the invariant covers amux validation/normalization, not only BurntSushi TOML decoding.

Part of LAB-1621.