### PR TITLE
LAB-1645: Make client capture non-blocking

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,9 @@ amux -s my-project
 # Inspect the current session
 amux capture --format json
 
+# Inspect what the attached client last rendered
+amux capture --client
+
 # Capture the full browsable buffer for one pane
 amux capture --history pane-1
 
@@ -169,6 +172,13 @@ Pane JSON includes a nested `meta` object for pane metadata, including the raw k
 `cursor.style` is one of `block`, `underline`, or `bar`. `terminal.palette` is the pane's effective 256-color ANSI palette in stable index order, encoded as lowercase hex without `#`. `terminal.hyperlink` is present when OSC 8 hyperlink state is active at the cursor. Capture JSON is additive: agents should ignore unknown fields so future releases can extend the schema without breaking existing parsers.
 
 For full-session JSON capture, `amux capture --history --format json` prepends each pane's retained scrollback to that pane's `content` array so agents can read the full pane buffer from one field.
+
+Client display capture reads the attached client's last rendered frame:
+
+```bash
+amux capture --client
+amux capture --client pane-1
+```
 
 Capture a single pane:
 
@@ -332,6 +342,7 @@ Higher-level prompt delegation now lives at the script layer: compose `wait idle
 | Command | Description |
 |---------|-------------|
 | `amux capture [pane]` | Capture screen output (text) |
+| `amux capture --client [pane]` | Capture the attached client's displayed screen |
 | `amux capture --history <pane>` | Capture retained scrollback plus visible screen |
 | `amux capture --history --rewrap <width> <pane>` | Best-effort rewrap retained history and visible content to a wider width |
 | `amux capture --format json [pane]` | Structured JSON capture |

--- a/internal/capture/capture.go
+++ b/internal/capture/capture.go
@@ -16,6 +16,7 @@ type Request struct {
 	ColorMap        bool
 	FormatJSON      bool
 	DisplayMode     bool
+	ClientMode      bool
 	HistoryMode     bool
 	RewrapSpecified bool
 	RewrapRaw       string
@@ -35,6 +36,8 @@ func ParseArgs(args []string) Request {
 			req.ColorMap = true
 		case "--display":
 			req.DisplayMode = true
+		case "--client":
+			req.ClientMode = true
 		case "--history":
 			req.HistoryMode = true
 		case "--rewrap":
@@ -72,6 +75,9 @@ func ArgsForRequest(req Request) []string {
 	if req.DisplayMode {
 		args = append(args, "--display")
 	}
+	if req.ClientMode {
+		args = append(args, "--client")
+	}
 	if req.HistoryMode {
 		args = append(args, "--history")
 	}
@@ -97,8 +103,11 @@ func ValidateScreenRequest(req Request) error {
 		(req.ColorMap && req.FormatJSON) {
 		return fmt.Errorf("--ansi, --colors, and --format json are mutually exclusive")
 	}
-	if req.DisplayMode && (req.IncludeANSI || req.ColorMap || req.FormatJSON || req.HistoryMode || req.PaneRef != "") {
+	if req.DisplayMode && (req.IncludeANSI || req.ColorMap || req.FormatJSON || req.ClientMode || req.HistoryMode || req.PaneRef != "") {
 		return fmt.Errorf("--display is mutually exclusive with other flags")
+	}
+	if req.ClientMode && (req.IncludeANSI || req.ColorMap || req.FormatJSON || req.HistoryMode) {
+		return fmt.Errorf("--client is mutually exclusive with --ansi, --colors, --format json, and --history")
 	}
 	if req.RewrapSpecified {
 		return fmt.Errorf("--rewrap requires --history")
@@ -110,6 +119,9 @@ func ValidateScreenRequest(req Request) error {
 func ValidateHistoryRequest(req Request) error {
 	if !req.HistoryMode {
 		return fmt.Errorf("internal error: captureHistory called without --history")
+	}
+	if req.ClientMode {
+		return fmt.Errorf("--history is mutually exclusive with --client")
 	}
 	if req.IncludeANSI || req.ColorMap || req.DisplayMode {
 		return fmt.Errorf("--history is mutually exclusive with --ansi, --colors, and --display")

--- a/internal/capture/capture_fuzz_test.go
+++ b/internal/capture/capture_fuzz_test.go
@@ -27,6 +27,9 @@ func FuzzParseArgs(f *testing.F) {
 		"--history\x00--rewrap\x0080\x00--rewrap\x00pane-3",
 		"--rewrap",
 		"--rewrap\x0080\x00--rewrap",
+		"--client",
+		"--client\x00pane-1",
+		"--client\x00--format\x00json",
 		"--display",
 		"--display\x00pane-1",
 		"--ansi\x00--colors",
@@ -103,6 +106,9 @@ func assertCaptureValidationResult(t *testing.T, req Request) (error, error) {
 		if req.DisplayMode && (req.IncludeANSI || req.ColorMap || req.FormatJSON || req.HistoryMode || req.PaneRef != "") {
 			t.Fatalf("display request with other options validated: %+v", req)
 		}
+		if req.ClientMode && (req.IncludeANSI || req.ColorMap || req.FormatJSON || req.HistoryMode) {
+			t.Fatalf("client request with incompatible options validated: %+v", req)
+		}
 		if req.RewrapSpecified {
 			t.Fatalf("screen request with --rewrap validated without --history: %+v", req)
 		}
@@ -116,7 +122,7 @@ func assertCaptureValidationResult(t *testing.T, req Request) (error, error) {
 		if !req.HistoryMode || req.PaneRef == "" {
 			t.Fatalf("history request without required fields validated: %+v", req)
 		}
-		if req.IncludeANSI || req.ColorMap || req.DisplayMode {
+		if req.IncludeANSI || req.ColorMap || req.DisplayMode || req.ClientMode {
 			t.Fatalf("history request with mutually exclusive flags validated: %+v", req)
 		}
 		if req.RewrapSpecified && req.RewrapWidth <= 0 {

--- a/internal/capture/capture_fuzz_test.go
+++ b/internal/capture/capture_fuzz_test.go
@@ -30,6 +30,7 @@ func FuzzParseArgs(f *testing.F) {
 		"--client",
 		"--client\x00pane-1",
 		"--client\x00--format\x00json",
+		"--display\x00--client",
 		"--display",
 		"--display\x00pane-1",
 		"--ansi\x00--colors",
@@ -103,10 +104,10 @@ func assertCaptureValidationResult(t *testing.T, req Request) (error, error) {
 		if req.ColorMap && req.FormatJSON {
 			t.Fatalf("screen request with mutually exclusive color/json modes validated: %+v", req)
 		}
-		if req.DisplayMode && (req.IncludeANSI || req.ColorMap || req.FormatJSON || req.HistoryMode || req.PaneRef != "") {
+		if req.DisplayMode && (req.IncludeANSI || req.ColorMap || req.FormatJSON || req.ClientMode || req.HistoryMode || req.PaneRef != "") {
 			t.Fatalf("display request with other options validated: %+v", req)
 		}
-		if req.ClientMode && (req.IncludeANSI || req.ColorMap || req.FormatJSON || req.HistoryMode) {
+		if req.ClientMode && (req.IncludeANSI || req.ColorMap || req.FormatJSON || req.DisplayMode || req.HistoryMode) {
 			t.Fatalf("client request with incompatible options validated: %+v", req)
 		}
 		if req.RewrapSpecified {

--- a/internal/capture/capture_test.go
+++ b/internal/capture/capture_test.go
@@ -47,6 +47,11 @@ func TestParseArgs(t *testing.T) {
 			args: []string{"--display"},
 			want: Request{DisplayMode: true},
 		},
+		{
+			name: "client",
+			args: []string{"--client", "pane-1"},
+			want: Request{ClientMode: true, PaneRef: "pane-1"},
+		},
 	}
 
 	for _, tt := range tests {
@@ -91,6 +96,15 @@ func TestValidateScreenRequest(t *testing.T) {
 			name:    "display with history",
 			req:     Request{DisplayMode: true, HistoryMode: true},
 			wantErr: "--display is mutually exclusive with other flags",
+		},
+		{
+			name:    "client with json",
+			req:     Request{ClientMode: true, FormatJSON: true},
+			wantErr: "--client is mutually exclusive with --ansi, --colors, --format json, and --history",
+		},
+		{
+			name: "client with pane",
+			req:  Request{ClientMode: true, PaneRef: "pane-1"},
 		},
 	}
 
@@ -137,6 +151,11 @@ func TestValidateHistoryRequest(t *testing.T) {
 			name:    "ansi not allowed",
 			req:     Request{HistoryMode: true, IncludeANSI: true, PaneRef: "pane-1"},
 			wantErr: "--history is mutually exclusive with --ansi, --colors, and --display",
+		},
+		{
+			name:    "client not allowed",
+			req:     Request{HistoryMode: true, ClientMode: true, PaneRef: "pane-1"},
+			wantErr: "--history is mutually exclusive with --client",
 		},
 		{
 			name:    "missing pane ref",

--- a/internal/cli/cli_commands_layout.go
+++ b/internal/cli/cli_commands_layout.go
@@ -26,6 +26,10 @@ func layoutCLICommands() map[string]commandHandler {
 			return inv.runSessionCommand(cmdName, cmdArgs)
 		},
 		"capture": func(inv invocation, args []string) int {
+			if hasHelpFlag(args) {
+				fmt.Fprintln(inv.runtime.Stdout, captureUsage)
+				return 0
+			}
 			return inv.runSessionCommand("capture", args)
 		},
 		"copy-mode": func(inv invocation, args []string) int {

--- a/internal/cli/cli_parse.go
+++ b/internal/cli/cli_parse.go
@@ -32,7 +32,7 @@ type sessionCommandSpec struct {
 var canonicalSessionCommands = map[string]sessionCommandSpec{
 	"_inject-proxy": {connectName: "_inject-proxy", argMode: sessionCommandForwardArgs},
 	"_layout-json":  {connectName: "_layout-json", argMode: sessionCommandNoArgs},
-	"capture":       {connectName: "capture", argMode: sessionCommandForwardArgs},
+	"capture":       {connectName: "capture", usage: captureUsage, argMode: sessionCommandForwardArgs},
 	"connect":       {connectName: "connect", minArgs: 1, usage: connectUsage, argMode: sessionCommandForwardArgs},
 	"copy-mode":     {connectName: "copy-mode", argMode: sessionCommandForwardArgs},
 	"cursor":        {connectName: "cursor", minArgs: 1, usage: cursorUsage, argMode: sessionCommandForwardArgs},

--- a/internal/cli/cli_usage.go
+++ b/internal/cli/cli_usage.go
@@ -9,6 +9,7 @@ import (
 const (
 	sendKeysUsage     = "usage: amux send-keys <pane> [--via pty|client] [--client <id>] [--wait ready|ui=input-idle] [--timeout <duration>] [--delay-final <duration>] [--hex] <keys>..."
 	mouseUsage        = "usage: amux mouse [--client <id>] [--timeout <duration>] (press <x> <y> | motion <x> <y> | release <x> <y> | click <x> <y> | click <pane> [--status-line] | drag <pane> --to <pane>)"
+	captureUsage      = "usage: amux capture [--client] [pane] [--history <pane>] [--ansi] [--colors]"
 	logUsage          = "usage: amux log <clients|panes>"
 	debugUsage        = "usage: amux debug <goroutines|profile|heap|socket|frames|client-goroutines|client-profile|client-heap> [--duration <duration>]"
 	leadUsage         = "usage: amux lead [pane] | amux lead --clear"
@@ -48,7 +49,7 @@ var commandUsageByName = map[string]string{
 	"_layout-json":     "usage: amux _layout-json",
 	"_server":          "usage: amux _server [session]",
 	"broadcast":        "usage: amux broadcast (--panes <pane,pane,...> | --window <index|name> | --match <glob>) [--hex] <keys>...",
-	"capture":          "usage: amux capture [pane] [--history <pane>] [--ansi] [--colors]",
+	"capture":          captureUsage,
 	"copy-mode":        "usage: amux copy-mode [pane] [--wait ui=copy-mode-shown] [--timeout <duration>]",
 	"cursor":           cursorUsage,
 	"connect":          connectUsage,
@@ -164,6 +165,8 @@ Usage:
   amux [-s session] debug client-heap  Print a live heap profile summary from the latest attached client pprof endpoint
   amux doctor fonts                    Print icon and Powerline font diagnostics
   amux [-s session] capture            Capture full composited screen
+  amux [-s session] capture --client [pane]
+                                       Capture the attached client's displayed screen
   amux [-s session] capture --history --format json
                                        Capture full-session JSON with per-pane scrollback prepended to content
   amux [-s session] capture <pane>     Capture a single pane's output

--- a/internal/cli/main_usage_test.go
+++ b/internal/cli/main_usage_test.go
@@ -90,6 +90,21 @@ func TestMainWaitUsage(t *testing.T) {
 	}
 }
 
+func TestMainCaptureHelpIncludesClientFlag(t *testing.T) {
+	t.Parallel()
+
+	out, code := runHermeticMain(t, "capture", "--help")
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0\n%s", code, out)
+	}
+	if !strings.Contains(out, "--client") {
+		t.Fatalf("capture help should include --client:\n%s", out)
+	}
+	if strings.Contains(out, "connecting to server") {
+		t.Fatalf("capture help should not dispatch to the server:\n%s", out)
+	}
+}
+
 func TestMainMetaCommandsHelpFlagsPrintUsage(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cli/main_usage_test.go
+++ b/internal/cli/main_usage_test.go
@@ -105,6 +105,22 @@ func TestMainCaptureHelpIncludesClientFlag(t *testing.T) {
 	}
 }
 
+func TestRunWithRuntimeCaptureHelpPrintsUsageWithoutServer(t *testing.T) {
+	t.Parallel()
+
+	h := newCLIRuntimeHarness()
+	handler := layoutCLICommands()["capture"]
+	if code := handler(invocation{runtime: h.runtime()}, []string{"--help"}); code != 0 {
+		t.Fatalf("capture handler help exit = %d, want 0", code)
+	}
+	if !strings.Contains(h.stdout.String(), "--client") {
+		t.Fatalf("stdout should include --client:\n%s", h.stdout.String())
+	}
+	if len(h.calls) != 0 {
+		t.Fatalf("capture --help should not call runtime, got %#v", h.calls)
+	}
+}
+
 func TestMainMetaCommandsHelpFlagsPrintUsage(t *testing.T) {
 	t.Parallel()
 

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -937,7 +937,7 @@ func (cr *ClientRenderer) HandleCaptureRequest(args []string, agentStatus map[ui
 		return clientFrameStatsResponse(cr.frameStats)
 	}
 	req := caputil.ParseArgs(args)
-	if !req.FormatJSON || req.IncludeANSI || req.ColorMap || req.DisplayMode {
+	if !req.FormatJSON || req.IncludeANSI || req.ColorMap || req.DisplayMode || req.ClientMode {
 		return cr.renderer.HandleCaptureRequest(args, agentStatus)
 	}
 	if req.PaneRef != "" {

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -2017,6 +2017,11 @@ func TestDisplayPanesOverlayDisplayOnly(t *testing.T) {
 		t.Fatalf("--display should include overlay labels, got:\n%s", resp.CmdOutput)
 	}
 
+	resp = cr.HandleCaptureRequest([]string{"--client"}, nil)
+	if !strings.Contains(resp.CmdOutput, "[1]") {
+		t.Fatalf("--client should include overlay labels from the display snapshot, got:\n%s", resp.CmdOutput)
+	}
+
 	resp = cr.HandleCaptureRequest([]string{}, nil)
 	if strings.Contains(resp.CmdOutput, "[1]") || strings.Contains(resp.CmdOutput, "[2]") {
 		t.Fatalf("plain capture request should not include overlay labels, got:\n%s", resp.CmdOutput)
@@ -2612,6 +2617,22 @@ func TestHandleCaptureRequest_DisplayFlag(t *testing.T) {
 		t.Errorf("--display should contain pane status, got: %q", resp.CmdOutput)
 	}
 
+	resp = cr.HandleCaptureRequest([]string{"--client"}, nil)
+	if resp.CmdErr != "" {
+		t.Errorf("--client error: %s", resp.CmdErr)
+	}
+	if !strings.Contains(resp.CmdOutput, "pane-1") {
+		t.Errorf("--client should contain pane status, got: %q", resp.CmdOutput)
+	}
+
+	resp = cr.HandleCaptureRequest([]string{"--client", "pane-1"}, nil)
+	if resp.CmdErr != "" {
+		t.Errorf("--client pane error: %s", resp.CmdErr)
+	}
+	if !strings.Contains(resp.CmdOutput, "hello from pane 1") {
+		t.Errorf("--client pane should contain pane content from display snapshot, got: %q", resp.CmdOutput)
+	}
+
 	// --display is mutually exclusive with other flags.
 	for _, args := range [][]string{
 		{"--display", "--ansi"},
@@ -2622,6 +2643,18 @@ func TestHandleCaptureRequest_DisplayFlag(t *testing.T) {
 		resp = cr.HandleCaptureRequest(args, nil)
 		if resp.CmdErr == "" {
 			t.Errorf("--display with %v should error", args[1:])
+		}
+	}
+
+	for _, args := range [][]string{
+		{"--client", "--ansi"},
+		{"--client", "--colors"},
+		{"--client", "--format", "json"},
+		{"--client", "--history", "pane-1"},
+	} {
+		resp = cr.HandleCaptureRequest(args, nil)
+		if resp.CmdErr == "" {
+			t.Errorf("--client with %v should error", args[1:])
 		}
 	}
 }

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -2606,6 +2606,13 @@ func TestHandleCaptureRequest_DisplayFlag(t *testing.T) {
 	if !strings.Contains(resp.CmdOutput, "no previous grid") {
 		t.Errorf("--display before render should show fallback, got: %q", resp.CmdOutput)
 	}
+	resp = cr.HandleCaptureRequest([]string{"--client"}, nil)
+	if resp.CmdErr != "" {
+		t.Errorf("--client before render error: %s", resp.CmdErr)
+	}
+	if !strings.Contains(resp.CmdOutput, "no previous grid") {
+		t.Errorf("--client before render should show fallback, got: %q", resp.CmdOutput)
+	}
 
 	// After a diff render, --display returns grid content.
 	cr.RenderDiff()
@@ -2631,6 +2638,10 @@ func TestHandleCaptureRequest_DisplayFlag(t *testing.T) {
 	}
 	if !strings.Contains(resp.CmdOutput, "hello from pane 1") {
 		t.Errorf("--client pane should contain pane content from display snapshot, got: %q", resp.CmdOutput)
+	}
+	resp = cr.HandleCaptureRequest([]string{"--client", "nope"}, nil)
+	if resp.CmdErr == "" || !strings.Contains(resp.CmdErr, `pane "nope" not found`) {
+		t.Errorf("--client missing pane error = %q, want pane not found", resp.CmdErr)
 	}
 
 	// --display is mutually exclusive with other flags.

--- a/internal/client/renderer.go
+++ b/internal/client/renderer.go
@@ -397,9 +397,6 @@ func (r *Renderer) CaptureDisplayPane(paneID uint32) string {
 		return ""
 	}
 	root, _ := snap.captureRoot(snap.height - render.GlobalBarHeight)
-	if root == nil {
-		return ""
-	}
 	cell := root.FindByPaneID(paneID)
 	if cell == nil {
 		return ""

--- a/internal/client/renderer.go
+++ b/internal/client/renderer.go
@@ -22,6 +22,7 @@ import (
 type Renderer struct {
 	state           atomic.Pointer[rendererSnapshot]
 	commands        chan rendererCommand
+	compositor      *render.Compositor
 	scrollbackLines int
 	closeOnce       sync.Once
 
@@ -32,13 +33,15 @@ type Renderer struct {
 
 // NewWithScrollback creates a Renderer with an explicit retained scrollback limit.
 func NewWithScrollback(width, height, scrollbackLines int) *Renderer {
+	compositor := render.NewCompositor(width, height, "")
 	r := &Renderer{
 		commands:        make(chan rendererCommand),
+		compositor:      compositor,
 		scrollbackLines: scrollbackLines,
 	}
 	initial := newRendererSnapshot(width, height, scrollbackLines)
 	r.state.Store(initial)
-	go r.actorLoop(initial, width, height)
+	go r.actorLoop(initial, compositor)
 	return r
 }
 
@@ -379,9 +382,34 @@ func (r *Renderer) Capture(stripANSI bool) string {
 // so a diff between Capture() and CaptureDisplay() reveals exactly where the
 // diff renderer diverges from ground truth.
 func (r *Renderer) CaptureDisplay() string {
-	return withRendererActorValue(r, func(st *rendererActorState) string {
-		return st.compositor.PrevGridText()
-	})
+	if r.compositor == nil {
+		return ""
+	}
+	return r.compositor.PrevGridText()
+}
+
+func (r *Renderer) CaptureDisplayPane(paneID uint32) string {
+	if r.compositor == nil {
+		return ""
+	}
+	snap := r.loadSnapshot()
+	if snap.layout == nil {
+		return ""
+	}
+	root, _ := snap.captureRoot(snap.height - render.GlobalBarHeight)
+	if root == nil {
+		return ""
+	}
+	cell := root.FindByPaneID(paneID)
+	if cell == nil {
+		return ""
+	}
+	contentH := mux.PaneContentHeight(cell.H)
+	maxContentH := snap.height - render.GlobalBarHeight - cell.Y - mux.StatusLineRows
+	if contentH > maxContentH {
+		contentH = maxContentH
+	}
+	return r.compositor.PrevGridTextRect(cell.X, cell.Y+mux.StatusLineRows, cell.W, contentH)
 }
 
 // CaptureColorMap renders a color map from client-side emulators.
@@ -738,8 +766,18 @@ func (r *Renderer) HandleCaptureRequest(args []string, agentStatus map[uint32]pr
 			CmdErr: err.Error()}
 	}
 
-	if req.DisplayMode {
-		out := r.CaptureDisplay()
+	if req.DisplayMode || req.ClientMode {
+		out := ""
+		if req.PaneRef != "" {
+			paneID, err := r.ResolvePaneID(req.PaneRef)
+			if err != nil {
+				return &proto.Message{Type: proto.MsgTypeCaptureResponse,
+					CmdErr: err.Error()}
+			}
+			out = r.CaptureDisplayPane(paneID)
+		} else {
+			out = r.CaptureDisplay()
+		}
 		if out == "" {
 			out = "(no previous grid — diff renderer has not run yet)"
 		}

--- a/internal/client/renderer_capture_snapshot_test.go
+++ b/internal/client/renderer_capture_snapshot_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/weill-labs/amux/internal/mux"
 	"github.com/weill-labs/amux/internal/proto"
 )
 
@@ -94,6 +95,44 @@ func TestCaptureDisplayDoesNotWaitForRendererActor(t *testing.T) {
 	}
 
 	close(actorRelease)
+}
+
+func TestCaptureDisplaySnapshotEdgeCases(t *testing.T) {
+	t.Parallel()
+
+	var zero Renderer
+	if got := zero.CaptureDisplay(); got != "" {
+		t.Fatalf("zero renderer CaptureDisplay() = %q, want empty", got)
+	}
+	if got := zero.CaptureDisplayPane(1); got != "" {
+		t.Fatalf("zero renderer CaptureDisplayPane() = %q, want empty", got)
+	}
+
+	r := NewWithScrollback(20, 4, 100)
+	t.Cleanup(r.Close)
+
+	if got := r.CaptureDisplayPane(1); got != "" {
+		t.Fatalf("CaptureDisplayPane without layout = %q, want empty", got)
+	}
+
+	r.HandleLayout(singlePane20xN(10))
+	if got := r.CaptureDisplayPane(99); got != "" {
+		t.Fatalf("CaptureDisplayPane for missing pane = %q, want empty", got)
+	}
+	if got := r.CaptureDisplayPane(1); got != "" {
+		t.Fatalf("CaptureDisplayPane without snapshot = %q, want empty", got)
+	}
+
+	r.withActor(func(st *rendererActorState) {
+		next := *st.snapshot
+		next.layout = mux.NewLeafByID(1, 0, 0, 20, 10)
+		next.height = 4
+		st.snapshot = &next
+		r.publishSnapshot(&next)
+	})
+	if got := r.CaptureDisplayPane(1); got != "" {
+		t.Fatalf("clamped CaptureDisplayPane without snapshot = %q, want empty", got)
+	}
 }
 
 func TestPaneCaptureMissingWarmSnapshotReturnsBlank(t *testing.T) {

--- a/internal/client/renderer_capture_snapshot_test.go
+++ b/internal/client/renderer_capture_snapshot_test.go
@@ -50,6 +50,52 @@ func TestHandleCaptureRequestDoesNotWaitForRendererActor(t *testing.T) {
 	close(actorRelease)
 }
 
+func TestCaptureDisplayDoesNotWaitForRendererActor(t *testing.T) {
+	t.Parallel()
+
+	cr := NewClientRenderer(20, 4)
+	t.Cleanup(cr.renderer.Close)
+
+	cr.HandleLayout(singlePane20x3())
+	cr.HandlePaneOutput(1, []byte("ready"))
+	cr.RenderDiff()
+
+	actorRelease := make(chan struct{})
+	actorStarted := make(chan struct{})
+	go cr.renderer.withActor(func(*rendererActorState) {
+		close(actorStarted)
+		<-actorRelease
+	})
+
+	select {
+	case <-actorStarted:
+	case <-time.After(time.Second):
+		t.Fatal("renderer actor did not start blocking command")
+	}
+
+	captureDone := make(chan string, 1)
+	go func() {
+		var out string
+		for i := 0; i < 100; i++ {
+			out = cr.CaptureDisplay()
+		}
+		captureDone <- out
+	}()
+
+	select {
+	case out := <-captureDone:
+		if !strings.Contains(out, "ready") {
+			t.Fatalf("display capture output = %q, want pane content", out)
+		}
+	case <-time.After(200 * time.Millisecond):
+		close(actorRelease)
+		out := <-captureDone
+		t.Fatalf("CaptureDisplay waited for renderer actor; output after release was %q", out)
+	}
+
+	close(actorRelease)
+}
+
 func TestPaneCaptureMissingWarmSnapshotReturnsBlank(t *testing.T) {
 	t.Parallel()
 

--- a/internal/client/renderer_state.go
+++ b/internal/client/renderer_state.go
@@ -313,12 +313,12 @@ func (r *Renderer) withActor(run func(*rendererActorState)) {
 	<-done
 }
 
-func (r *Renderer) actorLoop(initial *rendererSnapshot, width, height int) {
+func (r *Renderer) actorLoop(initial *rendererSnapshot, compositor *render.Compositor) {
 	state := &rendererActorState{
 		snapshot:          initial,
 		emulators:         make(map[uint32]mux.TerminalEmulator),
 		pendingPaneOutput: make(map[uint32]*paneOutputBuffer),
-		compositor:        render.NewCompositor(width, height, ""),
+		compositor:        compositor,
 	}
 	for cmd := range r.commands {
 		cmd.run(state)

--- a/internal/render/compositor.go
+++ b/internal/render/compositor.go
@@ -3,6 +3,7 @@ package render
 import (
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 	"unicode/utf8"
 
@@ -44,6 +45,7 @@ type Compositor struct {
 
 	// Previous frame's grid for diff rendering. Nil forces full paint.
 	prevGrid          *ScreenGrid
+	prevGridSnap      atomic.Pointer[ScreenGrid]
 	prevGridLayoutKey string
 	prevCursor        cursorRenderState
 	colorProfile      termenv.Profile
@@ -98,9 +100,7 @@ func (c *Compositor) Resize(width, height int) {
 	c.cachedBorderMap = nil
 	c.cachedBorderRoot = nil
 	c.cachedBorderH = 0
-	c.prevGrid = nil // force full repaint
-	c.prevGridLayoutKey = ""
-	c.prevCursor = cursorRenderState{}
+	c.clearPrevGrid()
 }
 
 // SetSessionName updates the session name shown in the global bar.
@@ -114,9 +114,7 @@ func (c *Compositor) SetColorProfile(profile termenv.Profile) {
 		return
 	}
 	c.colorProfile = profile
-	c.prevGrid = nil
-	c.prevGridLayoutKey = ""
-	c.prevCursor = cursorRenderState{}
+	c.clearPrevGrid()
 }
 
 // ColorProfile reports the compositor's current terminal color profile.
@@ -131,9 +129,7 @@ func (c *Compositor) SetIconSet(icons IconSet) {
 		return
 	}
 	c.iconSet = icons
-	c.prevGrid = nil
-	c.prevGridLayoutKey = ""
-	c.prevCursor = cursorRenderState{}
+	c.clearPrevGrid()
 }
 
 // IconSet reports the compositor's current human-facing status glyphs.
@@ -148,9 +144,7 @@ func (c *Compositor) SetStatusStyle(style string) {
 		return
 	}
 	c.statusStyle = style
-	c.prevGrid = nil
-	c.prevGridLayoutKey = ""
-	c.prevCursor = cursorRenderState{}
+	c.clearPrevGrid()
 }
 
 // StatusStyle reports the compositor's current human-facing status bar preset.
@@ -311,6 +305,7 @@ func (c *Compositor) RenderDiffWithOverlayDirtyStats(
 	newGrid, panesComposited := c.buildGridWithOverlayDirty(root, activePaneID, lookup, overlay, dirtyPanes, fullRedraw)
 	changes := DiffGrid(c.prevGrid, newGrid)
 	c.prevGrid = newGrid
+	c.publishPrevGridSnapshot(newGrid)
 	c.prevGridLayoutKey = layoutKey
 	nextCursor := c.cursorRenderStateForLayoutHeight(root, activePaneID, lookup, layoutHeight)
 	cursorChanged := !c.prevCursor.equal(nextCursor)
@@ -350,9 +345,22 @@ func (c *Compositor) RenderDiffWithOverlayDirtyStats(
 
 // ClearPrevGrid forces a full repaint on the next RenderDiff call.
 func (c *Compositor) ClearPrevGrid() {
+	c.clearPrevGrid()
+}
+
+func (c *Compositor) clearPrevGrid() {
 	c.prevGrid = nil
+	c.prevGridSnap.Store(nil)
 	c.prevGridLayoutKey = ""
 	c.prevCursor = cursorRenderState{}
+}
+
+func (c *Compositor) publishPrevGridSnapshot(g *ScreenGrid) {
+	if g == nil {
+		c.prevGridSnap.Store(nil)
+		return
+	}
+	c.prevGridSnap.Store(g.Clone())
 }
 
 func (c *Compositor) layoutReuseKey(root *mux.LayoutCell, activePaneID uint32, layoutHeight int) string {
@@ -390,10 +398,22 @@ func appendLayoutKeyInt(b *strings.Builder, v int) {
 // Each row is newline-separated; trailing spaces are trimmed.
 // Returns empty string if no previous grid exists (before first render).
 func (c *Compositor) PrevGridText() string {
-	if c.prevGrid == nil {
+	snap := c.prevGridSnap.Load()
+	if snap == nil {
 		return ""
 	}
-	return gridToText(c.prevGrid)
+	return gridToText(snap)
+}
+
+// PrevGridTextRect returns a plain-text crop of the previous frame's published
+// grid. The rectangle is clipped to the grid bounds and returns empty if no
+// snapshot has been published yet.
+func (c *Compositor) PrevGridTextRect(x, y, width, height int) string {
+	snap := c.prevGridSnap.Load()
+	if snap == nil {
+		return ""
+	}
+	return gridRectToText(snap, x, y, width, height)
 }
 
 // gridToText converts a ScreenGrid to plain text with trailing spaces trimmed.
@@ -414,6 +434,41 @@ func gridToText(g *ScreenGrid) string {
 				if preserveContinuations {
 					row = append(row, ' ')
 				}
+				continue
+			}
+			ch := cell.Char
+			if ch == "" {
+				ch = " "
+			}
+			row = append(row, ch...)
+		}
+		buf.WriteString(strings.TrimRight(string(row), " "))
+	}
+	return buf.String()
+}
+
+func gridRectToText(g *ScreenGrid, x, y, width, height int) string {
+	if g == nil || width <= 0 || height <= 0 {
+		return ""
+	}
+	startX := max(0, x)
+	startY := max(0, y)
+	endX := min(g.Width, x+width)
+	endY := min(g.Height, y+height)
+	if startX >= endX || startY >= endY {
+		return ""
+	}
+
+	var buf strings.Builder
+	row := make([]byte, 0, endX-startX)
+	for rowY := startY; rowY < endY; rowY++ {
+		if rowY > startY {
+			buf.WriteByte('\n')
+		}
+		row = row[:0]
+		for colX := startX; colX < endX; colX++ {
+			cell := g.Get(colX, rowY)
+			if cell.Width == 0 {
 				continue
 			}
 			ch := cell.Char

--- a/internal/render/compositor_snapshot_test.go
+++ b/internal/render/compositor_snapshot_test.go
@@ -76,3 +76,45 @@ func TestPrevGridSnapshotClearsWithPrevGridInvalidation(t *testing.T) {
 		t.Fatal("ClearPrevGrid should clear the published prevGrid snapshot")
 	}
 }
+
+func TestPrevGridTextRectCropsPublishedSnapshot(t *testing.T) {
+	t.Parallel()
+
+	comp := NewCompositor(6, 4, "test")
+	grid := NewScreenGrid(6, 4)
+	for y, row := range []string{"abcdef", "ghijkl", "mnopqr", "stuvwx"} {
+		for x, ch := range row {
+			grid.Set(x, y, ScreenCell{Char: string(ch), Width: 1})
+		}
+	}
+
+	comp.publishPrevGridSnapshot(grid)
+	grid.Set(1, 1, ScreenCell{Char: "X", Width: 1})
+
+	if got, want := comp.PrevGridTextRect(1, 1, 3, 2), "hij\nnop"; got != want {
+		t.Fatalf("PrevGridTextRect() = %q, want %q", got, want)
+	}
+	if got, want := comp.PrevGridTextRect(-2, -1, 4, 3), "ab\ngh"; got != want {
+		t.Fatalf("clipped PrevGridTextRect() = %q, want %q", got, want)
+	}
+	if got := comp.PrevGridTextRect(10, 10, 1, 1); got != "" {
+		t.Fatalf("out-of-bounds PrevGridTextRect() = %q, want empty", got)
+	}
+	if got := comp.PrevGridTextRect(0, 0, 0, 1); got != "" {
+		t.Fatalf("zero-width PrevGridTextRect() = %q, want empty", got)
+	}
+
+	blankAndWide := NewScreenGrid(4, 1)
+	blankAndWide.Set(0, 0, ScreenCell{Char: "a", Width: 1})
+	blankAndWide.Set(1, 0, ScreenCell{Width: 1})
+	blankAndWide.Set(2, 0, ScreenCell{Char: "b", Width: 1})
+	blankAndWide.Set(3, 0, ScreenCell{Width: 0})
+	if got, want := gridRectToText(blankAndWide, 0, 0, 4, 1), "a b"; got != want {
+		t.Fatalf("gridRectToText blank/wide row = %q, want %q", got, want)
+	}
+
+	comp.publishPrevGridSnapshot(nil)
+	if got := comp.PrevGridTextRect(0, 0, 1, 1); got != "" {
+		t.Fatalf("cleared PrevGridTextRect() = %q, want empty", got)
+	}
+}

--- a/internal/render/compositor_snapshot_test.go
+++ b/internal/render/compositor_snapshot_test.go
@@ -1,0 +1,78 @@
+package render
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/weill-labs/amux/internal/config"
+	"github.com/weill-labs/amux/internal/mux"
+)
+
+func TestRenderDiffPublishesPrevGridSnapshot(t *testing.T) {
+	t.Parallel()
+
+	comp := NewCompositor(20, 6, "test")
+	root := mux.NewLeaf(&mux.Pane{ID: 1}, 0, 0, 20, 5)
+	lookup := func(uint32) PaneData {
+		return &statusPaneData{
+			id:     1,
+			name:   "pane-1",
+			color:  config.TextColorHex,
+			screen: "snapshot row\n\n\n",
+		}
+	}
+
+	comp.RenderDiffWithOverlayDirtyStats(root, 1, lookup, OverlayState{}, nil, true)
+
+	snap := comp.prevGridSnap.Load()
+	if snap == nil {
+		t.Fatal("RenderDiff should publish a prevGrid snapshot")
+	}
+	if snap == comp.prevGrid {
+		t.Fatal("published snapshot should be a clone, not the mutable prevGrid pointer")
+	}
+	if got, want := gridToText(snap), gridToText(comp.prevGrid); got != want {
+		t.Fatalf("published snapshot text mismatch:\n--- got ---\n%s\n--- want ---\n%s", got, want)
+	}
+
+	comp.prevGrid.Set(0, 1, ScreenCell{Char: "X", Width: 1})
+	if got := gridToText(snap); strings.Contains(got, "Xnapshot row") {
+		t.Fatalf("published snapshot changed after prevGrid mutation:\n%s", got)
+	}
+}
+
+func TestPrevGridSnapshotClearsWithPrevGridInvalidation(t *testing.T) {
+	t.Parallel()
+
+	comp := NewCompositor(20, 6, "test")
+	root := mux.NewLeaf(&mux.Pane{ID: 1}, 0, 0, 20, 5)
+	lookup := func(uint32) PaneData {
+		return &statusPaneData{id: 1, name: "pane-1", color: config.TextColorHex}
+	}
+
+	comp.RenderDiff(root, 1, lookup)
+	if comp.prevGridSnap.Load() == nil {
+		t.Fatal("RenderDiff should publish a snapshot")
+	}
+
+	comp.Resize(30, 8)
+	if comp.prevGrid != nil {
+		t.Fatal("Resize should clear prevGrid")
+	}
+	if comp.prevGridSnap.Load() != nil {
+		t.Fatal("Resize should clear the published prevGrid snapshot")
+	}
+
+	comp.RenderDiff(root, 1, lookup)
+	if comp.prevGridSnap.Load() == nil {
+		t.Fatal("RenderDiff should republish a snapshot after resize")
+	}
+
+	comp.ClearPrevGrid()
+	if comp.prevGrid != nil {
+		t.Fatal("ClearPrevGrid should clear prevGrid")
+	}
+	if comp.prevGridSnap.Load() != nil {
+		t.Fatal("ClearPrevGrid should clear the published prevGrid snapshot")
+	}
+}

--- a/internal/server/commands/capture/capture.go
+++ b/internal/server/commands/capture/capture.go
@@ -15,6 +15,8 @@ type Context interface {
 func Capture(ctx Context, args []string) commandpkg.Result {
 	req := caputil.ParseArgs(args)
 	switch {
+	case req.ClientMode || req.DisplayMode:
+		return commandpkg.Result{Message: ctx.ForwardCapture(args)}
 	case req.HistoryMode && (req.PaneRef != "" || !req.FormatJSON):
 		return commandpkg.Result{Message: ctx.CaptureHistory(args)}
 	case req.PaneRef != "":

--- a/internal/server/commands/capture/capture_test.go
+++ b/internal/server/commands/capture/capture_test.go
@@ -1,0 +1,62 @@
+package capture
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/weill-labs/amux/internal/proto"
+)
+
+type captureCommandContext struct {
+	called string
+	args   []string
+}
+
+func (c *captureCommandContext) CaptureHistory(args []string) *proto.Message {
+	c.called = "history"
+	c.args = append([]string(nil), args...)
+	return &proto.Message{Type: proto.MsgTypeCaptureResponse, CmdOutput: "history"}
+}
+
+func (c *captureCommandContext) CapturePaneWithFallback(args []string) *proto.Message {
+	c.called = "pane"
+	c.args = append([]string(nil), args...)
+	return &proto.Message{Type: proto.MsgTypeCaptureResponse, CmdOutput: "pane"}
+}
+
+func (c *captureCommandContext) ForwardCapture(args []string) *proto.Message {
+	c.called = "forward"
+	c.args = append([]string(nil), args...)
+	return &proto.Message{Type: proto.MsgTypeCaptureResponse, CmdOutput: "forward"}
+}
+
+func TestCaptureClientAndDisplayForwardToClient(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "client", args: []string{"--client", "pane-1"}},
+		{name: "display", args: []string{"--display"}},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := &captureCommandContext{}
+			res := Capture(ctx, tt.args)
+			if ctx.called != "forward" {
+				t.Fatalf("called = %q, want forward", ctx.called)
+			}
+			if !reflect.DeepEqual(ctx.args, tt.args) {
+				t.Fatalf("args = %v, want %v", ctx.args, tt.args)
+			}
+			if res.Message == nil || res.Message.CmdOutput != "forward" {
+				t.Fatalf("result message = %#v, want forward capture response", res.Message)
+			}
+		})
+	}
+}

--- a/internal/server/commands_capture.go
+++ b/internal/server/commands_capture.go
@@ -65,7 +65,7 @@ func cmdCapture(ctx *CommandContext) {
 			return
 		}
 	}
-	if captureServerPathEnabled() && req.PaneRef != "" && !req.HistoryMode {
+	if captureServerPathEnabled() && req.PaneRef != "" && !req.ClientMode && !req.HistoryMode {
 		ctx.applyCommandResult(commandpkg.Result{Message: captureLocally(ctx, ctx.Args)})
 		return
 	}

--- a/internal/server/commands_capture_test.go
+++ b/internal/server/commands_capture_test.go
@@ -41,6 +41,61 @@ func TestCaptureServerEnvSinglePaneDoesNotSendClientCaptureRequest(t *testing.T)
 	}
 }
 
+func TestCaptureClientFlagForcesClientCaptureWhenServerEnvEnabled(t *testing.T) {
+	t.Setenv("AMUX_CAPTURE_SERVER", "1")
+
+	srv, sess, cleanup := newCommandTestSession(t)
+	defer cleanup()
+
+	pane := newStandaloneProxyPane(1, "pane-1")
+	pane.FeedOutput([]byte("SERVER-LOCAL\r\n"))
+	window := newTestWindowWithPanes(t, sess, 1, "main", pane)
+	setSessionLayoutForTest(t, sess, window.ID, []*mux.Window{window}, pane)
+
+	captureClient := attachCaptureClientForCommandTest(t, sess)
+	requestCh, errCh := respondToNextCaptureRequest(t, sess, captureClient, "CLIENT-PANE\n")
+
+	res := runTestCommand(t, srv, sess, "capture", "--client", "pane-1")
+	if res.cmdErr != "" {
+		t.Fatalf("capture cmdErr = %q, want empty", res.cmdErr)
+	}
+	if got, want := res.output, "CLIENT-PANE\n"; got != want {
+		t.Fatalf("capture output = %q, want %q", got, want)
+	}
+
+	select {
+	case err := <-errCh:
+		t.Fatalf("reading capture request: %v", err)
+	case msg := <-requestCh:
+		if msg.Type != MsgTypeCaptureRequest {
+			t.Fatalf("message type = %v, want %v", msg.Type, MsgTypeCaptureRequest)
+		}
+		if want := []string{"--client", "pane-1"}; !slices.Equal(msg.CmdArgs, want) {
+			t.Fatalf("capture request args = %v, want %v", msg.CmdArgs, want)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for forwarded capture request")
+	}
+}
+
+func TestCaptureClientFlagRequiresAttachedClient(t *testing.T) {
+	t.Parallel()
+
+	srv, sess, cleanup := newCommandTestSession(t)
+	defer cleanup()
+	sess.captureTiming.attachMaxRetries = 1
+
+	pane := newStandaloneProxyPane(1, "pane-1")
+	pane.FeedOutput([]byte("SERVER-LOCAL\r\n"))
+	window := newTestWindowWithPanes(t, sess, 1, "main", pane)
+	setSessionLayoutForTest(t, sess, window.ID, []*mux.Window{window}, pane)
+
+	res := runTestCommand(t, srv, sess, "capture", "--client", "pane-1")
+	if got, want := res.cmdErr, "no client attached"; got != want {
+		t.Fatalf("capture --client without client cmdErr = %q, want %q; output=%q", got, want, res.output)
+	}
+}
+
 func TestCaptureDefaultSinglePaneStillForwardsToAttachedClient(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Motivation

LAB-1634 showed that client-side display capture can still block rendering when repeated `capture --display` requests enter the renderer actor while a pane is busy. LAB-1645 keeps the user-perspective client capture path from LAB-1643, but moves it to a published frame snapshot so capture reads do not wait behind render work.

## Summary

- Publish a cloned `ScreenGrid` snapshot through `atomic.Pointer` after every diff render and clear it alongside `prevGrid` invalidation.
- Make `CaptureDisplay` read the snapshot directly instead of calling into the renderer actor; pane-scoped client capture crops the pane content rect from the same display snapshot.
- Add `capture --client [pane]` as the explicit client-side capture flag while leaving `--display` as the back-compat full-display alias.
- Keep overlay handling to option 1 for v1: capture reads only the rendered `prevGrid` snapshot, with no structured overlay JSON changes.

This PR covers LAB-1645 steps A, B, and C.

## Testing

Pre-code audit:

- `RenderDiffWithOverlayDirtyStats` builds a new grid, diffs it against the previous grid, then replaces `prevGrid`; dirty rendering clones `prevGrid` before mutation.
- `Resize`, `ClearPrevGrid`, and style/profile invalidation paths only nil out previous frame state; no audited path mutates a published grid in place.
- `CaptureDisplay` previously used `withRendererActorValue` and therefore waited behind the renderer actor.

LAB-1634 timing evidence before the fix:

- Built pre-fix binary at `/tmp/amux-lab1645-pre`.
- Ran a temp session with `nvim --clean` and a custom-bg theme in one pane plus heavy shell output in another pane.
- Ran 120 `capture --display` calls from another process while output was active: `captures=120 avg_ms=13.570 max_ms=22.198`; frame debug samples showed p50 about `609us`, p95 about `2.947ms`, p99 about `6.58ms`.

Passing checks:

- `go test ./internal/render -run 'TestRenderDiffPublishesPrevGridSnapshot|TestPrevGridSnapshotClearsWithPrevGridInvalidation' -count=100`
- `go test ./internal/client -run 'TestCaptureDisplayDoesNotWaitForRendererActor|TestDisplayPanesOverlayDisplayOnly|TestHandleCaptureRequest_DisplayFlag' -count=100`
- `go test ./internal/capture -run 'TestParseArgs|TestValidateScreenRequest|TestValidateHistoryRequest' -count=100`
- `go test ./internal/server -run 'TestCaptureClientFlag|TestCaptureServerEnvSinglePaneDoesNotSendClientCaptureRequest' -count=100`
- `go test ./internal/cli -run TestMainCaptureHelpIncludesClientFlag -count=100`
- `go test -race ./internal/render -run 'TestRenderDiffPublishesPrevGridSnapshot|TestPrevGridSnapshotClearsWithPrevGridInvalidation' -count=10`
- `go test -race ./internal/client -run 'TestCaptureDisplayDoesNotWaitForRendererActor|TestDisplayPanesOverlayDisplayOnly|TestHandleCaptureRequest_DisplayFlag' -count=10`
- `go test ./internal/render ./internal/client ./internal/capture ./internal/server ./internal/cli -timeout 120s`

Known unrelated failures from broader required verification:

- `go test -race ./internal/render/... ./internal/client/... -count=10`: the touched snapshot/client-capture tests pass under race, but the broad client package run hit existing attach/local-render teardown failures, including `send on closed channel` around `attach.go` / `local_render.go`.
- `go test ./... -timeout 120s -count=10`: failed with unrelated repeated full-suite timeouts across mux/remote/server/integration packages.
- `go test ./... -timeout 120s`: changed packages passed, but the run failed in `internal/mux` (`TestAgentStatusTreatsPromptTimeBashSelfForkAsIdle`) plus top-level integration timeout/clipboard failures.

## Review focus

- Snapshot publication should remain clone-before-store, and no code path should mutate a stored `ScreenGrid`.
- `--client` intentionally forces the client-forwarded path even when `AMUX_CAPTURE_SERVER=1` is enabled.
- Pane-scoped `--client` crops the client-rendered content area from the last display snapshot; this PR does not add structured overlay summaries.

Closes LAB-1645
