### PR TITLE
LAB-1644: Add env-gated server pane capture path

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -30,6 +30,9 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Prepare Claude Code install directory
+        run: mkdir -p "$HOME/.local/bin"
+
       - name: Run Claude Code Review
         id: claude-review
         uses: anthropics/claude-code-action@v1

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -30,14 +30,18 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Prepare Claude Code install directory
-        run: mkdir -p "$HOME/.local/bin"
+      - name: Install Claude Code CLI
+        id: claude-code
+        run: |
+          npm install -g @anthropic-ai/claude-code
+          echo "path=$(command -v claude)" >> "$GITHUB_OUTPUT"
 
       - name: Run Claude Code Review
         id: claude-review
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          path_to_claude_code_executable: ${{ steps.claude-code.outputs.path }}
           # Use the workflow token so PRs that modify this workflow can still
           # run; the default GitHub App token path rejects workflow-file diffs.
           github_token: ${{ github.token }}

--- a/internal/server/commands_capture.go
+++ b/internal/server/commands_capture.go
@@ -1,7 +1,10 @@
 package server
 
 import (
+	"os"
+
 	caputil "github.com/weill-labs/amux/internal/capture"
+	commandpkg "github.com/weill-labs/amux/internal/server/commands"
 	capturecmd "github.com/weill-labs/amux/internal/server/commands/capture"
 )
 
@@ -21,6 +24,33 @@ func (ctx captureCommandContext) ForwardCapture(args []string) *Message {
 	return ctx.Sess.forwardCaptureForActor(ctx.ActorPaneID, args)
 }
 
+func captureServerPathEnabled() bool {
+	return os.Getenv("AMUX_CAPTURE_SERVER") == "1"
+}
+
+func captureLocally(ctx *CommandContext, args []string) *Message {
+	req := caputil.ParseArgs(args)
+	if req.PaneRef != "" {
+		return captureSinglePaneLocally(ctx, req)
+	}
+	return ctx.Sess.forwardCaptureForActor(ctx.ActorPaneID, args)
+}
+
+func captureSinglePaneLocally(ctx *CommandContext, req caputil.Request) *Message {
+	if err := caputil.ValidateScreenRequest(req); err != nil {
+		return &Message{Type: MsgTypeCmdResult, CmdErr: err.Error()}
+	}
+	if req.ColorMap {
+		return &Message{Type: MsgTypeCmdResult, CmdErr: "--colors is only supported for full screen capture"}
+	}
+
+	target, err := ctx.Sess.resolveCapturePaneTargetForActor(ctx.ActorPaneID, req.PaneRef)
+	if err != nil {
+		return &Message{Type: MsgTypeCmdResult, CmdErr: err.Error()}
+	}
+	return ctx.Sess.capturePaneDirect(caputil.ArgsForRequest(req), target)
+}
+
 func cmdCapture(ctx *CommandContext) {
 	req := caputil.ParseArgs(ctx.Args)
 	if req.PaneRef != "" {
@@ -34,6 +64,10 @@ func cmdCapture(ctx *CommandContext) {
 			ctx.applyCommandResult(remoteCommandResult(ctx.Sess, ref.Host, "capture", caputil.ArgsForRequest(req)))
 			return
 		}
+	}
+	if captureServerPathEnabled() && req.PaneRef != "" && !req.HistoryMode {
+		ctx.applyCommandResult(commandpkg.Result{Message: captureLocally(ctx, ctx.Args)})
+		return
 	}
 	ctx.applyCommandResult(capturecmd.Capture(captureCommandContext{ctx}, ctx.Args))
 }

--- a/internal/server/commands_capture.go
+++ b/internal/server/commands_capture.go
@@ -30,10 +30,10 @@ func captureServerPathEnabled() bool {
 
 func captureLocally(ctx *CommandContext, args []string) *Message {
 	req := caputil.ParseArgs(args)
-	if req.PaneRef != "" {
-		return captureSinglePaneLocally(ctx, req)
+	if req.PaneRef == "" {
+		return &Message{Type: MsgTypeCmdResult, CmdErr: "server-side full-session capture is not implemented"}
 	}
-	return ctx.Sess.forwardCaptureForActor(ctx.ActorPaneID, args)
+	return captureSinglePaneLocally(ctx, req)
 }
 
 func captureSinglePaneLocally(ctx *CommandContext, req caputil.Request) *Message {

--- a/internal/server/commands_capture_test.go
+++ b/internal/server/commands_capture_test.go
@@ -3,9 +3,11 @@ package server
 import (
 	"net"
 	"slices"
+	"strings"
 	"testing"
 	"time"
 
+	caputil "github.com/weill-labs/amux/internal/capture"
 	"github.com/weill-labs/amux/internal/mux"
 )
 
@@ -110,6 +112,71 @@ func TestCaptureServerEnvFullSessionStillForwardsInStepOne(t *testing.T) {
 		}
 	case <-time.After(time.Second):
 		t.Fatal("timeout waiting for forwarded capture request")
+	}
+}
+
+func TestCaptureLocallyRejectsFullSessionDirectCall(t *testing.T) {
+	t.Parallel()
+
+	res := captureLocally(&CommandContext{}, nil)
+	if got, want := res.CmdErr, "server-side full-session capture is not implemented"; got != want {
+		t.Fatalf("captureLocally CmdErr = %q, want %q", got, want)
+	}
+}
+
+func TestCaptureSinglePaneLocallyRejectsInvalidScreenFlags(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		req  caputil.Request
+		want string
+	}{
+		{
+			name: "mutually exclusive formats",
+			req: caputil.Request{
+				PaneRef:     "pane-1",
+				IncludeANSI: true,
+				FormatJSON:  true,
+			},
+			want: "--ansi, --colors, and --format json are mutually exclusive",
+		},
+		{
+			name: "pane color map",
+			req: caputil.Request{
+				PaneRef:  "pane-1",
+				ColorMap: true,
+			},
+			want: "--colors is only supported for full screen capture",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			res := captureSinglePaneLocally(&CommandContext{}, tt.req)
+			if got := res.CmdErr; got != tt.want {
+				t.Fatalf("captureSinglePaneLocally CmdErr = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCaptureSinglePaneLocallyReturnsResolveError(t *testing.T) {
+	t.Parallel()
+
+	_, sess, cleanup := newCommandTestSession(t)
+	defer cleanup()
+
+	pane := newStandaloneProxyPane(1, "pane-1")
+	window := newTestWindowWithPanes(t, sess, 1, "main", pane)
+	setSessionLayoutForTest(t, sess, window.ID, []*mux.Window{window}, pane)
+
+	res := captureSinglePaneLocally(&CommandContext{Sess: sess}, caputil.Request{PaneRef: "missing"})
+	if got := res.CmdErr; !strings.Contains(got, "not found") {
+		t.Fatalf("captureSinglePaneLocally CmdErr = %q, want pane not found", got)
 	}
 }
 

--- a/internal/server/commands_capture_test.go
+++ b/internal/server/commands_capture_test.go
@@ -115,6 +115,36 @@ func TestCaptureServerEnvFullSessionStillForwardsInStepOne(t *testing.T) {
 	}
 }
 
+func TestCaptureServerEnvHistoryPaneStaysOnHistoryPath(t *testing.T) {
+	t.Setenv("AMUX_CAPTURE_SERVER", "1")
+
+	srv, sess, cleanup := newCommandTestSession(t)
+	defer cleanup()
+
+	pane := newStandaloneProxyPane(1, "pane-1")
+	pane.SetRetainedHistory([]string{"SERVER-HISTORY"})
+	pane.FeedOutput([]byte("SERVER-VISIBLE"))
+	window := newTestWindowWithPanes(t, sess, 1, "main", pane)
+	setSessionLayoutForTest(t, sess, window.ID, []*mux.Window{window}, pane)
+
+	captureClient := attachCaptureClientForCommandTest(t, sess)
+
+	res := runTestCommand(t, srv, sess, "capture", "--history", "pane-1")
+	if res.cmdErr != "" {
+		t.Fatalf("capture cmdErr = %q, want empty", res.cmdErr)
+	}
+	if got, want := res.output, "SERVER-HISTORY\nSERVER-VISIBLE\n"; got != want {
+		t.Fatalf("capture output = %q, want %q", got, want)
+	}
+
+	if err := captureClient.SetReadDeadline(time.Now().Add(25 * time.Millisecond)); err != nil {
+		t.Fatalf("SetReadDeadline: %v", err)
+	}
+	if msg, err := readMsgOnConn(captureClient); err == nil {
+		t.Fatalf("attached client received %v, want no client capture request", msg.Type)
+	}
+}
+
 func TestCaptureLocallyRejectsFullSessionDirectCall(t *testing.T) {
 	t.Parallel()
 

--- a/internal/server/commands_capture_test.go
+++ b/internal/server/commands_capture_test.go
@@ -1,0 +1,156 @@
+package server
+
+import (
+	"net"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/weill-labs/amux/internal/mux"
+)
+
+func TestCaptureServerEnvSinglePaneDoesNotSendClientCaptureRequest(t *testing.T) {
+	t.Setenv("AMUX_CAPTURE_SERVER", "1")
+
+	srv, sess, cleanup := newCommandTestSession(t)
+	defer cleanup()
+	sess.captureTiming.responseTimeout = 20 * time.Millisecond
+
+	pane := newStandaloneProxyPane(1, "pane-1")
+	pane.FeedOutput([]byte("SERVER-LOCAL\r\n"))
+	window := newTestWindowWithPanes(t, sess, 1, "main", pane)
+	setSessionLayoutForTest(t, sess, window.ID, []*mux.Window{window}, pane)
+
+	captureClient := attachCaptureClientForCommandTest(t, sess)
+
+	res := runTestCommand(t, srv, sess, "capture", "pane-1")
+	if res.cmdErr != "" {
+		t.Fatalf("capture cmdErr = %q, want empty", res.cmdErr)
+	}
+	if got, want := res.output, "SERVER-LOCAL\n"; got != want {
+		t.Fatalf("capture output = %q, want %q", got, want)
+	}
+
+	if err := captureClient.SetReadDeadline(time.Now().Add(25 * time.Millisecond)); err != nil {
+		t.Fatalf("SetReadDeadline: %v", err)
+	}
+	if msg, err := readMsgOnConn(captureClient); err == nil {
+		t.Fatalf("attached client received %v, want no client capture request", msg.Type)
+	}
+}
+
+func TestCaptureDefaultSinglePaneStillForwardsToAttachedClient(t *testing.T) {
+	t.Parallel()
+
+	srv, sess, cleanup := newCommandTestSession(t)
+	defer cleanup()
+
+	pane := newStandaloneProxyPane(1, "pane-1")
+	pane.FeedOutput([]byte("SERVER-LOCAL\r\n"))
+	window := newTestWindowWithPanes(t, sess, 1, "main", pane)
+	setSessionLayoutForTest(t, sess, window.ID, []*mux.Window{window}, pane)
+
+	captureClient := attachCaptureClientForCommandTest(t, sess)
+	requestCh, errCh := respondToNextCaptureRequest(t, sess, captureClient, "CLIENT-PANE\n")
+
+	res := runTestCommand(t, srv, sess, "capture", "pane-1")
+	if res.cmdErr != "" {
+		t.Fatalf("capture cmdErr = %q, want empty", res.cmdErr)
+	}
+	if got, want := res.output, "CLIENT-PANE\n"; got != want {
+		t.Fatalf("capture output = %q, want %q", got, want)
+	}
+
+	select {
+	case err := <-errCh:
+		t.Fatalf("reading capture request: %v", err)
+	case msg := <-requestCh:
+		if msg.Type != MsgTypeCaptureRequest {
+			t.Fatalf("message type = %v, want %v", msg.Type, MsgTypeCaptureRequest)
+		}
+		if want := []string{"1"}; !slices.Equal(msg.CmdArgs, want) {
+			t.Fatalf("capture request args = %v, want %v", msg.CmdArgs, want)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for forwarded capture request")
+	}
+}
+
+func TestCaptureServerEnvFullSessionStillForwardsInStepOne(t *testing.T) {
+	t.Setenv("AMUX_CAPTURE_SERVER", "1")
+
+	srv, sess, cleanup := newCommandTestSession(t)
+	defer cleanup()
+
+	pane := newStandaloneProxyPane(1, "pane-1")
+	pane.FeedOutput([]byte("SERVER-LOCAL\r\n"))
+	window := newTestWindowWithPanes(t, sess, 1, "main", pane)
+	setSessionLayoutForTest(t, sess, window.ID, []*mux.Window{window}, pane)
+
+	captureClient := attachCaptureClientForCommandTest(t, sess)
+	requestCh, errCh := respondToNextCaptureRequest(t, sess, captureClient, "CLIENT-FULL\n")
+
+	res := runTestCommand(t, srv, sess, "capture")
+	if res.cmdErr != "" {
+		t.Fatalf("capture cmdErr = %q, want empty", res.cmdErr)
+	}
+	if got, want := res.output, "CLIENT-FULL\n"; got != want {
+		t.Fatalf("capture output = %q, want %q", got, want)
+	}
+
+	select {
+	case err := <-errCh:
+		t.Fatalf("reading capture request: %v", err)
+	case msg := <-requestCh:
+		if msg.Type != MsgTypeCaptureRequest {
+			t.Fatalf("message type = %v, want %v", msg.Type, MsgTypeCaptureRequest)
+		}
+		if len(msg.CmdArgs) != 0 {
+			t.Fatalf("capture request args = %v, want empty", msg.CmdArgs)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for forwarded capture request")
+	}
+}
+
+func attachCaptureClientForCommandTest(t *testing.T, sess *Session) net.Conn {
+	t.Helper()
+
+	serverConn, peerConn := net.Pipe()
+	attached := newClientConn(serverConn)
+	attached.ID = "client-capture"
+	t.Cleanup(func() {
+		attached.Close()
+		_ = peerConn.Close()
+		_ = serverConn.Close()
+	})
+
+	mustSessionMutation(t, sess, func(sess *Session) {
+		sess.ensureClientManager().setClientsForTest(attached)
+	})
+	return peerConn
+}
+
+func respondToNextCaptureRequest(t *testing.T, sess *Session, conn net.Conn, output string) (<-chan *Message, <-chan error) {
+	t.Helper()
+
+	requestCh := make(chan *Message, 1)
+	errCh := make(chan error, 1)
+	go func() {
+		if err := conn.SetReadDeadline(time.Now().Add(time.Second)); err != nil {
+			errCh <- err
+			return
+		}
+		msg, err := readMsgOnConn(conn)
+		if err != nil {
+			errCh <- err
+			return
+		}
+		requestCh <- msg
+		sess.routeCaptureResponse(&Message{
+			Type:      MsgTypeCaptureResponse,
+			CmdOutput: output,
+		})
+	}()
+	return requestCh, errCh
+}


### PR DESCRIPTION
## Motivation

LAB-1644 splits capture so the common "what is in this pane?" query can read server-owned VT state instead of synchronously involving an attached rendering client. This first PR ships only the high-value single-pane path behind `AMUX_CAPTURE_SERVER=1`, which removes the client capture request that can trigger the LAB-1634 post-capture flicker for pane captures.

## Summary

- Add the step-1 server-side entry point in `internal/server/commands_capture.go`: `captureLocally` dispatches pane-targeted captures to `captureSinglePaneLocally`, which reuses the existing server pane snapshot path (`resolveCapturePaneTargetForActor` + `capturePaneDirect` / `buildServerCapturePane`).
- Gate the new path behind `AMUX_CAPTURE_SERVER=1`; default behavior remains the existing `forwardCaptureForActor` client path.
- Keep full-session capture on the legacy client-forwarding path even when the env flag is set. The `serverPaneData` adapter and full-session compositor path are intentionally left for step 2.
- Keep history capture on the existing history path under `AMUX_CAPTURE_SERVER=1`, with direct test coverage for `capture --history pane-1`.
- Add routing and guard-rail tests covering the env-gated pane path, default single-pane forwarding, step-1 full-session fallback, history fallback, invalid pane capture flags, and pane resolution errors.
- Install Claude Code via npm in the Claude Code Review workflow and pass the resolved executable path to the action, avoiding the native installer path that produced the prior `claude-review` infrastructure failures.

## Testing

- `go test ./internal/server -run 'TestCapture(ServerEnv|DefaultSinglePane|Locally|SinglePaneLocally)' -count=100`
- `go test ./internal/server -run 'TestCapture(ServerEnv|DefaultSinglePane|Locally|SinglePaneLocally)' -coverprofile=/tmp/server-capture.cover -covermode=count && go tool cover -func=/tmp/server-capture.cover | rg 'commands_capture.go|total:'`
- `go test ./test -run TestRemotePaneViaSSH -count=3 -timeout 120s`
- `go test ./test -run TestRespawnPreservesPaneMetadataAndCwdWhileResettingState -count=5 -timeout 120s`
- `go test ./test -run TestMouseCommandDragAutomaticallyCopiesSelection -count=3 -timeout 120s`
- `git diff --check`
- `scripts/push-and-watch-ci.sh` on commits `f892de1` and `e550cd2` passed required CI: `test` and `codecov/patch`.
- Latest `claude-review` on commit `c85fa91` passed and posted LGTM.
- Reran the failed CI `test` job from run `25420043662`; it passed after the earlier unrelated `TestRespawnPreservesPaneMetadataAndCwdWhileResettingState` flake.
- `go test ./... -timeout 120s` still reproduced load/order-sensitive integration failures outside this diff. One run failed `TestRespawnPreservesPaneMetadataAndCwdWhileResettingState`; another also failed `TestMouseCommandDragAutomaticallyCopiesSelection`. Both passed isolated with repeated runs.

## Review focus

- Check that `AMUX_CAPTURE_SERVER=1` affects only pane-targeted, non-history captures in this step-1 PR.
- Check that history captures still use the existing history path with the env flag set.
- Check that the server path does not send `MsgTypeCaptureRequest` to attached clients, preserving live rendering for pane captures during the soak.
- Check the explicit full-session boundary; the `serverPaneData` adapter and composited capture path should land separately in step 2.
- Check the Claude Code Review workflow change is limited to providing a known Claude executable path before invoking the action.