### PR TITLE
LAB-1651: Add Powerline status style preset

### DIFF
--- a/internal/client/attach.go
+++ b/internal/client/attach.go
@@ -562,6 +562,7 @@ func runSessionWithDeps(sessionName string, getTermSize func(int) (int, int, err
 	// Client-side renderer with per-pane emulators
 	cr := newAttachClientRenderer(cols, rows, scrollbackLines, stdout, processEnviron{}, termenv.WithTTY(true))
 	cr.SetCapabilities(negotiatedAttachCaps)
+	cr.SetStatusStyle(cfg.EffectiveStatusStyle())
 	cr.ConfigureLocalEcho(cfg.EffectiveLocalEchoMode(), cfg.EffectiveLocalEchoStyle())
 	cr.OnUIEvent = func(name string) {
 		_ = sender.Send(&proto.Message{

--- a/internal/client/status_style.go
+++ b/internal/client/status_style.go
@@ -1,0 +1,14 @@
+package client
+
+func (cr *ClientRenderer) SetStatusStyle(style string) {
+	if cr == nil || cr.renderer == nil {
+		return
+	}
+	cr.renderer.SetStatusStyle(style)
+}
+
+func (r *Renderer) SetStatusStyle(style string) {
+	r.withActor(func(st *rendererActorState) {
+		st.compositor.SetStatusStyle(style)
+	})
+}

--- a/internal/client/status_style_test.go
+++ b/internal/client/status_style_test.go
@@ -1,0 +1,50 @@
+package client
+
+import (
+	"testing"
+
+	"github.com/weill-labs/amux/internal/config"
+	"github.com/weill-labs/amux/internal/mux"
+)
+
+func TestClientRendererSetStatusStyleHandlesNilRenderer(t *testing.T) {
+	t.Parallel()
+
+	var nilClient *ClientRenderer
+	nilClient.SetStatusStyle(config.StatusStylePowerline)
+
+	emptyClient := &ClientRenderer{}
+	emptyClient.SetStatusStyle(config.StatusStylePowerline)
+}
+
+func TestRendererSetStatusStyleUpdatesCompositor(t *testing.T) {
+	t.Parallel()
+
+	r := NewWithScrollback(20, 4, mux.DefaultScrollbackLines)
+	t.Cleanup(r.Close)
+
+	r.SetStatusStyle(config.StatusStylePowerline)
+
+	got := withRendererActorValue(r, func(st *rendererActorState) string {
+		return st.compositor.StatusStyle()
+	})
+	if got != config.StatusStylePowerline {
+		t.Fatalf("StatusStyle() = %q, want %q", got, config.StatusStylePowerline)
+	}
+}
+
+func TestClientRendererSetStatusStyleUpdatesCompositor(t *testing.T) {
+	t.Parallel()
+
+	cr := NewClientRendererWithScrollback(20, 4, mux.DefaultScrollbackLines)
+	t.Cleanup(cr.renderer.Close)
+
+	cr.SetStatusStyle(config.StatusStylePowerline)
+
+	got := withRendererActorValue(cr.renderer, func(st *rendererActorState) string {
+		return st.compositor.StatusStyle()
+	})
+	if got != config.StatusStylePowerline {
+		t.Fatalf("StatusStyle() = %q, want %q", got, config.StatusStylePowerline)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -109,6 +109,16 @@ type ClientConfig struct {
 	LocalEchoStyle string `toml:"local_echo_style"`
 }
 
+const (
+	StatusStyleCompact   = "compact"
+	StatusStylePlain     = "plain"
+	StatusStylePowerline = "powerline"
+)
+
+type ThemeConfig struct {
+	StatusStyle string `toml:"status_style"`
+}
+
 type TransportConfig struct {
 	Preference []string `toml:"preference"`
 }
@@ -118,6 +128,7 @@ type Config struct {
 	ScrollbackLines *int            `toml:"scrollback_lines"`
 	Debug           DebugConfig     `toml:"debug"`
 	Client          ClientConfig    `toml:"client"`
+	Theme           ThemeConfig     `toml:"theme"`
 	Transport       TransportConfig `toml:"transport"`
 	Hosts           map[string]Host `toml:"hosts"`
 }
@@ -181,6 +192,9 @@ func parseConfig(data []byte) (*Config, error) {
 		return nil, err
 	}
 	if _, err := ResolveLocalEchoStyle(cfg.Client.LocalEchoStyle); err != nil {
+		return nil, err
+	}
+	if _, err := ResolveStatusStyle(cfg.Theme.StatusStyle); err != nil {
 		return nil, err
 	}
 
@@ -296,6 +310,17 @@ func ResolveLocalEchoStyle(style string) (string, error) {
 	}
 }
 
+func ResolveStatusStyle(style string) (string, error) {
+	switch style {
+	case "", StatusStyleCompact:
+		return StatusStyleCompact, nil
+	case StatusStylePlain, StatusStylePowerline:
+		return style, nil
+	default:
+		return "", fmt.Errorf(`status_style must be one of "compact", "plain", or "powerline"`)
+	}
+}
+
 func (c *Config) EffectiveLocalEchoMode() string {
 	if c == nil {
 		return "auto"
@@ -314,6 +339,17 @@ func (c *Config) EffectiveLocalEchoStyle() string {
 	style, err := ResolveLocalEchoStyle(c.Client.LocalEchoStyle)
 	if err != nil {
 		return "dim"
+	}
+	return style
+}
+
+func (c *Config) EffectiveStatusStyle() string {
+	if c == nil {
+		return StatusStyleCompact
+	}
+	style, err := ResolveStatusStyle(c.Theme.StatusStyle)
+	if err != nil {
+		return StatusStyleCompact
 	}
 	return style
 }

--- a/internal/config/config_fuzz_test.go
+++ b/internal/config/config_fuzz_test.go
@@ -43,6 +43,8 @@ address = "builder.example"
 		[]byte("[client]\nlocal_echo = \"always\"\nlocal_echo_style = \"underline\"\n"),
 		[]byte("[client]\nlocal_echo = \"maybe\"\n"),
 		[]byte("[client]\nlocal_echo_style = \"flashy\"\n"),
+		[]byte("[theme]\nstatus_style = \"powerline\"\n"),
+		[]byte("[theme]\nstatus_style = \"fancy\"\n"),
 		[]byte("[transport]\npreference = [\" ssh \", \"\", \"ssh\", \"mosh\"]\n"),
 		[]byte("scrollback_lines = 0\n"),
 		[]byte("[hosts.local]\nscrollback_lines = 0\n"),
@@ -87,6 +89,9 @@ func assertParsedConfigValid(t *testing.T, cfg *Config) {
 	}
 	if _, err := ResolveLocalEchoStyle(cfg.Client.LocalEchoStyle); err != nil {
 		t.Fatalf("local_echo_style did not validate after parse: %v", err)
+	}
+	if _, err := ResolveStatusStyle(cfg.Theme.StatusStyle); err != nil {
+		t.Fatalf("status_style did not validate after parse: %v", err)
 	}
 
 	preferences := cfg.TransportPreferences()

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -383,6 +383,11 @@ func TestEffectiveStatusStyleDefaultsToCompact(t *testing.T) {
 	if got := cfg.EffectiveStatusStyle(); got != "compact" {
 		t.Fatalf("EffectiveStatusStyle() = %q, want compact", got)
 	}
+
+	var nilCfg *Config
+	if got := nilCfg.EffectiveStatusStyle(); got != "compact" {
+		t.Fatalf("nil EffectiveStatusStyle() = %q, want compact", got)
+	}
 }
 
 func TestLoadRejectsInvalidThemeStatusStyle(t *testing.T) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -353,6 +353,57 @@ local_echo_style = "underline"
 	}
 }
 
+func TestLoadThemeStatusStyle(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	content := `
+[theme]
+status_style = "powerline"
+`
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	if got := cfg.EffectiveStatusStyle(); got != "powerline" {
+		t.Fatalf("EffectiveStatusStyle() = %q, want powerline", got)
+	}
+}
+
+func TestEffectiveStatusStyleDefaultsToCompact(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Config{}
+	if got := cfg.EffectiveStatusStyle(); got != "compact" {
+		t.Fatalf("EffectiveStatusStyle() = %q, want compact", got)
+	}
+}
+
+func TestLoadRejectsInvalidThemeStatusStyle(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	content := `
+[theme]
+status_style = "fancy"
+`
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	_, err := Load(path)
+	if err == nil || !strings.Contains(err.Error(), `status_style must be one of "compact", "plain", or "powerline"`) {
+		t.Fatalf("Load() error = %v, want invalid status_style message", err)
+	}
+}
+
 func TestLoadRejectsInvalidClientLocalEcho(t *testing.T) {
 	t.Parallel()
 

--- a/internal/render/compositor.go
+++ b/internal/render/compositor.go
@@ -48,6 +48,7 @@ type Compositor struct {
 	prevCursor        cursorRenderState
 	colorProfile      termenv.Profile
 	iconSet           IconSet
+	statusStyle       string
 }
 
 type cursorRenderState struct {
@@ -77,6 +78,7 @@ func NewCompositor(width, height int, sessionName string) *Compositor {
 		sessionName:  sessionName,
 		colorProfile: defaultColorProfile,
 		iconSet:      DefaultIconSet(),
+		statusStyle:  config.StatusStyleCompact,
 	}
 }
 
@@ -137,6 +139,23 @@ func (c *Compositor) SetIconSet(icons IconSet) {
 // IconSet reports the compositor's current human-facing status glyphs.
 func (c *Compositor) IconSet() IconSet {
 	return normalizeIconSet(c.iconSet)
+}
+
+// SetStatusStyle updates the human-facing status bar preset used by the compositor.
+func (c *Compositor) SetStatusStyle(style string) {
+	style = normalizeStatusStyle(style)
+	if c.statusStyle == style {
+		return
+	}
+	c.statusStyle = style
+	c.prevGrid = nil
+	c.prevGridLayoutKey = ""
+	c.prevCursor = cursorRenderState{}
+}
+
+// StatusStyle reports the compositor's current human-facing status bar preset.
+func (c *Compositor) StatusStyle() string {
+	return normalizeStatusStyle(c.statusStyle)
 }
 
 // LayoutHeight returns the height available for the layout tree
@@ -204,7 +223,7 @@ func (c *Compositor) RenderFullWithOverlayStats(root *mux.LayoutCell, activePane
 		pressed := overlay.IsPanePressed(pid)
 
 		// Per-pane status line
-		renderPaneStatusPressedWithProfileAndIcons(&buf, cell, isActive, pressed, pd, c.colorProfile, c.IconSet())
+		renderPaneStatusPressedWithProfileAndIconsAndStyle(&buf, cell, isActive, pressed, pd, c.colorProfile, c.IconSet(), c.StatusStyle())
 
 		// Pane content (shifted down by status line)
 		c.renderPaneContentWithLayoutHeight(&buf, cell, isActive, pd, layoutHeight)
@@ -229,7 +248,7 @@ func (c *Compositor) RenderFullWithOverlayStats(root *mux.LayoutCell, activePane
 	}
 
 	// Global status bar at bottom
-	renderGlobalBarWithProfile(&buf, c.sessionName, paneCount, c.width, c.height-1, c.windows, overlay.Message, c.now(), c.colorProfile)
+	renderGlobalBarWithProfileAndStyle(&buf, c.sessionName, paneCount, c.width, c.height-1, c.windows, overlay.Message, c.now(), c.colorProfile, c.StatusStyle())
 	if overlay.WindowDropIndicator != nil {
 		renderWindowDropIndicator(&buf, overlay.WindowDropIndicator, c.height-1, c.colorProfile)
 	}

--- a/internal/render/overlay_status_test.go
+++ b/internal/render/overlay_status_test.go
@@ -650,6 +650,40 @@ func TestBuildStatusCellsClipsLongTaskToPaneWidth(t *testing.T) {
 	}
 }
 
+func TestBuildPowerlineStatusCellsClipsLongTaskToPaneWidth(t *testing.T) {
+	t.Parallel()
+
+	const paneWidth = 24
+	cell := mux.NewLeaf(&mux.Pane{ID: 1}, 0, 0, paneWidth, 4)
+	grid := NewScreenGrid(paneWidth+1, 4)
+	grid.Set(paneWidth, 0, ScreenCell{Char: "│", Width: 1})
+	buildStatusCellsPressedWithIconsAndStyle(grid, cell, true, false, &statusPaneData{
+		id:    1,
+		name:  "pane-1",
+		task:  "sync-build-with-a-very-long-name",
+		color: config.TextColorHex,
+	}, DefaultIconSet(), "powerline")
+
+	var row strings.Builder
+	for x := 0; x < paneWidth; x++ {
+		ch := grid.Get(x, 0).Char
+		if ch == "" {
+			ch = " "
+		}
+		row.WriteString(ch)
+	}
+	line := strings.TrimRight(row.String(), " ")
+	if !strings.Contains(line, "sync") {
+		t.Fatalf("status row %q should keep the task prefix", line)
+	}
+	if !strings.Contains(line, "…") {
+		t.Fatalf("status row %q should include an ellipsis when clipped", line)
+	}
+	if got := grid.Get(paneWidth, 0).Char; got != "│" {
+		t.Fatalf("cell past pane edge = %q, want sentinel border", got)
+	}
+}
+
 func TestBuildStatusCellsMarksWideConnStatusRune(t *testing.T) {
 	t.Parallel()
 

--- a/internal/render/overlay_status_test.go
+++ b/internal/render/overlay_status_test.go
@@ -684,6 +684,64 @@ func TestBuildPowerlineStatusCellsClipsLongTaskToPaneWidth(t *testing.T) {
 	}
 }
 
+func TestBuildPowerlineStatusCellsUsesSeparatorColorTransitions(t *testing.T) {
+	t.Parallel()
+
+	const paneWidth = 48
+	cell := mux.NewLeaf(&mux.Pane{ID: 1}, 0, 0, paneWidth, 4)
+	grid := NewScreenGrid(paneWidth, 4)
+	buildStatusCellsPressedWithIconsAndStyle(grid, cell, true, false, &statusPaneData{
+		id:    1,
+		name:  "pane-1",
+		host:  "gpu",
+		task:  "build",
+		color: config.AccentColor(0),
+		trackedPRs: []proto.TrackedPR{
+			{Number: 42},
+		},
+	}, DefaultIconSet(), "powerline")
+
+	separators := powerlineSeparatorCells(grid, paneWidth)
+	if len(separators) < 3 {
+		t.Fatalf("powerline status row has %d separators, want at least 3", len(separators))
+	}
+
+	assertCellColors(t, separators[0], config.AccentColor(0), config.Surface1Hex)
+	assertCellColors(t, separators[1], config.Surface1Hex, config.GreenHex)
+	assertCellColors(t, separators[2], config.GreenHex, config.Surface1Hex)
+}
+
+func powerlineSeparatorCells(grid *ScreenGrid, width int) []ScreenCell {
+	var cells []ScreenCell
+	for x := 0; x < width; x++ {
+		cell := grid.Get(x, 0)
+		if cell.Char == powerlineRightSeparator {
+			cells = append(cells, cell)
+		}
+	}
+	return cells
+}
+
+func assertCellColors(t *testing.T, cell ScreenCell, wantFgHex, wantBgHex string) {
+	t.Helper()
+
+	wantFg := hexToColor(wantFgHex)
+	gotFg, ok := cell.Style.Fg.(interface {
+		RGBA() (uint32, uint32, uint32, uint32)
+	})
+	if !ok || !sameColor(gotFg, wantFg) {
+		t.Fatalf("separator fg = %v, want %s", cell.Style.Fg, wantFgHex)
+	}
+
+	wantBg := hexToColor(wantBgHex)
+	gotBg, ok := cell.Style.Bg.(interface {
+		RGBA() (uint32, uint32, uint32, uint32)
+	})
+	if !ok || !sameColor(gotBg, wantBg) {
+		t.Fatalf("separator bg = %v, want %s", cell.Style.Bg, wantBgHex)
+	}
+}
+
 func TestBuildStatusCellsMarksWideConnStatusRune(t *testing.T) {
 	t.Parallel()
 

--- a/internal/render/overlay_status_test.go
+++ b/internal/render/overlay_status_test.go
@@ -711,6 +711,161 @@ func TestBuildPowerlineStatusCellsUsesSeparatorColorTransitions(t *testing.T) {
 	assertCellColors(t, separators[2], config.GreenHex, config.Surface1Hex)
 }
 
+func TestRenderPaneStatusPowerlineFullANSI(t *testing.T) {
+	t.Parallel()
+
+	cell := mux.NewLeaf(&mux.Pane{ID: 1}, 0, 0, 64, 4)
+	buf := strings.Builder{}
+	renderPaneStatusPressedWithProfileAndIconsAndStyle(&buf, cell, true, true, &statusPaneData{
+		id:    1,
+		name:  "pane-1",
+		host:  "gpu",
+		task:  "build",
+		color: config.AccentColor(0),
+		trackedIssues: []proto.TrackedIssue{
+			{ID: "LAB-1651"},
+		},
+	}, defaultColorProfile, DefaultIconSet(), config.StatusStylePowerline)
+
+	raw := buf.String()
+	if !strings.Contains(raw, powerlineRightSeparator) {
+		t.Fatalf("raw status output missing powerline separator:\n%q", raw)
+	}
+	if !strings.Contains(raw, bgHexSequence(config.Surface1Hex, defaultColorProfile)) {
+		t.Fatalf("pressed powerline status should use pressed background in ANSI:\n%q", raw)
+	}
+
+	line := MaterializeGrid(raw, cell.W, 1)
+	for _, want := range []string{"[pane-1]", "LAB-1651", "@gpu", "build", powerlineRightSeparator} {
+		if !strings.Contains(line, want) {
+			t.Fatalf("powerline status line %q missing %q", line, want)
+		}
+	}
+}
+
+func TestBuildPowerlineStatusCellsStylesCompletedMetadata(t *testing.T) {
+	t.Parallel()
+
+	cell := mux.NewLeaf(&mux.Pane{ID: 1}, 0, 0, 64, 4)
+	grid := NewScreenGrid(64, 4)
+	buildStatusCellsPressedWithIconsAndStyle(grid, cell, true, false, &statusPaneData{
+		id:   1,
+		name: "pane-1",
+		trackedPRs: []proto.TrackedPR{
+			{Number: 42, Status: proto.TrackedStatusCompleted},
+			{Number: 314, Status: proto.TrackedStatusActive},
+		},
+		trackedIssues: []proto.TrackedIssue{
+			{ID: "LAB-450", Status: proto.TrackedStatusCompleted},
+		},
+		color: config.TextColorHex,
+	}, DefaultIconSet(), config.StatusStylePowerline)
+
+	for _, token := range []string{"#42", "LAB-450"} {
+		start := findRowLabel(grid, 0, cell.W, token)
+		if start < 0 {
+			t.Fatalf("status row %q missing %q", gridRowText(grid, 0, cell.W), token)
+		}
+		for offset := 0; offset < len([]rune(token)); offset++ {
+			if grid.Get(start+offset, 0).Style.Attrs&uv.AttrStrikethrough == 0 {
+				t.Fatalf("cell %q at x=%d should be strikethrough", token, start+offset)
+			}
+		}
+	}
+
+	start := findRowLabel(grid, 0, cell.W, "#314")
+	if start < 0 {
+		t.Fatalf("status row %q missing %q", gridRowText(grid, 0, cell.W), "#314")
+	}
+	for offset := 0; offset < len("#314"); offset++ {
+		if grid.Get(start+offset, 0).Style.Attrs&uv.AttrStrikethrough != 0 {
+			t.Fatalf("active metadata cell at x=%d should not be strikethrough", start+offset)
+		}
+	}
+}
+
+func TestPowerlineStatusHelpers(t *testing.T) {
+	t.Parallel()
+
+	if got := normalizeStatusStyle("made-up"); got != config.StatusStyleCompact {
+		t.Fatalf("normalizeStatusStyle invalid = %q, want compact", got)
+	}
+	if got := statusBarBaseBgHex(true); got != config.Surface1Hex {
+		t.Fatalf("statusBarBaseBgHex(true) = %q, want %q", got, config.Surface1Hex)
+	}
+	if got := alternatePowerlineBgHex(config.Surface1Hex); got != config.Surface0Hex {
+		t.Fatalf("alternatePowerlineBgHex(surface1) = %q, want %q", got, config.Surface0Hex)
+	}
+
+	segments := []paneStatusSegment{
+		{text: " ", role: paneStatusSegmentBackground},
+		{text: "name", role: paneStatusSegmentPaneBold},
+		{text: " ", role: paneStatusSegmentBackground},
+		{text: "", role: paneStatusSegmentText},
+	}
+	if _, ok := previousVisiblePaneStatusRole(segments, 0); ok {
+		t.Fatal("first segment should not have a previous visible role")
+	}
+	if got, ok := nextVisiblePaneStatusRole(segments, 0); !ok || got != paneStatusSegmentPaneBold {
+		t.Fatalf("next role = (%v, %v), want pane bold", got, ok)
+	}
+	if _, ok := nextVisiblePaneStatusRole(segments, len(segments)-1); ok {
+		t.Fatal("last segment should not have a next visible role")
+	}
+	if got, ok := lastVisiblePaneStatusRole(segments); !ok || got != paneStatusSegmentPaneBold {
+		t.Fatalf("last role = (%v, %v), want pane bold", got, ok)
+	}
+	if _, ok := lastVisiblePaneStatusRole([]paneStatusSegment{{text: " ", role: paneStatusSegmentBackground}}); ok {
+		t.Fatal("background-only segments should not have a visible role")
+	}
+
+	for _, tt := range []struct {
+		role paneStatusSegmentRole
+		want string
+	}{
+		{role: paneStatusSegmentDim, want: config.DimColorHex},
+		{role: paneStatusSegmentYellow, want: config.YellowHex},
+		{role: paneStatusSegmentRed, want: config.RedHex},
+		{role: paneStatusSegmentBackground, want: config.Surface0Hex},
+	} {
+		if got := panePowerlineRoleBgHex(tt.role, config.BlueHex, config.Surface0Hex); got != tt.want {
+			t.Fatalf("panePowerlineRoleBgHex(%v) = %q, want %q", tt.role, got, tt.want)
+		}
+	}
+
+	cells := appendStyledStatusCells(nil, "⚡", statusCellStyle{fgHex: config.GreenHex, bgHex: config.Surface0Hex})
+	if len(cells) != 2 || cells[0].width != 2 || cells[1].width != 0 {
+		t.Fatalf("wide status cells = %+v, want visible cell and continuation", cells)
+	}
+	cells = append(cells, styledStatusCell{char: "skip", width: 0})
+	var buf strings.Builder
+	writeStyledStatusCellsWithProfile(&buf, cells, defaultColorProfile)
+	if strings.Contains(buf.String(), "skip") {
+		t.Fatalf("width-zero status cell should not be written: %q", buf.String())
+	}
+
+	ansiStyle := statusCellStyleANSIWithProfile(statusCellStyle{
+		fgHex:         config.TextColorHex,
+		bgHex:         config.Surface0Hex,
+		bold:          true,
+		strikethrough: true,
+	}, defaultColorProfile)
+	for _, want := range []string{Bold, StrikeOn} {
+		if !strings.Contains(ansiStyle, want) {
+			t.Fatalf("status style ANSI %q missing %q", ansiStyle, want)
+		}
+	}
+
+	narrow := buildPowerlinePaneStatusCells(2, true, false, &statusPaneData{
+		id:    1,
+		name:  "pane-1",
+		color: config.TextColorHex,
+	}, DefaultIconSet())
+	if len(narrow) != 2 {
+		t.Fatalf("narrow powerline cells len = %d, want 2", len(narrow))
+	}
+}
+
 func powerlineSeparatorCells(grid *ScreenGrid, width int) []ScreenCell {
 	var cells []ScreenCell
 	for x := 0; x < width; x++ {
@@ -740,6 +895,18 @@ func assertCellColors(t *testing.T, cell ScreenCell, wantFgHex, wantBgHex string
 	if !ok || !sameColor(gotBg, wantBg) {
 		t.Fatalf("separator bg = %v, want %s", cell.Style.Bg, wantBgHex)
 	}
+}
+
+func gridRowText(grid *ScreenGrid, y, width int) string {
+	var row strings.Builder
+	for x := 0; x < width; x++ {
+		ch := grid.Get(x, y).Char
+		if ch == "" {
+			ch = " "
+		}
+		row.WriteString(ch)
+	}
+	return row.String()
 }
 
 func TestBuildStatusCellsMarksWideConnStatusRune(t *testing.T) {
@@ -921,6 +1088,96 @@ func TestBuildGlobalBarCellsColorsActiveTab(t *testing.T) {
 		if !ok || !sameColor(got, wantInactive) {
 			t.Fatalf("inactive tab cell %q should use the default text color", cell.Char)
 		}
+	}
+}
+
+func TestBuildGlobalBarCellsPowerline(t *testing.T) {
+	t.Parallel()
+
+	const width = 64
+	grid := NewScreenGrid(width, 2)
+	buildGlobalBarCellsWithStyle(grid, "session", 3, width, 1, []WindowInfo{
+		{Index: 1, Name: "editor", IsActive: true},
+		{Index: 2, Name: "logs", IsActive: false},
+	}, "", time.Date(2025, 1, 1, 12, 34, 0, 0, time.UTC), config.StatusStylePowerline)
+
+	row := gridRowText(grid, 1, width)
+	for _, want := range []string{"amux", powerlineRightSeparator, "1:editor", "2:logs", powerlineLeftSeparator, "? help", "12:34"} {
+		if !strings.Contains(row, want) {
+			t.Fatalf("powerline global bar row %q missing %q", row, want)
+		}
+	}
+
+	titleEnd := findRowLabel(grid, 1, width, powerlineRightSeparator)
+	if titleEnd < 0 {
+		t.Fatalf("powerline global bar row %q missing title separator", row)
+	}
+	assertCellColors(t, grid.Get(titleEnd, 1), config.BlueHex, config.Surface0Hex)
+}
+
+func TestRenderGlobalBarPowerlineFullANSI(t *testing.T) {
+	t.Parallel()
+
+	var buf strings.Builder
+	renderGlobalBarWithProfileAndStyle(&buf, "session", 2, 42, 0, nil, "error details that must truncate", time.Date(2025, 1, 1, 12, 34, 0, 0, time.UTC), defaultColorProfile, config.StatusStylePowerline)
+
+	raw := buf.String()
+	if !strings.Contains(raw, powerlineRightSeparator) {
+		t.Fatalf("raw global bar output missing powerline separator:\n%q", raw)
+	}
+	if !strings.Contains(raw, fgHexSequence(config.RedHex, defaultColorProfile)) {
+		t.Fatalf("message powerline global bar should use error foreground:\n%q", raw)
+	}
+
+	line := MaterializeGrid(raw, 42, 1)
+	for _, want := range []string{"amux", "session", "error details"} {
+		if !strings.Contains(line, want) {
+			t.Fatalf("powerline global bar line %q missing %q", line, want)
+		}
+	}
+}
+
+func TestCompositorSetStatusStyleInvalidatesGrid(t *testing.T) {
+	t.Parallel()
+
+	comp := NewCompositor(20, 6, "status")
+	root := mux.NewLeaf(&mux.Pane{ID: 1}, 0, 0, 20, 5)
+	lookup := func(uint32) PaneData {
+		return &statusPaneData{id: 1, name: "pane-1", color: config.TextColorHex}
+	}
+
+	comp.RenderDiff(root, 1, lookup)
+	if comp.LastGrid() == nil {
+		t.Fatal("RenderDiff should populate prevGrid")
+	}
+	comp.SetStatusStyle(config.StatusStyleCompact)
+	if comp.LastGrid() == nil {
+		t.Fatal("setting the current status style should keep prevGrid")
+	}
+
+	comp.SetStatusStyle(config.StatusStylePowerline)
+	if got := comp.StatusStyle(); got != config.StatusStylePowerline {
+		t.Fatalf("StatusStyle() = %q, want %q", got, config.StatusStylePowerline)
+	}
+	if comp.LastGrid() != nil {
+		t.Fatal("changing status style should invalidate prevGrid")
+	}
+
+	comp.RenderDiff(root, 1, lookup)
+	if comp.LastGrid() == nil {
+		t.Fatal("RenderDiff should repopulate prevGrid")
+	}
+	comp.SetStatusStyle(config.StatusStylePowerline)
+	if comp.LastGrid() == nil {
+		t.Fatal("setting the unchanged powerline status style should keep prevGrid")
+	}
+
+	comp.SetStatusStyle("invalid")
+	if got := comp.StatusStyle(); got != config.StatusStyleCompact {
+		t.Fatalf("invalid status style should normalize to compact, got %q", got)
+	}
+	if comp.LastGrid() != nil {
+		t.Fatal("normalizing to a different status style should invalidate prevGrid")
 	}
 }
 

--- a/internal/render/screen.go
+++ b/internal/render/screen.go
@@ -288,7 +288,7 @@ func (c *Compositor) buildGridWithOverlay(root *mux.LayoutCell, activePaneID uin
 	}
 
 	// Global bar cells.
-	buildGlobalBarCells(g, c.sessionName, paneCount, c.width, c.height-1, c.windows, overlay.Message, c.now())
+	buildGlobalBarCellsWithStyle(g, c.sessionName, paneCount, c.width, c.height-1, c.windows, overlay.Message, c.now(), c.StatusStyle())
 	buildWindowDropIndicatorCell(g, overlay.WindowDropIndicator, c.height-1)
 	if overlay.HelpBar != nil {
 		buildHelpBarCells(g, overlay.HelpBar)
@@ -314,7 +314,7 @@ type paneComposite struct {
 }
 
 func (c *Compositor) composePane(g *ScreenGrid, layoutHeight int, pane paneComposite) {
-	buildStatusCellsPressedWithIcons(g, pane.cell, pane.isActive, pane.pressed, pane.pd, c.IconSet())
+	buildStatusCellsPressedWithIconsAndStyle(g, pane.cell, pane.isActive, pane.pressed, pane.pd, c.IconSet(), c.StatusStyle())
 	contentH := c.visibleContentHeightForLayoutHeight(pane.cell, layoutHeight)
 	// Rebuild every row for both full redraws and dirty panes. TUI full-screen
 	// recomposes can move or clear lines without producing a pane-local dirty
@@ -399,7 +399,7 @@ func (c *Compositor) buildGridWithOverlayDirty(
 		buildPaneOverlayCells(g, root, lookup, overlay.PaneLabels)
 	}
 
-	buildGlobalBarCells(g, c.sessionName, paneCount, c.width, c.height-1, c.windows, overlay.Message, c.now())
+	buildGlobalBarCellsWithStyle(g, c.sessionName, paneCount, c.width, c.height-1, c.windows, overlay.Message, c.now(), c.StatusStyle())
 	buildWindowDropIndicatorCell(g, overlay.WindowDropIndicator, c.height-1)
 	if overlay.HelpBar != nil {
 		buildHelpBarCells(g, overlay.HelpBar)
@@ -671,6 +671,18 @@ func buildStatusCellsPressed(g *ScreenGrid, cell *mux.LayoutCell, isActive, pres
 }
 
 func buildStatusCellsPressedWithIcons(g *ScreenGrid, cell *mux.LayoutCell, isActive, pressed bool, pd PaneData, icons IconSet) {
+	buildStatusCellsPressedWithIconsAndStyle(g, cell, isActive, pressed, pd, icons, config.StatusStyleCompact)
+}
+
+func buildStatusCellsPressedWithIconsAndStyle(g *ScreenGrid, cell *mux.LayoutCell, isActive, pressed bool, pd PaneData, icons IconSet, statusStyle string) {
+	if normalizeStatusStyle(statusStyle) == config.StatusStylePowerline {
+		cells := buildPowerlinePaneStatusCells(cell.W, isActive, pressed, pd, icons)
+		for i := 0; i < cell.W; i++ {
+			g.Set(cell.X+i, cell.Y, screenCellFromStyledStatusCell(cells[i]))
+		}
+		return
+	}
+
 	y := cell.Y
 	bgHex := config.Surface0Hex
 	if pressed {
@@ -693,6 +705,20 @@ func buildStatusCellsPressedWithIcons(g *ScreenGrid, cell *mux.LayoutCell, isAct
 		}
 		g.Set(cell.X+i, y, sc)
 	}
+}
+
+func screenCellFromStyledStatusCell(cell styledStatusCell) ScreenCell {
+	style := uv.Style{
+		Fg: hexToColor(cell.style.fgHex),
+		Bg: hexToColor(cell.style.bgHex),
+	}
+	if cell.style.bold {
+		style.Attrs |= uv.AttrBold
+	}
+	if cell.style.strikethrough {
+		style.Attrs |= uv.AttrStrikethrough
+	}
+	return ScreenCell{Char: cell.char, Width: cell.width, Style: style}
 }
 
 // buildBorderCells writes border characters into the grid with proper colors.
@@ -722,6 +748,18 @@ func buildBorderCells(g *ScreenGrid, bm *borderMap, activePaneID uint32, activeC
 
 // buildGlobalBarCells writes the global status bar into the grid.
 func buildGlobalBarCells(g *ScreenGrid, sessionName string, paneCount int, width, yPos int, windows []WindowInfo, message string, now time.Time) {
+	buildGlobalBarCellsWithStyle(g, sessionName, paneCount, width, yPos, windows, message, now, config.StatusStyleCompact)
+}
+
+func buildGlobalBarCellsWithStyle(g *ScreenGrid, sessionName string, paneCount int, width, yPos int, windows []WindowInfo, message string, now time.Time, statusStyle string) {
+	if normalizeStatusStyle(statusStyle) == config.StatusStylePowerline {
+		cells := buildPowerlineGlobalBarCells(sessionName, paneCount, width, windows, message, now)
+		for i := 0; i < width && i < len(cells); i++ {
+			g.Set(i, yPos, screenCellFromStyledStatusCell(cells[i]))
+		}
+		return
+	}
+
 	bg := hexToColor(config.Surface0Hex)
 	textFg := hexToColor(config.TextColorHex)
 	redFg := hexToColor(config.RedHex)

--- a/internal/render/statusbar.go
+++ b/internal/render/statusbar.go
@@ -8,6 +8,7 @@ import (
 	"unicode"
 	"unicode/utf8"
 
+	"github.com/charmbracelet/x/ansi"
 	"github.com/mattn/go-runewidth"
 	"github.com/muesli/termenv"
 	"github.com/weill-labs/amux/internal/config"
@@ -22,6 +23,24 @@ const (
 	globalBarTitlePrefixVisibleWidth = 8 // " amux │ "
 	globalBarHelpVisibleWidth        = 6 // "? help"
 )
+
+const (
+	powerlineRightSeparator = "\ue0b0" // Nerd Font Powerline right-pointing solid separator.
+	powerlineLeftSeparator  = "\ue0b2" // Nerd Font Powerline left-pointing solid separator.
+)
+
+type statusCellStyle struct {
+	fgHex         string
+	bgHex         string
+	bold          bool
+	strikethrough bool
+}
+
+type styledStatusCell struct {
+	char  string
+	width int
+	style statusCellStyle
+}
 
 type globalBarWindowTab struct {
 	window  WindowInfo
@@ -78,6 +97,79 @@ func appendPaneStatusSegment(segments []paneStatusSegment, text string, role pan
 		return segments
 	}
 	return append(segments, paneStatusSegment{text: text, role: role})
+}
+
+func normalizeStatusStyle(style string) string {
+	resolved, err := config.ResolveStatusStyle(style)
+	if err != nil {
+		return config.StatusStyleCompact
+	}
+	return resolved
+}
+
+func statusBarBaseBgHex(pressed bool) string {
+	if pressed {
+		return config.Surface1Hex
+	}
+	return config.Surface0Hex
+}
+
+func alternatePowerlineBgHex(baseBg string) string {
+	if baseBg == config.Surface0Hex {
+		return config.Surface1Hex
+	}
+	return config.Surface0Hex
+}
+
+func appendStyledStatusCells(cells []styledStatusCell, text string, style statusCellStyle) []styledStatusCell {
+	for len(text) > 0 {
+		cluster, clusterWidth := ansi.FirstGraphemeCluster(text, ansi.GraphemeWidth)
+		if cluster == "" {
+			break
+		}
+		if clusterWidth <= 0 {
+			clusterWidth = 1
+		}
+		cells = append(cells, styledStatusCell{char: cluster, width: clusterWidth, style: style})
+		for i := 1; i < clusterWidth; i++ {
+			cells = append(cells, styledStatusCell{char: " ", width: 0, style: style})
+		}
+		text = text[len(cluster):]
+	}
+	return cells
+}
+
+func appendSingleWidthStatusCell(cells []styledStatusCell, char string, style statusCellStyle) []styledStatusCell {
+	return append(cells, styledStatusCell{char: char, width: 1, style: style})
+}
+
+func writeStyledStatusCellsWithProfile(buf *strings.Builder, cells []styledStatusCell, profile termenv.Profile) {
+	for _, cell := range cells {
+		if cell.width == 0 {
+			continue
+		}
+		buf.WriteString(statusCellStyleANSIWithProfile(cell.style, profile))
+		buf.WriteString(cell.char)
+	}
+	buf.WriteString(Reset)
+}
+
+func statusCellStyleANSIWithProfile(style statusCellStyle, profile termenv.Profile) string {
+	var buf strings.Builder
+	buf.WriteString(Reset)
+	if style.bgHex != "" {
+		buf.WriteString(bgHexSequence(style.bgHex, profile))
+	}
+	if style.fgHex != "" {
+		buf.WriteString(fgHexSequence(style.fgHex, profile))
+	}
+	if style.bold {
+		buf.WriteString(Bold)
+	}
+	if style.strikethrough {
+		buf.WriteString(StrikeOn)
+	}
+	return buf.String()
 }
 
 func buildPaneStatusSegmentsWithIcons(cellWidth int, isActive bool, pd PaneData, icons IconSet) []paneStatusSegment {
@@ -231,6 +323,123 @@ func trimPaneStatusSegmentsRight(segments []paneStatusSegment) []paneStatusSegme
 	return segments
 }
 
+func buildPowerlinePaneStatusCells(cellWidth int, isActive, pressed bool, pd PaneData, icons IconSet) []styledStatusCell {
+	baseBg := statusBarBaseBgHex(pressed)
+	paneColor := paneStatusColorHex(pd)
+	segments := buildPaneStatusSegmentsWithIcons(cellWidth, isActive, pd, icons)
+	cells := make([]styledStatusCell, 0, cellWidth)
+
+	for i, segment := range segments {
+		if isPowerlinePaneSeparatorSegment(segment) {
+			prevRole, prevOK := previousVisiblePaneStatusRole(segments, i)
+			nextRole, nextOK := nextVisiblePaneStatusRole(segments, i)
+			if prevOK && nextOK {
+				prevBg := panePowerlineRoleBgHex(prevRole, paneColor, baseBg)
+				nextBg := panePowerlineRoleBgHex(nextRole, paneColor, baseBg)
+				if prevBg != nextBg {
+					cells = appendSingleWidthStatusCell(cells, powerlineRightSeparator, statusCellStyle{
+						fgHex: prevBg,
+						bgHex: nextBg,
+					})
+					continue
+				}
+				cells = appendStyledStatusCells(cells, segment.text, panePowerlineRoleStyle(nextRole, paneColor, baseBg))
+				continue
+			}
+		}
+
+		cells = appendStyledStatusCells(cells, segment.text, panePowerlineRoleStyle(segment.role, paneColor, baseBg))
+	}
+
+	used := len(cells)
+	if used < cellWidth {
+		if lastRole, ok := lastVisiblePaneStatusRole(segments); ok {
+			lastBg := panePowerlineRoleBgHex(lastRole, paneColor, baseBg)
+			if lastBg != baseBg {
+				cells = appendSingleWidthStatusCell(cells, powerlineRightSeparator, statusCellStyle{
+					fgHex: lastBg,
+					bgHex: baseBg,
+				})
+				used++
+			}
+		}
+	}
+	for len(cells) < cellWidth {
+		cells = appendSingleWidthStatusCell(cells, " ", statusCellStyle{bgHex: baseBg})
+	}
+	if len(cells) > cellWidth {
+		return cells[:cellWidth]
+	}
+	return cells
+}
+
+func isPowerlinePaneSeparatorSegment(segment paneStatusSegment) bool {
+	return segment.role == paneStatusSegmentBackground && strings.TrimSpace(segment.text) == ""
+}
+
+func previousVisiblePaneStatusRole(segments []paneStatusSegment, index int) (paneStatusSegmentRole, bool) {
+	for i := index - 1; i >= 0; i-- {
+		if segments[i].text == "" || segments[i].role == paneStatusSegmentBackground {
+			continue
+		}
+		return segments[i].role, true
+	}
+	return paneStatusSegmentBackground, false
+}
+
+func nextVisiblePaneStatusRole(segments []paneStatusSegment, index int) (paneStatusSegmentRole, bool) {
+	for i := index + 1; i < len(segments); i++ {
+		if segments[i].text == "" || segments[i].role == paneStatusSegmentBackground {
+			continue
+		}
+		return segments[i].role, true
+	}
+	return paneStatusSegmentBackground, false
+}
+
+func lastVisiblePaneStatusRole(segments []paneStatusSegment) (paneStatusSegmentRole, bool) {
+	for i := len(segments) - 1; i >= 0; i-- {
+		if segments[i].text == "" || segments[i].role == paneStatusSegmentBackground {
+			continue
+		}
+		return segments[i].role, true
+	}
+	return paneStatusSegmentBackground, false
+}
+
+func panePowerlineRoleBgHex(role paneStatusSegmentRole, paneColor, baseBg string) string {
+	switch role {
+	case paneStatusSegmentPane, paneStatusSegmentPaneBold:
+		return paneColor
+	case paneStatusSegmentDim, paneStatusSegmentCompletedMeta:
+		return config.DimColorHex
+	case paneStatusSegmentText:
+		return alternatePowerlineBgHex(baseBg)
+	case paneStatusSegmentYellow:
+		return config.YellowHex
+	case paneStatusSegmentGreen:
+		return config.GreenHex
+	case paneStatusSegmentRed:
+		return config.RedHex
+	default:
+		return baseBg
+	}
+}
+
+func panePowerlineRoleStyle(role paneStatusSegmentRole, paneColor, baseBg string) statusCellStyle {
+	bg := panePowerlineRoleBgHex(role, paneColor, baseBg)
+	fg := config.Surface0Hex
+	if role == paneStatusSegmentText || bg == baseBg {
+		fg = config.TextColorHex
+	}
+	return statusCellStyle{
+		fgHex:         fg,
+		bgHex:         bg,
+		bold:          role == paneStatusSegmentPaneBold,
+		strikethrough: role == paneStatusSegmentCompletedMeta,
+	}
+}
+
 // renderPaneStatus draws a per-pane status line at the top of a pane cell.
 // Format: ● [name] @host task
 //
@@ -251,7 +460,16 @@ func renderPaneStatusPressedWithProfile(buf *strings.Builder, cell *mux.LayoutCe
 }
 
 func renderPaneStatusPressedWithProfileAndIcons(buf *strings.Builder, cell *mux.LayoutCell, isActive, pressed bool, pd PaneData, profile termenv.Profile, icons IconSet) {
+	renderPaneStatusPressedWithProfileAndIconsAndStyle(buf, cell, isActive, pressed, pd, profile, icons, config.StatusStyleCompact)
+}
+
+func renderPaneStatusPressedWithProfileAndIconsAndStyle(buf *strings.Builder, cell *mux.LayoutCell, isActive, pressed bool, pd PaneData, profile termenv.Profile, icons IconSet, statusStyle string) {
 	writeCursorTo(buf, cell.Y+1, cell.X+1)
+
+	if normalizeStatusStyle(statusStyle) == config.StatusStylePowerline {
+		writeStyledStatusCellsWithProfile(buf, buildPowerlinePaneStatusCells(cell.W, isActive, pressed, pd, icons), profile)
+		return
+	}
 
 	styles := newStatusBarStylesPressed(paneStatusColorHex(pd), pressed)
 	segments := buildPaneStatusSegmentsWithIcons(cell.W, isActive, pd, icons)
@@ -531,6 +749,80 @@ func globalBarStatusRightText(paneCount int, showHelp bool, now time.Time) strin
 	return right + now.Format("15:04") + " "
 }
 
+func powerlineGlobalBarStatusRightCells(paneCount int, showHelp bool, now time.Time, baseBg string) []styledStatusCell {
+	helpBg := alternatePowerlineBgHex(baseBg)
+	cells := make([]styledStatusCell, 0, 32)
+	baseStyle := statusCellStyle{fgHex: config.TextColorHex, bgHex: baseBg}
+	helpStyle := statusCellStyle{fgHex: config.TextColorHex, bgHex: helpBg, bold: true}
+
+	cells = appendStyledStatusCells(cells, " "+strconv.Itoa(paneCount)+" panes ", baseStyle)
+	if showHelp {
+		cells = appendSingleWidthStatusCell(cells, powerlineLeftSeparator, statusCellStyle{fgHex: helpBg, bgHex: baseBg})
+		cells = appendStyledStatusCells(cells, " ", helpStyle)
+		cells = appendStyledStatusCells(cells, "? help ", helpStyle)
+		cells = appendSingleWidthStatusCell(cells, powerlineLeftSeparator, statusCellStyle{fgHex: baseBg, bgHex: helpBg})
+		cells = appendStyledStatusCells(cells, " ", baseStyle)
+	} else {
+		cells = appendSingleWidthStatusCell(cells, powerlineLeftSeparator, statusCellStyle{fgHex: baseBg, bgHex: baseBg})
+		cells = appendStyledStatusCells(cells, " ", baseStyle)
+	}
+	cells = appendStyledStatusCells(cells, now.Format("15:04")+" ", baseStyle)
+	return cells
+}
+
+func buildPowerlineGlobalBarCells(sessionName string, paneCount int, width int, windows []WindowInfo, message string, now time.Time) []styledStatusCell {
+	baseBg := config.Surface0Hex
+	titleStyle := statusCellStyle{fgHex: config.Surface0Hex, bgHex: config.BlueHex, bold: true}
+	baseStyle := statusCellStyle{fgHex: config.TextColorHex, bgHex: baseBg}
+	focusedStyle := statusCellStyle{fgHex: config.BlueHex, bgHex: baseBg, bold: true}
+	errorStyle := statusCellStyle{fgHex: config.RedHex, bgHex: baseBg}
+
+	cells := make([]styledStatusCell, 0, width)
+	showHelp := globalBarShowsHelp(width, sessionName, paneCount, windows, message, now)
+	tabs := buildGlobalBarWindowTabs(windows)
+
+	cells = appendStyledStatusCells(cells, " amux ", titleStyle)
+	cells = appendSingleWidthStatusCell(cells, powerlineRightSeparator, statusCellStyle{fgHex: config.BlueHex, bgHex: baseBg})
+	cells = appendStyledStatusCells(cells, " ", baseStyle)
+
+	if len(tabs) > 0 {
+		for _, tab := range tabs {
+			style := baseStyle
+			if tab.window.IsActive {
+				style = focusedStyle
+			}
+			cells = appendStyledStatusCells(cells, tab.display, style)
+			cells = appendStyledStatusCells(cells, " ", baseStyle)
+		}
+		cells = appendSingleWidthStatusCell(cells, powerlineRightSeparator, statusCellStyle{fgHex: baseBg, bgHex: baseBg})
+		cells = appendStyledStatusCells(cells, " ", baseStyle)
+	} else {
+		cells = appendStyledStatusCells(cells, sessionName+" ", baseStyle)
+	}
+
+	var right []styledStatusCell
+	if message != "" {
+		maxText := width - len(cells) - 2
+		right = appendStyledStatusCells(right, " "+truncateRunes(message, maxText)+" ", errorStyle)
+	} else {
+		right = powerlineGlobalBarStatusRightCells(paneCount, showHelp, now, baseBg)
+	}
+
+	fill := width - len(cells) - len(right)
+	for i := 0; i < fill; i++ {
+		cells = appendSingleWidthStatusCell(cells, " ", statusCellStyle{bgHex: baseBg})
+	}
+	cells = append(cells, right...)
+
+	for len(cells) < width {
+		cells = appendSingleWidthStatusCell(cells, " ", statusCellStyle{bgHex: baseBg})
+	}
+	if len(cells) > width {
+		return cells[:width]
+	}
+	return cells
+}
+
 func globalBarStatusRightWidth(paneCount int, showHelp bool, now time.Time) int {
 	return utf8.RuneCountInString(globalBarStatusRightText(paneCount, showHelp, now))
 }
@@ -622,7 +914,16 @@ func renderGlobalBar(buf *strings.Builder, sessionName string, paneCount int, wi
 }
 
 func renderGlobalBarWithProfile(buf *strings.Builder, sessionName string, paneCount int, width, yPos int, windows []WindowInfo, message string, now time.Time, profile termenv.Profile) {
+	renderGlobalBarWithProfileAndStyle(buf, sessionName, paneCount, width, yPos, windows, message, now, profile, config.StatusStyleCompact)
+}
+
+func renderGlobalBarWithProfileAndStyle(buf *strings.Builder, sessionName string, paneCount int, width, yPos int, windows []WindowInfo, message string, now time.Time, profile termenv.Profile, statusStyle string) {
 	writeCursorTo(buf, yPos+1, 1)
+	if normalizeStatusStyle(statusStyle) == config.StatusStylePowerline {
+		writeStyledStatusCellsWithProfile(buf, buildPowerlineGlobalBarCells(sessionName, paneCount, width, windows, message, now), profile)
+		return
+	}
+
 	styles := newStatusBarStyles(config.TextColorHex)
 
 	showHelp := globalBarShowsHelp(width, sessionName, paneCount, windows, message, now)

--- a/internal/render/statusbar.go
+++ b/internal/render/statusbar.go
@@ -351,8 +351,7 @@ func buildPowerlinePaneStatusCells(cellWidth int, isActive, pressed bool, pd Pan
 		cells = appendStyledStatusCells(cells, segment.text, panePowerlineRoleStyle(segment.role, paneColor, baseBg))
 	}
 
-	used := len(cells)
-	if used < cellWidth {
+	if len(cells) < cellWidth {
 		if lastRole, ok := lastVisiblePaneStatusRole(segments); ok {
 			lastBg := panePowerlineRoleBgHex(lastRole, paneColor, baseBg)
 			if lastBg != baseBg {
@@ -360,7 +359,6 @@ func buildPowerlinePaneStatusCells(cellWidth int, isActive, pressed bool, pd Pan
 					fgHex: lastBg,
 					bgHex: baseBg,
 				})
-				used++
 			}
 		}
 	}

--- a/test/harness_test.go
+++ b/test/harness_test.go
@@ -487,7 +487,8 @@ func extractBorderColors(line string) []string {
 // isGlobalBar returns true if the line looks like the global status bar.
 // Matches the structural pattern: " amux │ ... panes │ HH:MM "
 func isGlobalBar(line string) bool {
-	return strings.Contains(line, " amux ") && strings.Contains(line, "panes │")
+	return strings.Contains(line, " amux ") &&
+		(strings.Contains(line, "panes │") || strings.Contains(line, "panes "))
 }
 
 // hasWindowTab returns true if the global bar contains a tab for the given

--- a/test/status_style_test.go
+++ b/test/status_style_test.go
@@ -1,0 +1,100 @@
+package test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/weill-labs/amux/internal/config"
+	"github.com/weill-labs/amux/internal/mux"
+	"github.com/weill-labs/amux/internal/proto"
+	"github.com/weill-labs/amux/internal/render"
+)
+
+type statusStylePaneData struct {
+	id            uint32
+	name          string
+	color         string
+	trackedPRs    []proto.TrackedPR
+	trackedIssues []proto.TrackedIssue
+	host          string
+	task          string
+}
+
+func (p *statusStylePaneData) RenderScreen(bool) string { return "" }
+func (p *statusStylePaneData) CellAt(int, int, bool) render.ScreenCell {
+	return render.ScreenCell{Char: " ", Width: 1}
+}
+func (p *statusStylePaneData) CopyModeOverlay() *proto.ViewportOverlay { return nil }
+func (p *statusStylePaneData) CursorPos() (int, int)                   { return 0, 0 }
+func (p *statusStylePaneData) CursorHidden() bool                      { return true }
+func (p *statusStylePaneData) HasCursorBlock() bool                    { return false }
+func (p *statusStylePaneData) ID() uint32                              { return p.id }
+func (p *statusStylePaneData) Name() string                            { return p.name }
+func (p *statusStylePaneData) TrackedPRs() []proto.TrackedPR           { return p.trackedPRs }
+func (p *statusStylePaneData) TrackedIssues() []proto.TrackedIssue     { return p.trackedIssues }
+func (p *statusStylePaneData) Issue() string                           { return "" }
+func (p *statusStylePaneData) Host() string                            { return p.host }
+func (p *statusStylePaneData) Task() string                            { return p.task }
+func (p *statusStylePaneData) Color() string                           { return p.color }
+func (p *statusStylePaneData) Idle() bool                              { return false }
+func (p *statusStylePaneData) IsLead() bool                            { return false }
+func (p *statusStylePaneData) ConnStatus() string                      { return "" }
+func (p *statusStylePaneData) InCopyMode() bool                        { return false }
+func (p *statusStylePaneData) CopyModeSearch() string                  { return "" }
+
+func TestStatusStyleGoldenOutputs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		style  string
+		golden string
+	}{
+		{name: "compact", style: "compact", golden: "status_style_compact.golden"},
+		{name: "powerline", style: "powerline", golden: "status_style_powerline.golden"},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			assertGolden(t, tt.golden, renderStatusStyleFrame(tt.style))
+		})
+	}
+}
+
+func renderStatusStyleFrame(style string) string {
+	const (
+		width        = 48
+		totalHeight  = 5
+		layoutHeight = totalHeight - render.GlobalBarHeight
+		sessionName  = "style"
+	)
+
+	root := mux.NewLeafByID(1, 0, 0, width, layoutHeight)
+	pane := &statusStylePaneData{
+		id:    1,
+		name:  "pane-1",
+		color: config.AccentColor(0),
+		trackedPRs: []proto.TrackedPR{
+			{Number: 42},
+		},
+		trackedIssues: []proto.TrackedIssue{
+			{ID: "LAB-1651"},
+		},
+		host: "gpu",
+		task: "build",
+	}
+
+	comp := render.NewCompositor(width, totalHeight, sessionName)
+	comp.SetStatusStyle(style)
+	comp.TimeNow = func() time.Time { return time.Date(2026, 5, 7, 12, 34, 0, 0, time.UTC) }
+	raw := comp.RenderFullWithOverlay(root, 1, func(id uint32) render.PaneData {
+		if id == 1 {
+			return pane
+		}
+		return nil
+	}, render.OverlayState{}, true)
+	return extractFrame(render.MaterializeGrid(raw, width, totalHeight), sessionName)
+}

--- a/test/status_style_test.go
+++ b/test/status_style_test.go
@@ -59,7 +59,7 @@ func TestStatusStyleGoldenOutputs(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			assertGolden(t, tt.golden, renderStatusStyleFrame(tt.style))
+			assertGolden(t, tt.golden, renderStatusStyleFrame(tt.style)+"\n")
 		})
 	}
 }

--- a/test/testdata/status_style_compact.golden
+++ b/test/testdata/status_style_compact.golden
@@ -1,0 +1,5 @@
+● [pane-1] #42, LAB-1651 @gpu build
+
+
+
+ amux │ style          1 panes │ ? help │ 12:34

--- a/test/testdata/status_style_compact.golden
+++ b/test/testdata/status_style_compact.golden
@@ -2,4 +2,4 @@
 
 
 
- amux │ style          1 panes │ ? help │ 12:34
+ amux │ SESSION          1 panes │ ? help │ 00:00

--- a/test/testdata/status_style_powerline.golden
+++ b/test/testdata/status_style_powerline.golden
@@ -1,0 +1,5 @@
+● [pane-1]#42, LAB-1651@gpubuild
+
+
+
+ amux  style          1 panes  ? help  12:34

--- a/test/testdata/status_style_powerline.golden
+++ b/test/testdata/status_style_powerline.golden
@@ -2,4 +2,4 @@
 
 
 
- amux  style          1 panes  ? help  12:34
+ amux  SESSION          1 panes  ? help  00:00


### PR DESCRIPTION
## Motivation

Nerd Font users need an opt-in status style that can render connected Powerline status segments without changing the default compact output. LAB-1649 has not merged and no LAB-1649 PR/remote branch was present when this branch was created, so this PR adds the minimal `[theme]` parser shape needed for `status_style` and leaves icon config consolidation to whichever sibling PR merges second.

## Summary

- Added `[theme] status_style = "compact" # compact | plain | powerline` with `compact` as the default and clear validation for invalid values.
- Routed the effective status style into the client-side compositor without touching server-owned pane metadata or structured capture JSON.
- Added a Powerline renderer for pane and global status bars that uses `U+E0B0` (``) for right-pointing transitions and `U+E0B2` (``) for left-pointing transitions.
- Kept compact output pinned with a golden fixture and added powerline goldens plus clipping, fg/bg transition, full-ANSI, and setter coverage.

## Testing

- `go test ./internal/config -run 'TestLoadThemeStatusStyle|TestEffectiveStatusStyleDefaultsToCompact|TestLoadRejectsInvalidThemeStatusStyle' -count=100`
- `go test ./internal/client -run 'TestClientRendererSetStatusStyleHandlesNilRenderer|TestRendererSetStatusStyleUpdatesCompositor|TestClientRendererSetStatusStyleUpdatesCompositor' -count=100`
- `go test ./internal/render -run 'TestBuildPowerlineStatusCellsClipsLongTaskToPaneWidth|TestBuildPowerlineStatusCellsUsesSeparatorColorTransitions|TestRenderPaneStatusPowerlineFullANSI|TestBuildPowerlineStatusCellsStylesCompletedMetadata|TestPowerlineStatusHelpers|TestBuildGlobalBarCellsPowerline|TestRenderGlobalBarPowerlineFullANSI|TestCompositorSetStatusStyleInvalidatesGrid' -count=100`
- `go test ./test -run TestStatusStyleGoldenOutputs -count=100`
- `go test ./internal/config ./internal/client ./internal/render`
- `go test -coverprofile=/tmp/lab1651-cover.out ./internal/config ./internal/render ./internal/client`
- `go run ./cmd/diffcoverage --base origin/main --module "$(go list -m)" --profile /tmp/lab1651-cover.out --target 70` (96.36% local diff coverage)
- `go test ./... -timeout 120s`
- `scripts/watch-pr-ci.sh 765`

## Review focus

- Check that `compact` preserves current output and `powerline` only changes human rendering, not JSON capture.
- Review the Powerline separator color transitions in `internal/render/statusbar.go`; the selected pair is `U+E0B0`/`U+E0B2` from the Nerd Fonts Powerline range.
- Review the temporary minimal `[theme]` parser shape against LAB-1649; if LAB-1649 lands first, this branch should rebase and consolidate the table fields.

Closes LAB-1651
