### PR TITLE
LAB-1753: Default single-pane capture to server path

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,8 @@ Capture a single pane:
 amux capture --format json pane-1
 ```
 
+Single-pane capture reads server-owned pane state by default and works without an attached interactive client. Use `--client` when you need the attached client's displayed view.
+
 History-aware pane capture:
 
 ```bash

--- a/docs/capture-architecture.md
+++ b/docs/capture-architecture.md
@@ -98,10 +98,11 @@ Recommendation: ship option 1 first, then add option 2 to JSON output. Option 3 
 
 Roll out the change compatibly:
 
-1. Today: `amux capture` calls client-side rendering and can flicker.
-2. Step 1: add server-side capture as a parallel implementation. Keep client-side capture as the default. Add `AMUX_CAPTURE_SERVER=1` as an opt-in environment flag.
-3. Step 2: flip the default after a soak window. `amux capture` becomes server-side. `amux capture --client` opts into the old user-perspective behavior.
-4. Step 3: deprecate the redundant `--display` flag, making it equivalent to `--client` without overlay metadata, or keep it as a fast-path alias.
+1. Before LAB-1644: `amux capture` called client-side rendering and could flicker.
+2. LAB-1644: add server-side single-pane capture as a parallel implementation behind `AMUX_CAPTURE_SERVER=1`.
+3. LAB-1753: flip single-pane capture to server-side by default. `amux capture --client pane-3` opts into the user-perspective behavior. `AMUX_CAPTURE_LEGACY_CLIENT=1` temporarily restores the old single-pane client-forwarded default as an emergency rollback knob during soak.
+4. LAB-1754: flip full-session capture to server-side once the compositor adapter path is ready.
+5. Later: deprecate the redundant `--display` flag, making it equivalent to `--client` without overlay metadata, or keep it as a fast-path alias.
 
 Existing scripts continue working. Most scripts call `amux capture --format json`, which is already a structural read that translates cleanly to server-side capture.
 

--- a/internal/server/commands_capture.go
+++ b/internal/server/commands_capture.go
@@ -24,8 +24,8 @@ func (ctx captureCommandContext) ForwardCapture(args []string) *Message {
 	return ctx.Sess.forwardCaptureForActor(ctx.ActorPaneID, args)
 }
 
-func captureServerPathEnabled() bool {
-	return os.Getenv("AMUX_CAPTURE_SERVER") == "1"
+func captureLegacyClientPathEnabled() bool {
+	return os.Getenv("AMUX_CAPTURE_LEGACY_CLIENT") == "1"
 }
 
 func captureLocally(ctx *CommandContext, args []string) *Message {
@@ -65,7 +65,7 @@ func cmdCapture(ctx *CommandContext) {
 			return
 		}
 	}
-	if captureServerPathEnabled() && req.PaneRef != "" && !req.ClientMode && !req.HistoryMode {
+	if req.PaneRef != "" && !req.ClientMode && !req.DisplayMode && !req.HistoryMode && !captureLegacyClientPathEnabled() {
 		ctx.applyCommandResult(commandpkg.Result{Message: captureLocally(ctx, ctx.Args)})
 		return
 	}

--- a/internal/server/commands_capture_test.go
+++ b/internal/server/commands_capture_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"encoding/json"
 	"net"
 	"slices"
 	"strings"
@@ -11,9 +12,7 @@ import (
 	"github.com/weill-labs/amux/internal/mux"
 )
 
-func TestCaptureServerEnvSinglePaneDoesNotSendClientCaptureRequest(t *testing.T) {
-	t.Setenv("AMUX_CAPTURE_SERVER", "1")
-
+func TestCaptureDefaultSinglePaneDoesNotSendClientCaptureRequest(t *testing.T) {
 	srv, sess, cleanup := newCommandTestSession(t)
 	defer cleanup()
 	sess.captureTiming.responseTimeout = 20 * time.Millisecond
@@ -41,8 +40,66 @@ func TestCaptureServerEnvSinglePaneDoesNotSendClientCaptureRequest(t *testing.T)
 	}
 }
 
-func TestCaptureClientFlagForcesClientCaptureWhenServerEnvEnabled(t *testing.T) {
-	t.Setenv("AMUX_CAPTURE_SERVER", "1")
+func TestCaptureDefaultSinglePaneJSONDoesNotSendClientCaptureRequest(t *testing.T) {
+	srv, sess, cleanup := newCommandTestSession(t)
+	defer cleanup()
+	sess.captureTiming.responseTimeout = 20 * time.Millisecond
+
+	pane := newStandaloneProxyPane(1, "pane-1")
+	pane.FeedOutput([]byte("SERVER-JSON\r\n"))
+	window := newTestWindowWithPanes(t, sess, 1, "main", pane)
+	setSessionLayoutForTest(t, sess, window.ID, []*mux.Window{window}, pane)
+
+	captureClient := attachCaptureClientForCommandTest(t, sess)
+
+	res := runTestCommand(t, srv, sess, "capture", "--format", "json", "pane-1")
+	if res.cmdErr != "" {
+		t.Fatalf("capture cmdErr = %q, want empty", res.cmdErr)
+	}
+	var capturePane struct {
+		Name    string   `json:"name"`
+		Content []string `json:"content"`
+	}
+	if err := json.Unmarshal([]byte(res.output), &capturePane); err != nil {
+		t.Fatalf("json.Unmarshal capture output: %v\n%s", err, res.output)
+	}
+	if capturePane.Name != "pane-1" {
+		t.Fatalf("capture pane name = %q, want pane-1", capturePane.Name)
+	}
+	if len(capturePane.Content) == 0 || capturePane.Content[0] != "SERVER-JSON" {
+		t.Fatalf("capture content = %#v, want SERVER-JSON as first row", capturePane.Content)
+	}
+
+	if err := captureClient.SetReadDeadline(time.Now().Add(25 * time.Millisecond)); err != nil {
+		t.Fatalf("SetReadDeadline: %v", err)
+	}
+	if msg, err := readMsgOnConn(captureClient); err == nil {
+		t.Fatalf("attached client received %v, want no client capture request", msg.Type)
+	}
+}
+
+func TestCaptureDefaultSinglePaneWorksWithoutAttachedClient(t *testing.T) {
+	t.Parallel()
+
+	srv, sess, cleanup := newCommandTestSession(t)
+	defer cleanup()
+
+	pane := newStandaloneProxyPane(1, "pane-1")
+	pane.FeedOutput([]byte("SERVER-LOCAL\r\n"))
+	window := newTestWindowWithPanes(t, sess, 1, "main", pane)
+	setSessionLayoutForTest(t, sess, window.ID, []*mux.Window{window}, pane)
+
+	res := runTestCommand(t, srv, sess, "capture", "pane-1")
+	if res.cmdErr != "" {
+		t.Fatalf("capture cmdErr = %q, want empty", res.cmdErr)
+	}
+	if got, want := res.output, "SERVER-LOCAL\n"; got != want {
+		t.Fatalf("capture output = %q, want %q", got, want)
+	}
+}
+
+func TestCaptureClientFlagForwardsToAttachedClient(t *testing.T) {
+	t.Parallel()
 
 	srv, sess, cleanup := newCommandTestSession(t)
 	defer cleanup()
@@ -78,26 +135,8 @@ func TestCaptureClientFlagForcesClientCaptureWhenServerEnvEnabled(t *testing.T) 
 	}
 }
 
-func TestCaptureClientFlagRequiresAttachedClient(t *testing.T) {
-	t.Parallel()
-
-	srv, sess, cleanup := newCommandTestSession(t)
-	defer cleanup()
-	sess.captureTiming.attachMaxRetries = 1
-
-	pane := newStandaloneProxyPane(1, "pane-1")
-	pane.FeedOutput([]byte("SERVER-LOCAL\r\n"))
-	window := newTestWindowWithPanes(t, sess, 1, "main", pane)
-	setSessionLayoutForTest(t, sess, window.ID, []*mux.Window{window}, pane)
-
-	res := runTestCommand(t, srv, sess, "capture", "--client", "pane-1")
-	if got, want := res.cmdErr, "no client attached"; got != want {
-		t.Fatalf("capture --client without client cmdErr = %q, want %q; output=%q", got, want, res.output)
-	}
-}
-
-func TestCaptureDefaultSinglePaneStillForwardsToAttachedClient(t *testing.T) {
-	t.Parallel()
+func TestCaptureLegacyClientEnvForwardsSinglePaneToAttachedClient(t *testing.T) {
+	t.Setenv("AMUX_CAPTURE_LEGACY_CLIENT", "1")
 
 	srv, sess, cleanup := newCommandTestSession(t)
 	defer cleanup()
@@ -133,9 +172,25 @@ func TestCaptureDefaultSinglePaneStillForwardsToAttachedClient(t *testing.T) {
 	}
 }
 
-func TestCaptureServerEnvFullSessionStillForwardsInStepOne(t *testing.T) {
-	t.Setenv("AMUX_CAPTURE_SERVER", "1")
+func TestCaptureClientFlagRequiresAttachedClient(t *testing.T) {
+	t.Parallel()
 
+	srv, sess, cleanup := newCommandTestSession(t)
+	defer cleanup()
+	sess.captureTiming.attachMaxRetries = 1
+
+	pane := newStandaloneProxyPane(1, "pane-1")
+	pane.FeedOutput([]byte("SERVER-LOCAL\r\n"))
+	window := newTestWindowWithPanes(t, sess, 1, "main", pane)
+	setSessionLayoutForTest(t, sess, window.ID, []*mux.Window{window}, pane)
+
+	res := runTestCommand(t, srv, sess, "capture", "--client", "pane-1")
+	if got, want := res.cmdErr, "no client attached"; got != want {
+		t.Fatalf("capture --client without client cmdErr = %q, want %q; output=%q", got, want, res.output)
+	}
+}
+
+func TestCaptureFullSessionStillForwardsToAttachedClient(t *testing.T) {
 	srv, sess, cleanup := newCommandTestSession(t)
 	defer cleanup()
 
@@ -170,9 +225,7 @@ func TestCaptureServerEnvFullSessionStillForwardsInStepOne(t *testing.T) {
 	}
 }
 
-func TestCaptureServerEnvHistoryPaneStaysOnHistoryPath(t *testing.T) {
-	t.Setenv("AMUX_CAPTURE_SERVER", "1")
-
+func TestCaptureHistoryPaneUsesServerHistoryPath(t *testing.T) {
 	srv, sess, cleanup := newCommandTestSession(t)
 	defer cleanup()
 

--- a/internal/server/commands_capture_test.go
+++ b/internal/server/commands_capture_test.go
@@ -13,6 +13,8 @@ import (
 )
 
 func TestCaptureDefaultSinglePaneDoesNotSendClientCaptureRequest(t *testing.T) {
+	t.Parallel()
+
 	srv, sess, cleanup := newCommandTestSession(t)
 	defer cleanup()
 	sess.captureTiming.responseTimeout = 20 * time.Millisecond
@@ -41,6 +43,8 @@ func TestCaptureDefaultSinglePaneDoesNotSendClientCaptureRequest(t *testing.T) {
 }
 
 func TestCaptureDefaultSinglePaneJSONDoesNotSendClientCaptureRequest(t *testing.T) {
+	t.Parallel()
+
 	srv, sess, cleanup := newCommandTestSession(t)
 	defer cleanup()
 	sess.captureTiming.responseTimeout = 20 * time.Millisecond
@@ -191,6 +195,8 @@ func TestCaptureClientFlagRequiresAttachedClient(t *testing.T) {
 }
 
 func TestCaptureFullSessionStillForwardsToAttachedClient(t *testing.T) {
+	t.Parallel()
+
 	srv, sess, cleanup := newCommandTestSession(t)
 	defer cleanup()
 
@@ -226,6 +232,8 @@ func TestCaptureFullSessionStillForwardsToAttachedClient(t *testing.T) {
 }
 
 func TestCaptureHistoryPaneUsesServerHistoryPath(t *testing.T) {
+	t.Parallel()
+
 	srv, sess, cleanup := newCommandTestSession(t)
 	defer cleanup()
 

--- a/test/capture_json_test.go
+++ b/test/capture_json_test.go
@@ -260,9 +260,9 @@ func TestCaptureJSON_ClientUIState(t *testing.T) {
 	}
 }
 
-func TestCapturePaneJSON_CopyMode(t *testing.T) {
+func TestCaptureLegacyClientPaneJSON_CopyMode(t *testing.T) {
 	t.Parallel()
-	h := newAmuxHarness(t)
+	h := newAmuxHarness(t, "AMUX_CAPTURE_LEGACY_CLIENT=1")
 
 	h.sendKeys("C-a", "[")
 	h.waitUI(proto.UIEventCopyModeShown, 3*time.Second)


### PR DESCRIPTION
## Motivation
Routine agent polling with `amux capture pane-N` and `amux capture --format json pane-N` still forwarded capture requests to an attached rendering client when one existed. LAB-1644 added the server-side pane capture path behind `AMUX_CAPTURE_SERVER=1`; this flips that path on by default for single-pane capture so the default answers from server-owned pane state.

## Summary
- Route non-history single-pane text and JSON capture through the server-side `mux.Pane` emulator path by default.
- Preserve explicit client-perspective capture through `--client` and `--display`, and leave full-session capture on the existing client-forwarded path for LAB-1754.
- Invert the env flag into `AMUX_CAPTURE_LEGACY_CLIENT=1` as a temporary rollback knob for the old single-pane client-forwarded default. Production code no longer reads `AMUX_CAPTURE_SERVER`; the remaining mention is historical rollout documentation.
- Update docs and tests, including legacy client-forwarded pane JSON copy-mode coverage under the rollback knob.

## Testing
- `go test ./internal/server -run 'TestCapture(DefaultSinglePane|ClientFlag|LegacyClientEnv|FullSession|HistoryPane|Locally|SinglePaneLocally)' -count=100`\n- `go test ./internal/capture ./internal/server/commands/capture -count=1`\n- `go test ./test -run TestCaptureLegacyClientPaneJSON_CopyMode -count=100 -timeout 120s`\n- `go test ./test -run TestRemotePaneViaSSH -count=3 -timeout 120s`\n- `go test ./test -run TestMouseCommandDragAutomaticallyCopiesSelection -count=5 -timeout 120s`\n- `go test ./internal/mux -run TestAgentStatusTreatsPromptTimeBashSelfForkAsIdle -count=20`\n- `git diff --check origin/main...HEAD`\n\nBroad-suite note: `go test ./... -timeout 120s` twice reproduced the existing load/order-sensitive `TestMouseCommandDragAutomaticallyCopiesSelection` timeout; it passed isolated with `-count=5`. A follow-up run with that mouse test skipped reproduced `TestAgentStatusTreatsPromptTimeBashSelfForkAsIdle`; it passed isolated with `-count=20`.\n\n## Review focus\n- Check that only single-pane non-history default capture flips to server-side; full-session capture remains client-forwarded.\n- Check that `--client`, `--display`, history capture, and remote pane forwarding still bypass the new default path as intended.\n- Check the temporary rollback decision: `AMUX_CAPTURE_LEGACY_CLIENT=1` restores the old single-pane client-forwarded default during soak.\n\nCloses LAB-1753