### PR TITLE
LAB-1632: Prevent resize smear after pane shrink

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -49,4 +49,4 @@ require (
 
 replace github.com/charmbracelet/ultraviolet => github.com/weill-labs/ultraviolet v0.0.0-20260404003102-9344cbfc286f
 
-replace github.com/charmbracelet/x/vt => github.com/weill-labs/x/vt v0.0.0-20260409063800-46c695d9bc39
+replace github.com/charmbracelet/x/vt => github.com/weill-labs/x/vt v0.0.0-20260507075017-67eb13d58575

--- a/go.sum
+++ b/go.sum
@@ -72,8 +72,8 @@ github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcU
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/weill-labs/ultraviolet v0.0.0-20260404003102-9344cbfc286f h1:JMTFuQ/08wrGci+AIUA67OuIMHtJaF369KhWwBel6/g=
 github.com/weill-labs/ultraviolet v0.0.0-20260404003102-9344cbfc286f/go.mod h1:Vo8TffMf0q7Uho/n8e6XpBZvOWtd3g39yX+9P5rRutA=
-github.com/weill-labs/x/vt v0.0.0-20260409063800-46c695d9bc39 h1:VYiGYuJPdJMNJ8ksHsXjBVEnFDPUqcSOlgaU8nOKyGU=
-github.com/weill-labs/x/vt v0.0.0-20260409063800-46c695d9bc39/go.mod h1:2djWW5EeP5QlpztEYYbbyyzUyyxVD71mWVQguNISHcM=
+github.com/weill-labs/x/vt v0.0.0-20260507075017-67eb13d58575 h1:8AouhVTd5q9WW7gyti4txCP06El5GeRCD623mUHlRBU=
+github.com/weill-labs/x/vt v0.0.0-20260507075017-67eb13d58575/go.mod h1:2djWW5EeP5QlpztEYYbbyyzUyyxVD71mWVQguNISHcM=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJuqunuUZ/Dhy/avygyECGrLceyNeo4LiM=
 golang.org/x/crypto v0.49.0 h1:+Ng2ULVvLHnJ/ZFEq4KdcDd/cfjrrjjNSXNzxg0Y4U4=

--- a/internal/mux/emulator.go
+++ b/internal/mux/emulator.go
@@ -496,6 +496,9 @@ func lineUsesFullWidthValue(width int, cell uv.Cell, ok bool) bool {
 }
 
 func cellUsesFullWidth(cell uv.Cell) bool {
+	if cell.Equal(&uv.EmptyCell) {
+		return false
+	}
 	if cell.Width == 0 {
 		return true
 	}

--- a/internal/mux/resize_smear_test.go
+++ b/internal/mux/resize_smear_test.go
@@ -1,0 +1,50 @@
+package mux
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestVTEmulatorResizeShrinkThenWidenKeepsDenseRowsSeparate(t *testing.T) {
+	t.Parallel()
+
+	const (
+		width       = 214
+		shrinkWidth = 80
+		height      = 12
+	)
+	emu := NewVTEmulatorWithDrain(width, height)
+	lines := make([]string, 0, 5)
+	for i := 1; i <= 5; i++ {
+		line := resizeSmearReproLine(i, width)
+		lines = append(lines, line)
+		mustWrite(t, emu, []byte(line+"\r\n"))
+	}
+
+	before := EmulatorContentLines(emu)
+	for i, want := range lines {
+		if got := before[i]; got != want {
+			t.Fatalf("before resize row %d = %q, want %q", i, got, want)
+		}
+	}
+
+	emu.Resize(shrinkWidth, height)
+	emu.Resize(width, height)
+
+	after := EmulatorContentLines(emu)
+	for i := range lines {
+		got := after[i]
+		marker := fmt.Sprintf("LINE_%d_BEGIN_", i+1)
+		if !strings.HasPrefix(got, marker) || strings.Count(got, "LINE_") != 1 {
+			t.Fatalf("after shrink/widen row %d = %q, want separate row beginning %q", i, got, marker)
+		}
+	}
+}
+
+func resizeSmearReproLine(i, width int) string {
+	letter := string(rune('A' + i - 1))
+	prefix := fmt.Sprintf("LINE_%d_BEGIN_", i)
+	suffix := fmt.Sprintf("_END_%d", i)
+	return prefix + strings.Repeat(letter, width-len(prefix)-len(suffix)) + suffix
+}


### PR DESCRIPTION
## Motivation

Pane shrink/widen cycles could leave visible rows smeared together when the vt reflow heuristic misread clipped dense rows as soft-wrap continuations. LAB-1632 traced this to the forked vt package, so this PR pins amux to the vt fix and adds amux-side coverage at the `vtEmulator.Resize` boundary.

## Summary

- Add an amux regression test that writes five dense 214-column rows, shrinks to 80 columns, widens back, and asserts the rows remain separate.
- Pin `github.com/charmbracelet/x/vt` to `github.com/weill-labs/x/vt v0.0.0-20260507075017-67eb13d58575`.
- Align amux's full-width cell helper with the vt fix by treating `uv.EmptyCell` as an empty right edge.

Mitigation choice: I chose option 3, snapshot-and-clear on shrink. For amux's usage, avoiding persistent visual smear after pane resizing is more important than preserving every clipped active-row tail in place, and this option keeps direct widening reflow for legitimate soft wraps instead of disabling merge globally. The vt fix snapshots rows that lose content into main-screen scrollback, clears the new right edge so later widen reflow sees clean rows, and avoids write-time bookkeeping that belongs in the long-term soft-wrap-bit refactor.

Underlying vt fix: weill-labs/x#12, commit `67eb13d58575470f2b4af3c9f9debc9e196027b9`.

Follow-up: `LAB-1728` tracks the durable per-line soft-wrap bit refactor so this PR stays limited to the short-term mitigation.

## Testing

- In `/home/cweill/github/weill-labs/x/vt`: `go test -run TestResizeShrinkThenWidenKeepsDenseRowsSeparate -count=100`
- In `/home/cweill/github/weill-labs/x/vt`: `go test ./...`
- `go test ./internal/mux -run TestVTEmulatorResizeShrinkThenWidenKeepsDenseRowsSeparate -count=100`
- `go test ./internal/mux -count=1`
- `go test ./... -timeout 120s`

## Review focus

Review the dependency pin plus `internal/mux/emulator.go`'s empty-cell handling against the vt behavior. The main tradeoff is the option 3 scrollback semantics on shrink: clipped non-empty rows are snapshotted to vt scrollback, while empty rows are ignored to avoid spurious history entries.

Closes LAB-1632
