### PR TITLE
LAB-1621: Fix capture rewrap parsing under fuzz

### DIFF
--- a/internal/capture/capture.go
+++ b/internal/capture/capture.go
@@ -39,6 +39,8 @@ func ParseArgs(args []string) Request {
 			req.HistoryMode = true
 		case "--rewrap":
 			req.RewrapSpecified = true
+			req.RewrapRaw = ""
+			req.RewrapWidth = 0
 			if i+1 < len(args) {
 				req.RewrapRaw = args[i+1]
 				if width, err := strconv.Atoi(args[i+1]); err == nil {

--- a/internal/capture/capture_fuzz_test.go
+++ b/internal/capture/capture_fuzz_test.go
@@ -43,12 +43,13 @@ func FuzzParseArgs(f *testing.F) {
 		req := ParseArgs(args)
 		assertRewrapWidthMatchesRaw(t, req)
 
-		normalized := ArgsForRequest(req)
-		if reparsed := ParseArgs(normalized); !reflect.DeepEqual(reparsed, req) {
-			t.Fatalf("ParseArgs(ArgsForRequest(ParseArgs(%q))) = %+v, want %+v; args=%q normalized=%q", raw, reparsed, req, args, normalized)
+		screenErr, historyErr := assertCaptureValidationResult(t, req)
+		if screenErr == nil || historyErr == nil {
+			normalized := ArgsForRequest(req)
+			if reparsed := ParseArgs(normalized); !reflect.DeepEqual(reparsed, req) {
+				t.Fatalf("ParseArgs(ArgsForRequest(ParseArgs(%q))) = %+v, want %+v; args=%q normalized=%q", raw, reparsed, req, args, normalized)
+			}
 		}
-
-		assertCaptureValidationResult(t, req)
 	})
 }
 
@@ -85,7 +86,7 @@ func assertRewrapWidthMatchesRaw(t *testing.T, req Request) {
 	}
 }
 
-func assertCaptureValidationResult(t *testing.T, req Request) {
+func assertCaptureValidationResult(t *testing.T, req Request) (error, error) {
 	t.Helper()
 
 	screenErr := ValidateScreenRequest(req)
@@ -122,4 +123,5 @@ func assertCaptureValidationResult(t *testing.T, req Request) {
 			t.Fatalf("history request with invalid --rewrap width validated: %+v", req)
 		}
 	}
+	return screenErr, historyErr
 }

--- a/internal/capture/capture_fuzz_test.go
+++ b/internal/capture/capture_fuzz_test.go
@@ -1,0 +1,125 @@
+package capture
+
+import (
+	"reflect"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// FuzzParseArgs seeds capture's flag parser with the supported flags, malformed
+// flag values, repeated --rewrap forms, conflicting output modes, unknown
+// positionals, empty argv elements, and raw non-UTF-8 bytes. These seeds keep
+// CI focused on the loose CLI contract while opt-in fuzzing mutates arbitrary
+// token sequences around them.
+func FuzzParseArgs(f *testing.F) {
+	for _, seed := range []string{
+		"",
+		"--ansi",
+		"--ansi\x00pane-1",
+		"--colors\x00pane-1",
+		"--format\x00json\x00pane-2",
+		"--format\x00xml\x00pane-2",
+		"--history\x00pane-3",
+		"--history\x00--rewrap\x0080\x00pane-3",
+		"--history\x00--rewrap\x00wide\x00pane-3",
+		"--history\x00--rewrap\x0080\x00--rewrap\x00wide\x00pane-3",
+		"--history\x00--rewrap\x0080\x00--rewrap\x00pane-3",
+		"--rewrap",
+		"--rewrap\x0080\x00--rewrap",
+		"--display",
+		"--display\x00pane-1",
+		"--ansi\x00--colors",
+		"--colors\x00--format\x00json",
+		"pane-1\x00pane-2",
+		"--unknown\x00pane-1",
+		string([]byte{'-', '-', 'r', 'e', 'w', 'r', 'a', 'p', 0xff, 0x00, '8', '0'}),
+	} {
+		f.Add(seed)
+	}
+
+	f.Fuzz(func(t *testing.T, raw string) {
+		args := captureFuzzArgs(raw)
+		req := ParseArgs(args)
+		assertRewrapWidthMatchesRaw(t, req)
+
+		normalized := ArgsForRequest(req)
+		if reparsed := ParseArgs(normalized); !reflect.DeepEqual(reparsed, req) {
+			t.Fatalf("ParseArgs(ArgsForRequest(ParseArgs(%q))) = %+v, want %+v; args=%q normalized=%q", raw, reparsed, req, args, normalized)
+		}
+
+		assertCaptureValidationResult(t, req)
+	})
+}
+
+func captureFuzzArgs(raw string) []string {
+	if raw == "" {
+		return nil
+	}
+	return strings.Split(raw, "\x00")
+}
+
+func assertRewrapWidthMatchesRaw(t *testing.T, req Request) {
+	t.Helper()
+	if !req.RewrapSpecified {
+		if req.RewrapRaw != "" || req.RewrapWidth != 0 {
+			t.Fatalf("rewrap unset but raw=%q width=%d", req.RewrapRaw, req.RewrapWidth)
+		}
+		return
+	}
+	if req.RewrapRaw == "" {
+		if req.RewrapWidth != 0 {
+			t.Fatalf("empty rewrap raw has width %d, want 0", req.RewrapWidth)
+		}
+		return
+	}
+	width, err := strconv.Atoi(req.RewrapRaw)
+	if err != nil {
+		if req.RewrapWidth != 0 {
+			t.Fatalf("invalid rewrap raw %q has width %d, want 0", req.RewrapRaw, req.RewrapWidth)
+		}
+		return
+	}
+	if req.RewrapWidth != width {
+		t.Fatalf("rewrap raw %q parsed width %d, want %d", req.RewrapRaw, req.RewrapWidth, width)
+	}
+}
+
+func assertCaptureValidationResult(t *testing.T, req Request) {
+	t.Helper()
+
+	screenErr := ValidateScreenRequest(req)
+	if screenErr != nil && screenErr.Error() == "" {
+		t.Fatal("ValidateScreenRequest returned an empty error")
+	}
+	if screenErr == nil {
+		if req.IncludeANSI && (req.ColorMap || req.FormatJSON) {
+			t.Fatalf("screen request with mutually exclusive output modes validated: %+v", req)
+		}
+		if req.ColorMap && req.FormatJSON {
+			t.Fatalf("screen request with mutually exclusive color/json modes validated: %+v", req)
+		}
+		if req.DisplayMode && (req.IncludeANSI || req.ColorMap || req.FormatJSON || req.HistoryMode || req.PaneRef != "") {
+			t.Fatalf("display request with other options validated: %+v", req)
+		}
+		if req.RewrapSpecified {
+			t.Fatalf("screen request with --rewrap validated without --history: %+v", req)
+		}
+	}
+
+	historyErr := ValidateHistoryRequest(req)
+	if historyErr != nil && historyErr.Error() == "" {
+		t.Fatal("ValidateHistoryRequest returned an empty error")
+	}
+	if historyErr == nil {
+		if !req.HistoryMode || req.PaneRef == "" {
+			t.Fatalf("history request without required fields validated: %+v", req)
+		}
+		if req.IncludeANSI || req.ColorMap || req.DisplayMode {
+			t.Fatalf("history request with mutually exclusive flags validated: %+v", req)
+		}
+		if req.RewrapSpecified && req.RewrapWidth <= 0 {
+			t.Fatalf("history request with invalid --rewrap width validated: %+v", req)
+		}
+	}
+}


### PR DESCRIPTION
## Motivation

LAB-1621 asks for fuzz coverage over parsers and untrusted input handlers. This PR covers target #3: the `amux capture` argument parser in `internal/capture`.

## Summary

- Add `FuzzParseArgs` for arbitrary NUL-separated capture argv tokens.
- Seed supported flags, malformed flag values, repeated `--rewrap` forms, conflicting output modes, unknown positionals, empty argv elements, and raw non-UTF-8 bytes.
- Fix a parser bug found by the red seed: repeated `--rewrap` kept a stale parsed width when a later `--rewrap` value was invalid or missing.
- Assert these invariants: `ParseArgs` must not panic; parsed `--rewrap` width state must match the current raw token; valid screen/history requests must round-trip through `ArgsForRequest`; validation returns either nil or a non-empty clean error.
- CI runs the seed corpus in normal `go test` mode. Full fuzzing remains opt-in with the operator command below.

Together with #750 and #751, this completes the minimum three-target LAB-1621 acceptance threshold.

## Testing

- `go test ./internal/capture -run=FuzzParseArgs -count=1` failed before the fix on the repeated invalid `--rewrap` seed.
- `go test ./internal/capture -run=FuzzParseArgs -count=1`
- `go test ./internal/capture -count=1`
- `go test ./internal/capture -run=FuzzParseArgs -fuzz=FuzzParseArgs -fuzztime=5m`
- `go test ./internal/capture -run=FuzzParseArgs -fuzz=FuzzParseArgs -fuzztime=10m`
- `go test ./internal/capture -run=FuzzParseArgs -count=100`

## Review focus

- Check the `--rewrap` state reset: each occurrence now clears prior raw/width state before consuming the next token.
- Check that the round-trip invariant is intentionally limited to requests that validate as screen or history captures, because malformed token order is not representable in the normalized `Request` shape.

Closes LAB-1621.