### PR TITLE
LAB-1634: Address capture snapshot review feedback

### DIFF
--- a/internal/client/renderer.go
+++ b/internal/client/renderer.go
@@ -450,6 +450,9 @@ func (r *Renderer) captureJSONValueWithHistory(agentStatus map[uint32]proto.Pane
 
 	capture.Panes = make([]proto.CapturePane, 0, len(paneWork))
 	for _, work := range paneWork {
+		// Full-session captures are snapshot-only to keep capture off the actor.
+		// If a pane has no warm emulator in this snapshot, paneCapture returns a
+		// blank pane. Pane-specific captures still fall back to actor lazy replay.
 		pane, ok := snap.paneCapture(work.paneID)
 		if !ok {
 			continue
@@ -503,7 +506,6 @@ func (r *Renderer) CapturePaneText(paneID uint32, includeANSI bool) string {
 
 func (r *Renderer) capturePaneTextFromActor(paneID uint32, includeANSI bool) string {
 	return withRendererActorValue(r, func(st *rendererActorState) string {
-		snap := st.snapshot
 		emu := st.ensurePaneEmulator(paneID)
 		if emu == nil {
 			return ""
@@ -511,7 +513,7 @@ func (r *Renderer) capturePaneTextFromActor(paneID uint32, includeANSI bool) str
 		st.warmPaneOutput(paneID, st.emulators)
 		r.publishPaneCapture(st, paneID)
 		if includeANSI {
-			return filterRenderedANSI(emu.Render(), snap.capabilities)
+			return filterRenderedANSI(emu.Render(), st.snapshot.capabilities)
 		}
 		return strings.Join(caputil.TrimOuterBlankRows(mux.EmulatorContentLines(emu)), "\n")
 	})

--- a/internal/client/renderer_capture_snapshot.go
+++ b/internal/client/renderer_capture_snapshot.go
@@ -73,10 +73,20 @@ func cloneTerminalState(state proto.TerminalState) proto.TerminalState {
 	return state
 }
 
-func emptyPaneRenderSnapshot(width, height, scrollbackLines int) paneRenderSnapshot {
-	emu := mux.NewVTEmulatorWithScrollback(width, height, scrollbackLines)
-	defer emu.Close()
-	return capturePaneRenderSnapshot(emu)
+func emptyPaneRenderSnapshot(width, height int) paneRenderSnapshot {
+	if height < 0 {
+		height = 0
+	}
+	screen := make([]paneBufferLine, height)
+	rendered := strings.Repeat("\n", max(0, height-1))
+	return paneRenderSnapshot{
+		width:            width,
+		height:           height,
+		cursorHidden:     true,
+		rendered:         rendered,
+		renderedNoCursor: rendered,
+		screen:           screen,
+	}
 }
 
 func (s *rendererSnapshot) paneCapture(paneID uint32) (paneRenderSnapshot, bool) {
@@ -93,7 +103,10 @@ func (s *rendererSnapshot) paneCapture(paneID uint32) (paneRenderSnapshot, bool)
 	if !ok {
 		return paneRenderSnapshot{}, false
 	}
-	return emptyPaneRenderSnapshot(width, height, s.scrollbackLines), true
+	// Full-session captures are snapshot-only. A pane absent from paneCaptures
+	// has no warm emulator in this snapshot, so represent it as blank here rather
+	// than entering the actor. Pane-specific captures keep the lazy replay path.
+	return emptyPaneRenderSnapshot(width, height), true
 }
 
 func (s *rendererSnapshot) captureCompositor() *render.Compositor {

--- a/internal/client/renderer_capture_snapshot_test.go
+++ b/internal/client/renderer_capture_snapshot_test.go
@@ -39,7 +39,7 @@ func TestHandleCaptureRequestDoesNotWaitForRendererActor(t *testing.T) {
 		if !strings.Contains(out, "ready") {
 			t.Fatalf("capture output = %q, want pane content", out)
 		}
-	case <-time.After(50 * time.Millisecond):
+	case <-time.After(2 * time.Second):
 		close(actorRelease)
 		out := <-captureDone
 		t.Fatalf("capture waited for renderer actor; output after release was %q", out)

--- a/internal/client/renderer_capture_snapshot_test.go
+++ b/internal/client/renderer_capture_snapshot_test.go
@@ -4,6 +4,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/weill-labs/amux/internal/proto"
 )
 
 func TestHandleCaptureRequestDoesNotWaitForRendererActor(t *testing.T) {
@@ -46,4 +48,58 @@ func TestHandleCaptureRequestDoesNotWaitForRendererActor(t *testing.T) {
 	}
 
 	close(actorRelease)
+}
+
+func TestPaneCaptureMissingWarmSnapshotReturnsBlank(t *testing.T) {
+	t.Parallel()
+
+	r := NewWithScrollback(20, 6, 100)
+	t.Cleanup(r.Close)
+
+	r.HandleLayout(singlePane20x5())
+	r.withActor(func(st *rendererActorState) {
+		next := *st.snapshot
+		next.paneCaptures = make(map[uint32]paneRenderSnapshot)
+		st.snapshot = &next
+		r.publishSnapshot(&next)
+	})
+
+	pane, ok := r.loadSnapshot().paneCapture(1)
+	if !ok {
+		t.Fatal("paneCapture returned no snapshot for existing pane")
+	}
+	if pane.width != 20 || pane.height != 4 {
+		t.Fatalf("pane size = %dx%d, want 20x4", pane.width, pane.height)
+	}
+	if len(pane.screen) != pane.height {
+		t.Fatalf("screen lines = %d, want %d", len(pane.screen), pane.height)
+	}
+	if got, want := pane.rendered, "\n\n\n"; got != want {
+		t.Fatalf("rendered blank pane = %q, want %q", got, want)
+	}
+	if !pane.cursorHidden {
+		t.Fatal("blank pane cursor should be hidden")
+	}
+}
+
+func TestCapturePaneTextActorFallbackUsesCurrentCapabilities(t *testing.T) {
+	t.Parallel()
+
+	r := NewWithScrollback(80, 24, 100)
+	t.Cleanup(r.Close)
+
+	r.SetCapabilities(proto.ClientCapabilities{Hyperlinks: true})
+	r.HandleLayout(singlePane20x3())
+	r.HandlePaneOutput(1, []byte("\033]8;;https://example.com\033\\test-link\033]8;;\033\\"))
+	r.withActor(func(st *rendererActorState) {
+		next := *st.snapshot
+		next.paneCaptures = make(map[uint32]paneRenderSnapshot)
+		st.snapshot = &next
+		r.publishSnapshot(&next)
+	})
+
+	ansi := r.CapturePaneText(1, true)
+	if !strings.Contains(ansi, "\033]8;") {
+		t.Fatalf("actor fallback should use current hyperlink capability, got %q", ansi)
+	}
 }

--- a/internal/client/renderer_state.go
+++ b/internal/client/renderer_state.go
@@ -124,6 +124,9 @@ func clonePaneRenderSnapshots(src map[uint32]paneRenderSnapshot) map[uint32]pane
 		return make(map[uint32]paneRenderSnapshot)
 	}
 	dst := make(map[uint32]paneRenderSnapshot, len(src))
+	// paneRenderSnapshot values are shallow-copied here. Their screen and
+	// scrollback slices are immutable after capturePaneRenderSnapshot returns, so
+	// sharing backing arrays across snapshot generations is intentional.
 	for paneID, snap := range src {
 		dst[paneID] = snap
 	}


### PR DESCRIPTION
## Motivation

PR #753 already merged, but later review feedback called out a few small follow-ups in the snapshot-backed capture path: ambiguous cold-pane behavior, a shallow-copy invariant that needed documentation, an avoidable temporary VT allocation, and a tight regression-test timeout.

## Summary

- Document full-session snapshot-only behavior for panes without warm capture state.
- Document the immutable-slice invariant behind shallow `paneRenderSnapshot` map copies.
- Replace the blank fallback's temporary VT emulator with a direct blank snapshot.
- Use the current actor snapshot capabilities after warming a pane-specific capture fallback.
- Relax the actor-blocking regression timeout to avoid scheduler-related flakes.

## Testing

- `go test ./internal/client -run 'TestHandleCaptureRequestDoesNotWaitForRendererActor|TestPaneCaptureMissingWarmSnapshotReturnsBlank|TestCapturePaneTextActorFallbackUsesCurrentCapabilities' -count=100 -timeout 120s`
- `go test ./internal/client -count=1`
- `golangci-lint run ./internal/client/...`
- `go test ./test -run 'TestMouseDragOntoWindowTabMovesPaneToWindow|TestMouseDragWindowTabDwellSwitchesWindowAndKeepsDrag|TestCapturePaneANSI_PreservesStyleAfterSGRReset' -count=1 -timeout 120s`

## Review focus

- Confirm the blank fallback still preserves full-session capture semantics for panes missing warm snapshot state.
- Confirm the comments describe the intended snapshot immutability and cold-pane tradeoff clearly enough for future maintainers.

Follow-up to #753 / LAB-1634.

