### PR TITLE
LAB-1641: Isolate test amux subprocess sessions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,7 +114,7 @@ When a change adds a new test or modifies an existing test, run that targeted te
 
 **Fix flaky tests by finding the root cause.** Never make tests serial to avoid a flake — that hides the bug (shared state, resource contention, missing synchronization) instead of fixing it. If tests deadlock under `-count=3 -parallel=2`, the fix is in the code, not the test runner flags.
 
-**Root CLI subprocess tests must use the shared hermetic helper.** Do not open-code `exec.Command(os.Args[0], ...)` or inherit ambient `AMUX_SESSION` / `TMUX` state in root package tests; route those tests through the shared helper so they always run with an isolated session and scrubbed env.
+**CLI subprocess tests must use the shared hermetic helper.** Do not open-code `exec.Command(os.Args[0], ...)` or `exec.Command(amuxBin, ...)`, and do not inherit ambient `AMUX_SESSION` / `TMUX` state in root or `test/` package tests. Route those tests through the shared helper, for example `newHermeticAmuxCommand(t, "-s", session, "list")`, so they always run with an isolated session and scrubbed env.
 
 **Changes to `main.go` CLI dispatch need direct unit coverage on the touched lines.** Keep the hermetic subprocess tests for end-to-end CLI behavior, but when a change touches the dispatch branches in `main.go`, add direct unit coverage (for example in `main_test.go`) for those specific lines too. Codecov patch coverage measures the changed `main.go` lines directly and may miss coverage that only arrives through subprocess tests.
 

--- a/internal/auditlog/rotation.go
+++ b/internal/auditlog/rotation.go
@@ -5,6 +5,8 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"sync"
 
 	"golang.org/x/sys/unix"
@@ -53,10 +55,12 @@ func NewRotatingFileWriter(path string, opts RotationOptions) (io.WriteCloser, e
 // inherited regular log files are not teed because that would recreate the
 // unbounded file this rotation avoids.
 func InstallProcessLogRotation(path string, opts RotationOptions) (io.Writer, func(), error) {
+	MarkSocketLogFDsCloseOnExec(filepath.Dir(path))
 	writer, err := NewRotatingFileWriter(path, opts)
 	if err != nil {
 		return nil, nil, err
 	}
+	MarkSocketLogFDsCloseOnExec(filepath.Dir(path))
 
 	teeFile := teeFileForFD(int(os.Stderr.Fd()))
 	logWriter := &lockedWriter{w: writer}
@@ -97,7 +101,41 @@ func teeFileForFD(fd int) *os.File {
 	if err != nil {
 		return nil
 	}
+	unix.CloseOnExec(teeFD)
 	return os.NewFile(uintptr(teeFD), "amux-log-stderr")
+}
+
+func MarkSocketLogFDsCloseOnExec(logDir string) {
+	if logDir == "" {
+		return
+	}
+	fdDir := "/proc/self/fd"
+	entries, err := os.ReadDir(fdDir)
+	if err != nil {
+		return
+	}
+	for _, entry := range entries {
+		fd, err := strconv.Atoi(entry.Name())
+		if err != nil || fd <= 2 {
+			continue
+		}
+		target, err := os.Readlink(filepath.Join(fdDir, entry.Name()))
+		if err != nil {
+			continue
+		}
+		if isSocketLogFDTarget(logDir, target) {
+			unix.CloseOnExec(fd)
+		}
+	}
+}
+
+func isSocketLogFDTarget(logDir, target string) bool {
+	cleanDir := filepath.Clean(logDir)
+	target = strings.TrimSuffix(target, " (deleted)")
+	if filepath.Dir(target) != cleanDir {
+		return false
+	}
+	return strings.Contains(filepath.Base(target), ".log")
 }
 
 func closeTeeFile(file *os.File) {

--- a/internal/auditlog/rotation.go
+++ b/internal/auditlog/rotation.go
@@ -60,7 +60,6 @@ func InstallProcessLogRotation(path string, opts RotationOptions) (io.Writer, fu
 	if err != nil {
 		return nil, nil, err
 	}
-	MarkSocketLogFDsCloseOnExec(filepath.Dir(path))
 
 	teeFile := teeFileForFD(int(os.Stderr.Fd()))
 	logWriter := &lockedWriter{w: writer}

--- a/internal/auditlog/rotation_test.go
+++ b/internal/auditlog/rotation_test.go
@@ -273,6 +273,71 @@ func TestTeeFileForFDInvalidFD(t *testing.T) {
 	closeTeeFile(nil)
 }
 
+func TestTeeFileForFDSetsCloseOnExec(t *testing.T) {
+	t.Parallel()
+
+	readPipe, writePipe, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("Pipe: %v", err)
+	}
+	defer readPipe.Close()
+	defer writePipe.Close()
+
+	tee := teeFileForFD(int(writePipe.Fd()))
+	if tee == nil {
+		t.Fatal("teeFileForFD(pipe) = nil, want file")
+	}
+	defer tee.Close()
+
+	assertCloseOnExec(t, int(tee.Fd()))
+}
+
+func TestMarkSocketLogFDsCloseOnExecMarksInheritedLogs(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	logFile, err := os.OpenFile(filepath.Join(dir, "main.log"), os.O_CREATE|os.O_RDWR|os.O_APPEND, 0o600)
+	if err != nil {
+		t.Fatalf("OpenFile log: %v", err)
+	}
+	defer logFile.Close()
+
+	dupFD, err := unix.Dup(int(logFile.Fd()))
+	if err != nil {
+		t.Fatalf("Dup log fd: %v", err)
+	}
+	defer unix.Close(dupFD)
+	clearCloseOnExec(t, dupFD)
+
+	MarkSocketLogFDsCloseOnExec(dir)
+
+	assertCloseOnExec(t, dupFD)
+}
+
+func clearCloseOnExec(t *testing.T, fd int) {
+	t.Helper()
+
+	flags, err := unix.FcntlInt(uintptr(fd), unix.F_GETFD, 0)
+	if err != nil {
+		t.Fatalf("F_GETFD: %v", err)
+	}
+	if _, err := unix.FcntlInt(uintptr(fd), unix.F_SETFD, flags&^unix.FD_CLOEXEC); err != nil {
+		t.Fatalf("F_SETFD clear close-on-exec: %v", err)
+	}
+}
+
+func assertCloseOnExec(t *testing.T, fd int) {
+	t.Helper()
+
+	flags, err := unix.FcntlInt(uintptr(fd), unix.F_GETFD, 0)
+	if err != nil {
+		t.Fatalf("F_GETFD: %v", err)
+	}
+	if flags&unix.FD_CLOEXEC == 0 {
+		t.Fatalf("fd %d missing FD_CLOEXEC", fd)
+	}
+}
+
 func totalRegularFileSize(t *testing.T, paths ...string) int64 {
 	t.Helper()
 

--- a/internal/cli/main_cli_subprocess_test.go
+++ b/internal/cli/main_cli_subprocess_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/weill-labs/amux/internal/server"
+	"github.com/weill-labs/amux/internal/testenv"
 )
 
 func TestMainCLISubprocessHelper(t *testing.T) {
@@ -81,7 +82,7 @@ func newHermeticMainCmdContext(t *testing.T, ctx context.Context, args ...string
 
 	session := hermeticMainSession(t.Name())
 	cmdArgs := append([]string{"-test.run=TestMainCLISubprocessHelper", "--", "-s", session}, args...)
-	cmd := exec.CommandContext(ctx, os.Args[0], cmdArgs...)
+	cmd := testenv.NewCommandContext(ctx, os.Args[0], cmdArgs...)
 	cmd.Env = hermeticMainEnv()
 	return cmd
 }
@@ -107,36 +108,7 @@ func hermeticMainSession(testName string) string {
 }
 
 func hermeticMainEnv() []string {
-	env := append([]string{}, os.Environ()...)
-	for _, key := range []string{
-		"AMUX_MAIN_HELPER",
-		"AMUX_PANE",
-		"AMUX_SESSION",
-		"TMUX",
-		"SSH_CONNECTION",
-		"SSH_CLIENT",
-		"SSH_TTY",
-		"TERM",
-	} {
-		env = removeEnvKey(env, key)
-	}
-	env = append(env,
-		"AMUX_MAIN_HELPER=1",
-		"TERM=xterm-256color",
-	)
-	return env
-}
-
-func removeEnvKey(env []string, key string) []string {
-	prefix := key + "="
-	filtered := env[:0]
-	for _, entry := range env {
-		if strings.HasPrefix(entry, prefix) {
-			continue
-		}
-		filtered = append(filtered, entry)
-	}
-	return filtered
+	return testenv.HermeticMainEnv()
 }
 
 func hermeticMainSocketPath(t *testing.T) string {

--- a/internal/cli/server_bootstrap.go
+++ b/internal/cli/server_bootstrap.go
@@ -42,7 +42,11 @@ func newBootstrapLoggerWithWriter(w io.Writer) *charmlog.Logger {
 }
 
 func installServerLogRotation(sessionName string) (io.Writer, func(), error) {
-	logPath := filepath.Join(server.SocketDir(), sessionName+".log")
+	logDir := os.Getenv("AMUX_LOG_DIR")
+	if logDir == "" {
+		logDir = server.SocketDir()
+	}
+	logPath := filepath.Join(logDir, sessionName+".log")
 	return auditlog.InstallProcessLogRotation(logPath, auditlog.DefaultRotationOptions())
 }
 

--- a/internal/cli/server_bootstrap_audit_test.go
+++ b/internal/cli/server_bootstrap_audit_test.go
@@ -7,7 +7,6 @@ import (
 	"go/parser"
 	"go/token"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -15,6 +14,7 @@ import (
 	"time"
 
 	"github.com/weill-labs/amux/internal/server"
+	"github.com/weill-labs/amux/internal/testenv"
 )
 
 func TestRunServerDoesNotLateSetLogger(t *testing.T) {
@@ -89,7 +89,7 @@ func TestServerBootstrapLogsServerStart(t *testing.T) {
 	defer shutdownRead.Close()
 
 	cmdArgs := []string{"-test.run=TestMainCLISubprocessHelper", "--", "_server", session}
-	cmd := exec.CommandContext(ctx, os.Args[0], cmdArgs...)
+	cmd := testenv.NewCommandContext(ctx, os.Args[0], cmdArgs...)
 	cmd.ExtraFiles = []*os.File{readyWrite, shutdownWrite}
 	cmd.Env = append(hermeticMainEnv(),
 		"HOME="+t.TempDir(),

--- a/internal/client/attach_bootstrap_memory_test.go
+++ b/internal/client/attach_bootstrap_memory_test.go
@@ -6,13 +6,13 @@ import (
 	"fmt"
 	"net"
 	"os"
-	"os/exec"
 	"runtime"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/weill-labs/amux/internal/proto"
+	"github.com/weill-labs/amux/internal/testenv"
 )
 
 const attachBootstrapPeakHeapSubprocessEnv = "AMUX_TEST_ATTACH_BOOTSTRAP_PEAK_HEAP"
@@ -25,8 +25,8 @@ func TestReadAttachBootstrapKeepsPeakHeapUnderBound(t *testing.T) {
 		return
 	}
 
-	cmd := exec.Command(os.Args[0], "-test.run=^TestReadAttachBootstrapKeepsPeakHeapUnderBound$", "-test.parallel=1")
-	cmd.Env = append(os.Environ(), attachBootstrapPeakHeapSubprocessEnv+"=1")
+	cmd := testenv.NewCommand(os.Args[0], "-test.run=^TestReadAttachBootstrapKeepsPeakHeapUnderBound$", "-test.parallel=1")
+	cmd.Env = append(testenv.HermeticAmuxEnv(), attachBootstrapPeakHeapSubprocessEnv+"=1")
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("peak-heap subprocess failed: %v\n%s", err, output)

--- a/internal/server/envvars.go
+++ b/internal/server/envvars.go
@@ -9,6 +9,7 @@ import "os"
 type ServerEnv struct {
 	ExitUnattached bool // AMUX_EXIT_UNATTACHED=1
 	NoWatch        bool // AMUX_NO_WATCH=1
+	LogDir         string
 }
 
 // ReadServerEnv reads all server-only env vars and unsets them from the
@@ -17,9 +18,11 @@ func ReadServerEnv() ServerEnv {
 	env := ServerEnv{
 		ExitUnattached: os.Getenv("AMUX_EXIT_UNATTACHED") == "1",
 		NoWatch:        os.Getenv("AMUX_NO_WATCH") == "1",
+		LogDir:         os.Getenv("AMUX_LOG_DIR"),
 	}
 	os.Unsetenv("AMUX_EXIT_UNATTACHED")
 	os.Unsetenv("AMUX_NO_WATCH")
+	os.Unsetenv("AMUX_LOG_DIR")
 	return env
 }
 
@@ -32,6 +35,9 @@ func (e ServerEnv) Export() []string {
 	}
 	if e.NoWatch {
 		out = append(out, "AMUX_NO_WATCH=1")
+	}
+	if e.LogDir != "" {
+		out = append(out, "AMUX_LOG_DIR="+e.LogDir)
 	}
 	return out
 }

--- a/internal/server/envvars_test.go
+++ b/internal/server/envvars_test.go
@@ -1,0 +1,37 @@
+package server
+
+import (
+	"os"
+	"slices"
+	"testing"
+)
+
+func TestReadServerEnvScrubsLogDirAndExportsForReload(t *testing.T) {
+	t.Setenv("AMUX_EXIT_UNATTACHED", "1")
+	t.Setenv("AMUX_NO_WATCH", "1")
+	t.Setenv("AMUX_LOG_DIR", "/tmp/amux-test-logs")
+
+	env := ReadServerEnv()
+	if !env.ExitUnattached {
+		t.Fatal("ExitUnattached = false, want true")
+	}
+	if !env.NoWatch {
+		t.Fatal("NoWatch = false, want true")
+	}
+	if env.LogDir != "/tmp/amux-test-logs" {
+		t.Fatalf("LogDir = %q, want /tmp/amux-test-logs", env.LogDir)
+	}
+
+	for _, key := range []string{"AMUX_EXIT_UNATTACHED", "AMUX_NO_WATCH", "AMUX_LOG_DIR"} {
+		if got := os.Getenv(key); got != "" {
+			t.Fatalf("%s still exported as %q", key, got)
+		}
+	}
+
+	exported := env.Export()
+	for _, want := range []string{"AMUX_EXIT_UNATTACHED=1", "AMUX_NO_WATCH=1", "AMUX_LOG_DIR=/tmp/amux-test-logs"} {
+		if !slices.Contains(exported, want) {
+			t.Fatalf("Export() = %v, want %q", exported, want)
+		}
+	}
+}

--- a/internal/server/session_lock_test.go
+++ b/internal/server/session_lock_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/weill-labs/amux/internal/mux"
+	"github.com/weill-labs/amux/internal/testenv"
 )
 
 const (
@@ -155,8 +156,8 @@ func TestNewServerWithScrollbackConcurrentStartsYieldSingleWinner(t *testing.T) 
 func startSessionLockHelper(t *testing.T, mode, session string) (*exec.Cmd, *bytes.Buffer) {
 	t.Helper()
 
-	cmd := exec.Command(os.Args[0], "-test.run=^TestSessionLockSubprocessHelper$")
-	cmd.Env = append(os.Environ(),
+	cmd := testenv.NewCommand(os.Args[0], "-test.run=^TestSessionLockSubprocessHelper$")
+	cmd.Env = append(testenv.HermeticAmuxEnv(),
 		sessionLockHelperModeEnv+"="+mode,
 		sessionLockHelperSessionEnv+"="+session,
 	)

--- a/internal/testenv/env.go
+++ b/internal/testenv/env.go
@@ -50,7 +50,7 @@ func NewCommandContext(ctx context.Context, name string, args ...string) *exec.C
 
 func RemoveEnvKey(env []string, key string) []string {
 	prefix := key + "="
-	filtered := env[:0]
+	filtered := make([]string, 0, len(env))
 	for _, entry := range env {
 		if strings.HasPrefix(entry, prefix) {
 			continue

--- a/internal/testenv/env.go
+++ b/internal/testenv/env.go
@@ -1,0 +1,61 @@
+package testenv
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+var blockedEnvKeys = []string{
+	"AMUX_CLIENT_CAPABILITIES",
+	"AMUX_COLOR_PROFILE",
+	"AMUX_LOG_DIR",
+	"AMUX_MAIN_HELPER",
+	"AMUX_PANE",
+	"AMUX_SESSION",
+	"CLICOLOR",
+	"CLICOLOR_FORCE",
+	"COLORTERM",
+	"NO_COLOR",
+	"SSH_CLIENT",
+	"SSH_CONNECTION",
+	"SSH_TTY",
+	"TERM",
+	"TERM_PROGRAM",
+	"TMUX",
+}
+
+func HermeticAmuxEnv() []string {
+	env := append([]string{}, os.Environ()...)
+	for _, key := range blockedEnvKeys {
+		env = RemoveEnvKey(env, key)
+	}
+	return append(env, "TERM=xterm-256color")
+}
+
+func HermeticMainEnv() []string {
+	return append(HermeticAmuxEnv(), "AMUX_MAIN_HELPER=1")
+}
+
+func NewCommand(name string, args ...string) *exec.Cmd {
+	return NewCommandContext(context.Background(), name, args...)
+}
+
+func NewCommandContext(ctx context.Context, name string, args ...string) *exec.Cmd {
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Env = HermeticAmuxEnv()
+	return cmd
+}
+
+func RemoveEnvKey(env []string, key string) []string {
+	prefix := key + "="
+	filtered := env[:0]
+	for _, entry := range env {
+		if strings.HasPrefix(entry, prefix) {
+			continue
+		}
+		filtered = append(filtered, entry)
+	}
+	return filtered
+}

--- a/internal/testenv/env_test.go
+++ b/internal/testenv/env_test.go
@@ -1,0 +1,83 @@
+package testenv
+
+import (
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestHermeticAmuxEnvScrubsAmuxAndTerminalVars(t *testing.T) {
+	for _, key := range blockedEnvKeys {
+		t.Setenv(key, "leaked")
+	}
+	t.Setenv("PATH", "/bin")
+
+	env := HermeticAmuxEnv()
+
+	for _, key := range blockedEnvKeys {
+		if key == "TERM" {
+			continue
+		}
+		if value, ok := lookupEnvEntry(env, key); ok {
+			t.Fatalf("%s leaked into hermetic env as %q", key, value)
+		}
+	}
+	if value, ok := lookupEnvEntry(env, "PATH"); !ok || value != "/bin" {
+		t.Fatalf("PATH = %q, %t; want /bin, true", value, ok)
+	}
+	if value, ok := lookupEnvEntry(env, "TERM"); !ok || value != "xterm-256color" {
+		t.Fatalf("TERM = %q, %t; want xterm-256color, true", value, ok)
+	}
+}
+
+func TestHermeticMainEnvAddsHelper(t *testing.T) {
+	t.Setenv("AMUX_MAIN_HELPER", "leaked")
+
+	env := HermeticMainEnv()
+
+	if value, ok := lookupEnvEntry(env, "AMUX_MAIN_HELPER"); !ok || value != "1" {
+		t.Fatalf("AMUX_MAIN_HELPER = %q, %t; want 1, true", value, ok)
+	}
+}
+
+func TestNewCommandUsesHermeticEnv(t *testing.T) {
+	t.Setenv("AMUX_SESSION", "main")
+
+	cmd := NewCommand("amux", "list")
+
+	if filepath.Base(cmd.Path) != "amux" {
+		t.Fatalf("Path = %q, want basename amux", cmd.Path)
+	}
+	if !slices.Equal(cmd.Args, []string{"amux", "list"}) {
+		t.Fatalf("Args = %v, want [amux list]", cmd.Args)
+	}
+	if value, ok := lookupEnvEntry(cmd.Env, "AMUX_SESSION"); ok {
+		t.Fatalf("AMUX_SESSION leaked into command env as %q", value)
+	}
+}
+
+func TestRemoveEnvKeyDoesNotMutateInput(t *testing.T) {
+	t.Parallel()
+
+	input := []string{"A=1", "DROP=old", "B=2"}
+
+	got := RemoveEnvKey(input, "DROP")
+
+	if !slices.Equal(got, []string{"A=1", "B=2"}) {
+		t.Fatalf("RemoveEnvKey() = %v, want [A=1 B=2]", got)
+	}
+	if !slices.Equal(input, []string{"A=1", "DROP=old", "B=2"}) {
+		t.Fatalf("input mutated to %v", input)
+	}
+}
+
+func lookupEnvEntry(env []string, key string) (string, bool) {
+	prefix := key + "="
+	for _, entry := range env {
+		if strings.HasPrefix(entry, prefix) {
+			return strings.TrimPrefix(entry, prefix), true
+		}
+	}
+	return "", false
+}

--- a/test/crash_recovery_test.go
+++ b/test/crash_recovery_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -494,9 +493,11 @@ func startServerForSession(t *testing.T, session, home string) *ServerHarness {
 		t.Fatalf("creating shutdown pipe: %v", err)
 	}
 
-	cmd := exec.Command(amuxBin, "_server", session)
+	cmd := newHermeticAmuxCommand(t, "_server", session)
 	cmd.ExtraFiles = []*os.File{writePipe, shutdownWritePipe}
-	env := upsertEnv(os.Environ(), "HOME", home)
+	logDir := testLogDir(home)
+	env := upsertEnv(cmd.Env, "HOME", home)
+	env = upsertEnv(env, "AMUX_LOG_DIR", logDir)
 	env = append(env, "AMUX_READY_FD=3", "AMUX_SHUTDOWN_FD=4", "AMUX_NO_WATCH=1", "AMUX_EXIT_UNATTACHED=1", "AMUX_DISABLE_META_REFRESH=1")
 
 	// Per-test cover dir
@@ -510,7 +511,6 @@ func startServerForSession(t *testing.T, session, home string) *ServerHarness {
 	}
 	cmd.Env = env
 
-	logDir := server.SocketDir()
 	mustMkdirAll(t, logDir, 0700)
 	logPath := filepath.Join(logDir, session+".log")
 	logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0600)

--- a/test/debug_test.go
+++ b/test/debug_test.go
@@ -6,7 +6,6 @@ import (
 	"net"
 	"net/http"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -194,8 +193,7 @@ func TestDebugCommandUsesServerSession(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	cmd := exec.CommandContext(ctx, amuxBin, "-s", h.session, "debug", "goroutines")
-	cmd.Env = h.commandWithContext(ctx).Env
+	cmd := h.commandWithContext(ctx, "debug", "goroutines")
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("amux -s %s debug goroutines: %v\n%s", h.session, err, out)

--- a/test/event_helpers_test.go
+++ b/test/event_helpers_test.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"net"
-	"os"
 	"os/exec"
 	"sync"
 	"testing"
@@ -83,9 +82,9 @@ func startEventsCLI(t *testing.T, h *ServerHarness, env []string, args ...string
 	t.Helper()
 
 	cmdArgs := append([]string{"-s", h.session, "events"}, args...)
-	cmd := exec.Command(amuxBin, cmdArgs...)
+	cmd := newHermeticAmuxCommand(t, cmdArgs...)
 
-	envVars := upsertEnv(os.Environ(), "HOME", h.home)
+	envVars := upsertEnv(cmd.Env, "HOME", h.home)
 	if h.coverDir != "" {
 		envVars = upsertEnv(envVars, "GOCOVERDIR", h.coverDir)
 	}
@@ -182,6 +181,13 @@ func mustReadEvent(t *testing.T, scanner *bufio.Scanner, timeout time.Duration) 
 		t.Fatal("timeout reading event")
 	}
 	return ev
+}
+
+func mustReadEventType(t *testing.T, scanner *bufio.Scanner, eventType string, timeout time.Duration) eventJSON {
+	t.Helper()
+	return mustReadMatchingEvent(t, scanner, timeout, eventType+" event", func(ev eventJSON) bool {
+		return ev.Type == eventType
+	})
 }
 
 func mustReadMatchingEvent(t *testing.T, scanner *bufio.Scanner, timeout time.Duration, description string, match func(eventJSON) bool) eventJSON {

--- a/test/events_test.go
+++ b/test/events_test.go
@@ -2,7 +2,6 @@ package test
 
 import (
 	"os"
-	"os/exec"
 	"strconv"
 	"strings"
 	"testing"
@@ -130,16 +129,10 @@ func TestEventsIdleBusyTransition(t *testing.T) {
 	// Generate activity — should trigger busy transition
 	h.sendKeys("pane-1", "echo activity", "Enter")
 
-	ev = mustReadEvent(t, scanner, 5*time.Second)
-	if ev.Type != "busy" {
-		t.Errorf("after activity: got %q, want busy", ev.Type)
-	}
+	mustReadEventType(t, scanner, "busy", 5*time.Second)
 
 	// Wait for idle timeout — should trigger idle transition
-	ev = mustReadEvent(t, scanner, config.VTIdleSettle+3*time.Second)
-	if ev.Type != "idle" {
-		t.Errorf("after quiet: got %q, want idle", ev.Type)
-	}
+	mustReadEventType(t, scanner, "idle", config.VTIdleSettle+3*time.Second)
 }
 
 func TestEventsExitedInitialSnapshot(t *testing.T) {
@@ -751,9 +744,9 @@ func TestEventsThrottleNonOutputPassthrough(t *testing.T) {
 // underlying dial error for initial stream setup.
 func TestEventsCLIConnectError(t *testing.T) {
 	t.Parallel()
-	cmd := exec.Command(amuxBin, "-s", "nonexistent-session-xyz", "events")
+	cmd := newHermeticAmuxCommand(t, "-s", "nonexistent-session-xyz", "events")
 	if gocoverDir != "" {
-		cmd.Env = append(os.Environ(), "GOCOVERDIR="+gocoverDir)
+		cmd.Env = upsertEnv(cmd.Env, "GOCOVERDIR", gocoverDir)
 	}
 	out, err := cmd.CombinedOutput()
 	if err == nil {

--- a/test/hermetic_subprocess_test.go
+++ b/test/hermetic_subprocess_test.go
@@ -28,7 +28,7 @@ func TestAmuxSubprocessesUseHermeticHelper(t *testing.T) {
 			}
 			return nil
 		}
-		if !strings.HasSuffix(path, "_test.go") || filepath.Base(path) == "script_helpers_test.go" {
+		if !strings.HasSuffix(path, "_test.go") {
 			return nil
 		}
 

--- a/test/hermetic_subprocess_test.go
+++ b/test/hermetic_subprocess_test.go
@@ -14,15 +14,16 @@ import (
 func TestAmuxSubprocessesUseHermeticHelper(t *testing.T) {
 	t.Parallel()
 
-	testDir := filepath.Join(repoRoot(t), "test")
+	root := repoRoot(t)
 	var offenders []string
 	fset := token.NewFileSet()
-	err := filepath.WalkDir(testDir, func(path string, d fs.DirEntry, err error) error {
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
 		if d.IsDir() {
-			if d.Name() == "testdata" {
+			switch d.Name() {
+			case ".git", "testdata":
 				return filepath.SkipDir
 			}
 			return nil
@@ -59,7 +60,7 @@ func TestAmuxSubprocessesUseHermeticHelper(t *testing.T) {
 			if len(call.Args) <= argIndex {
 				return true
 			}
-			if id, ok := call.Args[argIndex].(*ast.Ident); ok && id.Name == "amuxBin" {
+			if isForbiddenAmuxSubprocessTarget(call.Args[argIndex]) {
 				pos := fset.Position(call.Pos())
 				offenders = append(offenders, filepath.ToSlash(pos.Filename)+":"+strconv.Itoa(pos.Line))
 			}
@@ -71,6 +72,27 @@ func TestAmuxSubprocessesUseHermeticHelper(t *testing.T) {
 		t.Fatalf("scan test subprocesses: %v", err)
 	}
 	if len(offenders) > 0 {
-		t.Fatalf("exec.Command(amuxBin, ...) must go through the hermetic subprocess helper:\n%s", strings.Join(offenders, "\n"))
+		t.Fatalf("amux subprocess tests must go through the hermetic subprocess helper:\n%s", strings.Join(offenders, "\n"))
 	}
+}
+
+func isForbiddenAmuxSubprocessTarget(expr ast.Expr) bool {
+	if id, ok := expr.(*ast.Ident); ok && id.Name == "amuxBin" {
+		return true
+	}
+
+	index, ok := expr.(*ast.IndexExpr)
+	if !ok {
+		return false
+	}
+	idx, ok := index.Index.(*ast.BasicLit)
+	if !ok || idx.Value != "0" {
+		return false
+	}
+	sel, ok := index.X.(*ast.SelectorExpr)
+	if !ok || sel.Sel.Name != "Args" {
+		return false
+	}
+	pkg, ok := sel.X.(*ast.Ident)
+	return ok && pkg.Name == "os"
 }

--- a/test/hermetic_subprocess_test.go
+++ b/test/hermetic_subprocess_test.go
@@ -1,0 +1,76 @@
+package test
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestAmuxSubprocessesUseHermeticHelper(t *testing.T) {
+	t.Parallel()
+
+	testDir := filepath.Join(repoRoot(t), "test")
+	var offenders []string
+	fset := token.NewFileSet()
+	err := filepath.WalkDir(testDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			if d.Name() == "testdata" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, "_test.go") || filepath.Base(path) == "script_helpers_test.go" {
+			return nil
+		}
+
+		file, err := parser.ParseFile(fset, path, nil, 0)
+		if err != nil {
+			return err
+		}
+		ast.Inspect(file, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok || len(call.Args) == 0 {
+				return true
+			}
+			sel, ok := call.Fun.(*ast.SelectorExpr)
+			if !ok {
+				return true
+			}
+			pkg, ok := sel.X.(*ast.Ident)
+			if !ok || pkg.Name != "exec" {
+				return true
+			}
+			argIndex := 0
+			switch sel.Sel.Name {
+			case "Command":
+			case "CommandContext":
+				argIndex = 1
+			default:
+				return true
+			}
+			if len(call.Args) <= argIndex {
+				return true
+			}
+			if id, ok := call.Args[argIndex].(*ast.Ident); ok && id.Name == "amuxBin" {
+				pos := fset.Position(call.Pos())
+				offenders = append(offenders, filepath.ToSlash(pos.Filename)+":"+strconv.Itoa(pos.Line))
+			}
+			return true
+		})
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("scan test subprocesses: %v", err)
+	}
+	if len(offenders) > 0 {
+		t.Fatalf("exec.Command(amuxBin, ...) must go through the hermetic subprocess helper:\n%s", strings.Join(offenders, "\n"))
+	}
+}

--- a/test/hotreload_test.go
+++ b/test/hotreload_test.go
@@ -123,8 +123,9 @@ func rewriteBinaryAtomic(binPath string) error {
 func runAmuxCommandWithBin(tb testing.TB, binPath, home, coverDir, session string, args ...string) string {
 	tb.Helper()
 	cmdArgs := append([]string{"-s", session}, args...)
-	cmd := exec.Command(binPath, cmdArgs...)
-	env := upsertEnv(os.Environ(), "HOME", home)
+	cmd := newHermeticAmuxCommandWithBin(tb, binPath, cmdArgs...)
+	env := upsertEnv(cmd.Env, "HOME", home)
+	env = upsertEnv(env, "AMUX_LOG_DIR", testLogDir(home))
 	if coverDir != "" {
 		env = upsertEnv(env, "GOCOVERDIR", coverDir)
 	}

--- a/test/keybinding_test.go
+++ b/test/keybinding_test.go
@@ -51,7 +51,7 @@ func newAmuxHarnessWithConfig(t *testing.T, configContent string) *AmuxHarness {
 
 	t.Cleanup(func() {
 		// Best-effort detach (only works with default prefix).
-		_ = exec.Command(amuxBin, "-s", inner, "list").Run()
+		_ = newHermeticAmuxCommand(t, "-s", inner, "list").Run()
 		out, _ := exec.Command("pgrep", "-f", fmt.Sprintf("amux _server %s$", inner)).Output()
 		for _, pid := range strings.Split(strings.TrimSpace(string(out)), "\n") {
 			if pid != "" {

--- a/test/pane_log_test.go
+++ b/test/pane_log_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 	"time"
 
-	serverpkg "github.com/weill-labs/amux/internal/server"
 	listingcmd "github.com/weill-labs/amux/internal/server/commands/listing"
 )
 
@@ -157,8 +156,7 @@ func TestLogPanesSnapshotsExitContext(t *testing.T) {
 	wantListCwd := listingcmd.FormatListCwd(wantCwd, h.home, listingcmd.ListCwdWidth)
 	listOut := waitForListMetadata(t, h, wantListCwd)
 	if !strings.Contains(listOut, wantListCwd) {
-		logPath := filepath.Join(serverpkg.SocketDir(), h.session+".log")
-		logData, _ := os.ReadFile(logPath)
+		logData, _ := os.ReadFile(h.logPath)
 		t.Fatalf("list did not report cached cwd %q after idle refresh\n%s\nserver log:\n%s", wantListCwd, listOut, string(logData))
 	}
 

--- a/test/pty_client_harness_test.go
+++ b/test/pty_client_harness_test.go
@@ -43,8 +43,8 @@ func newPTYClientHarnessWithReadyOutput(tb testing.TB, server *ServerHarness, re
 func newPTYClientHarnessForSession(tb testing.TB, session, home, coverDir string, envVars ...string) *ptyClientHarness {
 	tb.Helper()
 
-	cmd := exec.Command(amuxBin, "-s", session)
-	env := os.Environ()
+	cmd := newHermeticAmuxCommand(tb, "-s", session)
+	env := cmd.Env
 	for _, key := range []string{
 		"AMUX_COLOR_PROFILE",
 		"AMUX_PANE",

--- a/test/script_helpers_test.go
+++ b/test/script_helpers_test.go
@@ -1,43 +1,49 @@
 package test
 
 import (
-	"os"
+	"context"
+	"os/exec"
 	"path/filepath"
 	"runtime"
-	"strings"
 	"testing"
+
+	"github.com/weill-labs/amux/internal/testenv"
 )
 
 func hermeticMainEnv() []string {
-	env := append([]string{}, os.Environ()...)
-	for _, key := range []string{
-		"AMUX_MAIN_HELPER",
-		"AMUX_PANE",
-		"AMUX_SESSION",
-		"TMUX",
-		"SSH_CONNECTION",
-		"SSH_CLIENT",
-		"SSH_TTY",
-		"TERM",
-	} {
-		env = removeEnvKey(env, key)
-	}
-	return append(env,
-		"AMUX_MAIN_HELPER=1",
-		"TERM=xterm-256color",
-	)
+	return testenv.HermeticMainEnv()
 }
 
-func removeEnvKey(env []string, key string) []string {
-	prefix := key + "="
-	filtered := env[:0]
-	for _, entry := range env {
-		if strings.HasPrefix(entry, prefix) {
-			continue
-		}
-		filtered = append(filtered, entry)
+func hermeticAmuxEnv() []string {
+	return testenv.HermeticAmuxEnv()
+}
+
+func newHermeticAmuxCommand(tb testing.TB, args ...string) *exec.Cmd {
+	if tb != nil {
+		tb.Helper()
 	}
-	return filtered
+	return newHermeticAmuxCommandContext(tb, context.Background(), args...)
+}
+
+func newHermeticAmuxCommandContext(tb testing.TB, ctx context.Context, args ...string) *exec.Cmd {
+	if tb != nil {
+		tb.Helper()
+	}
+	return newHermeticAmuxCommandWithBinContext(tb, ctx, amuxBin, args...)
+}
+
+func newHermeticAmuxCommandWithBin(tb testing.TB, binPath string, args ...string) *exec.Cmd {
+	if tb != nil {
+		tb.Helper()
+	}
+	return newHermeticAmuxCommandWithBinContext(tb, context.Background(), binPath, args...)
+}
+
+func newHermeticAmuxCommandWithBinContext(tb testing.TB, ctx context.Context, binPath string, args ...string) *exec.Cmd {
+	if tb != nil {
+		tb.Helper()
+	}
+	return testenv.NewCommandContext(ctx, binPath, args...)
 }
 
 func repoRoot(tb testing.TB) string {
@@ -54,4 +60,8 @@ func repoPath(tb testing.TB, rel string) string {
 	tb.Helper()
 
 	return filepath.Join(repoRoot(tb), filepath.FromSlash(rel))
+}
+
+func testLogDir(home string) string {
+	return filepath.Join(home, ".local", "state", "amux", "logs")
 }

--- a/test/script_helpers_test.go
+++ b/test/script_helpers_test.go
@@ -14,10 +14,6 @@ func hermeticMainEnv() []string {
 	return testenv.HermeticMainEnv()
 }
 
-func hermeticAmuxEnv() []string {
-	return testenv.HermeticAmuxEnv()
-}
-
 func newHermeticAmuxCommand(tb testing.TB, args ...string) *exec.Cmd {
 	if tb != nil {
 		tb.Helper()

--- a/test/server_harness_test.go
+++ b/test/server_harness_test.go
@@ -171,17 +171,19 @@ func newServerHarnessForSession(tb testing.TB, session, home string, cols, rows 
 		tb.Fatalf("creating shutdown pipe: %v", err)
 	}
 
-	cmd := exec.Command(amuxBin, "_server", session)
+	cmd := newHermeticAmuxCommand(tb, "_server", session)
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	cmd.ExtraFiles = []*os.File{writePipe, shutdownWritePipe} // fds 3 and 4 in child
 	if home == "" {
 		home = newTestHome(tb)
 	}
-	env := removeEnv(os.Environ(), "AMUX_EXIT_UNATTACHED")
+	logDir := testLogDir(home)
+	env := removeEnv(cmd.Env, "AMUX_EXIT_UNATTACHED")
 	for key := range harnessBlockedEnvKeys {
 		env = removeEnv(env, key)
 	}
 	env = upsertEnv(env, "HOME", home)
+	env = upsertEnv(env, "AMUX_LOG_DIR", logDir)
 	env = upsertEnv(env, "AMUX_COLOR_PROFILE", "TrueColor")
 	env = append(env, "AMUX_READY_FD=3", "AMUX_SHUTDOWN_FD=4", "AMUX_NO_WATCH=1", "AMUX_DISABLE_META_REFRESH=1")
 	if exitUnattached {
@@ -212,7 +214,6 @@ func newServerHarnessForSession(tb testing.TB, session, home string, cols, rows 
 	}
 	cmd.Env = env
 
-	logDir := server.SocketDir()
 	mustMkdirAll(tb, logDir, 0700)
 	logPath := filepath.Join(logDir, session+".log")
 	logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0600)
@@ -395,7 +396,9 @@ func (h *ServerHarness) cleanup() {
 	}
 	socketDir := server.SocketDir()
 	os.Remove(filepath.Join(socketDir, h.session))
-	os.Remove(filepath.Join(socketDir, h.session+".log"))
+	if h.logPath != "" {
+		os.Remove(h.logPath)
+	}
 	if h.home != "" {
 		_ = os.RemoveAll(h.home)
 		h.home = ""
@@ -483,12 +486,13 @@ func (h *ServerHarness) diagnosticState() (wait, cmd string) {
 
 func (h *ServerHarness) commandWithContext(ctx context.Context, args ...string) *exec.Cmd {
 	cmdArgs := append([]string{"-s", h.session}, args...)
-	cmd := exec.CommandContext(ctx, amuxBin, cmdArgs...)
-	env := os.Environ()
+	cmd := newHermeticAmuxCommandContext(h.tb, ctx, cmdArgs...)
+	env := cmd.Env
 	for key := range harnessBlockedEnvKeys {
 		env = removeEnv(env, key)
 	}
 	env = upsertEnv(env, "HOME", h.home)
+	env = upsertEnv(env, "AMUX_LOG_DIR", testLogDir(h.home))
 	if h.coverDir != "" {
 		env = upsertEnv(env, "GOCOVERDIR", h.coverDir)
 	}

--- a/test/terminfo_test.go
+++ b/test/terminfo_test.go
@@ -1,7 +1,6 @@
 package test
 
 import (
-	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -13,8 +12,8 @@ func TestInstallTerminfoCommand(t *testing.T) {
 
 	home := t.TempDir()
 	for i := 0; i < 2; i++ {
-		cmd := exec.Command(amuxBin, "install-terminfo")
-		cmd.Env = upsertEnv(os.Environ(), "HOME", home)
+		cmd := newHermeticAmuxCommand(t, "install-terminfo")
+		cmd.Env = upsertEnv(cmd.Env, "HOME", home)
 		out, err := cmd.CombinedOutput()
 		if err != nil {
 			t.Fatalf("install-terminfo run %d failed: %v\n%s", i+1, err, out)
@@ -35,8 +34,8 @@ func TestInstallTerminfoCommandFailsWithoutTic(t *testing.T) {
 	t.Parallel()
 
 	home := t.TempDir()
-	cmd := exec.Command(amuxBin, "install-terminfo")
-	cmd.Env = upsertEnv(upsertEnv(os.Environ(), "HOME", home), "PATH", t.TempDir())
+	cmd := newHermeticAmuxCommand(t, "install-terminfo")
+	cmd.Env = upsertEnv(upsertEnv(cmd.Env, "HOME", home), "PATH", t.TempDir())
 	out, err := cmd.CombinedOutput()
 	if err == nil {
 		t.Fatalf("install-terminfo unexpectedly succeeded:\n%s", out)
@@ -50,8 +49,8 @@ func TestServerBootstrapFailsWithoutTic(t *testing.T) {
 	t.Parallel()
 
 	home := t.TempDir()
-	cmd := exec.Command(amuxBin, "_server", "terminfo-fail")
-	cmd.Env = upsertEnv(upsertEnv(os.Environ(), "HOME", home), "PATH", t.TempDir())
+	cmd := newHermeticAmuxCommand(t, "_server", "terminfo-fail")
+	cmd.Env = upsertEnv(upsertEnv(cmd.Env, "HOME", home), "PATH", t.TempDir())
 	out, err := cmd.CombinedOutput()
 	if err == nil {
 		t.Fatalf("server bootstrap unexpectedly succeeded:\n%s", out)

--- a/test/test_sshd_test.go
+++ b/test/test_sshd_test.go
@@ -577,6 +577,40 @@ identity_file = "%s"
 `, user, host, port, identityFile)
 }
 
+func TestTestSSHServerExportsHermeticAmuxSession(t *testing.T) {
+	t.Setenv("AMUX_SESSION", "main")
+
+	fixture := setupTestSSHWithOptions(t, testSSHServerOptions{preloadAmux: true})
+	_, port, _ := net.SplitHostPort(fixture.Addr)
+	cmd := exec.Command(
+		"ssh",
+		"-i", fixture.KeyFile,
+		"-p", port,
+		"-o", "StrictHostKeyChecking=no",
+		"-o", "UserKnownHostsFile=/dev/null",
+		"127.0.0.1",
+		`printf 'AMUX_SESSION=%s\n' "$AMUX_SESSION"`,
+	)
+	cmd.Env = hermeticMainEnv()
+
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("ssh env probe failed: %v\n%s", err, out)
+	}
+	got := ""
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		if strings.HasPrefix(line, "AMUX_SESSION=") {
+			got = strings.TrimSpace(line)
+		}
+	}
+	if got == "AMUX_SESSION=" || got == "AMUX_SESSION=main" {
+		t.Fatalf("remote SSH fixture AMUX_SESSION = %q, want isolated non-main session", got)
+	}
+	if got == "" {
+		t.Fatalf("remote SSH fixture did not report AMUX_SESSION\n%s", out)
+	}
+}
+
 func currentUser() string {
 	u, err := user.Current()
 	if err != nil {

--- a/test/test_sshd_test.go
+++ b/test/test_sshd_test.go
@@ -28,6 +28,7 @@ import (
 
 type testSSHServerOptions struct {
 	preloadAmux bool
+	sessionName string
 }
 
 type testSSHServer struct {
@@ -126,6 +127,10 @@ func buildTestSSHExecEnv(homeDir string, opts testSSHServerOptions) []string {
 		execEnv = removeEnv(execEnv, key)
 	}
 	execEnv = upsertEnv(execEnv, "HOME", homeDir)
+	execEnv = upsertEnv(execEnv, "AMUX_LOG_DIR", testLogDir(homeDir))
+	if opts.sessionName != "" {
+		execEnv = upsertEnv(execEnv, "AMUX_SESSION", opts.sessionName)
+	}
 
 	if !opts.preloadAmux {
 		// Keep only base system tools on PATH so the remote starts without any
@@ -547,6 +552,9 @@ func setupTestSSHNoPreload(t *testing.T) testSSHFixture {
 
 func setupTestSSHWithOptions(t *testing.T, opts testSSHServerOptions) testSSHFixture {
 	t.Helper()
+	if opts.sessionName == "" {
+		opts.sessionName = randomTestSessionName(t)
+	}
 	pubKey, privPEM := generateTestKeyPair(t)
 	server := startTestSSHServer(t, pubKey, opts)
 

--- a/test/version_test.go
+++ b/test/version_test.go
@@ -1,7 +1,6 @@
 package test
 
 import (
-	"os/exec"
 	"strconv"
 	"strings"
 	"testing"
@@ -11,7 +10,7 @@ import (
 
 func TestVersionCommand(t *testing.T) {
 	t.Parallel()
-	out, err := exec.Command(amuxBin, "version").CombinedOutput()
+	out, err := newHermeticAmuxCommand(t, "version").CombinedOutput()
 	if err != nil {
 		t.Fatalf("amux version failed: %v\n%s", err, out)
 	}


### PR DESCRIPTION
## Motivation
Tests run from an attached `main` pane could inherit live amux environment and log file descriptors. In the LAB-1641 repro, `AMUX_SESSION=main go test ./test/... -run 'Reload|Takeover|Events'` wrote test-session records into `/tmp/amux-1000/main.log` and produced a real `client_connect` to `session":"main"` at 80x24 during `TestTakeoverAfterServerReload`.

## Summary
- Add a shared `internal/testenv` helper for hermetic amux subprocess environments and route root/test subprocess launch sites through it.
- Add a repo-level AST guard so direct `exec.Command(amuxBin, ...)` and `exec.Command(os.Args[0], ...)` test call sites cannot regress.
- Give test servers and SSH fixtures isolated log directories, while treating `AMUX_LOG_DIR` as server-only state that is scrubbed from pane shells and preserved across reload exec.
- Mark inherited socket-log descriptors close-on-exec and make stderr tee descriptors close-on-exec to close the FD inheritance/log tee path.
- Make the idle/busy event assertion tolerate unrelated queued events.
- Update `CLAUDE.md` with the test subprocess helper rule.

Confirmed hypotheses: A and C. Hypothesis A reproduced as a `main` session `client_connect` from the test path. Hypothesis C/log isolation was also present: after fixing A, the repro no longer resized `main`, but test-session log entries still reached `main.log` until log dir isolation and close-on-exec handling were added. Hypothesis B was not supported; I did not find test paths writing the installed amux binary.

## Testing
- Red checks failed before the fix:
  - `go test ./test -run 'TestAmuxSubprocessesUseHermeticHelper|TestTestSSHServerExportsHermeticAmuxSession' -timeout 60s`
  - `go test ./test -run '^TestTestSSHServerExportsHermeticAmuxSession$' -timeout 60s`
- Acceptance repro before fix: `MATCHING_MAIN_LOG_LINES=84`, including a `session":"main"` `client_connect` at 80x24 from `TestTakeoverAfterServerReload`.
- Acceptance repro after fix, after rebase, and after the auditlog coverage update: `AMUX_SESSION=main go test ./test/... -timeout 120s -count=3 -run 'Reload|Takeover|Events'` -> `ok`, `STATUS=0`, `MATCHES=0` from the live `main.log` tail.
- `go test ./test -run '^TestAmuxSubprocessesUseHermeticHelper$|^TestTestSSHServerExportsHermeticAmuxSession$' -count=100 -timeout 300s`
- `go test ./internal/auditlog ./internal/server -run 'TestTeeFileForFDSetsCloseOnExec|TestMarkSocketLogFDsCloseOnExecMarksInheritedLogs|TestInstallProcessLogRotationDoesNotTeeRegularStderr|TestReadServerEnvScrubsLogDirAndExportsForReload' -count=100 -timeout 120s`
- `go test ./internal/testenv ./internal/auditlog -run 'TestHermetic|TestNewCommandUsesHermeticEnv|TestRemoveEnvKeyDoesNotMutateInput|TestTeeFileForFDSetsCloseOnExec|TestMarkSocketLogFDsCloseOnExecMarksInheritedLogs|TestInstallProcessLogRotationDoesNotTeeRegularStderr' -count=100 -timeout 120s`
- `go test ./test -run '^TestParallelAudit$|^TestAmuxSubprocessesUseHermeticHelper$' -count=100 -timeout 180s`
- `go test ./test -run 'TestUnsupportedPrefixKeyFeedbackClearsOnLiteralPrefix|TestServerHotReload|TestHotReloadKeybinding' -count=10 -timeout 240s`
- `go test ./test -run '^TestExplicitPaneCommandsPreferActorWindowWithoutChangingFocus$' -count=20 -timeout 300s`
- `go test ./... -timeout 120s` passed before the final Codecov-only coverage update; the final branch passed the GitHub CI `test` workflow and Codecov patch check on PR #756.
- `git diff --check origin/main`
- Static grep for direct amux subprocess calls returned no offenders.

Note: early pre-fix repro attempts left stale hidden clients on the live `main` session, so final width sampling was not a clean signal. I did not detach or kill those clients because that would alter live session state.

## Review focus
- `internal/testenv` env scrub list and the `test/hermetic_subprocess_test.go` AST guard.
- `AMUX_LOG_DIR` as server-only env in `internal/server/envvars.go`, especially reload preservation without pane-shell leakage.
- `internal/auditlog/rotation.go` close-on-exec handling for inherited log descriptors.
- SSH fixture `AMUX_SESSION` behavior in `test/test_sshd_test.go`.
- Possible overlap with LAB-1620 race-condition audit around event tests and integration timing.

Closes LAB-1641
