### PR TITLE
LAB-1634: Serve captures from renderer snapshots

### DIFF
--- a/internal/client/attach.go
+++ b/internal/client/attach.go
@@ -640,7 +640,13 @@ func runSessionWithDeps(sessionName string, getTermSize func(int) (int, int, err
 				msgCh <- &RenderMsg{Typ: RenderMsgClipboard, Data: msg.PaneData}
 			case proto.MsgTypeCaptureRequest:
 				// Server is forwarding a capture request — render from
-				// client-side emulators and send the result back.
+				// client-side emulators and send the result back. Wait for the
+				// render loop to apply messages already queued by this reader so
+				// capture observes prior layout/output messages in socket order,
+				// while keeping the capture work itself off the render loop.
+				callLocalRenderAction[struct{}](cr, msgCh, func(*ClientRenderer) localRenderResult {
+					return localRenderResult{}
+				})
 				resp := cr.HandleCaptureRequest(msg.CmdArgs, msg.AgentStatus)
 				if err := sendMessage(resp); err != nil {
 					return

--- a/internal/client/attach.go
+++ b/internal/client/attach.go
@@ -641,9 +641,7 @@ func runSessionWithDeps(sessionName string, getTermSize func(int) (int, int, err
 			case proto.MsgTypeCaptureRequest:
 				// Server is forwarding a capture request — render from
 				// client-side emulators and send the result back.
-				resp := callLocalRenderAction[*proto.Message](cr, msgCh, func(cr *ClientRenderer) localRenderResult {
-					return localRenderResult{value: cr.HandleCaptureRequest(msg.CmdArgs, msg.AgentStatus)}
-				})
+				resp := cr.HandleCaptureRequest(msg.CmdArgs, msg.AgentStatus)
 				if err := sendMessage(resp); err != nil {
 					return
 				}

--- a/internal/client/attach_bootstrap.go
+++ b/internal/client/attach_bootstrap.go
@@ -192,6 +192,7 @@ func readImmediateAttachCorrectionFromSource(reader attachTimedReader, cr *Clien
 		}
 		if msg.Type == proto.MsgTypeLayout {
 			cr.HandleLayout(msg.Layout)
+			deadline = time.Now().Add(timeout)
 			continue
 		}
 		bufferedMsg, ok := newAttachBootstrapMessage(msg)

--- a/internal/client/color_profile.go
+++ b/internal/client/color_profile.go
@@ -55,11 +55,13 @@ func (cr *ClientRenderer) ColorProfile() termenv.Profile {
 func (r *Renderer) SetColorProfile(profile termenv.Profile) {
 	r.withActor(func(st *rendererActorState) {
 		st.compositor.SetColorProfile(profile)
+		next := *st.snapshot
+		next.colorProfile = profile
+		st.snapshot = &next
+		r.publishSnapshot(&next)
 	})
 }
 
 func (r *Renderer) ColorProfile() termenv.Profile {
-	return withRendererActorValue(r, func(st *rendererActorState) termenv.Profile {
-		return st.compositor.ColorProfile()
-	})
+	return r.loadSnapshot().colorProfile
 }

--- a/internal/client/renderer.go
+++ b/internal/client/renderer.go
@@ -77,6 +77,8 @@ func (r *Renderer) HandleLayout(snap *proto.LayoutSnapshot) bool {
 			height:          prev.height,
 			activeWinID:     snap.ActiveWindowID,
 			scrollbackLines: prev.scrollbackLines,
+			colorProfile:    prev.colorProfile,
+			paneCaptures:    clonePaneRenderSnapshots(prev.paneCaptures),
 		}
 
 		allPanes := snap.Panes
@@ -136,19 +138,11 @@ func (r *Renderer) HandleLayout(snap *proto.LayoutSnapshot) bool {
 		}
 		st.warmVisiblePanes(next, nextEmulators)
 		r.resizeSnapshotEmulators(next, nextEmulators)
+		st.refreshPaneCaptures(next, nextEmulators)
 
 		st.compositor.SetSessionName(snap.SessionName)
 		if len(snap.Windows) > 0 {
-			windows := make([]render.WindowInfo, len(snap.Windows))
-			for i, ws := range snap.Windows {
-				windows[i] = render.WindowInfo{
-					Index:    ws.Index,
-					Name:     ws.Name,
-					IsActive: ws.ID == snap.ActiveWindowID,
-					Panes:    len(ws.Panes),
-				}
-			}
-			st.compositor.SetWindows(windows)
+			st.compositor.SetWindows(windowInfoFromSnapshot(snap.Windows, snap.ActiveWindowID))
 		} else {
 			st.compositor.SetWindows(nil)
 		}
@@ -175,6 +169,12 @@ func (r *Renderer) HandlePaneOutput(paneID uint32, data []byte) bool {
 			return false
 		}
 		if !st.snapshot.paneVisible(paneID) {
+			if emu := st.emulators[paneID]; emu != nil {
+				st.warmPaneOutput(paneID, st.emulators)
+				_, _ = emu.Write(data)
+				r.publishPaneCapture(st, paneID)
+				return false
+			}
 			st.bufferPaneOutput(paneID, data)
 			return false
 		}
@@ -184,6 +184,7 @@ func (r *Renderer) HandlePaneOutput(paneID uint32, data []byte) bool {
 		}
 		st.warmPaneOutput(paneID, st.emulators)
 		_, _ = emu.Write(data)
+		r.publishPaneCapture(st, paneID)
 		return true
 	})
 }
@@ -215,6 +216,12 @@ func (r *Renderer) HandlePaneOutputInfo(paneID uint32, data []byte, trackCursor 
 			return paneOutputRenderInfo{}
 		}
 		if !st.snapshot.paneVisible(paneID) {
+			if emu := st.emulators[paneID]; emu != nil {
+				st.warmPaneOutput(paneID, st.emulators)
+				_, _ = emu.Write(data)
+				r.publishPaneCapture(st, paneID)
+				return paneOutputRenderInfo{}
+			}
 			st.bufferPaneOutput(paneID, data)
 			return paneOutputRenderInfo{}
 		}
@@ -238,6 +245,7 @@ func (r *Renderer) HandlePaneOutputInfo(paneID uint32, data []byte, trackCursor 
 		if trackCursor {
 			info.cursorChanged = before != captureTerminalCursorState(emu)
 		}
+		r.publishPaneCapture(st, paneID)
 		return info
 	})
 }
@@ -259,6 +267,7 @@ func (r *Renderer) Resize(width, height int) {
 		}
 		st.compositor.Resize(width, height)
 		r.resizeSnapshotEmulators(&next, st.emulators)
+		st.refreshPaneCaptures(&next, st.emulators)
 		st.snapshot = &next
 		r.publishSnapshot(&next)
 	})
@@ -351,20 +360,17 @@ func (r *Renderer) drainVisiblePaneScreenChanges(st *rendererActorState, root *m
 // Capture renders the full composited screen from client-side emulators.
 // If stripANSI is true, returns a plain-text grid preserving visual layout.
 func (r *Renderer) Capture(stripANSI bool) string {
-	return withRendererActorValue(r, func(st *rendererActorState) string {
-		snap := st.snapshot
-		if snap.layout == nil {
-			return ""
-		}
-		root, activePaneID := snap.captureRoot(st.compositor.LayoutHeight())
-		raw := st.compositor.RenderFullWithOverlay(root, activePaneID, func(paneID uint32) render.PaneData {
-			return r.paneLookupSnapshot(st, snap, paneID)
-		}, r.mergeOverlay(snap, render.OverlayState{}), false)
-		if stripANSI {
-			return render.MaterializeGrid(raw, snap.width, snap.height)
-		}
-		return raw
-	})
+	snap := r.loadSnapshot()
+	if snap.layout == nil {
+		return ""
+	}
+	comp := snap.captureCompositor()
+	root, activePaneID := snap.captureRoot(comp.LayoutHeight())
+	raw := comp.RenderFullWithOverlay(root, activePaneID, snap.paneLookupFromCaptureSnapshot, r.mergeOverlay(snap, render.OverlayState{}), false)
+	if stripANSI {
+		return render.MaterializeGrid(raw, snap.width, snap.height)
+	}
+	return raw
 }
 
 // CaptureDisplay returns what the diff renderer thinks the terminal displays.
@@ -379,17 +385,14 @@ func (r *Renderer) CaptureDisplay() string {
 
 // CaptureColorMap renders a color map from client-side emulators.
 func (r *Renderer) CaptureColorMap() string {
-	return withRendererActorValue(r, func(st *rendererActorState) string {
-		snap := st.snapshot
-		if snap.layout == nil {
-			return ""
-		}
-		root, activePaneID := snap.captureRoot(st.compositor.LayoutHeight())
-		raw := st.compositor.RenderFullWithOverlay(root, activePaneID, func(paneID uint32) render.PaneData {
-			return r.paneLookupSnapshot(st, snap, paneID)
-		}, r.mergeOverlay(snap, render.OverlayState{}), false)
-		return render.ExtractColorMap(raw, snap.width, snap.height) + "\n"
-	})
+	snap := r.loadSnapshot()
+	if snap.layout == nil {
+		return ""
+	}
+	comp := snap.captureCompositor()
+	root, activePaneID := snap.captureRoot(comp.LayoutHeight())
+	raw := comp.RenderFullWithOverlay(root, activePaneID, snap.paneLookupFromCaptureSnapshot, r.mergeOverlay(snap, render.OverlayState{}), false)
+	return render.ExtractColorMap(raw, snap.width, snap.height) + "\n"
 }
 
 func marshalIndented(v any) string {
@@ -404,101 +407,67 @@ func (r *Renderer) captureJSONValue(agentStatus map[uint32]proto.PaneAgentStatus
 }
 
 func (r *Renderer) captureJSONValueWithHistory(agentStatus map[uint32]proto.PaneAgentStatus, baseHistory map[uint32][]proto.StyledLine, includeHistory bool) (proto.CaptureJSON, bool) {
-	capture := proto.CaptureJSON{}
-	ok := false
-	r.withActor(func(st *rendererActorState) {
-		snap := st.snapshot
-		if snap.layout == nil {
-			ok = false
+	snap := r.loadSnapshot()
+	if snap.layout == nil {
+		return proto.CaptureJSON{}, false
+	}
+
+	root, _ := snap.captureRoot(snap.height - render.GlobalBarHeight)
+
+	capture := proto.CaptureJSON{
+		Session: snap.sessionName,
+		Width:   snap.width,
+		Height:  snap.height,
+		Notice:  snap.sessionNotice,
+	}
+	for _, ws := range snap.windows {
+		if ws.ID == snap.activeWinID {
+			capture.Window = proto.CaptureWindow{
+				ID: ws.ID, Name: ws.Name, Index: ws.Index,
+			}
+			break
+		}
+	}
+
+	type capturePaneWork struct {
+		paneID      uint32
+		position    proto.CapturePos
+		baseHistory []proto.StyledLine
+	}
+
+	paneWork := make([]capturePaneWork, 0)
+	root.Walk(func(c *mux.LayoutCell) {
+		paneID := c.CellPaneID()
+		if paneID == 0 {
 			return
 		}
-
-		root, _ := snap.captureRoot(snap.height - render.GlobalBarHeight)
-
-		capture = proto.CaptureJSON{
-			Session: snap.sessionName,
-			Width:   snap.width,
-			Height:  snap.height,
-			Notice:  snap.sessionNotice,
-		}
-		for _, ws := range snap.windows {
-			if ws.ID == snap.activeWinID {
-				capture.Window = proto.CaptureWindow{
-					ID: ws.ID, Name: ws.Name, Index: ws.Index,
-				}
-				break
-			}
-		}
-
-		type capturePaneWork struct {
-			paneID      uint32
-			position    proto.CapturePos
-			baseHistory []proto.StyledLine
-		}
-
-		paneWork := make([]capturePaneWork, 0)
-		root.Walk(func(c *mux.LayoutCell) {
-			paneID := c.CellPaneID()
-			if paneID == 0 {
-				return
-			}
-			paneWork = append(paneWork, capturePaneWork{
-				paneID:      paneID,
-				position:    proto.CapturePos{X: c.X, Y: c.Y, Width: c.W, Height: c.H},
-				baseHistory: baseHistory[paneID],
-			})
+		paneWork = append(paneWork, capturePaneWork{
+			paneID:      paneID,
+			position:    proto.CapturePos{X: c.X, Y: c.Y, Width: c.W, Height: c.H},
+			baseHistory: baseHistory[paneID],
 		})
-
-		emulators := make([]mux.TerminalEmulator, len(paneWork))
-		// Pre-warm serially so the fan-out only performs read-only access across
-		// the emulator and snapshot maps.
-		for i, work := range paneWork {
-			emulators[i] = st.ensurePaneEmulator(work.paneID)
-			if emulators[i] == nil {
-				continue
-			}
-			st.warmPaneOutput(work.paneID, st.emulators)
-		}
-
-		ordered := make([]proto.CapturePane, len(paneWork))
-		orderedOK := make([]bool, len(paneWork))
-		var wg sync.WaitGroup
-		for i, work := range paneWork {
-			emu := emulators[i]
-			if emu == nil {
-				continue
-			}
-			wg.Add(1)
-			go func(i int, work capturePaneWork, emu mux.TerminalEmulator) {
-				defer wg.Done()
-
-				cp, ok := r.buildCapturePaneFromEmulator(emu, snap, work.paneID, agentStatus, includeHistory, work.baseHistory)
-				if !ok {
-					return
-				}
-				cp.Position = &proto.CapturePos{
-					X:      work.position.X,
-					Y:      work.position.Y,
-					Width:  work.position.Width,
-					Height: work.position.Height,
-				}
-				ordered[i] = cp
-				orderedOK[i] = true
-			}(i, work, emu)
-		}
-		wg.Wait()
-
-		capture.Panes = make([]proto.CapturePane, 0, len(ordered))
-		for i := range ordered {
-			if !orderedOK[i] {
-				continue
-			}
-			capture.Panes = append(capture.Panes, ordered[i])
-		}
-
-		ok = true
 	})
-	return capture, ok
+
+	capture.Panes = make([]proto.CapturePane, 0, len(paneWork))
+	for _, work := range paneWork {
+		pane, ok := snap.paneCapture(work.paneID)
+		if !ok {
+			continue
+		}
+		cp, ok := r.buildCapturePaneFromPaneSnapshot(pane, snap, work.paneID, agentStatus, includeHistory, work.baseHistory)
+		if !ok {
+			continue
+		}
+		cp.Position = &proto.CapturePos{
+			X:      work.position.X,
+			Y:      work.position.Y,
+			Width:  work.position.Width,
+			Height: work.position.Height,
+		}
+		capture.Panes = append(capture.Panes, cp)
+	}
+
+	return capture, true
 }
 
 // CaptureJSON renders a structured JSON capture from client-side emulators.
@@ -521,6 +490,18 @@ func (r *Renderer) CaptureJSONWithHistory(agentStatus map[uint32]proto.PaneAgent
 
 // CapturePaneText returns a single pane's content from client-side emulators.
 func (r *Renderer) CapturePaneText(paneID uint32, includeANSI bool) string {
+	snap := r.loadSnapshot()
+	pane, ok := snap.paneCaptures[paneID]
+	if !ok {
+		return r.capturePaneTextFromActor(paneID, includeANSI)
+	}
+	if includeANSI {
+		return pane.ansiString(snap.capabilities)
+	}
+	return pane.textString()
+}
+
+func (r *Renderer) capturePaneTextFromActor(paneID uint32, includeANSI bool) string {
 	return withRendererActorValue(r, func(st *rendererActorState) string {
 		snap := st.snapshot
 		emu := st.ensurePaneEmulator(paneID)
@@ -528,6 +509,7 @@ func (r *Renderer) CapturePaneText(paneID uint32, includeANSI bool) string {
 			return ""
 		}
 		st.warmPaneOutput(paneID, st.emulators)
+		r.publishPaneCapture(st, paneID)
 		if includeANSI {
 			return filterRenderedANSI(emu.Render(), snap.capabilities)
 		}
@@ -538,10 +520,22 @@ func (r *Renderer) CapturePaneText(paneID uint32, includeANSI bool) string {
 // capturePaneValue builds the structured JSON payload for a single pane.
 // Returns false when the pane is not found.
 func (r *Renderer) capturePaneValue(paneID uint32, agentStatus map[uint32]proto.PaneAgentStatus) (proto.CapturePane, bool) {
+	snap := r.loadSnapshot()
+	pane, ok := snap.paneCaptures[paneID]
+	if !ok {
+		return r.capturePaneValueFromActor(paneID, agentStatus)
+	}
+	return r.buildCapturePaneFromPaneSnapshot(pane, snap, paneID, agentStatus, false, nil)
+}
+
+func (r *Renderer) capturePaneValueFromActor(paneID uint32, agentStatus map[uint32]proto.PaneAgentStatus) (proto.CapturePane, bool) {
 	pane := proto.CapturePane{}
 	ok := false
 	r.withActor(func(st *rendererActorState) {
 		pane, ok = r.buildCapturePane(st, st.snapshot, paneID, agentStatus, false, nil)
+		if ok {
+			r.publishPaneCapture(st, paneID)
+		}
 	})
 	return pane, ok
 }
@@ -648,6 +642,45 @@ func (r *Renderer) buildCapturePaneFromEmulator(emu mux.TerminalEmulator, snap *
 		TrackedIssues: info.TrackedIssues,
 		Cursor:        caputil.CursorFromState(col, row, emu.CursorHidden(), state),
 		Terminal:      caputil.TerminalFromState(state),
+		Content:       content,
+	}, agentStatus)
+	return cp, true
+}
+
+func (r *Renderer) buildCapturePaneFromPaneSnapshot(pane paneRenderSnapshot, snap *rendererSnapshot, paneID uint32, agentStatus map[uint32]proto.PaneAgentStatus, includeHistory bool, baseHistory []proto.StyledLine) (proto.CapturePane, bool) {
+	info, ok := snap.paneInfo[paneID]
+	if !ok {
+		return proto.CapturePane{}, false
+	}
+	content := paneRenderSnapshotLines(pane.screen)
+	if includeHistory {
+		scrollback, screen := paneRenderSnapshotBuffer(pane, proto.CloneStyledLines(baseHistory), snap.scrollbackLines)
+		content = make([]string, 0, len(scrollback)+len(screen))
+		for _, line := range scrollback {
+			content = append(content, line.text)
+		}
+		for _, line := range screen {
+			content = append(content, line.text)
+		}
+	}
+	cp := caputil.BuildPane(caputil.PaneInput{
+		ID:            info.ID,
+		Name:          info.Name,
+		Active:        info.ID == snap.activePaneID,
+		Lead:          info.ID == snap.leadPaneID,
+		Zoomed:        info.ID == snap.zoomedPaneID,
+		Host:          info.Host,
+		Task:          info.Task,
+		Color:         info.Color,
+		ColumnIndex:   info.ColumnIndex,
+		ConnStatus:    info.ConnStatus,
+		GitBranch:     info.GitBranch,
+		PR:            info.PR,
+		KV:            info.KV,
+		TrackedPRs:    info.TrackedPRs,
+		TrackedIssues: info.TrackedIssues,
+		Cursor:        caputil.CursorFromState(pane.cursorCol, pane.cursorRow, pane.cursorHidden, pane.terminal),
+		Terminal:      caputil.TerminalFromState(pane.terminal),
 		Content:       content,
 	}, agentStatus)
 	return cp, true

--- a/internal/client/renderer.go
+++ b/internal/client/renderer.go
@@ -686,18 +686,6 @@ func (r *Renderer) buildCapturePaneFromPaneSnapshot(pane paneRenderSnapshot, sna
 	return cp, true
 }
 
-func (r *Renderer) paneLookupSnapshot(st *rendererActorState, snap *rendererSnapshot, paneID uint32) render.PaneData {
-	emu, ok := st.emulators[paneID]
-	if !ok {
-		return nil
-	}
-	info, ok := snap.paneInfo[paneID]
-	if !ok {
-		return nil
-	}
-	return &clientPaneData{emu: emu, info: info, caps: snap.capabilities}
-}
-
 func (r *Renderer) mergeOverlay(snap *rendererSnapshot, overlay render.OverlayState) render.OverlayState {
 	if overlay.Message == "" {
 		overlay.Message = snap.sessionNotice

--- a/internal/client/renderer_capture_snapshot.go
+++ b/internal/client/renderer_capture_snapshot.go
@@ -1,0 +1,224 @@
+package client
+
+import (
+	"image/color"
+	"strings"
+
+	uv "github.com/charmbracelet/ultraviolet"
+	caputil "github.com/weill-labs/amux/internal/capture"
+	"github.com/weill-labs/amux/internal/mux"
+	"github.com/weill-labs/amux/internal/proto"
+	"github.com/weill-labs/amux/internal/render"
+)
+
+type paneRenderSnapshot struct {
+	cursorCol        int
+	cursorRow        int
+	cursorHidden     bool
+	terminal         proto.TerminalState
+	rendered         string
+	renderedNoCursor string
+	scrollback       []paneBufferLine
+	screen           []paneBufferLine
+	cursorBlockCol   int
+	cursorBlockRow   int
+	hasCursorBlock   bool
+}
+
+func capturePaneRenderSnapshot(emu mux.TerminalEmulator) paneRenderSnapshot {
+	width, height := emu.Size()
+	cursorCol, cursorRow := emu.CursorPosition()
+	scrollback := make([]paneBufferLine, emu.ScrollbackLen())
+	for row := range scrollback {
+		scrollback[row] = paneBufferLine{
+			text:  emu.ScrollbackLineText(row),
+			cells: captureScrollbackCells(emu, row, width),
+		}
+	}
+
+	screen := make([]paneBufferLine, height)
+	for row := 0; row < height; row++ {
+		screen[row] = paneBufferLine{
+			text:  emu.ScreenLineText(row),
+			cells: captureScreenCells(emu, row, width),
+		}
+	}
+
+	snap := paneRenderSnapshot{
+		cursorCol:        cursorCol,
+		cursorRow:        cursorRow,
+		cursorHidden:     emu.CursorHidden(),
+		terminal:         cloneTerminalState(emu.TerminalState()),
+		rendered:         emu.Render(),
+		renderedNoCursor: emu.RenderWithoutCursorBlock(),
+		scrollback:       scrollback,
+		screen:           screen,
+	}
+	if col, row, ok := emu.CursorBlockPosition(); ok {
+		snap.cursorBlockCol = col
+		snap.cursorBlockRow = row
+		snap.hasCursorBlock = true
+	}
+	return snap
+}
+
+func cloneTerminalState(state proto.TerminalState) proto.TerminalState {
+	state.Palette = append([]color.Color(nil), state.Palette...)
+	return state
+}
+
+func emptyPaneRenderSnapshot(width, height, scrollbackLines int) paneRenderSnapshot {
+	emu := mux.NewVTEmulatorWithScrollback(width, height, scrollbackLines)
+	defer emu.Close()
+	return capturePaneRenderSnapshot(emu)
+}
+
+func (s *rendererSnapshot) paneCapture(paneID uint32) (paneRenderSnapshot, bool) {
+	if paneID == 0 {
+		return paneRenderSnapshot{}, false
+	}
+	if snap, ok := s.paneCaptures[paneID]; ok {
+		return snap, true
+	}
+	if _, ok := s.paneInfo[paneID]; !ok {
+		return paneRenderSnapshot{}, false
+	}
+	width, height, ok := s.paneDimensions(paneID)
+	if !ok {
+		return paneRenderSnapshot{}, false
+	}
+	return emptyPaneRenderSnapshot(width, height, s.scrollbackLines), true
+}
+
+func (s *rendererSnapshot) captureCompositor() *render.Compositor {
+	comp := render.NewCompositor(s.width, s.height, s.sessionName)
+	comp.SetWindows(windowInfoFromSnapshot(s.windows, s.activeWinID))
+	comp.SetColorProfile(s.colorProfile)
+	return comp
+}
+
+func windowInfoFromSnapshot(windows []proto.WindowSnapshot, activeWinID uint32) []render.WindowInfo {
+	if len(windows) == 0 {
+		return nil
+	}
+	out := make([]render.WindowInfo, len(windows))
+	for i, ws := range windows {
+		out[i] = render.WindowInfo{
+			Index:    ws.Index,
+			Name:     ws.Name,
+			IsActive: ws.ID == activeWinID,
+			Panes:    len(ws.Panes),
+		}
+	}
+	return out
+}
+
+func (s *rendererSnapshot) paneLookupFromCaptureSnapshot(paneID uint32) render.PaneData {
+	info, ok := s.paneInfo[paneID]
+	if !ok {
+		return nil
+	}
+	pane, ok := s.paneCapture(paneID)
+	if !ok {
+		return nil
+	}
+	return &snapshotPaneData{pane: pane, info: info, caps: s.capabilities}
+}
+
+func paneRenderSnapshotLines(lines []paneBufferLine) []string {
+	if len(lines) == 0 {
+		return nil
+	}
+	out := make([]string, len(lines))
+	for i, line := range lines {
+		out[i] = line.text
+	}
+	return out
+}
+
+func paneRenderSnapshotBuffer(pane paneRenderSnapshot, baseHistory []proto.StyledLine, scrollbackLines int) (scrollback, screen []paneBufferLine) {
+	baseStart, liveStart := trimPaneBufferStarts(len(baseHistory), len(pane.scrollback), scrollbackLines)
+	scrollback = make([]paneBufferLine, 0, len(baseHistory)-baseStart+len(pane.scrollback)-liveStart)
+	for _, line := range baseHistory[baseStart:] {
+		scrollback = append(scrollback, paneBufferLine{
+			text:  line.Text,
+			cells: screenCellsFromProto(line.Cells),
+		})
+	}
+	scrollback = append(scrollback, pane.scrollback[liveStart:]...)
+	screen = append([]paneBufferLine(nil), pane.screen...)
+	return scrollback, screen
+}
+
+type snapshotPaneData struct {
+	pane paneRenderSnapshot
+	info proto.PaneSnapshot
+	caps proto.ClientCapabilities
+}
+
+func (p *snapshotPaneData) RenderScreen(active bool) string {
+	rendered := p.pane.rendered
+	if !active && p.pane.hasCursorBlock {
+		rendered = p.pane.renderedNoCursor
+	}
+	return filterRenderedANSI(rendered, p.caps)
+}
+
+func (p *snapshotPaneData) CellAt(col, row int, active bool) render.ScreenCell {
+	cell := paneBufferLineCell(p.pane.screen, row, col)
+	if !active && p.pane.hasCursorBlock && col == p.pane.cursorBlockCol && row == p.pane.cursorBlockRow {
+		stripSnapshotCursorBlock(&cell)
+	}
+	return cell
+}
+
+func stripSnapshotCursorBlock(cell *render.ScreenCell) {
+	if cell.Style.Attrs&uv.AttrReverse == 0 {
+		return
+	}
+	if cell.Char != " " && cell.Char != "" {
+		return
+	}
+	cell.Style.Attrs &^= uv.AttrReverse
+}
+
+func (p *snapshotPaneData) CopyModeOverlay() *proto.ViewportOverlay { return nil }
+func (p *snapshotPaneData) CursorPos() (col, row int) {
+	return p.pane.cursorCol, p.pane.cursorRow
+}
+func (p *snapshotPaneData) CursorHidden() bool { return p.pane.cursorHidden }
+func (p *snapshotPaneData) HasCursorBlock() bool {
+	return p.pane.hasCursorBlock
+}
+func (p *snapshotPaneData) ID() uint32   { return p.info.ID }
+func (p *snapshotPaneData) Name() string { return p.info.Name }
+func (p *snapshotPaneData) TrackedPRs() []proto.TrackedPR {
+	return proto.CloneTrackedPRs(p.info.TrackedPRs)
+}
+func (p *snapshotPaneData) TrackedIssues() []proto.TrackedIssue {
+	return proto.CloneTrackedIssues(p.info.TrackedIssues)
+}
+func (p *snapshotPaneData) Issue() string {
+	if p.info.KV == nil {
+		return ""
+	}
+	return p.info.KV["issue"]
+}
+func (p *snapshotPaneData) Host() string       { return p.info.Host }
+func (p *snapshotPaneData) Task() string       { return p.info.Task }
+func (p *snapshotPaneData) Color() string      { return p.info.Color }
+func (p *snapshotPaneData) Idle() bool         { return p.info.Idle }
+func (p *snapshotPaneData) IsLead() bool       { return p.info.Lead }
+func (p *snapshotPaneData) ConnStatus() string { return p.info.ConnStatus }
+func (p *snapshotPaneData) InCopyMode() bool   { return false }
+func (p *snapshotPaneData) CopyModeSearch() string {
+	return ""
+}
+
+func (p paneRenderSnapshot) ansiString(caps proto.ClientCapabilities) string {
+	return filterRenderedANSI(p.rendered, caps)
+}
+
+func (p paneRenderSnapshot) textString() string {
+	return strings.Join(caputil.TrimOuterBlankRows(paneRenderSnapshotLines(p.screen)), "\n")
+}

--- a/internal/client/renderer_capture_snapshot.go
+++ b/internal/client/renderer_capture_snapshot.go
@@ -12,17 +12,19 @@ import (
 )
 
 type paneRenderSnapshot struct {
-	width          int
-	height         int
-	cursorCol      int
-	cursorRow      int
-	cursorHidden   bool
-	terminal       proto.TerminalState
-	scrollback     []paneBufferLine
-	screen         []paneBufferLine
-	cursorBlockCol int
-	cursorBlockRow int
-	hasCursorBlock bool
+	width            int
+	height           int
+	cursorCol        int
+	cursorRow        int
+	cursorHidden     bool
+	terminal         proto.TerminalState
+	rendered         string
+	renderedNoCursor string
+	scrollback       []paneBufferLine
+	screen           []paneBufferLine
+	cursorBlockCol   int
+	cursorBlockRow   int
+	hasCursorBlock   bool
 }
 
 func capturePaneRenderSnapshot(emu mux.TerminalEmulator) paneRenderSnapshot {
@@ -44,20 +46,24 @@ func capturePaneRenderSnapshot(emu mux.TerminalEmulator) paneRenderSnapshot {
 		}
 	}
 
+	rendered := emu.Render()
 	snap := paneRenderSnapshot{
-		width:        width,
-		height:       height,
-		cursorCol:    cursorCol,
-		cursorRow:    cursorRow,
-		cursorHidden: emu.CursorHidden(),
-		terminal:     cloneTerminalState(emu.TerminalState()),
-		scrollback:   scrollback,
-		screen:       screen,
+		width:            width,
+		height:           height,
+		cursorCol:        cursorCol,
+		cursorRow:        cursorRow,
+		cursorHidden:     emu.CursorHidden(),
+		terminal:         cloneTerminalState(emu.TerminalState()),
+		rendered:         rendered,
+		renderedNoCursor: rendered,
+		scrollback:       scrollback,
+		screen:           screen,
 	}
 	if col, row, ok := emu.CursorBlockPosition(); ok {
 		snap.cursorBlockCol = col
 		snap.cursorBlockRow = row
 		snap.hasCursorBlock = true
+		snap.renderedNoCursor = emu.RenderWithoutCursorBlock()
 	}
 	return snap
 }
@@ -157,7 +163,11 @@ type snapshotPaneData struct {
 }
 
 func (p *snapshotPaneData) RenderScreen(active bool) string {
-	return filterRenderedANSI(render.RenderPaneViewportANSI(p.pane.width, p.pane.height, active, p), p.caps)
+	rendered := p.pane.rendered
+	if !active && p.pane.hasCursorBlock {
+		rendered = p.pane.renderedNoCursor
+	}
+	return filterRenderedANSI(rendered, p.caps)
 }
 
 func (p *snapshotPaneData) CellAt(col, row int, active bool) render.ScreenCell {
@@ -212,8 +222,7 @@ func (p *snapshotPaneData) CopyModeSearch() string {
 }
 
 func (p paneRenderSnapshot) ansiString(caps proto.ClientCapabilities) string {
-	data := snapshotPaneData{pane: p, caps: caps}
-	return data.RenderScreen(true)
+	return filterRenderedANSI(p.rendered, caps)
 }
 
 func (p paneRenderSnapshot) textString() string {

--- a/internal/client/renderer_capture_snapshot.go
+++ b/internal/client/renderer_capture_snapshot.go
@@ -12,17 +12,17 @@ import (
 )
 
 type paneRenderSnapshot struct {
-	cursorCol        int
-	cursorRow        int
-	cursorHidden     bool
-	terminal         proto.TerminalState
-	rendered         string
-	renderedNoCursor string
-	scrollback       []paneBufferLine
-	screen           []paneBufferLine
-	cursorBlockCol   int
-	cursorBlockRow   int
-	hasCursorBlock   bool
+	width          int
+	height         int
+	cursorCol      int
+	cursorRow      int
+	cursorHidden   bool
+	terminal       proto.TerminalState
+	scrollback     []paneBufferLine
+	screen         []paneBufferLine
+	cursorBlockCol int
+	cursorBlockRow int
+	hasCursorBlock bool
 }
 
 func capturePaneRenderSnapshot(emu mux.TerminalEmulator) paneRenderSnapshot {
@@ -45,14 +45,14 @@ func capturePaneRenderSnapshot(emu mux.TerminalEmulator) paneRenderSnapshot {
 	}
 
 	snap := paneRenderSnapshot{
-		cursorCol:        cursorCol,
-		cursorRow:        cursorRow,
-		cursorHidden:     emu.CursorHidden(),
-		terminal:         cloneTerminalState(emu.TerminalState()),
-		rendered:         emu.Render(),
-		renderedNoCursor: emu.RenderWithoutCursorBlock(),
-		scrollback:       scrollback,
-		screen:           screen,
+		width:        width,
+		height:       height,
+		cursorCol:    cursorCol,
+		cursorRow:    cursorRow,
+		cursorHidden: emu.CursorHidden(),
+		terminal:     cloneTerminalState(emu.TerminalState()),
+		scrollback:   scrollback,
+		screen:       screen,
 	}
 	if col, row, ok := emu.CursorBlockPosition(); ok {
 		snap.cursorBlockCol = col
@@ -157,11 +157,7 @@ type snapshotPaneData struct {
 }
 
 func (p *snapshotPaneData) RenderScreen(active bool) string {
-	rendered := p.pane.rendered
-	if !active && p.pane.hasCursorBlock {
-		rendered = p.pane.renderedNoCursor
-	}
-	return filterRenderedANSI(rendered, p.caps)
+	return filterRenderedANSI(render.RenderPaneViewportANSI(p.pane.width, p.pane.height, active, p), p.caps)
 }
 
 func (p *snapshotPaneData) CellAt(col, row int, active bool) render.ScreenCell {
@@ -216,7 +212,8 @@ func (p *snapshotPaneData) CopyModeSearch() string {
 }
 
 func (p paneRenderSnapshot) ansiString(caps proto.ClientCapabilities) string {
-	return filterRenderedANSI(p.rendered, caps)
+	data := snapshotPaneData{pane: p, caps: caps}
+	return data.RenderScreen(true)
 }
 
 func (p paneRenderSnapshot) textString() string {

--- a/internal/client/renderer_capture_snapshot_test.go
+++ b/internal/client/renderer_capture_snapshot_test.go
@@ -1,0 +1,47 @@
+package client
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestHandleCaptureRequestDoesNotWaitForRendererActor(t *testing.T) {
+	r := NewWithScrollback(20, 4, 100)
+	t.Cleanup(r.Close)
+
+	r.HandleLayout(singlePane20x3())
+	r.HandlePaneOutput(1, []byte("ready"))
+
+	actorRelease := make(chan struct{})
+	actorStarted := make(chan struct{})
+	go r.withActor(func(*rendererActorState) {
+		close(actorStarted)
+		<-actorRelease
+	})
+
+	select {
+	case <-actorStarted:
+	case <-time.After(time.Second):
+		t.Fatal("renderer actor did not start blocking command")
+	}
+
+	captureDone := make(chan string, 1)
+	go func() {
+		resp := r.HandleCaptureRequest([]string{"pane-1"}, nil)
+		captureDone <- resp.CmdOutput
+	}()
+
+	select {
+	case out := <-captureDone:
+		if !strings.Contains(out, "ready") {
+			t.Fatalf("capture output = %q, want pane content", out)
+		}
+	case <-time.After(50 * time.Millisecond):
+		close(actorRelease)
+		out := <-captureDone
+		t.Fatalf("capture waited for renderer actor; output after release was %q", out)
+	}
+
+	close(actorRelease)
+}

--- a/internal/client/renderer_capture_snapshot_test.go
+++ b/internal/client/renderer_capture_snapshot_test.go
@@ -7,6 +7,8 @@ import (
 )
 
 func TestHandleCaptureRequestDoesNotWaitForRendererActor(t *testing.T) {
+	t.Parallel()
+
 	r := NewWithScrollback(20, 4, 100)
 	t.Cleanup(r.Close)
 

--- a/internal/client/renderer_state.go
+++ b/internal/client/renderer_state.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/muesli/termenv"
 	"github.com/weill-labs/amux/internal/mux"
 	"github.com/weill-labs/amux/internal/proto"
 	"github.com/weill-labs/amux/internal/render"
@@ -25,6 +26,8 @@ type rendererSnapshot struct {
 	windows         []proto.WindowSnapshot
 	activeWinID     uint32
 	scrollbackLines int
+	colorProfile    termenv.Profile
+	paneCaptures    map[uint32]paneRenderSnapshot
 }
 
 func newRendererSnapshot(width, height, scrollbackLines int) *rendererSnapshot {
@@ -33,6 +36,8 @@ func newRendererSnapshot(width, height, scrollbackLines int) *rendererSnapshot {
 		width:           width,
 		height:          height,
 		scrollbackLines: scrollbackLines,
+		colorProfile:    termenv.TrueColor,
+		paneCaptures:    make(map[uint32]paneRenderSnapshot),
 	}
 }
 
@@ -112,6 +117,27 @@ func (s *rendererSnapshot) paneDimensions(paneID uint32) (int, int, bool) {
 
 func cloneWindowSnapshots(src []proto.WindowSnapshot) []proto.WindowSnapshot {
 	return append([]proto.WindowSnapshot(nil), src...)
+}
+
+func clonePaneRenderSnapshots(src map[uint32]paneRenderSnapshot) map[uint32]paneRenderSnapshot {
+	if len(src) == 0 {
+		return make(map[uint32]paneRenderSnapshot)
+	}
+	dst := make(map[uint32]paneRenderSnapshot, len(src))
+	for paneID, snap := range src {
+		dst[paneID] = snap
+	}
+	return dst
+}
+
+func prunePaneRenderSnapshots(src map[uint32]paneRenderSnapshot, panes map[uint32]proto.PaneSnapshot) map[uint32]paneRenderSnapshot {
+	dst := make(map[uint32]paneRenderSnapshot, len(src))
+	for paneID, snap := range src {
+		if _, ok := panes[paneID]; ok {
+			dst[paneID] = snap
+		}
+	}
+	return dst
 }
 
 type rendererCommand struct {
@@ -239,6 +265,29 @@ func (st *rendererActorState) warmVisiblePanes(snap *rendererSnapshot, emulators
 	for paneID := range snap.visiblePaneIDs {
 		st.warmPaneOutput(paneID, emulators)
 	}
+}
+
+func (st *rendererActorState) refreshPaneCaptures(snap *rendererSnapshot, emulators map[uint32]mux.TerminalEmulator) {
+	captures := prunePaneRenderSnapshots(snap.paneCaptures, snap.paneInfo)
+	for paneID, emu := range emulators {
+		if _, ok := snap.paneInfo[paneID]; !ok || emu == nil {
+			continue
+		}
+		captures[paneID] = capturePaneRenderSnapshot(emu)
+	}
+	snap.paneCaptures = captures
+}
+
+func (r *Renderer) publishPaneCapture(st *rendererActorState, paneID uint32) {
+	emu := st.emulators[paneID]
+	if emu == nil {
+		return
+	}
+	next := *st.snapshot
+	next.paneCaptures = clonePaneRenderSnapshots(st.snapshot.paneCaptures)
+	next.paneCaptures[paneID] = capturePaneRenderSnapshot(emu)
+	st.snapshot = &next
+	r.publishSnapshot(&next)
 }
 
 func (r *Renderer) loadSnapshot() *rendererSnapshot {


### PR DESCRIPTION
## Motivation

`amux capture` currently asks the live render path to synchronously render from client emulators. When capture blocks the render loop/renderer actor while pane output continues arriving, the client can overflow its coalescing budget, request a full redraw, and emit a large SGR-reset diff burst that is visible as a transient background flicker in TUIs like nvim.

## Summary

- Picked Option A: serve normal captures from the existing atomic renderer snapshot instead of synchronously entering the render actor.
- Extended `rendererSnapshot` with per-pane capture snapshots containing the full screen cell grid, live scrollback cells/text, cursor state, terminal state, cursor-block metadata, emulator-rendered ANSI, cursorless ANSI for inactive cursor-block panes, and the renderer color profile/session/window metadata needed for composition.
- Republish snapshots on layout/resize, color-profile changes, and every emulator write for visible panes or hidden panes that already have a warm emulator; cold hidden pane-specific captures still fall back to the actor to preserve lazy hidden-pane replay behavior.
- Changed full/text/color/JSON capture reads to load one atomic snapshot and compose from frozen `snapshotPaneData` with a fresh compositor, giving a consistent full-session view within a single snapshot.
- Changed attach capture handling to use a render-loop barrier for prior queued messages, then respond directly from snapshot-backed capture instead of running capture itself on the render loop.
- Preserved existing `capture --ansi pane-N` byte behavior by snapshotting the emulator-rendered ANSI instead of reserializing pane cells with a different SGR parameter order.
- Made the immediate attach correction window reset after layout corrections so resize-correction output is not dropped under race/coverage timing.

Design details:
- Snapshot contents: per-pane full visible screen cells, live scrollback cells/text, rendered ANSI, cursorless rendered ANSI when needed, cursor position/visibility, terminal metadata, cursor-block position, pane metadata, active/window/layout/session state, capabilities, and color profile.
- Republish timing: after layout/resize refreshes, after color profile updates, and after each emulator write for panes that already have emulator state.
- Read side: `Capture`, `CaptureColorMap`, full JSON, pane JSON, and pane text read `r.state.Load()` and use snapshot-backed pane data; attached capture requests first wait for a no-op render-loop barrier so prior layout/output messages are reflected in the snapshot. `--display` remains actor-backed because it intentionally reports diff-renderer display state.
- Worst-case staleness: capture sees the last atomically published renderer state after earlier queued messages have drained; it can still be behind socket messages that arrive after the capture request, but the panes/layout in each capture are internally consistent.

## Testing

- `go test ./internal/client -run TestHandleCaptureRequestDoesNotWaitForRendererActor -count=100`
- `go test ./internal/client -count=1`
- `go test -race ./internal/client -run TestReadAttachBootstrapAppliesImmediateReattachResizeCorrectionBeforeReturn -count=100 -timeout 120s`
- `go test ./internal/render -count=1`
- `go test ./test -run TestCapturePaneANSI_PreservesStyleAfterSGRReset -count=1 -timeout 60s`
- `go test ./test -run 'TestMouseDragOntoWindowTabMovesPaneToWindow|TestMouseDragWindowTabDwellSwitchesWindowAndKeepsDrag|TestCapturePaneANSI_PreservesStyleAfterSGRReset' -count=1 -timeout 120s`
- `go test ./test -run TestMouseDragAutomaticallyEntersCopyModeAndCopiesSelection -count=1 -timeout 120s`
- `golangci-lint run ./internal/client/...`
- `go test ./... -timeout 120s` currently fails locally under full package load with harness timing flakes observed in adjacent tests; the touched `internal/client` package and regression test pass, and isolated reruns passed for the named mouse/mux failures. `TestSendKeysEncodeParityMatrix` remains intermittently flaky in this workspace with raw key delivery timeouts unrelated to capture rendering.

## Review focus

- The snapshot publication points in `internal/client/renderer.go` and whether the cold-hidden fallback is the right compatibility tradeoff.
- The new `snapshotPaneData` adapter in `internal/client/renderer_capture_snapshot.go`, especially cursor-block stripping and preserving emulator-rendered ANSI for pane `--ansi` capture.
- The attach path change in `internal/client/attach.go`, where the no-op barrier preserves message ordering without doing capture work on the render loop.

Closes LAB-1634
