### PR TITLE
LAB-1650: Apply Nerd icons to pane status

### DIFF
--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -435,6 +435,39 @@ func TestClientRendererCaptureJSON(t *testing.T) {
 	}
 }
 
+func TestClientRendererCaptureJSONOmitsNerdIconGlyphs(t *testing.T) {
+	t.Parallel()
+
+	cr := NewClientRenderer(80, 24)
+	icons := render.NerdFontIconSet()
+	snap := singlePane20xN(23)
+	snap.Panes[0].Host = "gpu"
+	snap.Panes[0].Task = "build LAB-1650"
+	snap.Panes[0].ConnStatus = string(proto.Connected)
+	snap.Panes[0].TrackedPRs = []proto.TrackedPR{{Number: 42}}
+	snap.Panes[0].TrackedIssues = []proto.TrackedIssue{{ID: "LAB-1650"}}
+	snap.Windows[0].Panes[0] = snap.Panes[0]
+
+	cr.HandleLayout(snap)
+	cr.HandlePaneOutput(1, []byte("semantic capture"))
+	cr.renderer.withActor(func(st *rendererActorState) {
+		st.compositor.SetIconSet(icons)
+	})
+	cr.RenderDiff()
+
+	jsonOut := cr.CaptureJSON(nil)
+	for _, glyph := range nerdIconGlyphs(icons) {
+		if glyph != "" && strings.Contains(jsonOut, glyph) {
+			t.Fatalf("JSON capture contains Nerd glyph %q:\n%s", glyph, jsonOut)
+		}
+	}
+	for _, want := range []string{`"task": "build LAB-1650"`, `"tracked_prs"`, `"tracked_issues"`, `"conn_status": "connected"`} {
+		if !strings.Contains(jsonOut, want) {
+			t.Fatalf("JSON capture missing semantic field %q:\n%s", want, jsonOut)
+		}
+	}
+}
+
 func TestClientRendererCaptureJSONIncludesTerminalMetadata(t *testing.T) {
 	t.Parallel()
 
@@ -501,6 +534,25 @@ func TestClientRendererCaptureJSONIncludesTerminalMetadata(t *testing.T) {
 	}
 	if got, want := pane.Terminal.Palette[1], captureHexColor(ansi.IndexedColor(1)); got != want {
 		t.Fatalf("palette[1] = %q, want %q", got, want)
+	}
+}
+
+func nerdIconGlyphs(icons render.IconSet) []string {
+	return []string{
+		icons.PaneIdle,
+		icons.PaneActive,
+		icons.PaneBusy,
+		icons.PaneLead,
+		icons.PaneEscalated,
+		icons.PaneStuck,
+		icons.RemoteHost,
+		icons.PR,
+		icons.Issue,
+		icons.Task,
+		icons.CopyMode,
+		icons.Connected,
+		icons.Reconnecting,
+		icons.Disconnected,
 	}
 }
 

--- a/internal/render/icons.go
+++ b/internal/render/icons.go
@@ -12,6 +12,7 @@ type IconSet struct {
 	RemoteHost    string
 	PR            string
 	Issue         string
+	Task          string
 	CopyMode      string
 	Connected     string
 	Reconnecting  string
@@ -35,6 +36,7 @@ func UnicodeIconSet() IconSet {
 		RemoteHost:    "@",
 		PR:            "#",
 		Issue:         "",
+		Task:          "",
 		CopyMode:      "[copy]",
 		Connected:     "⚡",
 		Reconnecting:  "⟳",
@@ -54,6 +56,7 @@ func ASCIIIconSet() IconSet {
 		RemoteHost:    "@",
 		PR:            "#",
 		Issue:         "I",
+		Task:          "T",
 		CopyMode:      "C",
 		Connected:     "+",
 		Reconnecting:  "~",
@@ -61,22 +64,23 @@ func ASCIIIconSet() IconSet {
 	}
 }
 
-// NerdFontIconSet returns placeholder Private Use Area glyphs for future opt-in use.
+// NerdFontIconSet returns Private Use Area glyphs for opt-in Nerd Font rendering.
 func NerdFontIconSet() IconSet {
 	return IconSet{
-		PaneIdle:      "\uf10c",
-		PaneActive:    "\uf111",
-		PaneBusy:      "\uf013",
-		PaneLead:      "\uf04b",
-		PaneEscalated: "\uf071",
-		PaneStuck:     "\uf188",
-		RemoteHost:    "\uf489",
+		PaneIdle:      "\uebb5",
+		PaneActive:    "\uebb4",
+		PaneBusy:      "\ueb31",
+		PaneLead:      "\ueb59",
+		PaneEscalated: "\uea6c",
+		PaneStuck:     "\ueaaf",
+		RemoteHost:    "\ueb50",
 		PR:            "\uf407",
 		Issue:         "\uf41b",
-		CopyMode:      "\uf0c5",
-		Connected:     "\uf0e7",
-		Reconnecting:  "\uf021",
-		Disconnected:  "\uf00d",
+		Task:          "\ueb67",
+		CopyMode:      "\ueac0",
+		Connected:     "\U000f0c53",
+		Reconnecting:  "\uea77",
+		Disconnected:  "\U000f0c9b",
 	}
 }
 

--- a/internal/render/icons_test.go
+++ b/internal/render/icons_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"unicode/utf8"
 
+	"github.com/mattn/go-runewidth"
 	"github.com/weill-labs/amux/internal/config"
 	"github.com/weill-labs/amux/internal/mux"
 	"github.com/weill-labs/amux/internal/proto"
@@ -85,6 +86,7 @@ func TestCompositorUsesConfiguredIconSetForPaneStatus(t *testing.T) {
 		RemoteHost:    "R",
 		PR:            "P",
 		Issue:         "J",
+		Task:          "T",
 		CopyMode:      "C",
 		Connected:     "Z",
 		Reconnecting:  "Y",
@@ -117,15 +119,121 @@ func TestCompositorUsesConfiguredIconSetForPaneStatus(t *testing.T) {
 func assertStatusUsesSentinelIcons(t *testing.T, rendered string) {
 	t.Helper()
 
-	for _, want := range []string{"A", "C /query", "P42", "JLAB-1647", "Rgpu", "Z", "task"} {
+	for _, want := range []string{"A", "C /query", "P42", "JLAB-1647", "Rgpu", "Z", "T task"} {
 		if !strings.Contains(rendered, want) {
 			t.Fatalf("rendered status missing %q:\n%s", want, rendered)
 		}
 	}
-	for _, old := range []string{"●", "[copy]", "#42", "@gpu", "⚡"} {
+	for _, old := range []string{"●", "[copy]", "#42", "@gpu", "⚡", "Z task"} {
 		if strings.Contains(rendered, old) {
 			t.Fatalf("rendered status still contains old glyph %q:\n%s", old, rendered)
 		}
+	}
+}
+
+func TestNerdFontIconSetUsesPublishedGlyphs(t *testing.T) {
+	t.Parallel()
+
+	want := IconSet{
+		PaneIdle:      "\uebb5",     // nf-cod-circle_large
+		PaneActive:    "\uebb4",     // nf-cod-circle_large_filled
+		PaneBusy:      "\ueb31",     // nf-cod-pulse
+		PaneLead:      "\ueb59",     // nf-cod-star_full
+		PaneEscalated: "\uea6c",     // nf-cod-warning
+		PaneStuck:     "\ueaaf",     // nf-cod-bug
+		RemoteHost:    "\ueb50",     // nf-cod-server
+		PR:            "\uf407",     // nf-oct-git_pull_request
+		Issue:         "\uf41b",     // nf-oct-issue_opened
+		Task:          "\ueb67",     // nf-cod-tasklist
+		CopyMode:      "\ueac0",     // nf-cod-clippy
+		Connected:     "\U000f0c53", // nf-md-check_network
+		Reconnecting:  "\uea77",     // nf-cod-sync
+		Disconnected:  "\U000f0c9b", // nf-md-network_off
+	}
+	if got := NerdFontIconSet(); got != want {
+		t.Fatalf("NerdFontIconSet() = %#v, want %#v", got, want)
+	}
+	for name, value := range iconSetFieldMap(want) {
+		if value == "" {
+			t.Fatalf("NerdFontIconSet().%s is empty", name)
+		}
+		if width := runewidth.StringWidth(value); width != 1 {
+			t.Fatalf("NerdFontIconSet().%s width = %d, want 1", name, width)
+		}
+	}
+}
+
+func TestCompositorUsesNerdFontIconSetForPaneStatusMetadata(t *testing.T) {
+	t.Parallel()
+
+	icons := NerdFontIconSet()
+	root := mux.NewLeaf(&mux.Pane{ID: 1}, 0, 0, 96, 2)
+	pane := &statusPaneData{
+		id:            1,
+		name:          "pane-1",
+		trackedPRs:    []proto.TrackedPR{{Number: 42}},
+		trackedIssues: []proto.TrackedIssue{{ID: "LAB-1650"}},
+		host:          "gpu",
+		task:          "build LAB-1650",
+		color:         config.TextColorHex,
+		connStatus:    string(proto.Connected),
+		copyMode:      true,
+		copySearch:    "/query",
+	}
+	lookup := func(uint32) PaneData { return pane }
+
+	comp := NewCompositor(96, 3, "test")
+	comp.SetIconSet(icons)
+	rendered := MaterializeGrid(comp.RenderFull(root, 1, lookup), 96, 3)
+
+	for _, want := range []string{
+		icons.PaneActive,
+		icons.CopyMode + " /query",
+		icons.PR + "42",
+		icons.Issue + "LAB-1650",
+		icons.RemoteHost + "gpu",
+		icons.Connected,
+		icons.Task + " build LAB-1650",
+	} {
+		if !strings.Contains(rendered, want) {
+			t.Fatalf("Nerd status missing %q:\n%s", want, rendered)
+		}
+	}
+	for _, old := range []string{"●", "[copy]", "#42", "@gpu", "⚡", icons.Connected + " build LAB-1650"} {
+		if strings.Contains(rendered, old) {
+			t.Fatalf("Nerd status still contains fallback marker %q:\n%s", old, rendered)
+		}
+	}
+}
+
+func TestNerdFontPaneStatusClippingKeepsGlyphWidths(t *testing.T) {
+	t.Parallel()
+
+	icons := NerdFontIconSet()
+	root := mux.NewLeaf(&mux.Pane{ID: 1}, 0, 0, 34, 2)
+	pane := &statusPaneData{
+		id:            1,
+		name:          "pane-1",
+		trackedPRs:    []proto.TrackedPR{{Number: 42}},
+		trackedIssues: []proto.TrackedIssue{{ID: "LAB-1650-EXTRA-LONG"}},
+		host:          "remote",
+		task:          "long task name",
+		color:         config.TextColorHex,
+		connStatus:    string(proto.Reconnecting),
+	}
+	comp := NewCompositor(34, 3, "test")
+	comp.SetIconSet(icons)
+	rendered := MaterializeGrid(comp.RenderFull(root, 1, func(uint32) PaneData { return pane }), 34, 3)
+	statusLine := strings.Split(rendered, "\n")[0]
+
+	if width := runewidth.StringWidth(statusLine); width != 34 {
+		t.Fatalf("status line width = %d, want 34:\n%s", width, rendered)
+	}
+	if !strings.Contains(statusLine, "…") {
+		t.Fatalf("status line should be clipped with ellipsis:\n%s", rendered)
+	}
+	if !strings.Contains(statusLine, icons.PaneActive+" [pane-1]") {
+		t.Fatalf("status line missing active Nerd prefix:\n%s", rendered)
 	}
 }
 
@@ -150,6 +258,7 @@ func TestIconSetPresetsAndHelpers(t *testing.T) {
 		"RemoteHost":    ascii.RemoteHost,
 		"PR":            ascii.PR,
 		"Issue":         ascii.Issue,
+		"Task":          ascii.Task,
 		"CopyMode":      ascii.CopyMode,
 		"Connected":     ascii.Connected,
 		"Reconnecting":  ascii.Reconnecting,
@@ -164,25 +273,13 @@ func TestIconSetPresetsAndHelpers(t *testing.T) {
 		}
 	}
 
-	nerd := NerdFontIconSet()
-	for name, value := range map[string]string{
-		"PaneIdle":      nerd.PaneIdle,
-		"PaneActive":    nerd.PaneActive,
-		"PaneBusy":      nerd.PaneBusy,
-		"PaneLead":      nerd.PaneLead,
-		"PaneEscalated": nerd.PaneEscalated,
-		"PaneStuck":     nerd.PaneStuck,
-		"RemoteHost":    nerd.RemoteHost,
-		"PR":            nerd.PR,
-		"Issue":         nerd.Issue,
-		"CopyMode":      nerd.CopyMode,
-		"Connected":     nerd.Connected,
-		"Reconnecting":  nerd.Reconnecting,
-		"Disconnected":  nerd.Disconnected,
-	} {
+	for name, value := range iconSetFieldMap(NerdFontIconSet()) {
 		r, size := utf8.DecodeRuneInString(value)
-		if size == 0 || r < '\ue000' || r > '\uf8ff' {
-			t.Fatalf("NerdFontIconSet().%s = %q, want Private Use Area placeholder", name, value)
+		if size == 0 || !isPrivateUseAreaRune(r) {
+			t.Fatalf("NerdFontIconSet().%s = %q, want Nerd Font private-use glyph", name, value)
+		}
+		if width := runewidth.StringWidth(value); width != 1 {
+			t.Fatalf("NerdFontIconSet().%s width = %d, want 1", name, width)
 		}
 	}
 
@@ -207,4 +304,29 @@ func TestIconSetPresetsAndHelpers(t *testing.T) {
 			t.Fatalf("connStatusIcon(%q) = %q, want %q", status, got, want)
 		}
 	}
+}
+
+func iconSetFieldMap(icons IconSet) map[string]string {
+	return map[string]string{
+		"PaneIdle":      icons.PaneIdle,
+		"PaneActive":    icons.PaneActive,
+		"PaneBusy":      icons.PaneBusy,
+		"PaneLead":      icons.PaneLead,
+		"PaneEscalated": icons.PaneEscalated,
+		"PaneStuck":     icons.PaneStuck,
+		"RemoteHost":    icons.RemoteHost,
+		"PR":            icons.PR,
+		"Issue":         icons.Issue,
+		"Task":          icons.Task,
+		"CopyMode":      icons.CopyMode,
+		"Connected":     icons.Connected,
+		"Reconnecting":  icons.Reconnecting,
+		"Disconnected":  icons.Disconnected,
+	}
+}
+
+func isPrivateUseAreaRune(r rune) bool {
+	return (r >= 0xe000 && r <= 0xf8ff) ||
+		(r >= 0xf0000 && r <= 0xffffd) ||
+		(r >= 0x100000 && r <= 0x10fffd)
 }

--- a/internal/render/icons_test.go
+++ b/internal/render/icons_test.go
@@ -226,8 +226,8 @@ func TestNerdFontPaneStatusClippingKeepsGlyphWidths(t *testing.T) {
 	rendered := MaterializeGrid(comp.RenderFull(root, 1, func(uint32) PaneData { return pane }), 34, 3)
 	statusLine := strings.Split(rendered, "\n")[0]
 
-	if width := runewidth.StringWidth(statusLine); width != 34 {
-		t.Fatalf("status line width = %d, want 34:\n%s", width, rendered)
+	if width := runewidth.StringWidth(statusLine); width > 34 {
+		t.Fatalf("status line width = %d, want at most 34:\n%s", width, rendered)
 	}
 	if !strings.Contains(statusLine, "…") {
 		t.Fatalf("status line should be clipped with ellipsis:\n%s", rendered)

--- a/internal/render/statusbar.go
+++ b/internal/render/statusbar.go
@@ -154,9 +154,9 @@ func buildPaneStatusSegmentsWithIcons(cellWidth int, isActive bool, pd PaneData,
 		}
 	}
 
-	if pd.Task() != "" {
+	if taskText := paneStatusTaskText(pd.Task(), icons); taskText != "" {
 		segments = appendPaneStatusSegment(segments, " ", paneStatusSegmentBackground)
-		segments = appendPaneStatusSegment(segments, pd.Task(), paneStatusSegmentText)
+		segments = appendPaneStatusSegment(segments, taskText, paneStatusSegmentText)
 	}
 
 	return clipPaneStatusSegments(segments, cellWidth)
@@ -426,6 +426,17 @@ func truncateRunewidth(s string, maxWidth int) string {
 	return buf.String()
 }
 
+func paneStatusTaskText(task string, icons IconSet) string {
+	if task == "" {
+		return ""
+	}
+	icons = normalizeIconSet(icons)
+	if icons.Task == "" {
+		return task
+	}
+	return icons.Task + " " + task
+}
+
 func paneStatusUsedWidthWithoutMetadataWithIcons(isActive bool, pd PaneData, icons IconSet) int {
 	icons = normalizeIconSet(icons)
 	usedWidth := runewidth.StringWidth(paneStatusStateIcon(isActive, pd, icons)) + 1 + runewidth.StringWidth(pd.Name()) + 2 // "● [name]"
@@ -444,8 +455,8 @@ func paneStatusUsedWidthWithoutMetadataWithIcons(isActive bool, pd PaneData, ico
 	if cs := pd.ConnStatus(); cs != "" {
 		usedWidth += 1 + runewidth.StringWidth(connStatusIcon(cs, icons))
 	}
-	if pd.Task() != "" {
-		usedWidth += 1 + runewidth.StringWidth(pd.Task())
+	if taskText := paneStatusTaskText(pd.Task(), icons); taskText != "" {
+		usedWidth += 1 + runewidth.StringWidth(taskText)
 	}
 	return usedWidth
 }


### PR DESCRIPTION
## Motivation

amux pane status rows already expose state, metadata, connection, and task signals. Nerd Font mode should make those human-rendered signals easier to scan while keeping structured capture semantic and glyph-free.

## Summary

- Replaced the placeholder `NerdFontIconSet` values with verified Nerd Fonts 3.4.0 codepoints.
- Added `IconSet.Task` so task metadata can use the same icon abstraction as PRs, issues, copy mode, host, and connection state.
- Routed task status text and width accounting through the icon set without changing the default Unicode rendering.
- Added render tests for published Nerd glyphs, sentinel IconSet routing, narrow-pane clipping, and PR/issue/task metadata.
- Added a client JSON capture regression test that sets the compositor to Nerd icons and asserts JSON remains semantic.

## Chosen Nerd codepoints

| Segment | Nerd Font name | Codepoint | Notes |
| --- | --- | --- | --- |
| Idle pane | `nf-cod-circle_large` | `U+EBB5` | Outline pair for active/idle state. |
| Active pane | `nf-cod-circle_large_filled` | `U+EBB4` | Filled pair keeps active distinct from lead. |
| Busy pane | `nf-cod-pulse` | `U+EB31` | Reads as activity at one terminal cell. |
| Lead pane | `nf-cod-star_full` | `U+EB59` | Direct lead/favorite signal. |
| Escalated pane | `nf-cod-warning` | `U+EA6C` | Keeps the existing warning semantics. |
| Stuck pane | `nf-cod-bug` | `U+EAAF` | Matches blocked/problem state. |
| Remote host | `nf-cod-server` | `U+EB50` | Clear host/server marker. |
| Pull request | `nf-oct-git_pull_request` | `U+F407` | Existing Octicon PR marker. |
| Issue | `nf-oct-issue_opened` | `U+F41B` | Existing Octicon issue marker. |
| Task | `nf-cod-tasklist` | `U+EB67` | Adds a task prefix only when an icon set supplies one. |
| Copy mode | `nf-cod-clippy` | `U+EAC0` | Clipboard/copy-oriented marker. |
| Connected | `nf-md-check_network` | `U+F0C53` | Network check marker. |
| Reconnecting | `nf-cod-sync` | `U+EA77` | Reconnect/retry marker. |
| Disconnected | `nf-md-network_off` | `U+F0C9B` | Network-off marker. |

## Dependency status

LAB-1649 is still not present on current `origin/main`; there is no `[theme] icons = "nerd"` config knob in this branch. This PR only fills the existing `NerdFontIconSet` preset from LAB-1647 and depends on LAB-1649 to expose that preset to users.

## Testing

- `go test ./internal/render -run 'TestNerdFont|TestCompositorUsesConfiguredIconSetForPaneStatus|TestIconSetPresetsAndHelpers' -count=100`
- `go test ./internal/client -run TestClientRendererCaptureJSONOmitsNerdIconGlyphs -count=100`
- `go test ./internal/mux -run TestAgentStatusTreatsPromptTimeBashSelfForkAsIdle -count=1`
- `go test ./internal/server -run TestRespawnCommandFailureUsesSessionCloser -count=1`
- `go test ./test -run TestMouseDragAutomaticallyEntersCopyModeAndCopiesSelection -count=1 -timeout 120s`
- `go test ./... -timeout 120s`

The first full-suite attempt hit unrelated flakes in the three targeted tests above; each passed immediately on a targeted rerun, and the second full-suite run passed.

## Review focus

- Verify the codepoint choices, especially using Codicon filled/outline circles for active/idle instead of the issue body's stale `codicon-debug-start` codepoint note.
- Check that `Task` stays empty in the Unicode preset so default status rendering remains unchanged.
- Confirm structured JSON capture stays semantic and does not consume `IconSet`.
- I did not find missed production status glyph literals in `screen.go` or `statusbar.go`; remaining direct glyph hits are in `icons.go`, tests, or comments.

Closes LAB-1650
