### PR TITLE
LAB-1620: Fix server test races

### DIFF
--- a/internal/mux/pane_window_process_test.go
+++ b/internal/mux/pane_window_process_test.go
@@ -206,10 +206,12 @@ func newBashPromptSelfForkTestPane(t *testing.T, markerFile string) *Pane {
 		t.Skip("bash not available")
 	}
 
-	promptCommand := `printf started >"$MARKER_FILE"; PROMPT_COMMAND= PS1= bash --noprofile --norc -ic 'PROMPT_COMMAND= PS1= bash --noprofile --norc -ic "read -rt 0.3 _"; :'`
+	firstPromptFile := markerFile + ".first"
+	promptCommand := `if [[ ! -e "$FIRST_PROMPT_FILE" ]]; then : >"$FIRST_PROMPT_FILE"; printf started >"$MARKER_FILE"; else printf started >"$MARKER_FILE"; PROMPT_COMMAND= PS1= bash --noprofile --norc -ic 'PROMPT_COMMAND= PS1= bash --noprofile --norc -ic "read -rt 5 _"; :'; fi`
 	cmd := exec.Command(bashPath, "--noprofile", "--norc", "-i")
 	cmd.Env = append(os.Environ(),
 		"MARKER_FILE="+markerFile,
+		"FIRST_PROMPT_FILE="+firstPromptFile,
 		"PROMPT_COMMAND="+promptCommand,
 		"PS1=prompt> ",
 		"HISTFILE=/dev/null",
@@ -1214,7 +1216,7 @@ func TestAgentStatusTreatsPromptTimeBashSelfForkAsIdle(t *testing.T) {
 		t.Fatal("processName(shell) = empty, want bash")
 	}
 
-	waitUntil(t, time.Second, func() bool {
+	waitUntil(t, 5*time.Second, func() bool {
 		children := childPIDs(shellPID)
 		if len(children) != 1 || processName(children[0]) != shellName {
 			return false

--- a/internal/reload/reload_test.go
+++ b/internal/reload/reload_test.go
@@ -446,7 +446,9 @@ func TestWatchBinaryDeleteAndRecreate(t *testing.T) {
 
 	triggerReload := make(chan struct{}, 1)
 	ready := make(chan struct{})
-	go WatchBinary(binPath, triggerReload, ready)
+	stop := make(chan struct{})
+	t.Cleanup(func() { close(stop) })
+	go watchBinary(binPath, triggerReload, ready, stop)
 	<-ready
 
 	// Delete and recreate (simulates build tools that replace via rename)
@@ -596,7 +598,9 @@ func TestWatchBinaryInstallScriptSequence(t *testing.T) {
 
 	triggerReload := make(chan struct{}, 1)
 	ready := make(chan struct{})
-	go WatchBinary(binPath, triggerReload, ready)
+	stop := make(chan struct{})
+	t.Cleanup(func() { close(stop) })
+	go watchBinary(binPath, triggerReload, ready, stop)
 	<-ready
 
 	toolDir := newInstallScriptToolDir(t, "newbuild")
@@ -644,7 +648,9 @@ func TestWatchBinaryInstallScriptSequenceViaSymlinkPath(t *testing.T) {
 
 	triggerReload := make(chan struct{}, 1)
 	ready := make(chan struct{})
-	go WatchBinary(binPath, triggerReload, ready)
+	stop := make(chan struct{})
+	t.Cleanup(func() { close(stop) })
+	go watchBinary(binPath, triggerReload, ready, stop)
 	<-ready
 
 	toolDir := newInstallScriptToolDir(t, "newbuild")

--- a/internal/remote/host_conn_events.go
+++ b/internal/remote/host_conn_events.go
@@ -158,7 +158,9 @@ func (hc *HostConn) startConnect(reply chan error, connectFn func() (*connectOut
 	hc.setState(Connecting)
 	go func() {
 		outcome, err := connectFn()
-		hc.enqueue(connectDoneEvent{outcome: outcome, err: err})
+		if !hc.enqueue(connectDoneEvent{outcome: outcome, err: err}) && outcome != nil {
+			outcome.closeConns()
+		}
 	}()
 }
 

--- a/internal/remote/host_conn_test.go
+++ b/internal/remote/host_conn_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"golang.org/x/crypto/ssh"
 
@@ -476,6 +477,62 @@ func (s *stubNamedTransport) EnsureServer(context.Context, transport.Target, str
 	return nil
 }
 func (s *stubNamedTransport) Close() error { return nil }
+
+type closeTrackedTransport struct {
+	stubNamedTransport
+	closed chan struct{}
+	once   sync.Once
+}
+
+func (s *closeTrackedTransport) Close() error {
+	s.once.Do(func() {
+		close(s.closed)
+	})
+	return nil
+}
+
+func TestHostConnClosesLateConnectOutcomeAfterClose(t *testing.T) {
+	t.Parallel()
+
+	hc := NewHostConn("test", config.Host{}, "", nil, nil, nil)
+	started := make(chan struct{})
+	release := make(chan struct{})
+	returned := make(chan struct{})
+	serverConn, clientConn := net.Pipe()
+	defer serverConn.Close()
+	defer clientConn.Close()
+
+	tr := &closeTrackedTransport{closed: make(chan struct{})}
+	reply := make(chan error, 1)
+	testInActor(hc, func(hc *HostConn) {
+		hc.startConnect(reply, func() (*connectOutcome, error) {
+			close(started)
+			<-release
+			close(returned)
+			return &connectOutcome{amuxConn: clientConn, tr: tr}, nil
+		})
+	})
+
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("connect goroutine did not start")
+	}
+
+	hc.Close()
+	close(release)
+
+	select {
+	case <-returned:
+	case <-time.After(time.Second):
+		t.Fatal("connect goroutine did not return")
+	}
+	select {
+	case <-tr.closed:
+	case <-time.After(time.Second):
+		t.Fatal("late connect outcome transport was not closed after HostConn.Close")
+	}
+}
 
 func TestCloseConns(t *testing.T) {
 	t.Parallel()

--- a/internal/server/command_queue_test.go
+++ b/internal/server/command_queue_test.go
@@ -255,17 +255,11 @@ func TestQueuedCommandNewWindow(t *testing.T) {
 	srv, sess, cleanup := newCommandTestSession(t)
 	defer cleanup()
 
-	p1, err := sess.createPane(srv, 80, 23)
-	if err != nil {
-		t.Fatalf("createPane: %v", err)
-	}
-	p1.Start()
+	p1 := mustCreatePane(t, sess, srv, 80, 23)
 	w := mux.NewWindow(p1, 80, 23)
 	w.ID = 1
 	w.Name = "window-1"
-	sess.Windows = []*mux.Window{w}
-	sess.ActiveWindowID = w.ID
-	sess.Panes = []*mux.Pane{p1}
+	setSessionLayoutForTest(t, sess, w.ID, []*mux.Window{w}, p1)
 
 	before := sess.generation.Load()
 	res := runTestCommand(t, srv, sess, "new-window", "--name", "second")
@@ -294,17 +288,11 @@ func TestQueuedCommandSpawnLocal(t *testing.T) {
 	srv, sess, cleanup := newCommandTestSession(t)
 	defer cleanup()
 
-	p1, err := sess.createPane(srv, 80, 23)
-	if err != nil {
-		t.Fatalf("createPane: %v", err)
-	}
-	p1.Start()
+	p1 := mustCreatePane(t, sess, srv, 80, 23)
 	w := mux.NewWindow(p1, 80, 23)
 	w.ID = 1
 	w.Name = "window-1"
-	sess.Windows = []*mux.Window{w}
-	sess.ActiveWindowID = w.ID
-	sess.Panes = []*mux.Pane{p1}
+	setSessionLayoutForTest(t, sess, w.ID, []*mux.Window{w}, p1)
 
 	before := sess.generation.Load()
 	res := runTestCommand(t, srv, sess, "spawn", "--name", "worker-1", "--task", "build")
@@ -344,15 +332,9 @@ func TestQueuedCommandSpawnDoesNotBlockEventLoopWhileLocalPaneBuildRuns(t *testi
 	srv, sess, cleanup := newCommandTestSession(t)
 	defer cleanup()
 
-	p1, err := sess.createPane(srv, 80, 23)
-	if err != nil {
-		t.Fatalf("createPane: %v", err)
-	}
-	p1.Start()
+	p1 := mustCreatePane(t, sess, srv, 80, 23)
 	w := newTestWindowWithPanes(t, sess, 1, "window-1", p1)
-	sess.Windows = []*mux.Window{w}
-	sess.ActiveWindowID = w.ID
-	sess.Panes = []*mux.Pane{p1}
+	setSessionLayoutForTest(t, sess, w.ID, []*mux.Window{w}, p1)
 
 	buildStarted := make(chan struct{})
 	buildFinished := make(chan struct{})
@@ -530,17 +512,11 @@ func TestQueuedCommandInjectProxyAndUnsplice(t *testing.T) {
 	srv, sess, cleanup := newCommandTestSession(t)
 	defer cleanup()
 
-	p1, err := sess.createPane(srv, 80, 23)
-	if err != nil {
-		t.Fatalf("createPane: %v", err)
-	}
-	p1.Start()
+	p1 := mustCreatePane(t, sess, srv, 80, 23)
 	w := mux.NewWindow(p1, 80, 23)
 	w.ID = 1
 	w.Name = "window-1"
-	sess.Windows = []*mux.Window{w}
-	sess.ActiveWindowID = w.ID
-	sess.Panes = []*mux.Pane{p1}
+	setSessionLayoutForTest(t, sess, w.ID, []*mux.Window{w}, p1)
 
 	beforeInject := sess.generation.Load()
 	injectRes := runTestCommand(t, srv, sess, "_inject-proxy", "fake-host")

--- a/internal/server/dormant_test.go
+++ b/internal/server/dormant_test.go
@@ -65,19 +65,19 @@ func TestCmdListShowsDormant(t *testing.T) {
 	sess := srv.sessions["test-list-dormant"]
 
 	// Create pane-1 in a window.
-	pane1, err := sess.createPane(srv, 80, 23)
-	if err != nil {
-		t.Fatalf("createPane: %v", err)
-	}
-	pane1.Start()
+	pane1 := mustCreatePane(t, sess, srv, 80, 23)
 	w := mux.NewWindow(pane1, 80, 24)
-	w.ID = sess.windowCounter.Add(1)
-	w.Name = "window-1"
-	sess.Windows = append(sess.Windows, w)
-	sess.ActiveWindowID = w.ID
+	mustSessionMutation(t, sess, func(sess *Session) {
+		w.ID = sess.windowCounter.Add(1)
+		w.Name = "window-1"
+		sess.Windows = append(sess.Windows, w)
+		sess.ActiveWindowID = w.ID
+	})
 
 	// Add a dormant pane.
-	dormantID := sess.counter.Add(1)
+	dormantID := mustSessionQuery(t, sess, func(sess *Session) uint32 {
+		return sess.counter.Add(1)
+	})
 	dormantPane := newProxyPane(dormantID, mux.PaneMeta{
 		Name: "ssh-conn", Dormant: true, Color: "f5e0dc",
 	}, 80, 23,
@@ -85,7 +85,9 @@ func TestCmdListShowsDormant(t *testing.T) {
 		sess.paneExitCallback(),
 		func(data []byte) (int, error) { return len(data), nil },
 	)
-	sess.Panes = append(sess.Panes, dormantPane)
+	mustSessionMutation(t, sess, func(sess *Session) {
+		sess.Panes = append(sess.Panes, dormantPane)
+	})
 
 	// Run the list command via net.Pipe.
 	serverConn, peerConn := net.Pipe()

--- a/internal/server/find_pane_test.go
+++ b/internal/server/find_pane_test.go
@@ -94,20 +94,20 @@ func TestKillOrphanedPaneViaFallback(t *testing.T) {
 	sess := srv.sessions["test-kill-orphan"]
 
 	// Create pane-1 in a window (the normal, non-orphaned pane).
-	pane1, err := sess.createPane(srv, 80, 23)
-	if err != nil {
-		t.Fatalf("createPane: %v", err)
-	}
-	pane1.Start()
+	pane1 := mustCreatePane(t, sess, srv, 80, 23)
 	w := mux.NewWindow(pane1, 80, 24)
-	w.ID = sess.windowCounter.Add(1)
-	w.Name = "window-1"
-	sess.Windows = append(sess.Windows, w)
-	sess.ActiveWindowID = w.ID
+	mustSessionMutation(t, sess, func(sess *Session) {
+		w.ID = sess.windowCounter.Add(1)
+		w.Name = "window-1"
+		sess.Windows = append(sess.Windows, w)
+		sess.ActiveWindowID = w.ID
+	})
 
 	// Create an orphaned pane: add to flat registry but NOT to any window layout.
 	// This simulates a dormant SSH takeover pane or a pane orphaned by a race.
-	orphanID := sess.counter.Add(1)
+	orphanID := mustSessionQuery(t, sess, func(sess *Session) uint32 {
+		return sess.counter.Add(1)
+	})
 	orphanPane := newProxyPane(orphanID, mux.PaneMeta{
 		Name: "orphan-pane", Host: "remote", Color: "f5e0dc",
 	}, 80, 23,
@@ -115,7 +115,9 @@ func TestKillOrphanedPaneViaFallback(t *testing.T) {
 		sess.paneExitCallback(),
 		func(data []byte) (int, error) { return len(data), nil },
 	)
-	sess.Panes = append(sess.Panes, orphanPane)
+	mustSessionMutation(t, sess, func(sess *Session) {
+		sess.Panes = append(sess.Panes, orphanPane)
+	})
 
 	// Verify the orphan is in the flat registry but not in any layout tree.
 	state := mustSessionQuery(t, sess, func(sess *Session) struct {

--- a/internal/server/split_inherit_test.go
+++ b/internal/server/split_inherit_test.go
@@ -24,19 +24,19 @@ func TestSplitInheritsRemoteHost(t *testing.T) {
 	sess := srv.sessions["test-inherit"]
 
 	// Create pane-1 + window
-	pane1, err := sess.createPane(srv, 80, 23)
-	if err != nil {
-		t.Fatalf("createPane: %v", err)
-	}
-	pane1.Start()
+	pane1 := mustCreatePane(t, sess, srv, 80, 23)
 	w := mux.NewWindow(pane1, 80, 24)
-	w.ID = sess.windowCounter.Add(1)
-	w.Name = "window-1"
-	sess.Windows = append(sess.Windows, w)
-	sess.ActiveWindowID = w.ID
+	mustSessionMutation(t, sess, func(sess *Session) {
+		w.ID = sess.windowCounter.Add(1)
+		w.Name = "window-1"
+		sess.Windows = append(sess.Windows, w)
+		sess.ActiveWindowID = w.ID
+	})
 
 	// Create a proxy pane simulating a remote connection
-	proxyID := sess.counter.Add(1)
+	proxyID := mustSessionQuery(t, sess, func(sess *Session) uint32 {
+		return sess.counter.Add(1)
+	})
 	proxyPane := newProxyPane(proxyID, mux.PaneMeta{
 		Name: "pane-2", Host: "gpu-server", Color: "f5e0dc",
 	}, 40, 23,
@@ -44,11 +44,18 @@ func TestSplitInheritsRemoteHost(t *testing.T) {
 		sess.paneExitCallback(),
 		func(data []byte) (int, error) { return len(data), nil },
 	)
-	sess.Panes = append(sess.Panes, proxyPane)
-	if _, err := w.Split(mux.SplitHorizontal, proxyPane); err != nil {
-		t.Fatalf("Split: %v", err)
+	var splitErr error
+	mustSessionMutation(t, sess, func(sess *Session) {
+		sess.Panes = append(sess.Panes, proxyPane)
+		_, splitErr = w.Split(mux.SplitHorizontal, proxyPane)
+		if splitErr != nil {
+			return
+		}
+		w.FocusPane(proxyPane) // make proxy pane active
+	})
+	if splitErr != nil {
+		t.Fatalf("Split: %v", splitErr)
 	}
-	w.FocusPane(proxyPane) // make proxy pane active
 
 	// Send the split command through handleCommand with a pipe to capture the response.
 	// handleCommand may send layout broadcasts before the cmd result, so drain

--- a/internal/server/test_main_count_test.go
+++ b/internal/server/test_main_count_test.go
@@ -1,0 +1,43 @@
+package server
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestServerTestArgsWithCount(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		args []string
+		want []string
+	}{
+		{
+			name: "replaces equals form",
+			args: []string{"-test.v=true", "-test.count=10", "-test.run=TestFoo"},
+			want: []string{"-test.v=true", "-test.count=1", "-test.run=TestFoo"},
+		},
+		{
+			name: "replaces separated form",
+			args: []string{"-test.count", "10", "-test.run=TestFoo"},
+			want: []string{"-test.count=1", "-test.run=TestFoo"},
+		},
+		{
+			name: "appends when absent",
+			args: []string{"-test.run=TestFoo"},
+			want: []string{"-test.run=TestFoo", "-test.count=1"},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := serverTestArgsWithCount(tt.args, 1); !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("serverTestArgsWithCount() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/server/test_main_test.go
+++ b/internal/server/test_main_test.go
@@ -4,10 +4,11 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"os/exec"
 	"strconv"
 	"strings"
 	"testing"
+
+	"github.com/weill-labs/amux/internal/testenv"
 )
 
 const serverSplitCountChildEnv = "AMUX_SERVER_SPLIT_COUNT_CHILD"
@@ -38,8 +39,8 @@ func currentTestCount() int {
 func runServerTestCountInChildren(count int) int {
 	args := serverTestArgsWithCount(os.Args[1:], 1)
 	for i := 0; i < count; i++ {
-		cmd := exec.Command(os.Args[0], args...)
-		cmd.Env = append(os.Environ(),
+		cmd := testenv.NewCommand(os.Args[0], args...)
+		cmd.Env = append(cmd.Env,
 			serverSplitCountChildEnv+"=1",
 			fmt.Sprintf("AMUX_SERVER_SPLIT_COUNT_INDEX=%d", i+1),
 		)

--- a/internal/server/test_main_test.go
+++ b/internal/server/test_main_test.go
@@ -1,0 +1,80 @@
+package server
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+const serverSplitCountChildEnv = "AMUX_SERVER_SPLIT_COUNT_CHILD"
+
+func TestMain(m *testing.M) {
+	flag.Parse()
+
+	count := currentTestCount()
+	if count > 1 && os.Getenv(serverSplitCountChildEnv) != "1" {
+		os.Exit(runServerTestCountInChildren(count))
+	}
+
+	os.Exit(m.Run())
+}
+
+func currentTestCount() int {
+	countFlag := flag.Lookup("test.count")
+	if countFlag == nil {
+		return 1
+	}
+	count, err := strconv.Atoi(countFlag.Value.String())
+	if err != nil || count < 1 {
+		return 1
+	}
+	return count
+}
+
+func runServerTestCountInChildren(count int) int {
+	args := serverTestArgsWithCount(os.Args[1:], 1)
+	for i := 0; i < count; i++ {
+		cmd := exec.Command(os.Args[0], args...)
+		cmd.Env = append(os.Environ(),
+			serverSplitCountChildEnv+"=1",
+			fmt.Sprintf("AMUX_SERVER_SPLIT_COUNT_INDEX=%d", i+1),
+		)
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		if err := cmd.Run(); err != nil {
+			fmt.Fprintf(os.Stderr, "server test iteration %d/%d failed: %v\n", i+1, count, err)
+			return 1
+		}
+	}
+	return 0
+}
+
+func serverTestArgsWithCount(args []string, count int) []string {
+	next := make([]string, 0, len(args)+1)
+	replaced := false
+	countArg := "-test.count=" + strconv.Itoa(count)
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		switch {
+		case arg == "-test.count" || arg == "--test.count":
+			next = append(next, countArg)
+			replaced = true
+			if i+1 < len(args) {
+				i++
+			}
+		case strings.HasPrefix(arg, "-test.count=") || strings.HasPrefix(arg, "--test.count="):
+			next = append(next, countArg)
+			replaced = true
+		default:
+			next = append(next, arg)
+		}
+	}
+	if !replaced {
+		next = append(next, countArg)
+	}
+	return next
+}

--- a/test/amux_harness_test.go
+++ b/test/amux_harness_test.go
@@ -110,7 +110,7 @@ func newAmuxHarnessWithBinInDir(tb testing.TB, binPath, launchDir string, envVar
 		defer nestedHarnessStartupMu.Unlock()
 	}
 
-	var b [4]byte
+	var b [8]byte
 	mustRandRead(tb, b[:])
 	inner := fmt.Sprintf("t-%x", b)
 

--- a/test/bench_test.go
+++ b/test/bench_test.go
@@ -34,7 +34,7 @@ func newTmuxBenchHarness(b *testing.B) *TmuxBenchHarness {
 		b.Skip("tmux not found, skipping tmux benchmarks")
 	}
 
-	var buf [4]byte
+	var buf [8]byte
 	mustRandRead(b, buf[:])
 	session := fmt.Sprintf("bench-%x", buf)
 

--- a/test/crash_recovery_test.go
+++ b/test/crash_recovery_test.go
@@ -508,7 +508,7 @@ func startServerForSession(t *testing.T, session, home string) *ServerHarness {
 	// Per-test cover dir
 	var coverDir string
 	if gocoverDir != "" {
-		var b [4]byte
+		var b [8]byte
 		mustRandRead(t, b[:])
 		coverDir = filepath.Join(gocoverDir, fmt.Sprintf("recover-%x", b))
 		mustMkdirAll(t, coverDir, 0755)

--- a/test/crash_recovery_test.go
+++ b/test/crash_recovery_test.go
@@ -64,8 +64,9 @@ func TestCrashRecovery_LayoutRestored(t *testing.T) {
 	if err := h.signalServer(syscall.SIGKILL); err != nil {
 		t.Fatalf("SIGKILL server: %v", err)
 	}
-	ignoreCmdWait(h.cmd)
-	h.cmd = nil // prevent cleanup from trying to kill again
+	if !h.waitForSignaledServerExit(5 * time.Second) {
+		t.Fatal("server did not exit after SIGKILL")
+	}
 
 	// Verify crash checkpoint file still exists (SIGKILL = no cleanup)
 	if _, err := os.Stat(cpWrite.path); err != nil {
@@ -165,8 +166,9 @@ func TestCrashRecovery_FocusUpFromRestoredFullWidthBottomPane(t *testing.T) {
 	if err := h.signalServer(syscall.SIGKILL); err != nil {
 		t.Fatalf("SIGKILL server: %v", err)
 	}
-	ignoreCmdWait(h.cmd)
-	h.cmd = nil
+	if !h.waitForSignaledServerExit(5 * time.Second) {
+		t.Fatal("server did not exit after SIGKILL")
+	}
 
 	h2 := startServerForSession(t, h.session, h.home)
 	h2.assertActive("pane-10")
@@ -205,8 +207,9 @@ func TestCrashRecovery_PreservesHistoryCapture(t *testing.T) {
 	if err := h.signalServer(syscall.SIGKILL); err != nil {
 		t.Fatalf("SIGKILL server: %v", err)
 	}
-	ignoreCmdWait(h.cmd)
-	h.cmd = nil
+	if !h.waitForSignaledServerExit(5 * time.Second) {
+		t.Fatal("server did not exit after SIGKILL")
+	}
 
 	h2 := startServerForSession(t, h.session, h.home)
 
@@ -235,8 +238,9 @@ func TestCrashRecovery_ReplaysVisibleScreenForIdleShellPane(t *testing.T) {
 	if err := h.signalServer(syscall.SIGKILL); err != nil {
 		t.Fatalf("SIGKILL server: %v", err)
 	}
-	ignoreCmdWait(h.cmd)
-	h.cmd = nil
+	if !h.waitForSignaledServerExit(5 * time.Second) {
+		t.Fatal("server did not exit after SIGKILL")
+	}
 
 	h2 := startServerForSession(t, h.session, h.home)
 
@@ -266,8 +270,9 @@ func TestCrashRecovery_BusyPaneShowsRecoveryNoticeInsteadOfReplayingStaleScreen(
 	if err := h.signalServer(syscall.SIGKILL); err != nil {
 		t.Fatalf("SIGKILL server: %v", err)
 	}
-	ignoreCmdWait(h.cmd)
-	h.cmd = nil
+	if !h.waitForSignaledServerExit(5 * time.Second) {
+		t.Fatal("server did not exit after SIGKILL")
+	}
 
 	h2 := startServerForSession(t, h.session, h.home)
 

--- a/test/go_cache_test.go
+++ b/test/go_cache_test.go
@@ -5,12 +5,12 @@ import (
 	"testing"
 )
 
-func TestGoBuildEnvUsesPerBinaryCache(t *testing.T) {
+func TestGoBuildEnvUsesIsolatedCache(t *testing.T) {
 	t.Parallel()
 
 	binPath := filepath.Join(t.TempDir(), "bin", "amux")
 	env := goBuildEnv([]string{"PATH=/bin", "GOCACHE=/shared"}, binPath)
-	want := filepath.Join(filepath.Dir(binPath), ".gocache")
+	want := childGoCachePath(filepath.Dir(binPath))
 
 	if got := issueMetaEnvValue(env, "GOCACHE"); got != want {
 		t.Fatalf("GOCACHE = %q, want %q", got, want)
@@ -22,7 +22,7 @@ func TestIssueMetaScriptEnvUsesPerTestGoCache(t *testing.T) {
 
 	tempDir := t.TempDir()
 	env := issueMetaScriptEnv(tempDir)
-	want := filepath.Join(tempDir, ".gocache")
+	want := childGoCachePath(tempDir)
 
 	if got := issueMetaEnvValue(env, "GOCACHE"); got != want {
 		t.Fatalf("GOCACHE = %q, want %q", got, want)

--- a/test/go_cache_test.go
+++ b/test/go_cache_test.go
@@ -1,0 +1,30 @@
+package test
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestGoBuildEnvUsesPerBinaryCache(t *testing.T) {
+	t.Parallel()
+
+	binPath := filepath.Join(t.TempDir(), "bin", "amux")
+	env := goBuildEnv([]string{"PATH=/bin", "GOCACHE=/shared"}, binPath)
+	want := filepath.Join(filepath.Dir(binPath), ".gocache")
+
+	if got := issueMetaEnvValue(env, "GOCACHE"); got != want {
+		t.Fatalf("GOCACHE = %q, want %q", got, want)
+	}
+}
+
+func TestIssueMetaScriptEnvUsesPerTestGoCache(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	env := issueMetaScriptEnv(tempDir)
+	want := filepath.Join(tempDir, ".gocache")
+
+	if got := issueMetaEnvValue(env, "GOCACHE"); got != want {
+		t.Fatalf("GOCACHE = %q, want %q", got, want)
+	}
+}

--- a/test/golden_test.go
+++ b/test/golden_test.go
@@ -110,7 +110,11 @@ var timeRe = regexp.MustCompile(`\d{2}:\d{2}`)
 // normalizeGlobalBar replaces the random session name with SESSION and
 // the timestamp with 00:00.
 func normalizeGlobalBar(line string, sessionName string) string {
-	line = strings.ReplaceAll(line, sessionName, "SESSION")
+	replacement := "SESSION"
+	if extra := len([]rune(sessionName)) - len("t-00000000"); extra > 0 {
+		replacement += strings.Repeat(" ", extra)
+	}
+	line = strings.ReplaceAll(line, sessionName, replacement)
 	return timeRe.ReplaceAllString(line, "00:00")
 }
 

--- a/test/golden_test.go
+++ b/test/golden_test.go
@@ -114,6 +114,22 @@ func normalizeGlobalBar(line string, sessionName string) string {
 	return timeRe.ReplaceAllString(line, "00:00")
 }
 
+func TestNormalizeGlobalBarIgnoresTestSessionEntropyLength(t *testing.T) {
+	t.Parallel()
+
+	shortSession := "t-12345678"
+	longSession := "t-1234567890abcdef"
+	shortLine := " amux │ " + shortSession + "                                     3 panes │ ? help │ 12:34"
+	longLine := " amux │ " + longSession + "                             3 panes │ ? help │ 12:34"
+
+	gotShort := normalizeGlobalBar(shortLine, shortSession)
+	gotLong := normalizeGlobalBar(longLine, longSession)
+
+	if gotShort != gotLong {
+		t.Fatalf("normalized global bars differ:\nshort: %q\nlong:  %q", gotShort, gotLong)
+	}
+}
+
 // extractStructuralLine keeps pane status segments and box-drawing border
 // characters, replacing all other pane content with spaces.
 func extractStructuralLine(line string) string {

--- a/test/harness_cleanup_test.go
+++ b/test/harness_cleanup_test.go
@@ -109,3 +109,15 @@ func TestParseAmuxServerProcessLineRequiresFullCommand(t *testing.T) {
 		t.Fatal("parseAmuxServerProcessLine accepted pgrep output without command arguments")
 	}
 }
+
+func TestParseAmuxServerProcessLineAcceptsRemoteSessionSuffix(t *testing.T) {
+	t.Parallel()
+
+	pid, session, ok := parseAmuxServerProcessLine("2308581 /tmp/amux-test/amux _server t-01234567@hetzner-1", isTestSession)
+	if !ok {
+		t.Fatal("parseAmuxServerProcessLine rejected a remote test session")
+	}
+	if pid != "2308581" || session != "t-01234567" {
+		t.Fatalf("parseAmuxServerProcessLine() = (%q, %q), want (2308581, t-01234567)", pid, session)
+	}
+}

--- a/test/harness_cleanup_test.go
+++ b/test/harness_cleanup_test.go
@@ -69,3 +69,27 @@ func TestHasOtherActiveTestRunRemovesStaleLocks(t *testing.T) {
 		t.Fatalf("stale lock %s should be removed, stat err=%v", filepath.Base(lockPath), err)
 	}
 }
+
+func TestIsTestSessionAcceptsExpandedEntropy(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		session string
+		want    bool
+	}{
+		{name: "legacy eight hex", session: "t-0123abcd", want: true},
+		{name: "expanded sixteen hex", session: "t-0123456789abcdef", want: true},
+		{name: "too short", session: "t-1234", want: false},
+		{name: "non hex", session: "t-0123456789abcdeg", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := isTestSession(tt.session); got != tt.want {
+				t.Fatalf("isTestSession(%q) = %t, want %t", tt.session, got, tt.want)
+			}
+		})
+	}
+}

--- a/test/harness_cleanup_test.go
+++ b/test/harness_cleanup_test.go
@@ -93,3 +93,19 @@ func TestIsTestSessionAcceptsExpandedEntropy(t *testing.T) {
 		})
 	}
 }
+
+func TestParseAmuxServerProcessLineRequiresFullCommand(t *testing.T) {
+	t.Parallel()
+
+	pid, session, ok := parseAmuxServerProcessLine("498495 /tmp/amux-test/amux _server t-0123456789abcdef", isTestSession)
+	if !ok {
+		t.Fatal("parseAmuxServerProcessLine rejected a full amux server command")
+	}
+	if pid != "498495" || session != "t-0123456789abcdef" {
+		t.Fatalf("parseAmuxServerProcessLine() = (%q, %q), want (498495, t-0123456789abcdef)", pid, session)
+	}
+
+	if _, _, ok := parseAmuxServerProcessLine("498495 amux", isTestSession); ok {
+		t.Fatal("parseAmuxServerProcessLine accepted pgrep output without command arguments")
+	}
+}

--- a/test/harness_test.go
+++ b/test/harness_test.go
@@ -92,7 +92,7 @@ func TestMain(m *testing.M) {
 		fmt.Fprintf(os.Stderr, "creating test-run lock: %v\n", err)
 		os.Exit(1)
 	}
-	defer os.Remove(lockPath)
+	removeTestRunLock := func() { _ = os.Remove(lockPath) }
 
 	// Clean up orphaned test sessions from previous runs that may have
 	// been killed by a timeout panic (t.Cleanup doesn't run on panic).
@@ -107,6 +107,7 @@ func TestMain(m *testing.M) {
 	tmp, err := os.MkdirTemp("", "amux-test-*")
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "creating temp dir: %v\n", err)
+		removeTestRunLock()
 		os.Exit(1)
 	}
 	defer os.RemoveAll(tmp)
@@ -114,6 +115,7 @@ func TestMain(m *testing.M) {
 	amuxBin = tmp + "/amux"
 	if err := buildAmux(amuxBin); err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
+		removeTestRunLock()
 		os.Exit(1)
 	}
 
@@ -134,6 +136,7 @@ func TestMain(m *testing.M) {
 		}
 	}
 
+	removeTestRunLock()
 	os.Exit(code)
 }
 
@@ -178,32 +181,30 @@ func cleanupStaleTestSessions() {
 	staleSessions := make(map[string]bool)
 
 	// Kill orphaned amux server processes whose parent test process is gone.
-	out, _ := exec.Command("pgrep", "-fl", "amux _server t-").Output()
+	out, _ := exec.Command("pgrep", "-af", "amux _server t-").Output()
 	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
-		fields := strings.Fields(line)
-		if len(fields) >= 3 && isTestSession(fields[len(fields)-1]) {
-			session := fields[len(fields)-1]
-			if serverHasLiveTestParent(fields[0]) {
+		pid, session, ok := parseAmuxServerProcessLine(line, isTestSession)
+		if ok {
+			if serverHasLiveTestParent(pid) {
 				liveOwnedSessions[session] = true
 				continue
 			}
 			staleSessions[session] = true
-			killStaleServerProcess(fields[0])
+			killStaleServerProcess(pid)
 		}
 	}
 
 	// Also kill orphaned benchmark amux servers with the same parent check.
-	out, _ = exec.Command("pgrep", "-fl", "amux _server bench-").Output()
+	out, _ = exec.Command("pgrep", "-af", "amux _server bench-").Output()
 	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
-		fields := strings.Fields(line)
-		if len(fields) >= 3 && isBenchSession(fields[len(fields)-1]) {
-			session := fields[len(fields)-1]
-			if serverHasLiveTestParent(fields[0]) {
+		pid, session, ok := parseAmuxServerProcessLine(line, isBenchSession)
+		if ok {
+			if serverHasLiveTestParent(pid) {
 				liveOwnedSessions[session] = true
 				continue
 			}
 			staleSessions[session] = true
-			killStaleServerProcess(fields[0])
+			killStaleServerProcess(pid)
 		}
 	}
 
@@ -284,6 +285,21 @@ func hasOtherActiveTestRun(socketDir string, selfPID int) bool {
 		}
 	}
 	return false
+}
+
+func parseAmuxServerProcessLine(line string, matchSession func(string) bool) (pid, session string, ok bool) {
+	fields := strings.Fields(line)
+	if len(fields) < 3 {
+		return "", "", false
+	}
+	if parsedPID, err := strconv.Atoi(fields[0]); err != nil || parsedPID <= 0 {
+		return "", "", false
+	}
+	session = fields[len(fields)-1]
+	if !matchSession(session) {
+		return "", "", false
+	}
+	return fields[0], session, true
 }
 
 func parseTestRunLockPID(name string) (int, bool) {

--- a/test/harness_test.go
+++ b/test/harness_test.go
@@ -177,7 +177,7 @@ func cleanupStaleTestSessions() {
 	liveOwnedSessions := make(map[string]bool)
 	staleSessions := make(map[string]bool)
 
-	// Kill orphaned amux server processes, but only if their socket is stale
+	// Kill orphaned amux server processes whose parent test process is gone.
 	out, _ := exec.Command("pgrep", "-fl", "amux _server t-").Output()
 	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
 		fields := strings.Fields(line)
@@ -192,7 +192,7 @@ func cleanupStaleTestSessions() {
 		}
 	}
 
-	// Also kill orphaned benchmark amux servers (same liveness check)
+	// Also kill orphaned benchmark amux servers with the same parent check.
 	out, _ = exec.Command("pgrep", "-fl", "amux _server bench-").Output()
 	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
 		fields := strings.Fields(line)

--- a/test/harness_test.go
+++ b/test/harness_test.go
@@ -166,9 +166,9 @@ func newTestHome(tb testing.TB) string {
 // and log files left behind by previous test runs that were killed by a
 // timeout panic.
 //
-// Only kills servers whose sockets are unresponsive (stale). Live servers
-// that accept connections are left alone, making this safe even if another
-// `go test` invocation is running concurrently.
+// A live test-run lock protects concurrent `go test` invocations. When no other
+// run owns a lock, any test server without a live test parent is stale even if
+// its socket still accepts connections.
 func cleanupStaleTestSessions() {
 	socketDir := fmt.Sprintf("/tmp/amux-%d", os.Getuid())
 	if hasOtherActiveTestRun(socketDir, os.Getpid()) {
@@ -187,9 +187,6 @@ func cleanupStaleTestSessions() {
 				liveOwnedSessions[session] = true
 				continue
 			}
-			if isSocketAlive(filepath.Join(socketDir, session)) {
-				continue // server is live, don't kill
-			}
 			staleSessions[session] = true
 			killStaleServerProcess(fields[0])
 		}
@@ -203,9 +200,6 @@ func cleanupStaleTestSessions() {
 			session := fields[len(fields)-1]
 			if serverHasLiveTestParent(fields[0]) {
 				liveOwnedSessions[session] = true
-				continue
-			}
-			if isSocketAlive(filepath.Join(socketDir, session)) {
 				continue
 			}
 			staleSessions[session] = true
@@ -252,7 +246,7 @@ func cleanupStaleTestSessions() {
 		}
 		if isTestSession(base) || isBenchSession(base) {
 			sockPath := filepath.Join(socketDir, base)
-			if !isSocketAlive(sockPath) {
+			if staleSessions[base] || !isSocketAlive(sockPath) {
 				os.Remove(filepath.Join(socketDir, name))
 			}
 		}
@@ -413,22 +407,28 @@ func isSocketAlive(sockPath string) bool {
 	return true
 }
 
-// isTestSession returns true if the name matches the test session convention: t- followed by 8 hex chars.
-func isTestSession(name string) bool {
-	if len(name) != 10 || name[:2] != "t-" {
+func hasHexSuffix(name, prefix string, lengths ...int) bool {
+	if !strings.HasPrefix(name, prefix) {
 		return false
 	}
-	_, err := hex.DecodeString(name[2:])
-	return err == nil
+	suffix := strings.TrimPrefix(name, prefix)
+	for _, length := range lengths {
+		if len(suffix) == length {
+			_, err := hex.DecodeString(suffix)
+			return err == nil
+		}
+	}
+	return false
 }
 
-// isBenchSession returns true if the name matches the bench session convention: bench- followed by 8 hex chars.
+// isTestSession returns true if the name matches the test session convention.
+func isTestSession(name string) bool {
+	return hasHexSuffix(name, "t-", 8, 16)
+}
+
+// isBenchSession returns true if the name matches the bench session convention.
 func isBenchSession(name string) bool {
-	if len(name) != 14 || !strings.HasPrefix(name, "bench-") {
-		return false
-	}
-	_, err := hex.DecodeString(name[6:])
-	return err == nil
+	return hasHexSuffix(name, "bench-", 8, 16)
 }
 
 // ---------------------------------------------------------------------------

--- a/test/harness_test.go
+++ b/test/harness_test.go
@@ -296,6 +296,9 @@ func parseAmuxServerProcessLine(line string, matchSession func(string) bool) (pi
 		return "", "", false
 	}
 	session = fields[len(fields)-1]
+	if at := strings.Index(session, "@"); at >= 0 {
+		session = session[:at]
+	}
 	if !matchSession(session) {
 		return "", "", false
 	}

--- a/test/harness_test.go
+++ b/test/harness_test.go
@@ -24,6 +24,10 @@ var gocoverDir string
 // gocoverOwned is true when TestMain created gocoverDir (vs. inheriting it).
 var gocoverOwned bool
 
+// childGoCacheDir isolates nested go build/go run commands from the user's
+// ambient cache while preserving reuse within this test process.
+var childGoCacheDir string
+
 const testRunLockPrefix = "test-run-"
 
 // buildAmux builds the amux binary at binPath. When GOCOVERDIR is set,
@@ -46,11 +50,25 @@ func buildAmuxWithCommit(binPath, buildCommit string) error {
 		args = append(args, "-ldflags", "-X main.BuildCommit="+buildCommit)
 	}
 	args = append(args, "-o", binPath, "..")
-	out, err := exec.Command("go", args...).CombinedOutput()
+	cmd := exec.Command("go", args...)
+	cmd.Env = goBuildEnv(os.Environ(), binPath)
+	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("building amux: %w\n%s", err, out)
 	}
 	return nil
+}
+
+func goBuildEnv(baseEnv []string, binPath string) []string {
+	env := append([]string{}, baseEnv...)
+	return upsertEnv(env, "GOCACHE", childGoCachePath(filepath.Dir(binPath)))
+}
+
+func childGoCachePath(fallbackParent string) string {
+	if childGoCacheDir != "" {
+		return childGoCacheDir
+	}
+	return filepath.Join(fallbackParent, ".gocache")
 }
 
 func privateAmuxBin(tb testing.TB) string {
@@ -113,6 +131,7 @@ func TestMain(m *testing.M) {
 	defer os.RemoveAll(tmp)
 
 	amuxBin = tmp + "/amux"
+	childGoCacheDir = filepath.Join(tmp, ".gocache")
 	if err := buildAmux(amuxBin); err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 		removeTestRunLock()

--- a/test/hotreload_test.go
+++ b/test/hotreload_test.go
@@ -259,6 +259,7 @@ func TestHotReloadRebuildConvergesFromOutsideRepoWithMismatchedInstallMetadata(t
 	if !strings.Contains(before, "build: beforeoutside") {
 		t.Fatalf("status before binary rewrite = %q, want before build marker", before)
 	}
+	reloadGen := h.generation()
 	if err := buildAmuxAtomic(privateBin, "srvonlyreload"); err != nil {
 		t.Fatalf("rewriting private amux binary atomically: %v", err)
 	}
@@ -271,6 +272,7 @@ func TestHotReloadRebuildConvergesFromOutsideRepoWithMismatchedInstallMetadata(t
 	if !strings.Contains(after, "build: srvonlyreload") {
 		t.Fatalf("status after binary rewrite = %q, want new build marker", after)
 	}
+	h.waitForReloadedClient(reloadGen, 15*time.Second)
 
 	h.sendKeys("echo ONE_RELOAD_ONLY", "Enter")
 	if !h.waitFor("ONE_RELOAD_ONLY", 5*time.Second) {

--- a/test/issue_meta_check_test.go
+++ b/test/issue_meta_check_test.go
@@ -372,6 +372,7 @@ printf '%s\n' "$FAKE_GITHUB_MAIN_SHA"
 func issueMetaScriptEnv(tempDir string, extra ...string) []string {
 	env := append([]string{}, hermeticMainEnv()...)
 	env = upsertIssueMetaEnv(env, "PATH", tempDir+string(os.PathListSeparator)+issueMetaEnvValue(env, "PATH"))
+	env = upsertIssueMetaEnv(env, "GOCACHE", childGoCachePath(tempDir))
 	env = upsertIssueMetaEnv(env, "AMUX_PANE", "7")
 	env = upsertIssueMetaEnv(env, "AMUX_SESSION", "test-session")
 	return append(env, extra...)

--- a/test/keybinding_test.go
+++ b/test/keybinding_test.go
@@ -28,7 +28,7 @@ func writeTestConfigFile(t *testing.T, configContent string) string {
 func randomTestSessionName(t *testing.T) string {
 	t.Helper()
 
-	var b [4]byte
+	var b [8]byte
 	if _, err := rand.Read(b[:]); err != nil {
 		t.Fatalf("rand.Read: %v", err)
 	}

--- a/test/lint_helpers_test.go
+++ b/test/lint_helpers_test.go
@@ -55,13 +55,6 @@ func mustWrite(tb testing.TB, writer interface{ Write([]byte) (int, error) }, da
 	}
 }
 
-func ignoreCmdWait(cmd *exec.Cmd) {
-	if cmd == nil {
-		return
-	}
-	_ = cmd.Wait() //nolint:errcheck // shutdown-path tests intentionally reap signaled processes
-}
-
 func ignoreProcessKill(proc *os.Process) {
 	if proc == nil {
 		return

--- a/test/mouse_cli_test.go
+++ b/test/mouse_cli_test.go
@@ -79,7 +79,7 @@ func TestMouseCommandDragAutomaticallyCopiesSelection(t *testing.T) {
 
 	h := newAmuxHarness(t, "SSH_CONNECTION=1")
 
-	h.sendKeys("printf '\\033[2J\\033[Hhello from mouse\\n'; sleep 3", "Enter")
+	h.sendKeys(mouseCopyTargetCommand("hello from mouse", 3), "Enter")
 	if !h.waitFor("hello from mouse", 3*time.Second) {
 		t.Fatalf("expected mouse copy target output.\nScreen:\n%s", h.captureOuter())
 	}

--- a/test/mouse_copy_command_test.go
+++ b/test/mouse_copy_command_test.go
@@ -1,0 +1,17 @@
+package test
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestMouseCopyTargetCommandHidesTargetLiteral(t *testing.T) {
+	t.Parallel()
+
+	const target = "hello from mouse"
+	cmd := mouseCopyTargetCommand(target, 3)
+
+	if strings.Contains(cmd, target) {
+		t.Fatalf("command %q should not contain target literal %q", cmd, target)
+	}
+}

--- a/test/mouse_test.go
+++ b/test/mouse_test.go
@@ -152,6 +152,18 @@ func outerTextCoords(screen, substr string) (x, y int, ok bool) {
 	return 0, 0, false
 }
 
+func mouseCopyTargetCommand(target string, sleepSeconds int) string {
+	return fmt.Sprintf("printf '\\033[2J\\033[H%s\\n'; sleep %d", shellOctalEscapes(target), sleepSeconds)
+}
+
+func shellOctalEscapes(s string) string {
+	var b strings.Builder
+	for _, c := range []byte(s) {
+		fmt.Fprintf(&b, "\\%03o", c)
+	}
+	return b.String()
+}
+
 func waitOuterTextCoords(wait func(string, time.Duration) bool, capture func() string, substr string, timeout time.Duration) (x, y int, screen string, ok bool) {
 	if !wait(substr, timeout) {
 		return 0, 0, capture(), false
@@ -752,7 +764,7 @@ func TestMouseDragAutomaticallyEntersCopyModeAndCopiesSelection(t *testing.T) {
 
 	// Keep the target line visible long enough for slower CI runners to capture
 	// its screen coordinates before the shell prompt redraws.
-	h.sendKeys("printf '\\033[2J\\033[Hhello from mouse\\n'; sleep 1", "Enter")
+	h.sendKeys(mouseCopyTargetCommand("hello from mouse", 3), "Enter")
 	if !h.waitFor("hello from mouse", 3*time.Second) {
 		t.Fatalf("expected mouse copy target output.\nScreen:\n%s", h.captureOuter())
 	}

--- a/test/pane_ops_test.go
+++ b/test/pane_ops_test.go
@@ -479,14 +479,7 @@ func TestShutdownLeavesNoOrphans(t *testing.T) {
 	if err := h.signalServer(os.Interrupt); err != nil {
 		t.Fatalf("interrupting server: %v", err)
 	}
-	done := make(chan struct{})
-	go func() {
-		ignoreCmdWait(h.cmd)
-		close(done)
-	}()
-	select {
-	case <-done:
-	case <-time.After(10 * time.Second):
+	if !h.waitForSignaledServerExit(10 * time.Second) {
 		_ = h.signalServer(syscall.SIGKILL)
 		t.Fatal("server didn't shut down within 10 seconds")
 	}

--- a/test/server_harness_test.go
+++ b/test/server_harness_test.go
@@ -330,6 +330,17 @@ func (h *ServerHarness) signalServer(sig os.Signal) error {
 	return h.cmd.Process.Signal(sig)
 }
 
+func TestServerHarnessWaitForSignaledServerExitReusesBackgroundWaiter(t *testing.T) {
+	t.Parallel()
+
+	h := newServerHarnessPersistent(t)
+	if err := h.signalServer(syscall.SIGKILL); err != nil {
+		t.Fatalf("SIGKILL server: %v", err)
+	}
+
+	h.waitForSignaledServerExit(5 * time.Second)
+}
+
 // cleanup detaches the headless clients, sends SIGINT for graceful shutdown
 // (coverage flush) when needed, then cleans up the socket and log files. As a
 // fallback, kills the harness-owned process tree without touching later tests.

--- a/test/server_harness_test.go
+++ b/test/server_harness_test.go
@@ -338,7 +338,9 @@ func TestServerHarnessWaitForSignaledServerExitReusesBackgroundWaiter(t *testing
 		t.Fatalf("SIGKILL server: %v", err)
 	}
 
-	h.waitForSignaledServerExit(5 * time.Second)
+	if !h.waitForSignaledServerExit(5 * time.Second) {
+		t.Fatal("server did not exit after SIGKILL")
+	}
 }
 
 // cleanup detaches the headless clients, sends SIGINT for graceful shutdown
@@ -1170,6 +1172,11 @@ func (h *ServerHarness) waitForProcessExit(timeout time.Duration) bool {
 	case <-time.After(timeout):
 		return false
 	}
+}
+
+func (h *ServerHarness) waitForSignaledServerExit(timeout time.Duration) bool {
+	h.tb.Helper()
+	return h.waitForProcessExit(timeout)
 }
 
 // capture returns the server-side composited screen (plain text 2D grid).

--- a/test/server_harness_test.go
+++ b/test/server_harness_test.go
@@ -153,7 +153,7 @@ func newServerHarnessWithOptions(tb testing.TB, cols, rows int, configContent st
 
 func newServerHarnessForSession(tb testing.TB, session, home string, cols, rows int, configContent string, exitUnattached, keepalive bool, extraEnv ...string) *ServerHarness {
 	tb.Helper()
-	var b [4]byte
+	var b [8]byte
 	if session == "" {
 		mustRandRead(tb, b[:])
 		session = fmt.Sprintf("t-%x", b)

--- a/test/testdata/multi_column_wide_header_display.golden
+++ b/test/testdata/multi_column_wide_header_display.golden
@@ -10,4 +10,4 @@
                              │                             │                             │                             │
                              │                             │                             │                             │
                              │                             │                             │                             │
- amux │ SESSION                                                                                                        10 panes │ ? help │ 00:00
+ amux │ SESSION                                                                                                           10 panes │ ? help │ 00:00


### PR DESCRIPTION
## Motivation

LAB-1620 asks for a concurrency-only sweep across the repo. The baseline race run exposed test harness races, watcher lifecycle leaks, stale test daemon cleanup gaps, and race-detector resource pressure that made repeated `-race -count` sweeps unreliable.

This PR fixes the concurrency issues that were reproducible and in scope, and it documents the remaining acceptance gap after the branch was rebased onto the latest `origin/main`.

## Summary

- Route server integration test setup mutations through the session event loop instead of writing session state directly while the server is running.
- Stop reload watcher goroutines in tests, close late remote connection outcomes, and isolate nested Go build caches for hermetic subprocess tests.
- Expand test daemon cleanup to reap stale/orphaned test sessions and remote-suffixed sockets without touching non-test sessions.
- Split `internal/server` repeated race sweeps into child test processes so package-level `-count` runs do not accumulate race-detector process state.
- Stabilize mouse copy target detection and prompt self-fork process tests without removing `t.Parallel()`.

## Testing

- `go test -race ./internal/server -count=10 -timeout 300s` passed before the final rebase; after rebasing onto `origin/main`, this package now times out under `-race -count=10` in the large-history server tests.
- `go test -race ./internal/mux -count=10 -timeout 300s` passed before the final rebase; after rebasing onto `origin/main`, this package now times out under `-race -count=10` while many VT emulator goroutines are blocked in `github.com/weill-labs/x/vt`.
- Focused server race slices passed at `-count=100`.
- Focused mux prompt self-fork slice passed at `-count=100`.
- `go vet ./...` passed.
- `staticcheck ./...` and `errcheck ./...` were not run because the tools are not installed in this checkout.
- `go test -race ./... -timeout 300s -count=10` is still not clean after the rebase. The latest full/package sweeps did not emit new `WARNING: DATA RACE` reports, but they still hit pre-existing resource-pressure and timeout failures. Follow-up for orphan daemon root cause: LAB-1636.
- GitHub checks on head `2461211`: CI test, Claude review, Semgrep, and Codecov patch passed. The repo watcher scripts could not discover the PR locally because GitHub GraphQL quota was exhausted, so checks were watched via the GitHub REST API.

## Review focus

- The `internal/server` test helpers that now route setup through the session loop.
- The `TestMain` count splitting in `internal/server`, since it changes how repeated package sweeps are executed under `-race`.
- The stale/orphaned daemon cleanup guardrails, especially the session-name filtering that prevents non-test sessions from being killed.
- The post-rebase acceptance gap described above; this PR should stay draft until the full `go test -race ./... -timeout 300s -count=10` acceptance run is clean or the remaining failures are explicitly split to follow-up issues.

## Baseline triage

| Finding | Evidence | Classification | Disposition |
| --- | --- | --- | --- |
| Server test setup wrote live session state directly while the server event loop could read it. | Baseline race reports and code inspection around `TestKillOrphanedPaneViaFallback`, `TestQueuedCommandInjectProxyAndUnsplice`, `TestCmdListShowsDormant`, and `TestSplitInheritsRemoteHost`. | Test setup bug | Fixed by routing setup through server/session helpers instead of unsynchronized direct mutation. |
| Reload watcher goroutines outlived tests. | Manual sweep of reload tests and goroutine lifecycle; tests created watchers without stopping them. | Test setup bug | Fixed by stopping test watchers. |
| Late remote connection outcomes could leave resources open after cancellation. | Manual sweep of remote connection goroutine/select paths. | Genuine production bug | Fixed by closing late outcomes after the waiting side has moved on. |
| Stale/orphaned test daemons accumulated across race runs. | Baseline process list and repeated full-suite failures from lingering `amux _server t-*` processes. | Test harness bug | Partially fixed with safer reaping and stale command parsing; root-cause follow-up filed as LAB-1636. |
| `internal/server -race -count=10` collapsed under accumulated process/runtime state. | Baseline `internal/server` repeated race sweeps failed from resource pressure rather than a specific shared-memory race. | Test harness bug | Mitigated by running each count in a fresh child test process. |
| Golden tests used session entropy that destabilized repeated runs. | Code inspection and focused failing test for golden session entropy. | Test setup bug | Fixed by normalizing session entropy. |
| Nested Go subprocess tests shared ambient Go build/cache state. | Code inspection and focused failing test for nested Go cache isolation. | Test setup bug | Fixed by isolating nested Go cache directories. |
| Mouse copy target command detection flaked under repeated parallel runs. | Focused repeated race test around mouse copy command targeting. | Test setup bug | Fixed without removing parallelism. |
| Full-suite race command still times out after rebase. | Post-rebase `internal/mux` and `internal/server` package sweeps timed out under `-race -count=10`; no new race reports observed in latest logs. | Unresolved acceptance gap | Documented here; PR should remain draft until fixed or split with linked follow-up. |
| Layout invariant and parser fuzz concerns. | Scope guard from LAB-1620. | Out of scope | Forward to LAB-1619 or LAB-1621 if surfaced; no such fix included here. |

Closes LAB-1620
