### PR TITLE
LAB-1661: Add focused pane rename prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,6 +409,7 @@ Default prefix: `Ctrl-a`.
 | `Ctrl-a c` | Create new window |
 | `Ctrl-a n` / `Ctrl-a p` | Next/previous window |
 | `Ctrl-a ;` | Last active window |
+| `Ctrl-a .` | Rename active pane |
 | `Ctrl-a q` | Show pane labels for quick jump |
 | `Ctrl-a ?` | Toggle keybinding help bar |
 | `Ctrl-a 1-9` | Select window by number |

--- a/internal/client/attach.go
+++ b/internal/client/attach.go
@@ -378,6 +378,18 @@ func showWindowRenamePromptOnRenderLoop(cr *ClientRenderer, msgCh chan<- *Render
 	})
 }
 
+func showPaneRenamePromptOnRenderLoop(cr *ClientRenderer, msgCh chan<- *RenderMsg) bool {
+	return callLocalRenderAction[bool](cr, msgCh, func(cr *ClientRenderer) localRenderResult {
+		if !cr.ShowPaneRenamePrompt() {
+			return localRenderResult{value: false}
+		}
+		return localRenderResult{
+			effects: overlayRenderNowResult().effects,
+			value:   true,
+		}
+	})
+}
+
 func handleChooserInputOnRenderLoop(cr *ClientRenderer, msgCh chan<- *RenderMsg, raw []byte) chooserInputResult {
 	return callLocalRenderAction[chooserInputResult](cr, msgCh, func(cr *ClientRenderer) localRenderResult {
 		if !cr.ChooserActive() {
@@ -402,6 +414,18 @@ func handleWindowRenamePromptInputOnRenderLoop(cr *ClientRenderer, msgCh chan<- 
 		return localRenderResult{
 			effects: overlayRenderNowResult().effects,
 			value:   cr.HandleWindowRenamePromptInput(raw),
+		}
+	})
+}
+
+func handlePaneRenamePromptInputOnRenderLoop(cr *ClientRenderer, msgCh chan<- *RenderMsg, raw []byte) promptCommand {
+	return callLocalRenderAction[promptCommand](cr, msgCh, func(cr *ClientRenderer) localRenderResult {
+		if !cr.PaneRenamePromptActive() {
+			return localRenderResult{value: promptCommand{}}
+		}
+		return localRenderResult{
+			effects: overlayRenderNowResult().effects,
+			value:   cr.HandlePaneRenamePromptInput(raw),
 		}
 	})
 }
@@ -830,6 +854,10 @@ func runSessionWithDeps(sessionName string, getTermSize func(int) (int, int, err
 					if !showWindowRenamePromptOnRenderLoop(cr, msgCh) {
 						_ = writeOutput("\a")
 					}
+				case "rename-pane":
+					if !showPaneRenamePromptOnRenderLoop(cr, msgCh) {
+						_ = writeOutput("\a")
+					}
 				case "split":
 					handleSplitBinding(cr, sender, binding, stdout)
 				case "compat-bell":
@@ -1159,6 +1187,19 @@ func runSessionWithDeps(sessionName string, getTermSize func(int) (int, int, err
 
 				if cr.WindowRenamePromptActive() {
 					action := handleWindowRenamePromptInputOnRenderLoop(cr, msgCh, normalized)
+					if action.bell {
+						if err := writeOutput("\a"); err != nil {
+							return true
+						}
+					}
+					if action.command != "" {
+						sender.Command(action.command, action.args)
+					}
+					return false
+				}
+
+				if cr.PaneRenamePromptActive() {
+					action := handlePaneRenamePromptInputOnRenderLoop(cr, msgCh, normalized)
 					if action.bell {
 						if err := writeOutput("\a"); err != nil {
 							return true

--- a/internal/client/attach_session_test.go
+++ b/internal/client/attach_session_test.go
@@ -1344,12 +1344,19 @@ func TestRunSessionRenamePanePromptEscapeCancels(t *testing.T) {
 	h.output.waitContains(t, "rename-pane")
 
 	h.send(t, &proto.Message{Type: proto.MsgTypeTypeKeys, Input: []byte("agent-1\x1b")})
-	h.send(t, &proto.Message{Type: proto.MsgTypeCaptureRequest, CmdArgs: []string{"--format", "json"}})
-	capture := h.waitMessage(t, func(msg *proto.Message) bool {
-		return msg.Type == proto.MsgTypeCaptureResponse
-	})
-	if strings.Contains(capture.CmdOutput, `"prompt": "rename-pane"`) {
-		t.Fatalf("capture output = %q, want rename-pane prompt hidden after escape", capture.CmdOutput)
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		h.send(t, &proto.Message{Type: proto.MsgTypeCaptureRequest, CmdArgs: []string{"--format", "json"}})
+		capture := h.waitMessage(t, func(msg *proto.Message) bool {
+			return msg.Type == proto.MsgTypeCaptureResponse
+		})
+		if !strings.Contains(capture.CmdOutput, `"prompt": "rename-pane"`) {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("capture output = %q, want rename-pane prompt hidden after escape", capture.CmdOutput)
+		}
+		time.Sleep(25 * time.Millisecond)
 	}
 
 	h.send(t, &proto.Message{Type: proto.MsgTypeExit})

--- a/internal/client/attach_session_test.go
+++ b/internal/client/attach_session_test.go
@@ -1282,6 +1282,82 @@ func TestRunSessionRenameWindowPromptHandlesTypeKeys(t *testing.T) {
 	}
 }
 
+func TestRunSessionRenamePanePromptHandlesTypeKeys(t *testing.T) {
+	// Not parallel: newRunSessionHarness uses t.Setenv, so t.Parallel() would panic.
+	h := newRunSessionHarness(t, func(int) (int, int, error) {
+		return 80, 24, nil
+	})
+
+	attach := h.waitAttach(t)
+	if attach.Type != proto.MsgTypeAttach {
+		t.Fatalf("attach type = %d, want %d", attach.Type, proto.MsgTypeAttach)
+	}
+
+	h.send(t, &proto.Message{Type: proto.MsgTypeLayout, Layout: sessionLayoutSnapshot(h.session)})
+	h.send(t, &proto.Message{Type: proto.MsgTypePaneOutput, PaneID: 1, PaneData: []byte("left")})
+	h.send(t, &proto.Message{Type: proto.MsgTypePaneOutput, PaneID: 2, PaneData: []byte("right")})
+	h.output.waitContains(t, render.AltScreenEnter)
+
+	h.writeInput(t, []byte{0x01, '.'})
+	h.output.waitContains(t, "rename-pane")
+
+	h.send(t, &proto.Message{Type: proto.MsgTypeCaptureRequest, CmdArgs: []string{"--format", "json"}})
+	capture := h.waitMessage(t, func(msg *proto.Message) bool {
+		return msg.Type == proto.MsgTypeCaptureResponse
+	})
+	if !strings.Contains(capture.CmdOutput, `"prompt": "rename-pane"`) {
+		t.Fatalf("capture output = %q, want rename-pane prompt state", capture.CmdOutput)
+	}
+
+	h.send(t, &proto.Message{Type: proto.MsgTypeTypeKeys, Input: []byte("agent-1\r")})
+	h.waitMessage(t, func(msg *proto.Message) bool {
+		return msg.Type == proto.MsgTypeCommand &&
+			msg.CmdName == "rename" &&
+			len(msg.CmdArgs) == 2 &&
+			msg.CmdArgs[0] == "pane-1" &&
+			msg.CmdArgs[1] == "agent-1"
+	})
+
+	h.send(t, &proto.Message{Type: proto.MsgTypeExit})
+	if err := h.waitRunResult(t); err != nil {
+		t.Fatalf("RunSession() = %v, want nil", err)
+	}
+}
+
+func TestRunSessionRenamePanePromptEscapeCancels(t *testing.T) {
+	// Not parallel: newRunSessionHarness uses t.Setenv, so t.Parallel() would panic.
+	h := newRunSessionHarness(t, func(int) (int, int, error) {
+		return 80, 24, nil
+	})
+
+	attach := h.waitAttach(t)
+	if attach.Type != proto.MsgTypeAttach {
+		t.Fatalf("attach type = %d, want %d", attach.Type, proto.MsgTypeAttach)
+	}
+
+	h.send(t, &proto.Message{Type: proto.MsgTypeLayout, Layout: sessionLayoutSnapshot(h.session)})
+	h.send(t, &proto.Message{Type: proto.MsgTypePaneOutput, PaneID: 1, PaneData: []byte("left")})
+	h.send(t, &proto.Message{Type: proto.MsgTypePaneOutput, PaneID: 2, PaneData: []byte("right")})
+	h.output.waitContains(t, render.AltScreenEnter)
+
+	h.writeInput(t, []byte{0x01, '.'})
+	h.output.waitContains(t, "rename-pane")
+
+	h.send(t, &proto.Message{Type: proto.MsgTypeTypeKeys, Input: []byte("agent-1\x1b")})
+	h.send(t, &proto.Message{Type: proto.MsgTypeCaptureRequest, CmdArgs: []string{"--format", "json"}})
+	capture := h.waitMessage(t, func(msg *proto.Message) bool {
+		return msg.Type == proto.MsgTypeCaptureResponse
+	})
+	if strings.Contains(capture.CmdOutput, `"prompt": "rename-pane"`) {
+		t.Fatalf("capture output = %q, want rename-pane prompt hidden after escape", capture.CmdOutput)
+	}
+
+	h.send(t, &proto.Message{Type: proto.MsgTypeExit})
+	if err := h.waitRunResult(t); err != nil {
+		t.Fatalf("RunSession() = %v, want nil", err)
+	}
+}
+
 func TestRunSessionRenameWindowPromptBellPaths(t *testing.T) {
 	// Not parallel: the subtests below use newRunSessionHarness, so t.Parallel() would panic.
 	t.Run("prefix binding bells when no active window can be resolved", func(t *testing.T) {

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -287,10 +287,17 @@ func (cr *ClientRenderer) overlayStateFromSnapshot(state *clientSnapshot) render
 		WindowDropIndicator: cr.windowTabDragIndicatorFromSnapshot(state),
 		Chooser:             cr.chooserOverlayFromSnapshot(state),
 		HelpBar:             state.ui.helpBar.renderOverlay(cr.renderer.loadSnapshot().width),
-		TextInput:           cr.windowRenamePromptOverlayFromSnapshot(state),
+		TextInput:           cr.textInputOverlayFromSnapshot(state),
 		Message:             state.ui.message,
 		PressedPaneID:       paneDragSourcePaneID(state.ui.paneDrag),
 	}
+}
+
+func (cr *ClientRenderer) textInputOverlayFromSnapshot(state *clientSnapshot) *render.TextInputOverlay {
+	if overlay := cr.windowRenamePromptOverlayFromSnapshot(state); overlay != nil {
+		return overlay
+	}
+	return cr.paneRenamePromptOverlayFromSnapshot(state)
 }
 
 func (cr *ClientRenderer) ShowPrefixMessage(msg string) {

--- a/internal/client/client_state.go
+++ b/internal/client/client_state.go
@@ -52,6 +52,7 @@ func cloneClientUIState(src clientUIState) clientUIState {
 	dst.chooser = cloneChooserState(src.chooser)
 	dst.paneDrag = clonePaneDragOverlayState(src.paneDrag)
 	dst.windowRenamePrompt = cloneWindowRenamePromptState(src.windowRenamePrompt)
+	dst.paneRenamePrompt = clonePaneRenamePromptState(src.paneRenamePrompt)
 	dst.helpBar = cloneHelpBarState(src.helpBar)
 	return dst
 }
@@ -85,6 +86,14 @@ func cloneDisplayPanesState(src *displayPanesState) *displayPanesState {
 }
 
 func cloneWindowRenamePromptState(src *windowRenamePromptState) *windowRenamePromptState {
+	if src == nil {
+		return nil
+	}
+	dst := *src
+	return &dst
+}
+
+func clonePaneRenamePromptState(src *paneRenamePromptState) *paneRenamePromptState {
 	if src == nil {
 		return nil
 	}

--- a/internal/client/help_bar.go
+++ b/internal/client/help_bar.go
@@ -82,6 +82,7 @@ func buildHelpBar(kb *config.Keybindings) *helpBarState {
 		helpBarItemForKeys(helpBindingDisplay(kb, helpBindingSelector{action: "prev-window"}), "prev-win"),
 		helpBarItemForKeys(helpWindowNumberDisplay(kb), "jump"),
 		helpBarItemForKeys(helpBindingDisplay(kb, helpBindingSelector{action: "rename-window"}), "rename"),
+		helpBarItemForKeys(helpBindingDisplay(kb, helpBindingSelector{action: "rename-pane"}), "rename-pane"),
 		helpBarItemForKeys(helpBindingDisplay(kb, helpBindingSelector{action: "last-window"}), "last-win"),
 		helpBarItemForKeys(helpBindingDisplay(kb, helpBindingSelector{action: "toggle-lead"}), "lead"),
 		helpBarItemForKeys(helpBindingDisplay(kb, helpBindingSelector{action: "detach"}), "detach"),

--- a/internal/client/help_bar_test.go
+++ b/internal/client/help_bar_test.go
@@ -70,6 +70,9 @@ func TestHelpBarReflowsAcrossRows(t *testing.T) {
 	if len(wide.Rows) >= len(narrow.Rows) {
 		t.Fatalf("wide help bar rows = %d, want fewer than narrow rows = %d", len(wide.Rows), len(narrow.Rows))
 	}
+	if !strings.Contains(strings.Join(wide.Rows, "\n"), ". rename-pane") {
+		t.Fatalf("wide help bar rows = %q, want pane rename binding", wide.Rows)
+	}
 }
 
 func TestHelpBarDisplayOnlyAndDismiss(t *testing.T) {

--- a/internal/client/help_bar_test.go
+++ b/internal/client/help_bar_test.go
@@ -29,7 +29,7 @@ func TestBuildHelpBarUsesBindingMap(t *testing.T) {
 	if !strings.Contains(view, "? close") {
 		t.Fatalf("help bar view = %q, want the toggle key to advertise close while active", view)
 	}
-	for _, want := range []string{"\\ root-vsplit", "_ root-hsplit", "x kill", "z zoom"} {
+	for _, want := range []string{"\\ root-vsplit", "_ root-hsplit", "x kill", "z zoom", ". rename-pane"} {
 		if !strings.Contains(view, want) {
 			t.Fatalf("help bar view = %q, want %q item", view, want)
 		}
@@ -86,7 +86,7 @@ func TestHelpBarDisplayOnlyAndDismiss(t *testing.T) {
 	cr.RenderDiff()
 
 	display := cr.CaptureDisplay()
-	for _, want := range []string{"? close", "x kill", "c new-win"} {
+	for _, want := range []string{"? close", "x kill", "c new-win", ". rename-pane"} {
 		if !strings.Contains(display, want) {
 			t.Fatalf("display capture should include %q in the bottom help bar, got:\n%s", want, display)
 		}

--- a/internal/client/pane_rename_prompt.go
+++ b/internal/client/pane_rename_prompt.go
@@ -1,0 +1,141 @@
+package client
+
+import (
+	"fmt"
+	"strings"
+	"unicode"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/weill-labs/amux/internal/bubblesutil"
+	"github.com/weill-labs/amux/internal/render"
+)
+
+const paneRenamePromptTitle = "rename-pane"
+
+type paneRenamePromptState struct {
+	paneRef string
+	input   bubblesutil.TextInputState
+}
+
+func (st *paneRenamePromptState) title() string {
+	return paneRenamePromptTitle
+}
+
+func (cr *ClientRenderer) PaneRenamePromptActive() bool {
+	return cr.loadState().ui.paneRenamePrompt != nil
+}
+
+func (cr *ClientRenderer) ShowPaneRenamePrompt() bool {
+	paneID := cr.ActivePaneID()
+	if paneID == 0 {
+		return false
+	}
+	pane, ok := cr.renderer.PaneInfoSnapshot(paneID)
+	if !ok {
+		return false
+	}
+	paneRef := pane.Name
+	if paneRef == "" {
+		paneRef = fmt.Sprintf("%d", paneID)
+	}
+	result := cr.reduceUI(uiActionShowPaneRenamePrompt{
+		prompt: &paneRenamePromptState{paneRef: paneRef},
+	})
+	cr.emitUIEvents(result.uiEvents)
+	return true
+}
+
+func (cr *ClientRenderer) HidePaneRenamePrompt() bool {
+	changed, result := updateClientStateValue(cr, func(next *clientSnapshot) (bool, clientUIResult) {
+		changed := next.ui.paneRenamePrompt != nil
+		return changed, next.ui.reduce(uiActionHidePaneRenamePrompt{})
+	})
+	cr.emitUIEvents(result.uiEvents)
+	return changed
+}
+
+func (cr *ClientRenderer) HandlePaneRenamePromptInput(raw []byte) promptCommand {
+	if len(raw) == 0 {
+		return promptCommand{}
+	}
+	if !cr.PaneRenamePromptActive() {
+		return promptCommand{}
+	}
+
+	result := promptCommand{}
+	for len(raw) > 0 {
+		msg, consumed, ok := bubblesutil.DecodeKey(raw)
+		if !ok || consumed <= 0 {
+			result.bell = true
+			raw = raw[1:]
+			continue
+		}
+		raw = raw[consumed:]
+
+		switch msg.Type {
+		case tea.KeyEsc:
+			cr.HidePaneRenamePrompt()
+			return promptCommand{}
+		case tea.KeyEnter:
+			return cr.submitPaneRenamePrompt()
+		default:
+			if bubblesutil.IsTextInputKey(msg.Type) {
+				cr.applyPaneRenamePromptKey(msg)
+				continue
+			}
+			result.bell = true
+		}
+	}
+	return result
+}
+
+func (cr *ClientRenderer) applyPaneRenamePromptKey(msg tea.KeyMsg) {
+	cr.updateState(func(next *clientSnapshot) clientUIResult {
+		if next.ui.paneRenamePrompt == nil {
+			return clientUIResult{}
+		}
+		next.ui.paneRenamePrompt = clonePaneRenamePromptState(next.ui.paneRenamePrompt)
+		next.ui.paneRenamePrompt.input.Update(msg)
+		next.ui.dirty = true
+		return clientUIResult{}
+	})
+}
+
+func (cr *ClientRenderer) submitPaneRenamePrompt() promptCommand {
+	command, result := updateClientStateValue(cr, func(next *clientSnapshot) (promptCommand, clientUIResult) {
+		if next.ui.paneRenamePrompt == nil {
+			return promptCommand{}, clientUIResult{}
+		}
+		value := next.ui.paneRenamePrompt.input.Value
+		if !validPaneRenamePromptName(value) {
+			return promptCommand{bell: true}, clientUIResult{}
+		}
+		paneRef := next.ui.paneRenamePrompt.paneRef
+		return promptCommand{
+			command: "rename",
+			args:    []string{paneRef, value},
+		}, next.ui.reduce(uiActionHidePaneRenamePrompt{})
+	})
+	cr.emitUIEvents(result.uiEvents)
+	return command
+}
+
+func validPaneRenamePromptName(name string) bool {
+	return name != "" &&
+		!strings.Contains(name, "/") &&
+		strings.IndexFunc(name, unicode.IsSpace) < 0
+}
+
+func (cr *ClientRenderer) paneRenamePromptOverlay() *render.TextInputOverlay {
+	return cr.paneRenamePromptOverlayFromSnapshot(cr.loadState())
+}
+
+func (cr *ClientRenderer) paneRenamePromptOverlayFromSnapshot(state *clientSnapshot) *render.TextInputOverlay {
+	if state.ui.paneRenamePrompt == nil {
+		return nil
+	}
+	return &render.TextInputOverlay{
+		Title: state.ui.paneRenamePrompt.title(),
+		Input: state.ui.paneRenamePrompt.input.Value,
+	}
+}

--- a/internal/client/pane_rename_prompt_test.go
+++ b/internal/client/pane_rename_prompt_test.go
@@ -1,0 +1,104 @@
+package client
+
+import "testing"
+
+func TestPaneRenamePromptSubmitAndCancel(t *testing.T) {
+	t.Parallel()
+
+	t.Run("submit", func(t *testing.T) {
+		t.Parallel()
+
+		cr := buildTestRenderer(t)
+		if !cr.ShowPaneRenamePrompt() {
+			t.Fatal("ShowPaneRenamePrompt should succeed")
+		}
+		cr.HandlePaneRenamePromptInput([]byte("agent-1"))
+
+		if overlay := cr.paneRenamePromptOverlay(); overlay == nil || overlay.Title != "rename-pane" || overlay.Input != "agent-1" {
+			t.Fatalf("paneRenamePromptOverlay = %+v, want rename-pane input %q", overlay, "agent-1")
+		}
+
+		got := cr.HandlePaneRenamePromptInput([]byte{'\r'})
+		if got.command != "rename" ||
+			len(got.args) != 2 ||
+			got.args[0] != "pane-1" ||
+			got.args[1] != "agent-1" {
+			t.Fatalf("enter action = %+v, want rename pane-1 agent-1", got)
+		}
+		if cr.PaneRenamePromptActive() {
+			t.Fatal("PaneRenamePromptActive should be false after submit")
+		}
+	})
+
+	t.Run("escape cancels", func(t *testing.T) {
+		t.Parallel()
+
+		cr := buildTestRenderer(t)
+		if !cr.ShowPaneRenamePrompt() {
+			t.Fatal("ShowPaneRenamePrompt should succeed")
+		}
+		cr.HandlePaneRenamePromptInput([]byte("agent-1"))
+
+		got := cr.HandlePaneRenamePromptInput([]byte{0x1b})
+		if got.bell || got.command != "" || len(got.args) != 0 {
+			t.Fatalf("escape action = %+v, want cancel", got)
+		}
+		if cr.PaneRenamePromptActive() {
+			t.Fatal("PaneRenamePromptActive should be false after escape")
+		}
+	})
+}
+
+func TestPaneRenamePromptRejectsInvalidNames(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{name: "empty"},
+		{name: "slash", input: "agent/1"},
+		{name: "whitespace", input: "agent 1"},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cr := buildTestRenderer(t)
+			if !cr.ShowPaneRenamePrompt() {
+				t.Fatal("ShowPaneRenamePrompt should succeed")
+			}
+			if tt.input != "" {
+				cr.HandlePaneRenamePromptInput([]byte(tt.input))
+			}
+
+			got := cr.HandlePaneRenamePromptInput([]byte{'\r'})
+			if !got.bell || got.command != "" || len(got.args) != 0 {
+				t.Fatalf("enter action = %+v, want validation bell", got)
+			}
+			if !cr.PaneRenamePromptActive() {
+				t.Fatal("PaneRenamePromptActive should remain true after invalid submit")
+			}
+		})
+	}
+}
+
+func TestPaneRenamePromptRequiresFocusedPane(t *testing.T) {
+	t.Parallel()
+
+	cr := NewClientRenderer(80, 24)
+	if cr.ShowPaneRenamePrompt() {
+		t.Fatal("ShowPaneRenamePrompt should fail without a layout")
+	}
+
+	cr = NewClientRenderer(80, 24)
+	snap := twoPane80x23()
+	snap.ActivePaneID = 99
+	snap.Windows[0].ActivePaneID = 99
+	cr.HandleLayout(snap)
+	if cr.ShowPaneRenamePrompt() {
+		t.Fatal("ShowPaneRenamePrompt should fail without a matching active pane")
+	}
+}

--- a/internal/client/ui_state.go
+++ b/internal/client/ui_state.go
@@ -15,6 +15,7 @@ type clientUIState struct {
 	windowTabDrag      *windowTabDragOverlayState
 	chooser            *chooserState
 	windowRenamePrompt *windowRenamePromptState
+	paneRenamePrompt   *paneRenamePromptState
 	helpBar            *helpBarState
 	message            string
 	inputIdle          bool
@@ -79,6 +80,12 @@ type uiActionShowWindowRenamePrompt struct {
 }
 
 type uiActionHideWindowRenamePrompt struct{}
+
+type uiActionShowPaneRenamePrompt struct {
+	prompt *paneRenamePromptState
+}
+
+type uiActionHidePaneRenamePrompt struct{}
 
 type uiActionShowHelpBar struct {
 	bar *helpBarState
@@ -178,6 +185,15 @@ func (st *clientUIState) reduce(action any) clientUIResult {
 		st.windowRenamePrompt = nil
 		st.dirty = true
 		return clientUIResult{}
+	case uiActionShowPaneRenamePrompt:
+		return st.reduceShowPaneRenamePrompt(action)
+	case uiActionHidePaneRenamePrompt:
+		if st.paneRenamePrompt == nil {
+			return clientUIResult{}
+		}
+		st.paneRenamePrompt = nil
+		st.dirty = true
+		return clientUIResult{}
 	case uiActionShowHelpBar:
 		return st.reduceShowHelpBar(action)
 	case uiActionHideHelpBar:
@@ -231,6 +247,9 @@ func (st *clientUIState) reduceHandleLayout(action uiActionHandleLayout) clientU
 		if st.windowRenamePrompt != nil {
 			st.windowRenamePrompt = nil
 		}
+		if st.paneRenamePrompt != nil {
+			st.paneRenamePrompt = nil
+		}
 		if st.helpBar != nil {
 			st.helpBar = nil
 		}
@@ -268,6 +287,9 @@ func (st *clientUIState) reduceShowChooser(action uiActionShowChooser) clientUIR
 	if st.windowRenamePrompt != nil {
 		st.windowRenamePrompt = nil
 	}
+	if st.paneRenamePrompt != nil {
+		st.paneRenamePrompt = nil
+	}
 	if st.helpBar != nil {
 		st.helpBar = nil
 	}
@@ -299,7 +321,34 @@ func (st *clientUIState) reduceShowWindowRenamePrompt(action uiActionShowWindowR
 	if st.helpBar != nil {
 		st.helpBar = nil
 	}
+	if st.paneRenamePrompt != nil {
+		st.paneRenamePrompt = nil
+	}
 	st.windowRenamePrompt = action.prompt
+	st.dirty = true
+	return result
+}
+
+func (st *clientUIState) reduceShowPaneRenamePrompt(action uiActionShowPaneRenamePrompt) clientUIResult {
+	result := clientUIResult{}
+	if st.displayPanes != nil {
+		st.displayPanes = nil
+		result.uiEvents = append(result.uiEvents, proto.UIEventDisplayPanesHidden)
+	}
+	if st.paneDrag != nil {
+		st.paneDrag = nil
+	}
+	if st.chooser != nil {
+		result.uiEvents = append(result.uiEvents, st.chooser.mode.hiddenEvent())
+		st.chooser = nil
+	}
+	if st.windowRenamePrompt != nil {
+		st.windowRenamePrompt = nil
+	}
+	if st.helpBar != nil {
+		st.helpBar = nil
+	}
+	st.paneRenamePrompt = action.prompt
 	st.dirty = true
 	return result
 }
@@ -316,6 +365,9 @@ func (st *clientUIState) reduceShowHelpBar(action uiActionShowHelpBar) clientUIR
 	}
 	if st.windowRenamePrompt != nil {
 		st.windowRenamePrompt = nil
+	}
+	if st.paneRenamePrompt != nil {
+		st.paneRenamePrompt = nil
 	}
 	if st.paneDrag != nil {
 		st.paneDrag = nil
@@ -350,6 +402,8 @@ func (st *clientUIState) captureUI() *proto.CaptureUI {
 	prompt := ""
 	if st.windowRenamePrompt != nil {
 		prompt = st.windowRenamePrompt.title()
+	} else if st.paneRenamePrompt != nil {
+		prompt = st.paneRenamePrompt.title()
 	}
 	return &proto.CaptureUI{
 		CopyMode:     len(st.copyModes) > 0,

--- a/internal/client/ui_state_test.go
+++ b/internal/client/ui_state_test.go
@@ -45,6 +45,8 @@ func snapshotClientUIState(st clientUIState) clientUIStateSnapshot {
 	prompt := ""
 	if st.windowRenamePrompt != nil {
 		prompt = st.windowRenamePrompt.title()
+	} else if st.paneRenamePrompt != nil {
+		prompt = st.paneRenamePrompt.title()
 	}
 
 	return clientUIStateSnapshot{
@@ -302,6 +304,26 @@ func TestClientUIStateReduceTransitions(t *testing.T) {
 			},
 		},
 		{
+			name: "show pane rename prompt hides chooser and display panes",
+			setup: func(st *clientUIState) {
+				st.displayPanes = &displayPanesState{}
+				st.chooser = &chooserState{mode: chooserModeWindow}
+			},
+			action: uiActionShowPaneRenamePrompt{
+				prompt: &paneRenamePromptState{paneRef: "pane-1", input: bubblesutil.TextInputState{Value: "agent-1", Cursor: 7}},
+			},
+			wantState: clientUIStateSnapshot{
+				dirty:           true,
+				prompt:          "rename-pane",
+				copyModePaneIDs: []uint32{},
+				inputIdle:       true,
+			},
+			wantEvents: []string{
+				proto.UIEventDisplayPanesHidden,
+				proto.UIEventChooseWindowHidden,
+			},
+		},
+		{
 			name: "show help bar hides chooser display panes prompt and pane drag",
 			setup: func(st *clientUIState) {
 				st.displayPanes = &displayPanesState{}
@@ -341,6 +363,18 @@ func TestClientUIStateReduceTransitions(t *testing.T) {
 				st.windowRenamePrompt = &windowRenamePromptState{input: bubblesutil.TextInputState{Value: "logs", Cursor: 4}}
 			},
 			action: uiActionHideWindowRenamePrompt{},
+			wantState: clientUIStateSnapshot{
+				dirty:           true,
+				copyModePaneIDs: []uint32{},
+				inputIdle:       true,
+			},
+		},
+		{
+			name: "hide pane rename prompt clears prompt state",
+			setup: func(st *clientUIState) {
+				st.paneRenamePrompt = &paneRenamePromptState{paneRef: "pane-1", input: bubblesutil.TextInputState{Value: "agent-1", Cursor: 7}}
+			},
+			action: uiActionHidePaneRenamePrompt{},
 			wantState: clientUIStateSnapshot{
 				dirty:           true,
 				copyModePaneIDs: []uint32{},

--- a/internal/config/keybindings.go
+++ b/internal/config/keybindings.go
@@ -47,6 +47,7 @@ func DefaultKeybindings() *Keybindings {
 			'p': {Action: "prev-window"},
 			';': {Action: "last-window"},
 			',': {Action: "rename-window"},
+			'.': {Action: "rename-pane"},
 			'q': {Action: "display-panes"},
 			'?': {Action: "help"},
 			's': {Action: "choose-tree"},

--- a/internal/config/keybindings_test.go
+++ b/internal/config/keybindings_test.go
@@ -69,6 +69,11 @@ func TestDefaultKeybindings(t *testing.T) {
 			want: Binding{Action: "rename-window"},
 		},
 		{
+			name: "period opens rename pane prompt",
+			key:  '.',
+			want: Binding{Action: "rename-pane"},
+		},
+		{
 			name: "semicolon toggles the last window",
 			key:  ';',
 			want: Binding{Action: "last-window"},

--- a/test/help_bar_test.go
+++ b/test/help_bar_test.go
@@ -12,7 +12,10 @@ func TestHelpBarShowsAndDismisses(t *testing.T) {
 	h := newAmuxHarness(t)
 
 	h.sendClientKeys("C-a", "?")
-	if !h.waitFor("? close", 3*time.Second) || !h.waitFor("q panes", 3*time.Second) || !h.waitFor("root-vsplit", 3*time.Second) {
+	if !h.waitFor("? close", 3*time.Second) ||
+		!h.waitFor("q panes", 3*time.Second) ||
+		!h.waitFor(". rename-pane", 3*time.Second) ||
+		!h.waitFor("root-vsplit", 3*time.Second) {
 		t.Fatalf("expected bottom help bar, got:\n%s", h.captureOuter())
 	}
 	screen := h.captureOuter()
@@ -23,6 +26,22 @@ func TestHelpBarShowsAndDismisses(t *testing.T) {
 	h.sendClientKeys("?")
 	if !waitForOuterGone(h, "? close", 3*time.Second) {
 		t.Fatalf("expected help bar to dismiss on ?\nScreen:\n%s", h.captureOuter())
+	}
+}
+
+func TestHelpBarExpandedViewIncludesRenamePane(t *testing.T) {
+	t.Parallel()
+
+	h := newAmuxHarness(t)
+	gen := h.generation()
+	h.outer.runCmd("resize-window", "160", "40")
+	h.waitLayout(gen)
+
+	h.sendClientKeys("C-a", "?")
+	if !h.waitFor("? close", 3*time.Second) ||
+		!h.waitFor(". rename-pane", 3*time.Second) ||
+		!h.waitFor("root-vsplit", 3*time.Second) {
+		t.Fatalf("expected expanded help bar to include pane rename, got:\n%s", h.captureOuter())
 	}
 }
 

--- a/test/help_bar_test.go
+++ b/test/help_bar_test.go
@@ -29,22 +29,6 @@ func TestHelpBarShowsAndDismisses(t *testing.T) {
 	}
 }
 
-func TestHelpBarExpandedViewIncludesRenamePane(t *testing.T) {
-	t.Parallel()
-
-	h := newAmuxHarness(t)
-	gen := h.generation()
-	h.outer.runCmd("resize-window", "160", "40")
-	h.waitLayout(gen)
-
-	h.sendClientKeys("C-a", "?")
-	if !h.waitFor("? close", 3*time.Second) ||
-		!h.waitFor(". rename-pane", 3*time.Second) ||
-		!h.waitFor("root-vsplit", 3*time.Second) {
-		t.Fatalf("expected expanded help bar to include pane rename, got:\n%s", h.captureOuter())
-	}
-}
-
 func TestHelpBarConsumesDismissKeyOnly(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Motivation

Pane renaming is currently only available through `amux rename <pane-ref> <new-name>`, while windows already have `Ctrl-a ,` for interactive renaming. This adds the matching in-flow keybinding for the focused pane.

## Summary

- Add `Ctrl-a .` as a `rename-pane` local keybinding.
- Add a pane rename prompt that targets the currently focused pane and dispatches `rename <focused-pane-ref> <new-name>`.
- Reject empty pane names, names containing `/`, and names containing whitespace before dispatch.
- Advertise `. rename-pane` in the help bar and add the README keybinding row.
- Keep existing `Ctrl-a ,` window rename behavior covered.

## Testing

- `go test ./internal/config -run TestDefaultKeybindings -count=100`
- `go test ./internal/client -run 'Test(ClientUIStateReduceTransitions|PaneRenamePrompt|RunSessionRename(Window|Pane)Prompt|BuildHelpBarUsesBindingMap|HelpBarDisplayOnlyAndDismiss|HelpBarReflowsAcrossRows)' -count=100`
- `go test ./test -run 'TestHelpBarShowsAndDismisses' -count=100`
- `go test ./test -run 'TestSendKeysEncodeParityMatrix/keypad_enter$' -count=1`
- `go test ./test -run 'TestSendKeysEncodeParityMatrix/function_key_f7$' -count=1`
- `go test ./test -run 'TestLastWindowKeybinding$' -count=1`
- `go test ./test -run 'TestDisplayPanesQuickJump$' -count=1`
- `go test ./... -timeout 120s` was attempted twice; both runs failed in unrelated integration flakes outside this diff (`TestSendKeysEncodeParityMatrix` on different keys, then client attach/startup flakes). The exact failing subtests passed when rerun directly.

## Review focus

Design choices confirmed:
- Key: `.` because it mirrors the existing `,` window rename binding and no binding conflict exists.
- Scope: focused pane only; the prompt captures the focused pane ref when it opens.
- Validation: prompt rejects empty names, `/`, and whitespace before sending the server command.
- Cancel: `Esc` hides the prompt without dispatching a command.

Please check the client UI state transitions and the prompt dispatch path in `internal/client/attach.go` and `internal/client/pane_rename_prompt.go`.

Closes LAB-1661
