### PR TITLE
LAB-1713: Remove powerline pane name brackets

### DIFF
--- a/internal/render/icons.go
+++ b/internal/render/icons.go
@@ -11,6 +11,8 @@ type IconSet struct {
 	PaneLead      string
 	PaneEscalated string
 	PaneStuck     string
+	PaneNameOpen  string
+	PaneNameClose string
 	RemoteHost    string
 	PR            string
 	Issue         string
@@ -49,6 +51,8 @@ func UnicodeIconSet() IconSet {
 		PaneLead:      "▶",
 		PaneEscalated: "◆",
 		PaneStuck:     "◈",
+		PaneNameOpen:  "[",
+		PaneNameClose: "]",
 		RemoteHost:    "@",
 		PR:            "#",
 		Issue:         "",
@@ -69,6 +73,8 @@ func ASCIIIconSet() IconSet {
 		PaneLead:      ">",
 		PaneEscalated: "!",
 		PaneStuck:     "x",
+		PaneNameOpen:  "[",
+		PaneNameClose: "]",
 		RemoteHost:    "@",
 		PR:            "#",
 		Issue:         "I",
@@ -89,6 +95,8 @@ func NerdFontIconSet() IconSet {
 		PaneLead:      "\ueb59",
 		PaneEscalated: "\uea6c",
 		PaneStuck:     "\ueaaf",
+		PaneNameOpen:  "[",
+		PaneNameClose: "]",
 		RemoteHost:    "\ueb50",
 		PR:            "\uf407",
 		Issue:         "\uf41b",

--- a/internal/render/icons_test.go
+++ b/internal/render/icons_test.go
@@ -83,6 +83,8 @@ func TestCompositorUsesConfiguredIconSetForPaneStatus(t *testing.T) {
 		PaneLead:      "L",
 		PaneEscalated: "E",
 		PaneStuck:     "S",
+		PaneNameOpen:  "{",
+		PaneNameClose: "}",
 		RemoteHost:    "R",
 		PR:            "P",
 		Issue:         "J",
@@ -119,7 +121,7 @@ func TestCompositorUsesConfiguredIconSetForPaneStatus(t *testing.T) {
 func assertStatusUsesSentinelIcons(t *testing.T, rendered string) {
 	t.Helper()
 
-	for _, want := range []string{"A", "C /query", "P42", "JLAB-1647", "Rgpu", "Z", "T task"} {
+	for _, want := range []string{"A", "{pane-1}", "C /query", "P42", "JLAB-1647", "Rgpu", "Z", "T task"} {
 		if !strings.Contains(rendered, want) {
 			t.Fatalf("rendered status missing %q:\n%s", want, rendered)
 		}
@@ -135,12 +137,14 @@ func TestNerdFontIconSetUsesPublishedGlyphs(t *testing.T) {
 	t.Parallel()
 
 	want := IconSet{
-		PaneIdle:      "\uebb5",     // nf-cod-circle_large
-		PaneActive:    "\uebb4",     // nf-cod-circle_large_filled
-		PaneBusy:      "\ueb31",     // nf-cod-pulse
-		PaneLead:      "\ueb59",     // nf-cod-star_full
-		PaneEscalated: "\uea6c",     // nf-cod-warning
-		PaneStuck:     "\ueaaf",     // nf-cod-bug
+		PaneIdle:      "\uebb5", // nf-cod-circle_large
+		PaneActive:    "\uebb4", // nf-cod-circle_large_filled
+		PaneBusy:      "\ueb31", // nf-cod-pulse
+		PaneLead:      "\ueb59", // nf-cod-star_full
+		PaneEscalated: "\uea6c", // nf-cod-warning
+		PaneStuck:     "\ueaaf", // nf-cod-bug
+		PaneNameOpen:  "[",
+		PaneNameClose: "]",
 		RemoteHost:    "\ueb50",     // nf-cod-server
 		PR:            "\uf407",     // nf-oct-git_pull_request
 		Issue:         "\uf41b",     // nf-oct-issue_opened
@@ -268,6 +272,8 @@ func TestIconSetPresetsAndHelpers(t *testing.T) {
 		"PaneLead":      ascii.PaneLead,
 		"PaneEscalated": ascii.PaneEscalated,
 		"PaneStuck":     ascii.PaneStuck,
+		"PaneNameOpen":  ascii.PaneNameOpen,
+		"PaneNameClose": ascii.PaneNameClose,
 		"RemoteHost":    ascii.RemoteHost,
 		"PR":            ascii.PR,
 		"Issue":         ascii.Issue,

--- a/internal/render/icons_test.go
+++ b/internal/render/icons_test.go
@@ -126,7 +126,7 @@ func assertStatusUsesSentinelIcons(t *testing.T, rendered string) {
 			t.Fatalf("rendered status missing %q:\n%s", want, rendered)
 		}
 	}
-	for _, old := range []string{"●", "[copy]", "#42", "@gpu", "⚡", "Z task"} {
+	for _, old := range []string{"●", "[pane-1]", "[copy]", "#42", "@gpu", "⚡", "Z task"} {
 		if strings.Contains(rendered, old) {
 			t.Fatalf("rendered status still contains old glyph %q:\n%s", old, rendered)
 		}

--- a/internal/render/overlay_status_test.go
+++ b/internal/render/overlay_status_test.go
@@ -736,7 +736,13 @@ func TestRenderPaneStatusPowerlineFullANSI(t *testing.T) {
 	}
 
 	line := MaterializeGrid(raw, cell.W, 1)
-	for _, want := range []string{"[pane-1]", "LAB-1651", "@gpu", "build", powerlineRightSeparator} {
+	if !strings.Contains(line, "pane-1") {
+		t.Fatalf("powerline status line %q missing pane name", line)
+	}
+	if strings.Contains(line, "[pane-1]") {
+		t.Fatalf("powerline status line should omit pane name brackets: %q", line)
+	}
+	for _, want := range []string{"LAB-1651", "@gpu", "build", powerlineRightSeparator} {
 		if !strings.Contains(line, want) {
 			t.Fatalf("powerline status line %q missing %q", line, want)
 		}

--- a/internal/render/statusbar.go
+++ b/internal/render/statusbar.go
@@ -175,6 +175,7 @@ func statusCellStyleANSIWithProfile(style statusCellStyle, profile termenv.Profi
 func buildPaneStatusSegmentsWithIcons(cellWidth int, isActive bool, pd PaneData, icons IconSet) []paneStatusSegment {
 	icons = normalizeIconSet(icons)
 	idle := !isActive && pd.Idle()
+	paneName := paneStatusNameText(pd.Name(), icons)
 
 	segments := make([]paneStatusSegment, 0, 16)
 
@@ -195,11 +196,11 @@ func buildPaneStatusSegmentsWithIcons(cellWidth int, isActive bool, pd PaneData,
 
 	switch {
 	case isActive:
-		segments = appendPaneStatusSegment(segments, "["+pd.Name()+"]", paneStatusSegmentPaneBold)
+		segments = appendPaneStatusSegment(segments, paneName, paneStatusSegmentPaneBold)
 	case idle:
-		segments = appendPaneStatusSegment(segments, "["+pd.Name()+"]", paneStatusSegmentDim)
+		segments = appendPaneStatusSegment(segments, paneName, paneStatusSegmentDim)
 	default:
-		segments = appendPaneStatusSegment(segments, "["+pd.Name()+"]", paneStatusSegmentText)
+		segments = appendPaneStatusSegment(segments, paneName, paneStatusSegmentText)
 	}
 
 	if pd.IsLead() {
@@ -326,6 +327,7 @@ func trimPaneStatusSegmentsRight(segments []paneStatusSegment) []paneStatusSegme
 func buildPowerlinePaneStatusCells(cellWidth int, isActive, pressed bool, pd PaneData, icons IconSet) []styledStatusCell {
 	baseBg := statusBarBaseBgHex(pressed)
 	paneColor := paneStatusColorHex(pd)
+	icons = powerlinePaneStatusIcons(icons)
 	segments := buildPaneStatusSegmentsWithIcons(cellWidth, isActive, pd, icons)
 	cells := make([]styledStatusCell, 0, cellWidth)
 
@@ -653,9 +655,21 @@ func paneStatusTaskText(task string, icons IconSet) string {
 	return icons.Task + " " + task
 }
 
+func paneStatusNameText(name string, icons IconSet) string {
+	icons = normalizeIconSet(icons)
+	return icons.PaneNameOpen + name + icons.PaneNameClose
+}
+
+func powerlinePaneStatusIcons(icons IconSet) IconSet {
+	icons = normalizeIconSet(icons)
+	icons.PaneNameOpen = ""
+	icons.PaneNameClose = ""
+	return icons
+}
+
 func paneStatusUsedWidthWithoutMetadataWithIcons(isActive bool, pd PaneData, icons IconSet) int {
 	icons = normalizeIconSet(icons)
-	usedWidth := runewidth.StringWidth(paneStatusStateIcon(isActive, pd, icons)) + 1 + runewidth.StringWidth(pd.Name()) + 2 // "● [name]"
+	usedWidth := runewidth.StringWidth(paneStatusStateIcon(isActive, pd, icons)) + 1 + runewidth.StringWidth(paneStatusNameText(pd.Name(), icons))
 	if pd.IsLead() {
 		usedWidth += 7 // " [lead]"
 	}

--- a/internal/render/statusbar.go
+++ b/internal/render/statusbar.go
@@ -656,7 +656,6 @@ func paneStatusTaskText(task string, icons IconSet) string {
 }
 
 func paneStatusNameText(name string, icons IconSet) string {
-	icons = normalizeIconSet(icons)
 	return icons.PaneNameOpen + name + icons.PaneNameClose
 }
 

--- a/test/golden_test.go
+++ b/test/golden_test.go
@@ -99,7 +99,10 @@ func normalizeIdleIcon(line string) string {
 
 // isStatusLine returns true if the line contains a pane status indicator.
 func isStatusLine(line string) bool {
-	return strings.Contains(line, "[pane-") || strings.Contains(line, "[w-LAB-")
+	return strings.Contains(line, "[pane-") ||
+		strings.Contains(line, " pane-") ||
+		strings.Contains(line, "[w-LAB-") ||
+		strings.Contains(line, " w-LAB-")
 }
 
 var timeRe = regexp.MustCompile(`\d{2}:\d{2}`)

--- a/test/testdata/status_style_powerline.golden
+++ b/test/testdata/status_style_powerline.golden
@@ -1,4 +1,4 @@
-● [pane-1]#42, LAB-1651@gpubuild
+● pane-1#42, LAB-1651@gpubuild
 
 
 


### PR DESCRIPTION
## Motivation

The powerline status style already uses angled separators and colored fills to delimit status segments. Rendering pane names as `[pane-1]` in that style adds redundant punctuation, while the default compact style still needs the brackets for visual framing.

## Summary

- Added pane-name frame glyphs to `IconSet`, with the existing default presets keeping `[` and `]`.
- Derived powerline pane status rendering from the configured icon set with an empty pane-name frame.
- Updated the powerline status golden and assertions to require `pane-1` without `[pane-1]`.

## Testing

- `go test ./internal/render -run 'TestRenderPaneStatusPowerlineFullANSI|TestCompositorUsesConfiguredIconSetForPaneStatus|TestNerdFontIconSetUsesPublishedGlyphs|TestIconSetPresetsAndHelpers' -count=100`
- `go test ./test -run 'TestStatusStyleGoldenOutputs' -count=100`
- `go test ./internal/render -run 'TestRenderPaneStatusPowerlineFullANSI|TestCompositorUsesConfiguredIconSetForPaneStatus|TestNerdFontIconSetUsesPublishedGlyphs|TestIconSetPresetsAndHelpers' -count=1`
- `go test ./test -run 'TestStatusStyleGoldenOutputs/(compact|powerline)' -count=1`
- `go test ./internal/mux -run TestAgentStatusTreatsPromptTimeBashSelfForkAsIdle -count=1`
- `go test ./test -run 'TestRespawnPreservesPaneMetadataAndCwdWhileResettingState|TestMouseDragAutomaticallyEntersCopyModeAndCopiesSelection|TestMouseCommandDragAutomaticallyCopiesSelection' -count=1 -timeout 120s`
- `go test ./test -run TestSplitWithinWindow -count=1 -timeout 120s`

Attempted `go test ./... -timeout 120s`; local runs were blocked by unrelated integration flakes/timeouts and one `./test` TestMain build timeout while other long-running Go builds were active on the machine. The isolated failed tests listed above passed on rerun.

## Review focus

- Confirm the powerline-specific icon derivation only removes pane-name framing and does not alter configured state/metadata glyphs.
- Confirm compact/default status output remains bracketed; the compact golden was included in the repeated status-style slice.

Closes LAB-1713
