### PR TITLE
LAB-1647: Add IconSet abstraction for renderer status glyphs

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,6 +420,11 @@ Default prefix: `Ctrl-a`.
 
 Config file: `~/.config/amux/config.toml` (or set `AMUX_CONFIG` env var).
 
+Status-line glyphs are centralized behind an internal renderer icon set. The
+current Unicode rendering stays the default; ASCII and Nerd Font presets exist
+as implementation hooks, with user-facing configuration and terminal caveat docs
+planned separately.
+
 For attach-time terminal capability negotiation, you can override auto-detection
 with `AMUX_CLIENT_CAPABILITIES`. Use a comma-separated list of capability names:
 `kitty_keyboard`, `hyperlinks`, `rich_underline`, `cursor_metadata`,

--- a/internal/render/compositor.go
+++ b/internal/render/compositor.go
@@ -47,6 +47,7 @@ type Compositor struct {
 	prevGridLayoutKey string
 	prevCursor        cursorRenderState
 	colorProfile      termenv.Profile
+	iconSet           IconSet
 }
 
 type cursorRenderState struct {
@@ -75,6 +76,7 @@ func NewCompositor(width, height int, sessionName string) *Compositor {
 		height:       height,
 		sessionName:  sessionName,
 		colorProfile: defaultColorProfile,
+		iconSet:      DefaultIconSet(),
 	}
 }
 
@@ -118,6 +120,23 @@ func (c *Compositor) SetColorProfile(profile termenv.Profile) {
 // ColorProfile reports the compositor's current terminal color profile.
 func (c *Compositor) ColorProfile() termenv.Profile {
 	return c.colorProfile
+}
+
+// SetIconSet updates the human-facing status glyphs used by the compositor.
+func (c *Compositor) SetIconSet(icons IconSet) {
+	icons = normalizeIconSet(icons)
+	if c.iconSet == icons {
+		return
+	}
+	c.iconSet = icons
+	c.prevGrid = nil
+	c.prevGridLayoutKey = ""
+	c.prevCursor = cursorRenderState{}
+}
+
+// IconSet reports the compositor's current human-facing status glyphs.
+func (c *Compositor) IconSet() IconSet {
+	return normalizeIconSet(c.iconSet)
 }
 
 // LayoutHeight returns the height available for the layout tree
@@ -185,7 +204,7 @@ func (c *Compositor) RenderFullWithOverlayStats(root *mux.LayoutCell, activePane
 		pressed := overlay.IsPanePressed(pid)
 
 		// Per-pane status line
-		renderPaneStatusPressedWithProfile(&buf, cell, isActive, pressed, pd, c.colorProfile)
+		renderPaneStatusPressedWithProfileAndIcons(&buf, cell, isActive, pressed, pd, c.colorProfile, c.IconSet())
 
 		// Pane content (shifted down by status line)
 		c.renderPaneContentWithLayoutHeight(&buf, cell, isActive, pd, layoutHeight)

--- a/internal/render/icons.go
+++ b/internal/render/icons.go
@@ -1,0 +1,88 @@
+package render
+
+// IconSet centralizes human-facing renderer glyphs. Structured capture and
+// event APIs remain semantic and should not consume this type.
+type IconSet struct {
+	PaneIdle      string
+	PaneActive    string
+	PaneBusy      string
+	PaneLead      string
+	PaneEscalated string
+	PaneStuck     string
+	RemoteHost    string
+	PR            string
+	Issue         string
+	CopyMode      string
+	Connected     string
+	Reconnecting  string
+	Disconnected  string
+}
+
+// DefaultIconSet returns the renderer's backward-compatible icon set.
+func DefaultIconSet() IconSet {
+	return UnicodeIconSet()
+}
+
+// UnicodeIconSet returns the current default compact Unicode glyphs.
+func UnicodeIconSet() IconSet {
+	return IconSet{
+		PaneIdle:      "◇",
+		PaneActive:    "●",
+		PaneBusy:      "○",
+		PaneLead:      "▶",
+		PaneEscalated: "◆",
+		PaneStuck:     "◈",
+		RemoteHost:    "@",
+		PR:            "#",
+		Issue:         "",
+		CopyMode:      "[copy]",
+		Connected:     "⚡",
+		Reconnecting:  "⟳",
+		Disconnected:  "✕",
+	}
+}
+
+// ASCIIIconSet returns single-cell fallbacks for terminals with limited glyph support.
+func ASCIIIconSet() IconSet {
+	return IconSet{
+		PaneIdle:      ".",
+		PaneActive:    "*",
+		PaneBusy:      "o",
+		PaneLead:      ">",
+		PaneEscalated: "!",
+		PaneStuck:     "x",
+		RemoteHost:    "@",
+		PR:            "#",
+		Issue:         "I",
+		CopyMode:      "C",
+		Connected:     "+",
+		Reconnecting:  "~",
+		Disconnected:  "x",
+	}
+}
+
+// NerdFontIconSet returns placeholder Private Use Area glyphs for future opt-in use.
+func NerdFontIconSet() IconSet {
+	return IconSet{
+		PaneIdle:      "\uf10c",
+		PaneActive:    "\uf111",
+		PaneBusy:      "\uf013",
+		PaneLead:      "\uf04b",
+		PaneEscalated: "\uf071",
+		PaneStuck:     "\uf188",
+		RemoteHost:    "\uf489",
+		PR:            "\uf407",
+		Issue:         "\uf41b",
+		CopyMode:      "\uf0c5",
+		Connected:     "\uf0e7",
+		Reconnecting:  "\uf021",
+		Disconnected:  "\uf00d",
+	}
+}
+
+func normalizeIconSet(icons IconSet) IconSet {
+	if icons == (IconSet{}) {
+		return DefaultIconSet()
+	}
+	return icons
+}

--- a/internal/render/icons_test.go
+++ b/internal/render/icons_test.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/weill-labs/amux/internal/config"
 	"github.com/weill-labs/amux/internal/mux"
@@ -124,6 +125,86 @@ func assertStatusUsesSentinelIcons(t *testing.T, rendered string) {
 	for _, old := range []string{"●", "[copy]", "#42", "@gpu", "⚡"} {
 		if strings.Contains(rendered, old) {
 			t.Fatalf("rendered status still contains old glyph %q:\n%s", old, rendered)
+		}
+	}
+}
+
+func TestIconSetPresetsAndHelpers(t *testing.T) {
+	t.Parallel()
+
+	if got := DefaultIconSet(); got != UnicodeIconSet() {
+		t.Fatalf("DefaultIconSet() = %#v, want unicode preset", got)
+	}
+	if got := normalizeIconSet(IconSet{}); got != UnicodeIconSet() {
+		t.Fatalf("normalizeIconSet(zero) = %#v, want unicode preset", got)
+	}
+
+	ascii := ASCIIIconSet()
+	for name, value := range map[string]string{
+		"PaneIdle":      ascii.PaneIdle,
+		"PaneActive":    ascii.PaneActive,
+		"PaneBusy":      ascii.PaneBusy,
+		"PaneLead":      ascii.PaneLead,
+		"PaneEscalated": ascii.PaneEscalated,
+		"PaneStuck":     ascii.PaneStuck,
+		"RemoteHost":    ascii.RemoteHost,
+		"PR":            ascii.PR,
+		"Issue":         ascii.Issue,
+		"CopyMode":      ascii.CopyMode,
+		"Connected":     ascii.Connected,
+		"Reconnecting":  ascii.Reconnecting,
+		"Disconnected":  ascii.Disconnected,
+	} {
+		if len(value) != 1 {
+			t.Fatalf("ASCIIIconSet().%s = %q, want single-character fallback", name, value)
+		}
+		r, _ := utf8.DecodeRuneInString(value)
+		if r < 0x20 || r > 0x7e {
+			t.Fatalf("ASCIIIconSet().%s = %q, want printable ASCII", name, value)
+		}
+	}
+
+	nerd := NerdFontIconSet()
+	for name, value := range map[string]string{
+		"PaneIdle":      nerd.PaneIdle,
+		"PaneActive":    nerd.PaneActive,
+		"PaneBusy":      nerd.PaneBusy,
+		"PaneLead":      nerd.PaneLead,
+		"PaneEscalated": nerd.PaneEscalated,
+		"PaneStuck":     nerd.PaneStuck,
+		"RemoteHost":    nerd.RemoteHost,
+		"PR":            nerd.PR,
+		"Issue":         nerd.Issue,
+		"CopyMode":      nerd.CopyMode,
+		"Connected":     nerd.Connected,
+		"Reconnecting":  nerd.Reconnecting,
+		"Disconnected":  nerd.Disconnected,
+	} {
+		r, size := utf8.DecodeRuneInString(value)
+		if size == 0 || r < '\ue000' || r > '\uf8ff' {
+			t.Fatalf("NerdFontIconSet().%s = %q, want Private Use Area placeholder", name, value)
+		}
+	}
+
+	comp := NewCompositor(20, 3, "test")
+	comp.SetIconSet(DefaultIconSet())
+	if got := comp.IconSet(); got != DefaultIconSet() {
+		t.Fatalf("IconSet after no-op SetIconSet(default) = %#v, want default", got)
+	}
+
+	sentinel := IconSet{PaneLead: "L", Connected: "C", Reconnecting: "R", Disconnected: "D"}
+	lead := &statusPaneData{lead: true}
+	if got := paneStatusStateIcon(false, lead, sentinel); got != "L" {
+		t.Fatalf("paneStatusStateIcon(lead) = %q, want L", got)
+	}
+	for status, want := range map[string]string{
+		string(proto.Connected):    "C",
+		string(proto.Reconnecting): "R",
+		string(proto.Disconnected): "D",
+		"unknown":                  "",
+	} {
+		if got := connStatusIcon(status, sentinel); got != want {
+			t.Fatalf("connStatusIcon(%q) = %q, want %q", status, got, want)
 		}
 	}
 }

--- a/internal/render/icons_test.go
+++ b/internal/render/icons_test.go
@@ -8,6 +8,10 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+
+	"github.com/weill-labs/amux/internal/config"
+	"github.com/weill-labs/amux/internal/mux"
+	"github.com/weill-labs/amux/internal/proto"
 )
 
 func TestStatusGlyphLiteralsAreCentralizedInIconSet(t *testing.T) {
@@ -64,5 +68,62 @@ func TestStatusGlyphLiteralsAreCentralizedInIconSet(t *testing.T) {
 
 	if len(offenders) > 0 {
 		t.Fatalf("status glyph literals must route through IconSet; found direct literals at:\n%s", strings.Join(offenders, "\n"))
+	}
+}
+
+func TestCompositorUsesConfiguredIconSetForPaneStatus(t *testing.T) {
+	t.Parallel()
+
+	icons := IconSet{
+		PaneIdle:      "I",
+		PaneActive:    "A",
+		PaneBusy:      "B",
+		PaneLead:      "L",
+		PaneEscalated: "E",
+		PaneStuck:     "S",
+		RemoteHost:    "R",
+		PR:            "P",
+		Issue:         "J",
+		CopyMode:      "C",
+		Connected:     "Z",
+		Reconnecting:  "Y",
+		Disconnected:  "X",
+	}
+	root := mux.NewLeaf(&mux.Pane{ID: 1}, 0, 0, 80, 2)
+	pane := &statusPaneData{
+		id:            1,
+		name:          "pane-1",
+		trackedPRs:    []proto.TrackedPR{{Number: 42}},
+		trackedIssues: []proto.TrackedIssue{{ID: "LAB-1647"}},
+		host:          "gpu",
+		task:          "task",
+		color:         config.TextColorHex,
+		connStatus:    string(proto.Connected),
+		copyMode:      true,
+		copySearch:    "/query",
+	}
+	lookup := func(uint32) PaneData { return pane }
+
+	full := NewCompositor(80, 3, "test")
+	full.SetIconSet(icons)
+	assertStatusUsesSentinelIcons(t, MaterializeGrid(full.RenderFull(root, 1, lookup), 80, 3))
+
+	diff := NewCompositor(80, 3, "test")
+	diff.SetIconSet(icons)
+	assertStatusUsesSentinelIcons(t, MaterializeGrid(diff.RenderDiffWithOverlay(root, 1, lookup, OverlayState{}), 80, 3))
+}
+
+func assertStatusUsesSentinelIcons(t *testing.T, rendered string) {
+	t.Helper()
+
+	for _, want := range []string{"A", "C /query", "P42", "JLAB-1647", "Rgpu", "Z", "task"} {
+		if !strings.Contains(rendered, want) {
+			t.Fatalf("rendered status missing %q:\n%s", want, rendered)
+		}
+	}
+	for _, old := range []string{"●", "[copy]", "#42", "@gpu", "⚡"} {
+		if strings.Contains(rendered, old) {
+			t.Fatalf("rendered status still contains old glyph %q:\n%s", old, rendered)
+		}
 	}
 }

--- a/internal/render/icons_test.go
+++ b/internal/render/icons_test.go
@@ -1,0 +1,68 @@
+package render
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestStatusGlyphLiteralsAreCentralizedInIconSet(t *testing.T) {
+	t.Parallel()
+
+	statusGlyphs := map[rune]struct{}{
+		'◇': {},
+		'●': {},
+		'○': {},
+		'▶': {},
+		'◯': {},
+		'◆': {},
+		'◈': {},
+		'⚡': {},
+		'⟳': {},
+		'✕': {},
+	}
+
+	files, err := filepath.Glob("*.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fset := token.NewFileSet()
+	var offenders []string
+	for _, path := range files {
+		base := filepath.Base(path)
+		if strings.HasSuffix(base, "_test.go") || base == "icons.go" {
+			continue
+		}
+
+		file, err := parser.ParseFile(fset, path, nil, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", path, err)
+		}
+		ast.Inspect(file, func(n ast.Node) bool {
+			lit, ok := n.(*ast.BasicLit)
+			if !ok || lit.Kind != token.STRING {
+				return true
+			}
+			value, err := strconv.Unquote(lit.Value)
+			if err != nil {
+				t.Fatalf("unquote %s: %v", fset.Position(lit.Pos()), err)
+			}
+			for _, r := range value {
+				if _, ok := statusGlyphs[r]; ok {
+					offenders = append(offenders, fset.Position(lit.Pos()).String())
+					break
+				}
+			}
+			return true
+		})
+	}
+
+	if len(offenders) > 0 {
+		t.Fatalf("status glyph literals must route through IconSet; found direct literals at:\n%s", strings.Join(offenders, "\n"))
+	}
+}

--- a/internal/render/screen.go
+++ b/internal/render/screen.go
@@ -306,7 +306,7 @@ type paneComposite struct {
 }
 
 func (c *Compositor) composePane(g *ScreenGrid, layoutHeight int, pane paneComposite) {
-	buildStatusCellsPressed(g, pane.cell, pane.isActive, pane.pressed, pane.pd)
+	buildStatusCellsPressedWithIcons(g, pane.cell, pane.isActive, pane.pressed, pane.pd, c.IconSet())
 	contentH := c.visibleContentHeightForLayoutHeight(pane.cell, layoutHeight)
 	// Rebuild every row for both full redraws and dirty panes. TUI full-screen
 	// recomposes can move or clear lines without producing a pane-local dirty
@@ -659,6 +659,10 @@ func buildStatusCells(g *ScreenGrid, cell *mux.LayoutCell, isActive bool, pd Pan
 }
 
 func buildStatusCellsPressed(g *ScreenGrid, cell *mux.LayoutCell, isActive, pressed bool, pd PaneData) {
+	buildStatusCellsPressedWithIcons(g, cell, isActive, pressed, pd, DefaultIconSet())
+}
+
+func buildStatusCellsPressedWithIcons(g *ScreenGrid, cell *mux.LayoutCell, isActive, pressed bool, pd PaneData, icons IconSet) {
 	y := cell.Y
 	bgHex := config.Surface0Hex
 	if pressed {
@@ -668,7 +672,7 @@ func buildStatusCellsPressed(g *ScreenGrid, cell *mux.LayoutCell, isActive, pres
 	colorHex := paneStatusColorHex(pd)
 	palette := newPaneStatusGridPalette(colorHex, bg)
 	var cells []ScreenCell
-	for _, segment := range buildPaneStatusSegments(cell.W, isActive, pd) {
+	for _, segment := range buildPaneStatusSegmentsWithIcons(cell.W, isActive, pd, icons) {
 		cells = appendStyledCells(cells, segment.text, palette.style(segment.role))
 	}
 

--- a/internal/render/statusbar.go
+++ b/internal/render/statusbar.go
@@ -80,10 +80,6 @@ func appendPaneStatusSegment(segments []paneStatusSegment, text string, role pan
 	return append(segments, paneStatusSegment{text: text, role: role})
 }
 
-func buildPaneStatusSegments(cellWidth int, isActive bool, pd PaneData) []paneStatusSegment {
-	return buildPaneStatusSegmentsWithIcons(cellWidth, isActive, pd, DefaultIconSet())
-}
-
 func buildPaneStatusSegmentsWithIcons(cellWidth int, isActive bool, pd PaneData, icons IconSet) []paneStatusSegment {
 	icons = normalizeIconSet(icons)
 	idle := !isActive && pd.Idle()
@@ -285,10 +281,6 @@ func truncateRunes(s string, max int) string {
 	return string(runes[:max-1]) + "…"
 }
 
-func paneStatusMetadataItems(prs []proto.TrackedPR, issues []proto.TrackedIssue, rawIssue string) []paneStatusMetadataItem {
-	return paneStatusMetadataItemsWithIcons(prs, issues, rawIssue, DefaultIconSet())
-}
-
 func paneStatusMetadataItemsWithIcons(prs []proto.TrackedPR, issues []proto.TrackedIssue, rawIssue string, icons IconSet) []paneStatusMetadataItem {
 	icons = normalizeIconSet(icons)
 	issues = paneStatusTrackedIssues(issues, rawIssue)
@@ -328,10 +320,6 @@ func paneStatusTrackedIssues(issues []proto.TrackedIssue, rawIssue string) []pro
 		ID:     id,
 		Status: proto.TrackedStatusActive,
 	}}
-}
-
-func paneStatusMetadataItemsForPane(pd PaneData) []paneStatusMetadataItem {
-	return paneStatusMetadataItemsForPaneWithIcons(pd, DefaultIconSet())
 }
 
 func paneStatusMetadataItemsForPaneWithIcons(pd PaneData, icons IconSet) []paneStatusMetadataItem {
@@ -436,10 +424,6 @@ func truncateRunewidth(s string, maxWidth int) string {
 		usedWidth += runeWidth
 	}
 	return buf.String()
-}
-
-func paneStatusUsedWidthWithoutMetadata(pd PaneData) int {
-	return paneStatusUsedWidthWithoutMetadataWithIcons(true, pd, DefaultIconSet())
 }
 
 func paneStatusUsedWidthWithoutMetadataWithIcons(isActive bool, pd PaneData, icons IconSet) int {

--- a/internal/render/statusbar.go
+++ b/internal/render/statusbar.go
@@ -81,21 +81,26 @@ func appendPaneStatusSegment(segments []paneStatusSegment, text string, role pan
 }
 
 func buildPaneStatusSegments(cellWidth int, isActive bool, pd PaneData) []paneStatusSegment {
+	return buildPaneStatusSegmentsWithIcons(cellWidth, isActive, pd, DefaultIconSet())
+}
+
+func buildPaneStatusSegmentsWithIcons(cellWidth int, isActive bool, pd PaneData, icons IconSet) []paneStatusSegment {
+	icons = normalizeIconSet(icons)
 	idle := !isActive && pd.Idle()
 
 	segments := make([]paneStatusSegment, 0, 16)
 
 	switch {
 	case pd.IsLead() && isActive:
-		segments = appendPaneStatusSegment(segments, "▶", paneStatusSegmentPane)
+		segments = appendPaneStatusSegment(segments, icons.PaneLead, paneStatusSegmentPane)
 	case pd.IsLead():
-		segments = appendPaneStatusSegment(segments, "▶", paneStatusSegmentDim)
+		segments = appendPaneStatusSegment(segments, icons.PaneLead, paneStatusSegmentDim)
 	case isActive:
-		segments = appendPaneStatusSegment(segments, "●", paneStatusSegmentPane)
+		segments = appendPaneStatusSegment(segments, icons.PaneActive, paneStatusSegmentPane)
 	case idle:
-		segments = appendPaneStatusSegment(segments, "◇", paneStatusSegmentDim)
+		segments = appendPaneStatusSegment(segments, icons.PaneIdle, paneStatusSegmentDim)
 	default:
-		segments = appendPaneStatusSegment(segments, "○", paneStatusSegmentDim)
+		segments = appendPaneStatusSegment(segments, icons.PaneBusy, paneStatusSegmentDim)
 	}
 
 	segments = appendPaneStatusSegment(segments, " ", paneStatusSegmentBackground)
@@ -116,15 +121,15 @@ func buildPaneStatusSegments(cellWidth int, isActive bool, pd PaneData) []paneSt
 
 	if pd.InCopyMode() {
 		segments = appendPaneStatusSegment(segments, " ", paneStatusSegmentBackground)
-		copyText := "[copy]"
+		copyText := icons.CopyMode
 		if search := pd.CopyModeSearch(); search != "" {
 			copyText += " " + search
 		}
 		segments = appendPaneStatusSegment(segments, copyText, paneStatusSegmentYellow)
 	}
 
-	metaItems := paneStatusMetadataItemsForPane(pd)
-	metaSegments := paneStatusMetadataSegments(metaItems, availableMetadataWidth(cellWidth, pd))
+	metaItems := paneStatusMetadataItemsForPaneWithIcons(pd, icons)
+	metaSegments := paneStatusMetadataSegments(metaItems, availableMetadataWidthWithIcons(cellWidth, isActive, pd, icons))
 	if len(metaSegments) > 0 {
 		segments = appendPaneStatusSegment(segments, " ", paneStatusSegmentBackground)
 		for _, segment := range metaSegments {
@@ -138,18 +143,18 @@ func buildPaneStatusSegments(cellWidth int, isActive bool, pd PaneData) []paneSt
 
 	if pd.Host() != "" && pd.Host() != mux.DefaultHost {
 		segments = appendPaneStatusSegment(segments, " ", paneStatusSegmentBackground)
-		segments = appendPaneStatusSegment(segments, "@"+pd.Host(), paneStatusSegmentGreen)
+		segments = appendPaneStatusSegment(segments, icons.RemoteHost+pd.Host(), paneStatusSegmentGreen)
 	}
 
 	if cs := pd.ConnStatus(); cs != "" {
 		segments = appendPaneStatusSegment(segments, " ", paneStatusSegmentBackground)
 		switch cs {
-		case "connected":
-			segments = appendPaneStatusSegment(segments, "⚡", paneStatusSegmentGreen)
-		case "reconnecting":
-			segments = appendPaneStatusSegment(segments, "⟳", paneStatusSegmentYellow)
-		case "disconnected":
-			segments = appendPaneStatusSegment(segments, "✕", paneStatusSegmentRed)
+		case string(proto.Connected):
+			segments = appendPaneStatusSegment(segments, icons.Connected, paneStatusSegmentGreen)
+		case string(proto.Reconnecting):
+			segments = appendPaneStatusSegment(segments, icons.Reconnecting, paneStatusSegmentYellow)
+		case string(proto.Disconnected):
+			segments = appendPaneStatusSegment(segments, icons.Disconnected, paneStatusSegmentRed)
 		}
 	}
 
@@ -246,10 +251,14 @@ func renderPaneStatusWithProfile(buf *strings.Builder, cell *mux.LayoutCell, isA
 }
 
 func renderPaneStatusPressedWithProfile(buf *strings.Builder, cell *mux.LayoutCell, isActive, pressed bool, pd PaneData, profile termenv.Profile) {
+	renderPaneStatusPressedWithProfileAndIcons(buf, cell, isActive, pressed, pd, profile, DefaultIconSet())
+}
+
+func renderPaneStatusPressedWithProfileAndIcons(buf *strings.Builder, cell *mux.LayoutCell, isActive, pressed bool, pd PaneData, profile termenv.Profile, icons IconSet) {
 	writeCursorTo(buf, cell.Y+1, cell.X+1)
 
 	styles := newStatusBarStylesPressed(paneStatusColorHex(pd), pressed)
-	segments := buildPaneStatusSegments(cell.W, isActive, pd)
+	segments := buildPaneStatusSegmentsWithIcons(cell.W, isActive, pd, icons)
 	for _, segment := range segments {
 		writeStyledTextWithProfile(buf, styles.pane(segment.role), segment.text, profile)
 	}
@@ -277,6 +286,11 @@ func truncateRunes(s string, max int) string {
 }
 
 func paneStatusMetadataItems(prs []proto.TrackedPR, issues []proto.TrackedIssue, rawIssue string) []paneStatusMetadataItem {
+	return paneStatusMetadataItemsWithIcons(prs, issues, rawIssue, DefaultIconSet())
+}
+
+func paneStatusMetadataItemsWithIcons(prs []proto.TrackedPR, issues []proto.TrackedIssue, rawIssue string, icons IconSet) []paneStatusMetadataItem {
+	icons = normalizeIconSet(icons)
 	issues = paneStatusTrackedIssues(issues, rawIssue)
 	items := make([]paneStatusMetadataItem, 0, len(prs)+len(issues))
 	for _, pr := range prs {
@@ -284,7 +298,7 @@ func paneStatusMetadataItems(prs []proto.TrackedPR, issues []proto.TrackedIssue,
 			continue
 		}
 		items = append(items, paneStatusMetadataItem{
-			text:   "#" + strconv.Itoa(pr.Number),
+			text:   icons.PR + strconv.Itoa(pr.Number),
 			status: normalizeTrackedStatus(pr.Status),
 		})
 	}
@@ -294,7 +308,7 @@ func paneStatusMetadataItems(prs []proto.TrackedPR, issues []proto.TrackedIssue,
 			continue
 		}
 		items = append(items, paneStatusMetadataItem{
-			text:   id,
+			text:   icons.Issue + id,
 			status: normalizeTrackedStatus(issue.Status),
 		})
 	}
@@ -317,14 +331,22 @@ func paneStatusTrackedIssues(issues []proto.TrackedIssue, rawIssue string) []pro
 }
 
 func paneStatusMetadataItemsForPane(pd PaneData) []paneStatusMetadataItem {
-	return paneStatusMetadataItems(pd.TrackedPRs(), pd.TrackedIssues(), pd.Issue())
+	return paneStatusMetadataItemsForPaneWithIcons(pd, DefaultIconSet())
+}
+
+func paneStatusMetadataItemsForPaneWithIcons(pd PaneData, icons IconSet) []paneStatusMetadataItem {
+	return paneStatusMetadataItemsWithIcons(pd.TrackedPRs(), pd.TrackedIssues(), pd.Issue(), icons)
 }
 
 func availableMetadataWidth(cellWidth int, pd PaneData) int {
-	if len(paneStatusMetadataItemsForPane(pd)) == 0 {
+	return availableMetadataWidthWithIcons(cellWidth, true, pd, DefaultIconSet())
+}
+
+func availableMetadataWidthWithIcons(cellWidth int, isActive bool, pd PaneData, icons IconSet) int {
+	if len(paneStatusMetadataItemsForPaneWithIcons(pd, icons)) == 0 {
 		return 0
 	}
-	return cellWidth - paneStatusUsedWidthWithoutMetadata(pd) - 1
+	return cellWidth - paneStatusUsedWidthWithoutMetadataWithIcons(isActive, pd, icons) - 1
 }
 
 func normalizeTrackedStatus(status proto.TrackedStatus) proto.TrackedStatus {
@@ -417,26 +439,59 @@ func truncateRunewidth(s string, maxWidth int) string {
 }
 
 func paneStatusUsedWidthWithoutMetadata(pd PaneData) int {
-	usedWidth := 2 + runewidth.StringWidth(pd.Name()) + 2 // "● [name]"
+	return paneStatusUsedWidthWithoutMetadataWithIcons(true, pd, DefaultIconSet())
+}
+
+func paneStatusUsedWidthWithoutMetadataWithIcons(isActive bool, pd PaneData, icons IconSet) int {
+	icons = normalizeIconSet(icons)
+	usedWidth := runewidth.StringWidth(paneStatusStateIcon(isActive, pd, icons)) + 1 + runewidth.StringWidth(pd.Name()) + 2 // "● [name]"
 	if pd.IsLead() {
 		usedWidth += 7 // " [lead]"
 	}
 	if pd.InCopyMode() {
-		usedWidth += 7 // " [copy]"
+		usedWidth += 1 + runewidth.StringWidth(icons.CopyMode)
 		if search := pd.CopyModeSearch(); search != "" {
 			usedWidth += 1 + runewidth.StringWidth(search)
 		}
 	}
 	if pd.Host() != "" && pd.Host() != mux.DefaultHost {
-		usedWidth += 2 + runewidth.StringWidth(pd.Host())
+		usedWidth += 1 + runewidth.StringWidth(icons.RemoteHost) + runewidth.StringWidth(pd.Host())
 	}
 	if cs := pd.ConnStatus(); cs != "" {
-		usedWidth += 2 // " ⚡" or " ⟳" or " ✕"
+		usedWidth += 1 + runewidth.StringWidth(connStatusIcon(cs, icons))
 	}
 	if pd.Task() != "" {
 		usedWidth += 1 + runewidth.StringWidth(pd.Task())
 	}
 	return usedWidth
+}
+
+func paneStatusStateIcon(isActive bool, pd PaneData, icons IconSet) string {
+	icons = normalizeIconSet(icons)
+	switch {
+	case pd.IsLead():
+		return icons.PaneLead
+	case isActive:
+		return icons.PaneActive
+	case pd.Idle():
+		return icons.PaneIdle
+	default:
+		return icons.PaneBusy
+	}
+}
+
+func connStatusIcon(status string, icons IconSet) string {
+	icons = normalizeIconSet(icons)
+	switch status {
+	case string(proto.Connected):
+		return icons.Connected
+	case string(proto.Reconnecting):
+		return icons.Reconnecting
+	case string(proto.Disconnected):
+		return icons.Disconnected
+	default:
+		return ""
+	}
 }
 
 func buildGlobalBarWindowTabs(windows []WindowInfo) []globalBarWindowTab {


### PR DESCRIPTION
## Motivation

LAB-1647 needs an internal foundation before Nerd Font rendering can be exposed safely. Status glyphs were hardcoded in renderer paths, which would make future ascii/unicode/nerdfont selection scattered and error-prone.

This PR is only the foundation for the parent epic. It does not expose user config and does not close LAB-1647.

## Summary

- Added `render.IconSet` as a value struct with `PaneIdle`, `PaneActive`, `PaneBusy`, `PaneLead`, `PaneEscalated`, `PaneStuck`, `RemoteHost`, `PR`, `Issue`, `CopyMode`, `Connected`, `Reconnecting`, and `Disconnected` fields.
- Added `unicode`, `ascii`, and placeholder `nerdfont` presets. `unicode` remains the default for byte-compatible output.
- Routed pane status, metadata prefixes, copy-mode labels, remote-host prefixes, and connection markers through the configured icon set in both full ANSI and cell-grid/diff rendering paths.
- Added an AST regression test so renderer status glyph literals stay centralized in `icons.go`.
- Added a short README note that the internal abstraction exists; user-facing docs remain a sibling issue.

## Testing

- `grep -rn '[◇●○▶◯◆◈]' --include='*.go' internal/`
- `go test ./internal/render -run 'TestIconSet|TestStatusGlyphLiteralsAreCentralizedInIconSet|TestCompositorUsesConfiguredIconSetForPaneStatus' -count=100`
- `go test ./internal/render -count=10`
- `go test ./test -run TestGolden -count=10`
- `git diff --exit-code -- test/testdata`
- `go test ./internal/client`
- `golangci-lint run ./...`
- `go test -coverprofile=/tmp/lab1647-render-cover.out ./internal/render`
- `go run ./cmd/diffcoverage --base origin/main --module "$(go list -m)" --profile /tmp/lab1647-render-cover.out --target 70`
- `go test ./test -run 'TestMouseDragAutomaticallyEntersCopyModeAndCopiesSelection|TestMouseCommandDragAutomaticallyCopiesSelection|TestSendKeysEncodeParityMatrix' -count=1 -timeout 120s`
- `go test ./... -timeout 120s` passed before the final rebase. After rebasing onto current `origin/main`, repeated full-suite attempts hit unrelated integration harness flakes/timeouts in mouse clipboard waits and send-keys parity; the affected slice above passed on targeted rerun.

Goldens verified unchanged via `go test ./test -run TestGolden -count=10` and `git diff --exit-code -- test/testdata`.

## Review focus

- The `IconSet` shape is intentionally a plain struct rather than a strategy interface: current call sites need named glyph strings, not behavior.
- `Compositor.SetIconSet` invalidates the previous grid so future config plumbing can switch icon sets without stale diff rendering.
- Structured capture/event APIs remain untouched and glyph-free.
- No TOML config, Powerline preset, diagnostics command, or real user-visible Nerd Font mode is included here.

## Sibling issues

- LAB-1649: Expose theme icon config
- LAB-1650: Apply Nerd icons to pane status metadata
- LAB-1651: Add Powerline status style preset
- LAB-1652: Add font diagnostics for icon rendering
- LAB-1653: Document icon modes and terminal caveats

The sibling issues already existed under LAB-1647; I updated the five follow-ups with explicit parent body references and priority 3.

Closes LAB-1648
Part of LAB-1647