### PR TITLE
LAB-1649: Expose theme icon config

### DIFF
--- a/internal/client/attach.go
+++ b/internal/client/attach.go
@@ -564,6 +564,7 @@ func runSessionWithDeps(sessionName string, getTermSize func(int) (int, int, err
 	cr.SetCapabilities(negotiatedAttachCaps)
 	cr.SetStatusStyle(cfg.EffectiveStatusStyle())
 	cr.ConfigureLocalEcho(cfg.EffectiveLocalEchoMode(), cfg.EffectiveLocalEchoStyle())
+	cr.ConfigureTheme(cfg)
 	cr.OnUIEvent = func(name string) {
 		_ = sender.Send(&proto.Message{
 			Type:    proto.MsgTypeUIEvent,

--- a/internal/client/renderer.go
+++ b/internal/client/renderer.go
@@ -78,6 +78,7 @@ func (r *Renderer) HandleLayout(snap *proto.LayoutSnapshot) bool {
 			activeWinID:     snap.ActiveWindowID,
 			scrollbackLines: prev.scrollbackLines,
 			colorProfile:    prev.colorProfile,
+			iconSet:         prev.iconSet,
 			paneCaptures:    clonePaneRenderSnapshots(prev.paneCaptures),
 		}
 

--- a/internal/client/renderer_capture_snapshot.go
+++ b/internal/client/renderer_capture_snapshot.go
@@ -112,6 +112,7 @@ func (s *rendererSnapshot) captureCompositor() *render.Compositor {
 	comp := render.NewCompositor(s.width, s.height, s.sessionName)
 	comp.SetWindows(windowInfoFromSnapshot(s.windows, s.activeWinID))
 	comp.SetColorProfile(s.colorProfile)
+	comp.SetIconSet(s.iconSet)
 	return comp
 }
 

--- a/internal/client/renderer_state.go
+++ b/internal/client/renderer_state.go
@@ -27,6 +27,7 @@ type rendererSnapshot struct {
 	activeWinID     uint32
 	scrollbackLines int
 	colorProfile    termenv.Profile
+	iconSet         render.IconSet
 	paneCaptures    map[uint32]paneRenderSnapshot
 }
 
@@ -37,6 +38,7 @@ func newRendererSnapshot(width, height, scrollbackLines int) *rendererSnapshot {
 		height:          height,
 		scrollbackLines: scrollbackLines,
 		colorProfile:    termenv.TrueColor,
+		iconSet:         render.DefaultIconSet(),
 		paneCaptures:    make(map[uint32]paneRenderSnapshot),
 	}
 }

--- a/internal/client/theme.go
+++ b/internal/client/theme.go
@@ -1,0 +1,60 @@
+package client
+
+import (
+	"github.com/weill-labs/amux/internal/config"
+	"github.com/weill-labs/amux/internal/render"
+)
+
+func iconSetForConfig(mode string) render.IconSet {
+	icons, ok := render.IconSetForName(mode)
+	if !ok {
+		return render.DefaultIconSet()
+	}
+	return icons
+}
+
+func (cr *ClientRenderer) ConfigureTheme(cfg *config.Config) {
+	if cfg == nil {
+		cr.SetIconSet(render.DefaultIconSet())
+		return
+	}
+	cr.SetIconSet(iconSetForConfig(cfg.EffectiveThemeIcons()))
+}
+
+func (cr *ClientRenderer) SetIconSet(icons render.IconSet) {
+	if cr == nil || cr.renderer == nil {
+		return
+	}
+	cr.renderer.SetIconSet(icons)
+}
+
+func (cr *ClientRenderer) IconSet() render.IconSet {
+	if cr == nil || cr.renderer == nil {
+		return render.DefaultIconSet()
+	}
+	return cr.renderer.IconSet()
+}
+
+func (r *Renderer) SetIconSet(icons render.IconSet) {
+	r.withActor(func(st *rendererActorState) {
+		st.compositor.SetIconSet(icons)
+		next := *st.snapshot
+		next.iconSet = st.compositor.IconSet()
+		st.snapshot = &next
+		r.publishSnapshot(&next)
+	})
+}
+
+func (r *Renderer) IconSet() render.IconSet {
+	if r == nil {
+		return render.DefaultIconSet()
+	}
+	snap := r.loadSnapshot()
+	if snap == nil {
+		return render.DefaultIconSet()
+	}
+	if snap.iconSet == (render.IconSet{}) {
+		return render.DefaultIconSet()
+	}
+	return snap.iconSet
+}

--- a/internal/client/theme_test.go
+++ b/internal/client/theme_test.go
@@ -1,0 +1,58 @@
+package client
+
+import (
+	"testing"
+
+	"github.com/weill-labs/amux/internal/config"
+	"github.com/weill-labs/amux/internal/mux"
+	"github.com/weill-labs/amux/internal/render"
+)
+
+func TestConfigureThemeSetsRendererIconSet(t *testing.T) {
+	t.Parallel()
+
+	ascii := config.ThemeIconsASCII
+	nerd := config.ThemeIconsNerd
+
+	tests := []struct {
+		name string
+		cfg  *config.Config
+		want render.IconSet
+	}{
+		{
+			name: "nil config defaults to unicode",
+			cfg:  nil,
+			want: render.UnicodeIconSet(),
+		},
+		{
+			name: "unset theme defaults to unicode",
+			cfg:  &config.Config{},
+			want: render.UnicodeIconSet(),
+		},
+		{
+			name: "ascii",
+			cfg:  &config.Config{Theme: config.ThemeConfig{Icons: &ascii}},
+			want: render.ASCIIIconSet(),
+		},
+		{
+			name: "nerd",
+			cfg:  &config.Config{Theme: config.ThemeConfig{Icons: &nerd}},
+			want: render.NerdFontIconSet(),
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cr := NewClientRendererWithScrollback(20, 4, mux.DefaultScrollbackLines)
+			defer cr.renderer.Close()
+
+			cr.ConfigureTheme(tt.cfg)
+			if got := cr.IconSet(); got != tt.want {
+				t.Fatalf("IconSet() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -113,10 +113,21 @@ const (
 	StatusStyleCompact   = "compact"
 	StatusStylePlain     = "plain"
 	StatusStylePowerline = "powerline"
+
+	ThemeIconsASCII   = "ascii"
+	ThemeIconsUnicode = "unicode"
+	ThemeIconsNerd    = "nerd"
 )
 
+// ThemeConfig controls client-side presentation.
+//
+// Example:
+//
+//	[theme]
+//	icons = "unicode" # ascii | unicode | nerd
 type ThemeConfig struct {
-	StatusStyle string `toml:"status_style"`
+	StatusStyle string  `toml:"status_style"`
+	Icons       *string `toml:"icons"`
 }
 
 type TransportConfig struct {
@@ -195,6 +206,9 @@ func parseConfig(data []byte) (*Config, error) {
 		return nil, err
 	}
 	if _, err := ResolveStatusStyle(cfg.Theme.StatusStyle); err != nil {
+		return nil, err
+	}
+	if _, err := ResolveThemeIcons(cfg.Theme.Icons); err != nil {
 		return nil, err
 	}
 
@@ -352,6 +366,29 @@ func (c *Config) EffectiveStatusStyle() string {
 		return StatusStyleCompact
 	}
 	return style
+}
+
+func ResolveThemeIcons(icons *string) (string, error) {
+	if icons == nil {
+		return ThemeIconsUnicode, nil
+	}
+	switch *icons {
+	case ThemeIconsASCII, ThemeIconsUnicode, ThemeIconsNerd:
+		return *icons, nil
+	default:
+		return "", fmt.Errorf(`theme.icons must be one of "ascii", "unicode", or "nerd"`)
+	}
+}
+
+func (c *Config) EffectiveThemeIcons() string {
+	if c == nil {
+		return ThemeIconsUnicode
+	}
+	icons, err := ResolveThemeIcons(c.Theme.Icons)
+	if err != nil {
+		return ThemeIconsUnicode
+	}
+	return icons
 }
 
 func (c *Config) TransportPreferences() []string {

--- a/internal/config/config_fuzz_test.go
+++ b/internal/config/config_fuzz_test.go
@@ -45,6 +45,9 @@ address = "builder.example"
 		[]byte("[client]\nlocal_echo_style = \"flashy\"\n"),
 		[]byte("[theme]\nstatus_style = \"powerline\"\n"),
 		[]byte("[theme]\nstatus_style = \"fancy\"\n"),
+		[]byte("[theme]\nicons = \"unicode\"\n"),
+		[]byte("[theme]\nicons = \"powerline\"\n"),
+		[]byte("[theme]\nicons = \"\"\n"),
 		[]byte("[transport]\npreference = [\" ssh \", \"\", \"ssh\", \"mosh\"]\n"),
 		[]byte("scrollback_lines = 0\n"),
 		[]byte("[hosts.local]\nscrollback_lines = 0\n"),
@@ -92,6 +95,9 @@ func assertParsedConfigValid(t *testing.T, cfg *Config) {
 	}
 	if _, err := ResolveStatusStyle(cfg.Theme.StatusStyle); err != nil {
 		t.Fatalf("status_style did not validate after parse: %v", err)
+	}
+	if _, err := ResolveThemeIcons(cfg.Theme.Icons); err != nil {
+		t.Fatalf("theme.icons did not validate after parse: %v", err)
 	}
 
 	preferences := cfg.TransportPreferences()

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -409,6 +409,109 @@ status_style = "fancy"
 	}
 }
 
+func TestLoadThemeIcons(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		content string
+		want    string
+	}{
+		{
+			name:    "empty config defaults to unicode",
+			content: "",
+			want:    ThemeIconsUnicode,
+		},
+		{
+			name: "ascii",
+			content: `
+[theme]
+icons = "ascii"
+`,
+			want: ThemeIconsASCII,
+		},
+		{
+			name: "unicode",
+			content: `
+[theme]
+icons = "unicode"
+`,
+			want: ThemeIconsUnicode,
+		},
+		{
+			name: "nerd",
+			content: `
+[theme]
+icons = "nerd"
+`,
+			want: ThemeIconsNerd,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			dir := t.TempDir()
+			path := filepath.Join(dir, "config.toml")
+			if err := os.WriteFile(path, []byte(tt.content), 0644); err != nil {
+				t.Fatalf("WriteFile: %v", err)
+			}
+
+			cfg, err := Load(path)
+			if err != nil {
+				t.Fatalf("Load: %v", err)
+			}
+			if got := cfg.EffectiveThemeIcons(); got != tt.want {
+				t.Fatalf("EffectiveThemeIcons() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLoadRejectsInvalidThemeIcons(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		content string
+	}{
+		{
+			name: "unknown value",
+			content: `
+[theme]
+icons = "powerline"
+`,
+		},
+		{
+			name: "empty string",
+			content: `
+[theme]
+icons = ""
+`,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			dir := t.TempDir()
+			path := filepath.Join(dir, "config.toml")
+			if err := os.WriteFile(path, []byte(tt.content), 0644); err != nil {
+				t.Fatalf("WriteFile: %v", err)
+			}
+
+			_, err := Load(path)
+			if err == nil || !strings.Contains(err.Error(), `theme.icons must be one of "ascii", "unicode", or "nerd"`) {
+				t.Fatalf("Load() error = %v, want theme.icons validation error", err)
+			}
+		})
+	}
+}
+
 func TestLoadRejectsInvalidClientLocalEcho(t *testing.T) {
 	t.Parallel()
 

--- a/internal/render/icons.go
+++ b/internal/render/icons.go
@@ -1,5 +1,7 @@
 package render
 
+import "github.com/weill-labs/amux/internal/config"
+
 // IconSet centralizes human-facing renderer glyphs. Structured capture and
 // event APIs remain semantic and should not consume this type.
 type IconSet struct {
@@ -22,6 +24,20 @@ type IconSet struct {
 // DefaultIconSet returns the renderer's backward-compatible icon set.
 func DefaultIconSet() IconSet {
 	return UnicodeIconSet()
+}
+
+// IconSetForName returns the preset icon set for a validated config name.
+func IconSetForName(name string) (IconSet, bool) {
+	switch name {
+	case config.ThemeIconsASCII:
+		return ASCIIIconSet(), true
+	case config.ThemeIconsUnicode:
+		return UnicodeIconSet(), true
+	case config.ThemeIconsNerd:
+		return NerdFontIconSet(), true
+	default:
+		return IconSet{}, false
+	}
 }
 
 // UnicodeIconSet returns the current default compact Unicode glyphs.

--- a/internal/render/icons_test.go
+++ b/internal/render/icons_test.go
@@ -246,6 +246,19 @@ func TestIconSetPresetsAndHelpers(t *testing.T) {
 	if got := normalizeIconSet(IconSet{}); got != UnicodeIconSet() {
 		t.Fatalf("normalizeIconSet(zero) = %#v, want unicode preset", got)
 	}
+	for name, want := range map[string]IconSet{
+		config.ThemeIconsASCII:   ASCIIIconSet(),
+		config.ThemeIconsUnicode: UnicodeIconSet(),
+		config.ThemeIconsNerd:    NerdFontIconSet(),
+	} {
+		got, ok := IconSetForName(name)
+		if !ok || got != want {
+			t.Fatalf("IconSetForName(%q) = %#v, %v; want %#v, true", name, got, ok, want)
+		}
+	}
+	if got, ok := IconSetForName("powerline"); ok || got != (IconSet{}) {
+		t.Fatalf("IconSetForName(powerline) = %#v, %v; want zero, false", got, ok)
+	}
 
 	ascii := ASCIIIconSet()
 	for name, value := range map[string]string{


### PR DESCRIPTION
## Motivation

Nerd Font glyphs need an explicit opt-in so users whose terminal fonts cannot render them can stay on the existing Unicode default or choose ASCII fallbacks. LAB-1649 adds the config knob that sibling theme/icon work can consume.

## Summary

- Added `[theme] icons = "unicode"` config parsing with `ascii`, `unicode`, and `nerd` validation.
- Added render preset lookup for the existing IconSet presets.
- Applied the effective theme icon mode to the interactive client renderer and capture compositor snapshot without changing server-owned pane state.

## Testing

- `go vet ./...`
- `go test ./internal/config -run 'TestLoadThemeIcons|TestLoadRejectsInvalidThemeIcons|TestLoadThemeStatusStyle|TestEffectiveStatusStyleDefaultsToCompact|TestLoadRejectsInvalidThemeStatusStyle' -count=100`
- `go test ./internal/client -run 'TestConfigureThemeSetsRendererIconSet|TestRendererSetStatusStyleUpdatesCompositor|TestClientRendererSetStatusStyleUpdatesCompositor|TestClientRendererSetStatusStyleHandlesNilRenderer' -count=100`
- `go test ./internal/render -run 'TestIconSetPresetsAndHelpers|TestCompositorSetStatusStyleInvalidatesGrid' -count=100`
- `go test ./internal/config ./internal/client ./internal/render -count=1`
- `go test ./test -run TestGolden -count=1`

## Review focus

Please check the config API shape, especially the `*string` field used to distinguish unset config from `icons = ""`, and the client-side renderer plumbing through snapshots/capture compositors. After rebasing over LAB-1651, also check that `[theme].icons` composes cleanly with `[theme].status_style` in the shared config table.

Closes LAB-1649
