### PR TITLE
LAB-1731: Drop scrollback cell value copies

### DIFF
--- a/internal/mux/emulator.go
+++ b/internal/mux/emulator.go
@@ -311,9 +311,9 @@ func (v *vtEmulator) ScrollbackLineText(y int) string {
 		return ""
 	}
 	var buf strings.Builder
-	for _, cell := range line {
-		if cell.Content != "" {
-			buf.WriteString(cell.Content)
+	for i := range line {
+		if line[i].Content != "" {
+			buf.WriteString(line[i].Content)
 		}
 	}
 	return buf.String()

--- a/internal/mux/emulator.go
+++ b/internal/mux/emulator.go
@@ -312,8 +312,9 @@ func (v *vtEmulator) ScrollbackLineText(y int) string {
 	}
 	var buf strings.Builder
 	for i := range line {
-		if line[i].Content != "" {
-			buf.WriteString(line[i].Content)
+		content := line[i].Content
+		if content != "" {
+			buf.WriteString(content)
 		}
 	}
 	return buf.String()

--- a/internal/mux/emulator_bench_test.go
+++ b/internal/mux/emulator_bench_test.go
@@ -87,6 +87,39 @@ func BenchmarkEmulatorContentLines(b *testing.B) {
 	})
 }
 
+func BenchmarkScrollbackLineText(b *testing.B) {
+	const (
+		width           = 200
+		height          = 60
+		scrollbackLines = 5000
+	)
+
+	emu := NewVTEmulatorWithScrollback(width, height, scrollbackLines)
+	defer emu.Close()
+
+	var payload strings.Builder
+	wideText := strings.Repeat("scrollback payload ", 16)
+	for line := 0; line < scrollbackLines+height; line++ {
+		fmt.Fprintf(&payload, "\033[3%dm%04d %s\033[0m\r\n", line%8, line, wideText)
+	}
+	mustWrite(b, emu, []byte(payload.String()))
+
+	rows := emu.ScrollbackLen()
+	if rows == 0 {
+		b.Fatal("expected scrollback rows")
+	}
+
+	total := 0
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; b.Loop(); i++ {
+		total += len(emu.ScrollbackLineText(i % rows))
+	}
+	if total == 0 {
+		b.Fatal("expected scrollback text")
+	}
+}
+
 func BenchmarkScreenContains(b *testing.B) {
 	emu := NewVTEmulatorWithDrain(80, 24)
 	payload := realisticTerminalPayload(80 * 24)


### PR DESCRIPTION
## Motivation

LAB-1731 identified `ScrollbackLineText` as the top `runtime.duffcopy` caller in the live client after the LAB-1663 scrollback snapshot fix. This PR covers fix 3 only: avoid copying each large `uv.Cell` while extracting scrollback text.

## Summary

- Add `BenchmarkScrollbackLineText` with a 200x60 emulator and retained styled scrollback rows.
- Change `ScrollbackLineText` to range by index and bind `Content` once per cell instead of ranging cell values.
- Grep audit found no remaining `for _, cell := range line` sibling patterns in `internal/mux/emulator.go`.

## Testing

- `go test ./internal/mux -run '^$' -bench '^BenchmarkScrollbackLineText$' -benchmem -count=10`
- `go test ./internal/client -run '^$' -bench '^BenchmarkCapturePaneRenderSnapshotStyledScrollback1KB$' -benchmem -count=10`
- `go test ./internal/mux -run '^(TestScreenLineText|TestScreenLineTextWideChars|TestScreenLineTextGraphemeClusters|TestScreenLineTextTrailingSpaces)$' -count=100`
- `go test ./internal/mux -count=1`
- `go test ./internal/client -count=1`
- `make install`
- Live client pprof before/final from `/tmp/amux-$(id -u)/main.client.pprof`
- `go test ./internal/mux -run '^TestGitBranch$' -count=100` after a full-suite tempdir cleanup flake
- `go test ./test -run '^TestRemotePaneViaSSHAutoDeploy$' -count=1 -timeout 120s` after a full-suite remote timeout

Attempted but not clean:

- `go test ./internal/mux/... -count=100` failed in unrelated process/PTY timing tests (`TestAgentStatusTreatsPromptTimeBashSelfForkAsIdle`, `TestPaneRespawnPreservesMetadataAndSuppressesExitCallback`, `TestPaneActorDoesNotDeadlockAfterDrainResponsesExit`, and timeout-bound process tests).
- `go test ./... -timeout 120s` failed once in `TestGitBranch/not_a_git_repo` tempdir cleanup (`bad file descriptor`); `TestGitBranch` then passed 100 reruns.
- `go test ./... -timeout 120s` failed once in `TestRemotePaneViaSSHAutoDeploy`; that exact test passed on rerun.

## Baseline numbers

Hardware: AMD EPYC-Milan Processor, linux/amd64, Go 1.25.0.

| Benchmark | Before | After | Change |
| --- | ---: | ---: | ---: |
| `BenchmarkScrollbackLineText` median ns/op | 2,765 | 1,576 | 1.75x faster |
| `BenchmarkScrollbackLineText` bytes/op | 375-376 | 375-376 | unchanged |
| `BenchmarkScrollbackLineText` allocs/op | 5 | 5 | unchanged |
| `BenchmarkCapturePaneRenderSnapshotStyledScrollback1KB` median ns/op | 16,697,136 | 3,006,256 | 5.55x faster |

Live pprof:

| Profile | Before | Final |
| --- | ---: | ---: |
| Build ID | `e5aa3ea9d9b261b502661cafa8987fb1bf8be937` | `4b53f1585c486358e79a0d787dd0e8bf365cfb73` |
| CPU samples / 20s | 20.49s | 0.60s |
| `ScrollbackLineText` cumulative CPU | 10.49s / 51.20% | 0.13s / 21.67% |
| `runtime.duffcopy` flat CPU | 7.15s / 34.90% | 0.04s / 6.67% |
| `runtime.duffcopy` callers | `ScrollbackLineText` 5.64s / 78.88% | `DiffGrid` 30ms, `clonePaneRenderSnapshots` 10ms; no `ScrollbackLineText` caller |

The final live profile used a temporary attached client because no client was attached after `make install`; workload was lower than the original profile, so the key comparison is caller attribution rather than total client CPU.

## Review focus

- Confirm the indexed loop preserves `ScrollbackLineText` output while avoiding per-cell `uv.Cell` value copies.
- Check that the benchmark is representative for retained styled scrollback rows without adding unrelated behavior.
- This PR intentionally does not touch `captureScreenCells` or `ScreenGrid.Clone`; those remain the next LAB-1731 PRs.

Audit notes for the later fixes:

- `prevGrid` is private to the compositor actor and is replaced immediately after `DiffGrid`; `prevGridLayoutKey` is only an invalidation key, not a grid alias.
- `paneRenderSnapshot` screen slices are shallow-copied across snapshots and documented immutable, so the later `captureScreenCells` buffer reuse must transfer ownership into snapshot-owned rows or a snapshot-owned block.

References LAB-1731.
