### PR TITLE
LAB-1640: Memoize pane history payload encoding

### DIFF
--- a/internal/mux/pane.go
+++ b/internal/mux/pane.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/creack/pty"
 	"github.com/weill-labs/amux/internal/debugowner"
+	"github.com/weill-labs/amux/internal/proto"
 	"github.com/weill-labs/amux/internal/termprofile"
 )
 
@@ -97,6 +98,8 @@ type Pane struct {
 	suppressExit  atomic.Bool
 
 	outputSeq        atomic.Uint64
+	paneHistorySeq   atomic.Uint64
+	paneHistoryCache proto.PaneHistoryPayloadCache
 	baseHistory      atomic.Pointer[paneBaseHistory]
 	scrollbackWidths []int
 	scrollbackLines  int
@@ -912,6 +915,7 @@ func (p *Pane) Respawn(sessionName, dir string) error {
 		storeUnixTime(&p.idleSinceUnix, time.Time{})
 		p.liveCwd = dir
 		p.Meta.Dir = dir
+		p.paneHistorySeq.Add(1)
 		wireScrollbackCallbacks(p)
 	})
 	return nil

--- a/internal/mux/pane_emulator.go
+++ b/internal/mux/pane_emulator.go
@@ -25,6 +25,7 @@ func wireScrollbackCallbacks(p *Pane) {
 func (p *Pane) ReplayScreen(data string) {
 	p.withActor(func() {
 		_, _ = p.emulator.Write([]byte(data))
+		p.paneHistorySeq.Add(1)
 	})
 }
 
@@ -56,6 +57,7 @@ func (p *Pane) drainResponses(emulator TerminalEmulator, ptmx *os.File, done cha
 func (p *Pane) applyOutput(data []byte) uint64 {
 	return paneActorValue(p, func() uint64 {
 		_, _ = p.emulator.Write(data)
+		p.paneHistorySeq.Add(1)
 		return p.outputSeq.Add(1)
 	})
 }
@@ -81,6 +83,7 @@ func (p *Pane) Resize(cols, rows int) error {
 			p.emulator.Resize(cols, rows)
 		}
 		if sizeChanged {
+			p.paneHistorySeq.Add(1)
 			if err := p.resizePTY(cols, rows); err != nil {
 				return err
 			}
@@ -148,6 +151,15 @@ func (p *Pane) StyledHistorySnapshot() (history []proto.StyledLine) {
 	return history
 }
 
+func (p *Pane) StyledHistorySnapshotWithCache() (history []proto.StyledLine, version uint64, cache *proto.PaneHistoryPayloadCache) {
+	p.withActor(func() {
+		history = p.styledHistorySnapshot()
+		version = p.paneHistorySeq.Load()
+		cache = &p.paneHistoryCache
+	})
+	return history, version, cache
+}
+
 // StyledHistoryScreenSnapshot returns retained history with frozen cell styles,
 // current screen, and the latest live-output sequence included in that state.
 func (p *Pane) StyledHistoryScreenSnapshot() (history []proto.StyledLine, screen string, seq uint64) {
@@ -157,6 +169,17 @@ func (p *Pane) StyledHistoryScreenSnapshot() (history []proto.StyledLine, screen
 		seq = p.outputSeq.Load()
 	})
 	return history, screen, seq
+}
+
+func (p *Pane) StyledHistoryScreenSnapshotWithCache() (history []proto.StyledLine, screen string, seq uint64, version uint64, cache *proto.PaneHistoryPayloadCache) {
+	p.withActor(func() {
+		history = p.styledHistorySnapshot()
+		screen = RenderWithCursor(p.emulator)
+		seq = p.outputSeq.Load()
+		version = p.paneHistorySeq.Load()
+		cache = &p.paneHistoryCache
+	})
+	return history, screen, seq, version, cache
 }
 
 func (p *Pane) terminalSnapshot() PaneTerminalSnapshot {
@@ -331,6 +354,7 @@ func (p *Pane) SetRetainedHistory(lines []string) {
 			lines = lines[len(lines)-limit:]
 		}
 		p.baseHistory.Store(&paneBaseHistory{lines: append([]string(nil), lines...)})
+		p.paneHistorySeq.Add(1)
 	})
 }
 
@@ -343,6 +367,7 @@ func (p *Pane) ResetState() {
 		if p.emulator != nil {
 			p.emulator.Reset()
 		}
+		p.paneHistorySeq.Add(1)
 	})
 }
 

--- a/internal/proto/pane_history_bench_test.go
+++ b/internal/proto/pane_history_bench_test.go
@@ -1,0 +1,25 @@
+package proto
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestEncodePaneHistoryPayloadDeterministicForIdlePane(t *testing.T) {
+	t.Parallel()
+
+	msg := benchmarkPaneHistoryMessage(128, 80)
+
+	first, err := encodePaneHistoryPayload(msg)
+	if err != nil {
+		t.Fatalf("first encodePaneHistoryPayload: %v", err)
+	}
+	second, err := encodePaneHistoryPayload(msg)
+	if err != nil {
+		t.Fatalf("second encodePaneHistoryPayload: %v", err)
+	}
+
+	if !bytes.Equal(first, second) {
+		t.Fatalf("consecutive encodes of unchanged pane history differed")
+	}
+}

--- a/internal/proto/pane_history_bench_test.go
+++ b/internal/proto/pane_history_bench_test.go
@@ -23,3 +23,14 @@ func TestEncodePaneHistoryPayloadDeterministicForIdlePane(t *testing.T) {
 		t.Fatalf("consecutive encodes of unchanged pane history differed")
 	}
 }
+
+func BenchmarkEncodePaneHistoryPayload(b *testing.B) {
+	msg := benchmarkPaneHistoryMessage(10_000, 80)
+
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := encodePaneHistoryPayload(msg); err != nil {
+			b.Fatalf("encodePaneHistoryPayload: %v", err)
+		}
+	}
+}

--- a/internal/proto/pane_history_bench_test.go
+++ b/internal/proto/pane_history_bench_test.go
@@ -24,8 +24,56 @@ func TestEncodePaneHistoryPayloadDeterministicForIdlePane(t *testing.T) {
 	}
 }
 
+func TestEncodePaneHistoryPayloadCacheHitMatchesFreshEncode(t *testing.T) {
+	// Not parallel: testing.AllocsPerRun panics inside parallel tests.
+	freshMsg := benchmarkPaneHistoryMessage(128, 80)
+	fresh, err := encodePaneHistoryPayload(freshMsg)
+	if err != nil {
+		t.Fatalf("fresh encodePaneHistoryPayload: %v", err)
+	}
+
+	var cache PaneHistoryPayloadCache
+	cachedMsg := benchmarkPaneHistoryMessage(128, 80)
+	cachedMsg.SetPaneHistoryPayloadCache(&cache, 1)
+	if _, err := encodePaneHistoryPayload(cachedMsg); err != nil {
+		t.Fatalf("warm cache encodePaneHistoryPayload: %v", err)
+	}
+
+	var hit []byte
+	allocs := testing.AllocsPerRun(100, func() {
+		var err error
+		hit, err = encodePaneHistoryPayload(cachedMsg)
+		if err != nil {
+			t.Fatalf("cached encodePaneHistoryPayload: %v", err)
+		}
+	})
+
+	if allocs != 0 {
+		t.Fatalf("cache-hit allocations = %.1f, want 0", allocs)
+	}
+	if !bytes.Equal(hit, fresh) {
+		t.Fatal("cache-hit payload differed from fresh encode")
+	}
+}
+
 func BenchmarkEncodePaneHistoryPayload(b *testing.B) {
 	msg := benchmarkPaneHistoryMessage(10_000, 80)
+
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := encodePaneHistoryPayload(msg); err != nil {
+			b.Fatalf("encodePaneHistoryPayload: %v", err)
+		}
+	}
+}
+
+func BenchmarkEncodePaneHistoryPayloadCacheHit(b *testing.B) {
+	msg := benchmarkPaneHistoryMessage(10_000, 80)
+	var cache PaneHistoryPayloadCache
+	msg.SetPaneHistoryPayloadCache(&cache, 1)
+	if _, err := encodePaneHistoryPayload(msg); err != nil {
+		b.Fatalf("warm cache encodePaneHistoryPayload: %v", err)
+	}
 
 	b.ReportAllocs()
 	for b.Loop() {

--- a/internal/proto/wire.go
+++ b/internal/proto/wire.go
@@ -176,6 +176,10 @@ type Message struct {
 	// MsgTypePaneHistory
 	History       []string
 	StyledHistory []StyledLine
+	// paneHistoryPayloadCache is server-local encode metadata. It is
+	// intentionally unexported so gob and JSON never include it on the wire.
+	paneHistoryPayloadCache   *PaneHistoryPayloadCache
+	paneHistoryPayloadVersion uint64
 
 	// MsgTypeLayout
 	Layout *LayoutSnapshot

--- a/internal/proto/wire_pane_history.go
+++ b/internal/proto/wire_pane_history.go
@@ -8,6 +8,7 @@ import (
 	"image/color"
 	"io"
 	"strings"
+	"sync"
 
 	uv "github.com/charmbracelet/ultraviolet"
 	"github.com/charmbracelet/x/ansi"
@@ -54,6 +55,59 @@ type paneHistoryStyleKey struct {
 type paneHistoryReader struct {
 	br *bufio.Reader
 	lr *io.LimitedReader
+}
+
+// PaneHistoryPayloadCache memoizes one encoded pane-history payload for a
+// pane content version. It is safe for concurrent writers serving multiple
+// attached clients.
+type PaneHistoryPayloadCache struct {
+	mu      sync.Mutex
+	version uint64
+	payload []byte
+	valid   bool
+}
+
+// SetPaneHistoryPayloadCache attaches server-local cache metadata for binary
+// pane-history encoding. The metadata is not encoded on the wire.
+func (m *Message) SetPaneHistoryPayloadCache(cache *PaneHistoryPayloadCache, version uint64) {
+	if m == nil {
+		return
+	}
+	m.paneHistoryPayloadCache = cache
+	m.paneHistoryPayloadVersion = version
+}
+
+func (c *PaneHistoryPayloadCache) get(version uint64) ([]byte, bool) {
+	if c == nil {
+		return nil, false
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if !c.valid || c.version != version {
+		return nil, false
+	}
+	return c.payload, true
+}
+
+// PayloadLen reports the cached payload length for version when present.
+func (c *PaneHistoryPayloadCache) PayloadLen(version uint64) (int, bool) {
+	payload, ok := c.get(version)
+	if !ok {
+		return 0, false
+	}
+	return len(payload), true
+}
+
+func (c *PaneHistoryPayloadCache) store(version uint64, payload []byte) []byte {
+	if c == nil {
+		return payload
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.version = version
+	c.payload = payload
+	c.valid = true
+	return c.payload
 }
 
 func newPaneHistoryReader(r io.Reader, limit int64) *paneHistoryReader {
@@ -137,7 +191,18 @@ func encodePaneHistoryPayload(msg *Message) ([]byte, error) {
 	if msg == nil {
 		return nil, fmt.Errorf("nil message")
 	}
+	if payload, ok := msg.paneHistoryPayloadCache.get(msg.paneHistoryPayloadVersion); ok {
+		return payload, nil
+	}
 
+	payload, err := encodePaneHistoryPayloadFresh(msg)
+	if err != nil {
+		return nil, err
+	}
+	return msg.paneHistoryPayloadCache.store(msg.paneHistoryPayloadVersion, payload), nil
+}
+
+func encodePaneHistoryPayloadFresh(msg *Message) ([]byte, error) {
 	var payload bytes.Buffer
 	flags := byte(0)
 	if paneHistoryMatchesStyledText(msg.History, msg.StyledHistory) {

--- a/internal/server/pane_history_chunk.go
+++ b/internal/server/pane_history_chunk.go
@@ -8,6 +8,7 @@ import (
 )
 
 const paneHistoryChunkThreshold = 4 * 1024 * 1024
+const paneHistoryBinaryFrameHeaderSize = 9
 
 func chunkPaneHistoryMessages(paneID uint32, history []proto.StyledLine, maxChunkSize int, binaryPaneHistory bool) ([]*Message, error) {
 	if len(history) == 0 {
@@ -25,6 +26,26 @@ func chunkPaneHistoryMessages(paneID uint32, history []proto.StyledLine, maxChun
 		}
 		messages = append(messages, newPaneHistoryMessage(paneID, history[start:end]))
 		start = end
+	}
+	return messages, nil
+}
+
+func chunkPaneHistoryMessagesWithCache(paneID uint32, history []proto.StyledLine, maxChunkSize int, binaryPaneHistory bool, cache *proto.PaneHistoryPayloadCache, version uint64) ([]*Message, error) {
+	if len(history) == 0 {
+		return nil, nil
+	}
+	if binaryPaneHistory && cache != nil {
+		if payloadLen, ok := cache.PayloadLen(version); ok && payloadLen+paneHistoryBinaryFrameHeaderSize <= maxChunkSize {
+			return []*Message{newPaneHistoryMessageWithCache(paneID, history, cache, version)}, nil
+		}
+	}
+
+	messages, err := chunkPaneHistoryMessages(paneID, history, maxChunkSize, binaryPaneHistory)
+	if err != nil {
+		return nil, err
+	}
+	if len(messages) == 1 {
+		messages[0].SetPaneHistoryPayloadCache(cache, version)
 	}
 	return messages, nil
 }
@@ -58,6 +79,14 @@ func newPaneHistoryMessage(paneID uint32, history []proto.StyledLine) *Message {
 		History:       proto.StyledLineText(history),
 		StyledHistory: append([]proto.StyledLine(nil), history...),
 	}
+}
+
+func newPaneHistoryMessageWithCache(paneID uint32, history []proto.StyledLine, cache *proto.PaneHistoryPayloadCache, version uint64) *Message {
+	msg := newPaneHistoryMessage(paneID, history)
+	if cache != nil {
+		msg.SetPaneHistoryPayloadCache(cache, version)
+	}
+	return msg
 }
 
 func estimatePaneHistoryMessageSize(msg *Message, binaryPaneHistory bool) (int, error) {

--- a/internal/server/pane_history_chunk_test.go
+++ b/internal/server/pane_history_chunk_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"bytes"
 	"fmt"
 	"net"
 	"strings"
@@ -106,6 +107,35 @@ func TestNewPaneHistoryMessageCopiesStyledLineHeaders(t *testing.T) {
 	}
 }
 
+func TestPaneHistoryBinaryEncodingDeterministicForIdlePane(t *testing.T) {
+	t.Parallel()
+
+	pane := newProxyPane(9, mux.PaneMeta{
+		Name:  "pane-9",
+		Host:  mux.DefaultHost,
+		Color: "f5e0dc",
+	}, 80, 4, nil, nil, func(data []byte) (int, error) { return len(data), nil })
+	t.Cleanup(func() {
+		if err := pane.Close(); err != nil {
+			t.Fatalf("Close pane: %v", err)
+		}
+		if err := pane.WaitClosed(); err != nil {
+			t.Fatalf("WaitClosed pane: %v", err)
+		}
+	})
+
+	pane.FeedOutput([]byte("\x1b[31mred\x1b[0m line\r\nplain line\r\n\x1b[1;34mbold blue\x1b[0m\r\nidle"))
+
+	firstHistory := pane.StyledHistorySnapshot()
+	secondHistory := pane.StyledHistorySnapshot()
+	first := encodePaneHistoryBinaryForTest(t, newPaneHistoryMessage(pane.ID, firstHistory))
+	second := encodePaneHistoryBinaryForTest(t, newPaneHistoryMessage(pane.ID, secondHistory))
+
+	if !bytes.Equal(first, second) {
+		t.Fatal("consecutive binary pane history encodes for an idle pane differed")
+	}
+}
+
 func TestHandleAttachChunksLargePaneHistoryDuringBootstrap(t *testing.T) {
 	t.Parallel()
 
@@ -192,6 +222,18 @@ func TestHandleAttachChunksLargePaneHistoryDuringBootstrap(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatal("handleAttach did not exit after detach")
 	}
+}
+
+func encodePaneHistoryBinaryForTest(t *testing.T, msg *Message) []byte {
+	t.Helper()
+
+	var buf bytes.Buffer
+	writer := proto.NewWriter(&buf)
+	writer.SetBinaryPaneHistory(true)
+	if err := writer.WriteMsg(msg); err != nil {
+		t.Fatalf("WriteMsg: %v", err)
+	}
+	return append([]byte(nil), buf.Bytes()...)
 }
 
 func largeHistoryLines(lineCount, lineWidth int) []string {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -902,7 +902,7 @@ func (s *Server) handleAttach(cc *clientConn, msg *Message) {
 	bootstrapSeqs := make(map[uint32]uint64, len(res.paneSnapshots))
 	for _, ps := range res.paneSnapshots {
 		if len(ps.styledHistory) > 0 {
-			messages, err := chunkPaneHistoryMessages(ps.paneID, ps.styledHistory, paneHistoryChunkThreshold, cc.capabilities.BinaryPaneHistory)
+			messages, err := chunkPaneHistoryMessagesWithCache(ps.paneID, ps.styledHistory, paneHistoryChunkThreshold, cc.capabilities.BinaryPaneHistory, ps.historyCache, ps.historyVersion)
 			if err != nil {
 				cc.Close()
 				return

--- a/internal/server/session_broadcast.go
+++ b/internal/server/session_broadcast.go
@@ -99,9 +99,9 @@ func (s *Session) broadcastPaneOutputNow(paneID uint32, data []byte, seq uint64)
 	s.triggerCrashCheckpoint()
 }
 
-func (s *Session) broadcastPaneHistoryNow(paneID uint32, history []proto.StyledLine) {
+func (s *Session) broadcastPaneHistoryNow(update paneHistoryUpdate) {
 	clients := s.ensureClientManager().snapshotClients()
-	msg := newPaneHistoryMessage(paneID, history)
+	msg := newPaneHistoryMessageWithCache(update.paneID, update.history, update.historyCache, update.historyVersion)
 	for _, c := range clients {
 		c.sendPaneMessage(msg)
 	}

--- a/internal/server/session_events_client.go
+++ b/internal/server/session_events_client.go
@@ -8,10 +8,12 @@ import (
 )
 
 type attachPaneSnapshot struct {
-	paneID        uint32
-	styledHistory []proto.StyledLine
-	screen        []byte
-	outputSeq     uint64
+	paneID         uint32
+	styledHistory  []proto.StyledLine
+	historyVersion uint64
+	historyCache   *proto.PaneHistoryPayloadCache
+	screen         []byte
+	outputSeq      uint64
 }
 
 type attachResult struct {
@@ -400,8 +402,10 @@ func (s *Session) handleAttachEvent(srv *Server, cc *clientConn, cols, rows int)
 	for _, p := range s.Panes {
 		snapshot := attachPaneSnapshot{paneID: p.ID}
 		if _, ok := activePaneIDs[p.ID]; ok {
-			history, screen, seq := p.StyledHistoryScreenSnapshot()
+			history, screen, seq, historyVersion, historyCache := p.StyledHistoryScreenSnapshotWithCache()
 			snapshot.styledHistory = history
+			snapshot.historyVersion = historyVersion
+			snapshot.historyCache = historyCache
 			snapshot.screen = []byte(screen)
 			snapshot.outputSeq = seq
 		} else {

--- a/internal/server/session_events_layout.go
+++ b/internal/server/session_events_layout.go
@@ -356,8 +356,10 @@ func (ctx *MutationContext) ensureClientManager() *clientManager {
 }
 
 type paneHistoryUpdate struct {
-	paneID  uint32
-	history []proto.StyledLine
+	paneID         uint32
+	history        []proto.StyledLine
+	historyVersion uint64
+	historyCache   *proto.PaneHistoryPayloadCache
 }
 
 func windowPaneHistories(w *mux.Window) []paneHistoryUpdate {
@@ -369,13 +371,15 @@ func windowPaneHistories(w *mux.Window) []paneHistoryUpdate {
 		if cell == nil || cell.Pane == nil {
 			return
 		}
-		history := cell.Pane.StyledHistorySnapshot()
+		history, historyVersion, historyCache := cell.Pane.StyledHistorySnapshotWithCache()
 		if len(history) == 0 {
 			return
 		}
 		histories = append(histories, paneHistoryUpdate{
-			paneID:  cell.Pane.ID,
-			history: history,
+			paneID:         cell.Pane.ID,
+			history:        history,
+			historyVersion: historyVersion,
+			historyCache:   historyCache,
 		})
 	})
 	return histories
@@ -482,10 +486,10 @@ func (e commandMutationEvent) handle(s *Session) {
 			res.broadcastLayout = false
 		}
 		for _, ph := range deferredHistories {
-			s.broadcastPaneHistoryNow(ph.paneID, ph.history)
+			s.broadcastPaneHistoryNow(ph)
 		}
 		for _, ph := range res.paneHistories {
-			s.broadcastPaneHistoryNow(ph.paneID, ph.history)
+			s.broadcastPaneHistoryNow(ph)
 		}
 		res.paneHistories = nil
 		for _, pr := range res.paneRenders {


### PR DESCRIPTION
## Motivation

`encodePaneHistoryPayload` showed up as a dominant allocator in LAB-1640's heap, alloc, and CPU profiles. The issue's main premise was that unchanged idle panes should encode deterministically, so repeated binary history sends can reuse the same payload instead of rebuilding the full run-length encoded body.

## Summary

- Added determinism coverage proving two consecutive idle pane history encodes produce byte-identical binary output.
- Added benchmark coverage for cold `encodePaneHistoryPayload` and the memoized cache-hit path.
- Added a per-pane content version and server-local `PaneHistoryPayloadCache` attached to pane-history messages.
- Reused cached whole-pane binary payloads when the pane version is unchanged, including the attach chunking fast path when the cached whole payload fits the threshold.
- Deferred Improvement B (`sync.Pool` for encoder buffers) until a post-A profile shows the cold encoder is still worth optimizing.

## Testing

- `go test ./internal/proto -run 'TestEncodePaneHistoryPayload' -count=100`
- `go test ./internal/server -run 'TestPaneHistoryBinaryEncodingDeterministicForIdlePane|TestHandleAttachChunksLargePaneHistoryDuringBootstrap|TestChunkPaneHistoryMessagesSplitsLargeHistoryUnderThreshold' -count=100`
- `go test ./test -run TestParallelAudit -count=1`
- `go test ./internal/proto ./internal/server ./internal/mux -timeout 120s -count=1`
- `go test ./... -timeout 120s -count=1`
- `go test ./internal/proto -run '^$' -bench 'BenchmarkEncodePaneHistoryPayload' -benchmem -count=10`
- `go test -race ./internal/proto -run 'TestEncodePaneHistoryPayload' -count=1`
- `go test -race ./internal/server -run 'TestPaneHistoryBinaryEncodingDeterministicForIdlePane' -count=1`

Additional verification notes:

- `go test ./... -timeout 120s -count=10` was attempted earlier and hit unrelated package timeout/resource pressure; the targeted failures were rerun successfully.
- `go test -race ./... -timeout 300s` was attempted earlier and failed in the integration harness on an existing double-`Cmd.Wait()` race (`test/server_harness_test.go:1015` vs `test/lint_helpers_test.go:62`). The new proto and server tests pass under `-race`.

## Baseline Numbers

Hardware: Hetzner KVM, AMD EPYC-Milan Processor, 8 vCPU, Linux x86_64 (`6.8.0-90-generic`).

| Benchmark | Before | After | Δ |
|---|---|---|---|
| encode/cold | 10.02k allocs/op, 86.13 MiB/op, 153.0 ms/op ±6% | 10.02k allocs/op, 86.13 MiB/op, 148.3 ms/op ±14% | ~ |
| encode/cache-hit | n/a | 0 allocs/op, 0 B/op, 17.36 ns/op ±4% | new |

## Review focus

- Cache invalidation in `internal/mux/pane.go` and `internal/mux/pane_emulator.go`.
- The unexported cache fields on `proto.Message`, which must remain server-local and off the wire.
- The chunking fast path in `internal/server/pane_history_chunk.go`; cached payloads are only reused for whole-pane binary messages, not partial chunks.
- Improvement B is intentionally not included here; re-profile after this lands before adding a buffer pool.

Refs LAB-1640
