### PR TITLE
LAB-1663: Stop snapshotting scrollback cells

### DIFF
--- a/internal/client/renderer_bench_test.go
+++ b/internal/client/renderer_bench_test.go
@@ -280,6 +280,32 @@ func BenchmarkRendererHandlePaneOutputVisibility(b *testing.B) {
 	})
 }
 
+func BenchmarkCapturePaneRenderSnapshotStyledScrollback1KB(b *testing.B) {
+	const (
+		width           = 80
+		height          = 24
+		scrollbackLines = mux.DefaultScrollbackLines
+		payloadSize     = 1024
+	)
+
+	emu := mux.NewVTEmulatorWithScrollback(width, height, scrollbackLines)
+	defer emu.Close()
+	if _, err := emu.Write(benchScrollbackPayload(1, scrollbackLines+height)); err != nil {
+		b.Fatalf("preload scrollback: %v", err)
+	}
+	payload := benchTerminalPayload(payloadSize)
+
+	b.SetBytes(payloadSize)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		if _, err := emu.Write(payload); err != nil {
+			b.Fatalf("write payload: %v", err)
+		}
+		_ = capturePaneRenderSnapshot(emu)
+	}
+}
+
 func BenchmarkCaptureJSON(b *testing.B) {
 	for _, panes := range []int{2, 4, 8, 16} {
 		b.Run(fmt.Sprintf("panes_%d", panes), func(b *testing.B) {

--- a/internal/client/renderer_capture_snapshot.go
+++ b/internal/client/renderer_capture_snapshot.go
@@ -33,8 +33,7 @@ func capturePaneRenderSnapshot(emu mux.TerminalEmulator) paneRenderSnapshot {
 	scrollback := make([]paneBufferLine, emu.ScrollbackLen())
 	for row := range scrollback {
 		scrollback[row] = paneBufferLine{
-			text:  emu.ScrollbackLineText(row),
-			cells: captureScrollbackCells(emu, row, width),
+			text: emu.ScrollbackLineText(row),
 		}
 	}
 

--- a/internal/client/renderer_queries.go
+++ b/internal/client/renderer_queries.go
@@ -189,7 +189,8 @@ func trimPaneBufferStarts(baseLen, liveLen, limit int) (baseStart, liveStart int
 func captureScrollbackCells(emu mux.TerminalEmulator, row, width int) []render.ScreenCell {
 	cells := make([]render.ScreenCell, width)
 	for col := 0; col < width; col++ {
-		cells[col] = render.CellFromUV(emu.ScrollbackCellAt(col, row))
+		cell, ok := emu.ScrollbackCellAt(col, row)
+		cells[col] = render.CellFromUVValue(cell, ok)
 	}
 	return cells
 }

--- a/internal/mux/emulator.go
+++ b/internal/mux/emulator.go
@@ -502,13 +502,6 @@ func cellUsesFullWidth(cell uv.Cell) bool {
 	return cell.Content != "" || (!cell.IsZero() && !cell.Equal(&uv.EmptyCell))
 }
 
-func protoCellFromUV(cell *uv.Cell) proto.Cell {
-	if cell == nil {
-		return proto.Cell{Char: " ", Width: 1}
-	}
-	return protoCellFromUVValue(*cell, true)
-}
-
 func protoCellFromUVValue(cell uv.Cell, ok bool) proto.Cell {
 	if !ok {
 		return proto.Cell{Char: " ", Width: 1}

--- a/internal/mux/emulator.go
+++ b/internal/mux/emulator.go
@@ -64,8 +64,8 @@ type TerminalEmulator interface {
 	ScrollbackLineText(y int) string
 
 	// ScrollbackCellAt returns the raw cell at (col, row) in retained
-	// scrollback (0=oldest row). Returns nil for out-of-bounds.
-	ScrollbackCellAt(col, row int) *uv.Cell
+	// scrollback (0=oldest row). ok is false for out-of-bounds.
+	ScrollbackCellAt(col, row int) (cell uv.Cell, ok bool)
 
 	// RenderWithoutCursorBlock renders the screen with the cursor cell's
 	// reverse-video attribute cleared. Used for inactive pane rendering so
@@ -319,17 +319,16 @@ func (v *vtEmulator) ScrollbackLineText(y int) string {
 	return buf.String()
 }
 
-func (v *vtEmulator) ScrollbackCellAt(col, row int) *uv.Cell {
+func (v *vtEmulator) ScrollbackCellAt(col, row int) (uv.Cell, bool) {
 	sb := v.emu.Scrollback()
 	if sb == nil || row < 0 || row >= sb.Len() || col < 0 {
-		return nil
+		return uv.Cell{}, false
 	}
 	line := sb.Line(row)
 	if line == nil || col >= len(line) {
-		return nil
+		return uv.Cell{}, false
 	}
-	cell := line[col]
-	return &cell
+	return line[col], true
 }
 
 // screenLineTextInner extracts plain text from screen row y across w columns.
@@ -434,10 +433,11 @@ func EmulatorScrollbackHistoryLines(emu TerminalEmulator, widths []int) []Captur
 		if y < len(widths) {
 			sourceWidth = widths[y]
 		}
+		cell, ok := emu.ScrollbackCellAt(sourceWidth-1, y)
 		lines[y] = CaptureHistoryLine{
 			Text:        emu.ScrollbackLineText(y),
 			SourceWidth: sourceWidth,
-			Filled:      lineUsesFullWidth(sourceWidth, func(x int) *uv.Cell { return emu.ScrollbackCellAt(x, y) }),
+			Filled:      lineUsesFullWidthValue(sourceWidth, cell, ok),
 		}
 	}
 	return lines
@@ -454,7 +454,8 @@ func EmulatorScrollbackStyledLines(emu TerminalEmulator) []proto.StyledLine {
 			Cells: make([]proto.Cell, width),
 		}
 		for x := 0; x < width; x++ {
-			line.Cells[x] = protoCellFromUV(emu.ScrollbackCellAt(x, y))
+			cell, ok := emu.ScrollbackCellAt(x, y)
+			line.Cells[x] = protoCellFromUVValue(cell, ok)
 		}
 		lines[y] = line
 	}
@@ -484,6 +485,17 @@ func lineUsesFullWidth(width int, cellAt func(int) *uv.Cell) bool {
 	if cell == nil {
 		return false
 	}
+	return cellUsesFullWidth(*cell)
+}
+
+func lineUsesFullWidthValue(width int, cell uv.Cell, ok bool) bool {
+	if width <= 0 || !ok {
+		return false
+	}
+	return cellUsesFullWidth(cell)
+}
+
+func cellUsesFullWidth(cell uv.Cell) bool {
 	if cell.Width == 0 {
 		return true
 	}
@@ -492,6 +504,13 @@ func lineUsesFullWidth(width int, cellAt func(int) *uv.Cell) bool {
 
 func protoCellFromUV(cell *uv.Cell) proto.Cell {
 	if cell == nil {
+		return proto.Cell{Char: " ", Width: 1}
+	}
+	return protoCellFromUVValue(*cell, true)
+}
+
+func protoCellFromUVValue(cell uv.Cell, ok bool) proto.Cell {
+	if !ok {
 		return proto.Cell{Char: " ", Width: 1}
 	}
 	char := cell.Content

--- a/internal/mux/emulator_test.go
+++ b/internal/mux/emulator_test.go
@@ -681,9 +681,9 @@ func TestScrollbackCellAt(t *testing.T) {
 		t.Fatalf("Write: %v", err)
 	}
 
-	cell := emu.ScrollbackCellAt(0, 0)
-	if cell == nil {
-		t.Fatal("ScrollbackCellAt(0, 0) = nil, want styled cell")
+	cell, ok := emu.ScrollbackCellAt(0, 0)
+	if !ok {
+		t.Fatal("ScrollbackCellAt(0, 0) ok = false, want styled cell")
 	}
 	if cell.Content != "r" {
 		t.Fatalf("ScrollbackCellAt(0, 0).Content = %q, want %q", cell.Content, "r")
@@ -697,11 +697,11 @@ func TestScrollbackCellAt(t *testing.T) {
 		t.Fatalf("ScrollbackCellAt(0, 0).Style.Fg = (%d,%d,%d,%d), want (%d,%d,%d,%d)",
 			gotR, gotG, gotB, gotA, wantR, wantG, wantB, wantA)
 	}
-	if got := emu.ScrollbackCellAt(99, 0); got != nil {
-		t.Fatalf("ScrollbackCellAt(99, 0) = %#v, want nil", got)
+	if got, ok := emu.ScrollbackCellAt(99, 0); ok {
+		t.Fatalf("ScrollbackCellAt(99, 0) = %#v, true; want false", got)
 	}
-	if got := emu.ScrollbackCellAt(-1, 0); got != nil {
-		t.Fatalf("ScrollbackCellAt(-1, 0) = %#v, want nil", got)
+	if got, ok := emu.ScrollbackCellAt(-1, 0); ok {
+		t.Fatalf("ScrollbackCellAt(-1, 0) = %#v, true; want false", got)
 	}
 }
 

--- a/internal/render/screen.go
+++ b/internal/render/screen.go
@@ -222,6 +222,14 @@ func CellFromUV(c *uv.Cell) ScreenCell {
 	if c == nil {
 		return ScreenCell{Char: " ", Width: 1}
 	}
+	return CellFromUVValue(*c, true)
+}
+
+// CellFromUVValue converts a VT library cell value to a ScreenCell.
+func CellFromUVValue(c uv.Cell, ok bool) ScreenCell {
+	if !ok {
+		return ScreenCell{Char: " ", Width: 1}
+	}
 	char := c.Content
 	if char == "" {
 		char = " "


### PR DESCRIPTION
## Motivation

LAB-1663 identified a client rendering regression from PR #753: every PTY output event rebuilt a full per-pane capture snapshot, including up to 5000 scrollback rows x pane width cells. Live pprof showed `captureScrollbackCells` dominating allocation space and `capturePaneRenderSnapshot` on the render actor hot path, while PR #753's actor-free capture behavior still needs to remain in place to avoid reintroducing LAB-1634 flicker.

## Summary

- Add a targeted benchmark for `capturePaneRenderSnapshot` with styled 1 KB output and a full 5000-line scrollback buffer.
- Stop storing live scrollback cell grids in per-write render capture snapshots; the capture paths only consume scrollback text there, while copy-mode/history bootstrap still captures styled scrollback cells through the existing buffer snapshot path.
- Change `mux.TerminalEmulator.ScrollbackCellAt` to return a cell value plus `ok`, avoiding the heap allocation from returning `&cell` for remaining styled-scrollback callers.
- Keep capture snapshot publication off the renderer actor read path; the existing LAB-1634 regression test still passes 100 runs.

Chosen fix path:

I used the low-risk part of sketch A for the expensive data: live scrollback cells are no longer eagerly snapshotted on output because snapshot-backed capture does not read them. Scrollback text remains in the published snapshot so `capture --history --format json` stays actor-free and socket-order consistent after the attach barrier. I also applied sketch C by changing `ScrollbackCellAt` to return by value. I did not implement D because the benchmark and pprof evidence showed the full scrollback cell grid was the allocation cliff; coalescing would still pay that cost whenever a batch published.

LAB-1634 consistency check:

The LAB-1634 test coverage verifies that capture does not wait for a blocked renderer actor. Attach capture requests still use the existing lightweight render-loop barrier before responding from snapshots, so capture observes prior socket-queued layout/output without doing the expensive capture work on the actor.

## Baseline numbers

Hardware: AMD EPYC-Milan Processor, linux/amd64.

| Benchmark | Before | After | Change |
| --- | ---: | ---: | ---: |
| `BenchmarkCapturePaneRenderSnapshotStyledScrollback1KB` ns/op | 41,250,597 | 4,331,100 | 9.5x faster |
| bytes/op | 71,993,185 | 984,735 | 73.1x less |
| allocs/op | 234,438 | 18,375 | 12.8x less |

Pprof repro:

| Profile | Before | After |
| --- | ---: | ---: |
| CPU: `capturePaneRenderSnapshot` cumulative | 30.65% | 2.43% |
| Alloc-space: `captureScrollbackCells` | 96.87% / 26.59 GB | absent |
| Total alloc-space during repro | 27.45 GB | 1.98 GB |

## Testing

- `go test ./internal/client -run '^TestHandleCaptureRequestDoesNotWaitForRendererActor$' -count=100`
- `go test ./internal/mux -run '^TestScrollbackCellAt$' -count=100`
- `go test ./internal/render -run '^TestCellFromUV$' -count=100`
- `go test ./internal/client -run '^(TestClientRendererHandleCaptureRequestHistoryJSONPrependsScrollback|TestRendererHandleCaptureRequestHistoryJSONWithoutBootstrapHistory)$' -count=100`
- `go test ./internal/client -run '^TestPaneBufferSnapshotCellAccess$' -count=100`
- `go test -race ./internal/client -run '^(TestHandleCaptureRequestDoesNotWaitForRendererActor|TestClientRendererHandleCaptureRequestHistoryJSONPrependsScrollback|TestRendererHandleCaptureRequestHistoryJSONWithoutBootstrapHistory|TestPaneBufferSnapshotCellAccess|TestPaneBufferSnapshotScrollbackCellAtOutOfRange)$' -count=10`
- `go test -race ./internal/mux -run '^TestScrollbackCellAt$' -count=10`
- `go test -race ./internal/render -run '^TestCellFromUV$' -count=10`
- `go test ./internal/client ./internal/mux ./internal/render -count=1`
- `go test ./... -timeout 120s`
- `go test ./internal/client -run '^$' -bench '^BenchmarkCapturePaneRenderSnapshotStyledScrollback1KB$' -benchmem -benchtime=60s -count=1`

Attempted:

- `go test -race ./... -count=10` did not pass locally under repeated race load. Failures were unrelated to this diff: CLI subprocess help timeouts, a run-session harness `os.File` close/read race, mux prompt-time self-fork idle timeouts, server integration timeouts, and test harness `Cmd.Wait` races.

## Review focus

- Check that removing live scrollback cells from `paneRenderSnapshot` is valid for current snapshot-backed capture consumers, especially `--history --format json`.
- Check the `ScrollbackCellAt` API change and value-to-render/proto conversion helpers.
- Check that the LAB-1634 actor-free capture invariant is preserved by the unchanged regression test.

Closes LAB-1663