### PR TITLE
LAB-1632: Pin vt dependency to merged resize fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -49,4 +49,4 @@ require (
 
 replace github.com/charmbracelet/ultraviolet => github.com/weill-labs/ultraviolet v0.0.0-20260404003102-9344cbfc286f
 
-replace github.com/charmbracelet/x/vt => github.com/weill-labs/x/vt v0.0.0-20260507075017-67eb13d58575
+replace github.com/charmbracelet/x/vt => github.com/weill-labs/x/vt v0.0.0-20260507214137-ae9013d883a6

--- a/go.sum
+++ b/go.sum
@@ -72,8 +72,8 @@ github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcU
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/weill-labs/ultraviolet v0.0.0-20260404003102-9344cbfc286f h1:JMTFuQ/08wrGci+AIUA67OuIMHtJaF369KhWwBel6/g=
 github.com/weill-labs/ultraviolet v0.0.0-20260404003102-9344cbfc286f/go.mod h1:Vo8TffMf0q7Uho/n8e6XpBZvOWtd3g39yX+9P5rRutA=
-github.com/weill-labs/x/vt v0.0.0-20260507075017-67eb13d58575 h1:8AouhVTd5q9WW7gyti4txCP06El5GeRCD623mUHlRBU=
-github.com/weill-labs/x/vt v0.0.0-20260507075017-67eb13d58575/go.mod h1:2djWW5EeP5QlpztEYYbbyyzUyyxVD71mWVQguNISHcM=
+github.com/weill-labs/x/vt v0.0.0-20260507214137-ae9013d883a6 h1:oihsjSkH2cpX0oYkyrwgP3CuZ0onBgq8fR7MSsV2Roc=
+github.com/weill-labs/x/vt v0.0.0-20260507214137-ae9013d883a6/go.mod h1:2djWW5EeP5QlpztEYYbbyyzUyyxVD71mWVQguNISHcM=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJuqunuUZ/Dhy/avygyECGrLceyNeo4LiM=
 golang.org/x/crypto v0.49.0 h1:+Ng2ULVvLHnJ/ZFEq4KdcDd/cfjrrjjNSXNzxg0Y4U4=


### PR DESCRIPTION
## Motivation

PR #768 pinned amux to the vt resize-smear fix while the underlying vt PR was still on a side branch. The vt fix is now merged into `weill-labs/x/main`, so amux should pin to the main-reachable pseudo-version for cleaner dependency history.

## Summary

- Update the `github.com/charmbracelet/x/vt` replacement to `github.com/weill-labs/x/vt v0.0.0-20260507214137-ae9013d883a6`.
- Refresh `go.sum` for the merged vt commit.

## Testing

- `go test ./internal/mux -run TestVTEmulatorResizeShrinkThenWidenKeepsDenseRowsSeparate -count=100`
- `go test ./internal/mux -count=1`
- `go test ./... -timeout 120s`

## Review focus

This PR should be dependency-only. Verify the pseudo-version points at the merged `weill-labs/x` main commit from weill-labs/x#12, not the earlier side-branch commit.

Closes LAB-1632
