### PR TITLE
LAB-1653: Document theme icon modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,10 +432,8 @@ Default prefix: `Ctrl-a`.
 
 Config file: `~/.config/amux/config.toml` (or set `AMUX_CONFIG` env var).
 
-Status-line glyphs are centralized behind an internal renderer icon set. The
-current Unicode rendering stays the default; ASCII and Nerd Font presets exist
-as implementation hooks, with user-facing configuration and terminal caveat docs
-planned separately.
+Theme icon modes, status styles, Nerd Font caveats, and fallback guidance are
+covered in [docs/themes.md](docs/themes.md).
 
 For attach-time terminal capability negotiation, you can override auto-detection
 with `AMUX_CLIENT_CAPABILITIES`. Use a comma-separated list of capability names:

--- a/docs/themes.md
+++ b/docs/themes.md
@@ -1,0 +1,165 @@
+# Themes And Terminal Fonts
+
+amux theme settings control human-facing status glyphs and status-line shape.
+They do not change pane state, structured capture JSON, or event payloads.
+Agents should keep using semantic fields such as pane state, host, tracked PRs,
+and tracked issues instead of parsing rendered glyphs.
+
+Config file: `~/.config/amux/config.toml` unless `AMUX_CONFIG` points
+somewhere else.
+
+## Icon Mode
+
+`[theme] icons` selects the renderer icon preset:
+
+```toml
+[theme]
+icons = "unicode" # ascii | unicode | nerd
+```
+
+Valid values:
+
+| Value | Use when | Notes |
+| --- | --- | --- |
+| `unicode` | Your terminal handles common Unicode symbols. | Default. Uses compact symbols such as `●`, `◇`, `⚡`, and `[copy]`. |
+| `ascii` | You need the safest fallback for plain terminals, CI logs, serial consoles, or remote environments with unknown font support. | Uses printable single-cell ASCII markers such as `*`, `.`, `+`, `#`, `I`, and `T`. |
+| `nerd` | Your terminal is configured to use a Nerd Font-compatible patched font. | Uses Private Use Area glyphs for pane state, hosts, PRs, issues, tasks, copy mode, and connection state. |
+
+Examples:
+
+```toml
+[theme]
+icons = "ascii"
+```
+
+```toml
+[theme]
+icons = "unicode"
+```
+
+```toml
+[theme]
+icons = "nerd"
+```
+
+amux does not install, select, or manage terminal fonts. `icons = "nerd"` only
+tells amux to emit Nerd Font glyphs. The terminal emulator still decides which
+font is used to draw those glyphs.
+
+Nerd Font icons and Powerline separators use Unicode Private Use Area code
+points. Without a compatible patched font, those glyphs may render as boxes,
+question marks, blank cells, or mismatched-width characters. That is a terminal
+font setup problem, not a pane, PTY, or capture bug.
+
+## Status Style
+
+`[theme] status_style` selects the status-line preset:
+
+```toml
+[theme]
+status_style = "compact" # compact | plain | powerline
+```
+
+Valid values:
+
+| Value | Use when | Notes |
+| --- | --- | --- |
+| `compact` | You want the default status-line layout. | Default. Uses normal separators and works with `ascii`, `unicode`, or `nerd` icons. |
+| `plain` | You want to avoid Powerline separators. | A non-Powerline fallback style for terminals where separator glyphs are unreliable. |
+| `powerline` | Your terminal font renders Powerline separator glyphs correctly. | Uses Powerline separators in pane status lines and the global bar. |
+
+Icon mode and status style are independent:
+
+```toml
+[theme]
+icons = "nerd"
+status_style = "powerline"
+```
+
+If pane status separators render as boxes or look misaligned, keep the icon mode
+you want and switch the status style back to a non-Powerline value:
+
+```toml
+[theme]
+icons = "nerd"
+status_style = "compact"
+```
+
+## Font Diagnostic
+
+Run the local diagnostic to see what your current terminal font renders:
+
+```bash
+amux doctor fonts
+```
+
+The command prints samples for the `ascii`, `unicode`, and `nerd` icon presets,
+plus the Powerline separators used by `status_style = "powerline"`. It does not
+connect to an amux server, install fonts, change config, or mutate terminal
+settings.
+
+If any sample appears as a box, question mark, missing glyph, blank cell, or
+badly aligned glyph, choose a fallback config until the terminal font is fixed:
+
+```toml
+[theme]
+icons = "ascii"
+status_style = "compact"
+```
+
+## Text Captures
+
+Text-mode captures are useful for checking the shape of rendered status lines.
+The exact colors are omitted here.
+
+Default Unicode icons with compact status:
+
+```text
+● [pane-1] #42, LAB-1651 @gpu build
+
+
+
+ amux │ SESSION          1 panes │ ? help │ 00:00
+```
+
+Nerd icons with compact status:
+
+```text
+ [pane-1] 42, LAB-1651 gpu  build
+
+
+
+ amux │ SESSION          1 panes │ ? help │ 00:00
+```
+
+Nerd icons with Powerline status:
+
+```text
+ pane-142, LAB-1651gpu build
+
+
+
+ amux  SESSION          1 panes  ? help  00:00
+```
+
+If the Nerd or Powerline examples look wrong in your editor or terminal, use the
+diagnostic command in the terminal where you run amux. Markdown renderers,
+browsers, and code review tools often use different fonts from your terminal.
+
+## Fallback Guidance
+
+Use `icons = "ascii"` and `status_style = "compact"` for CI, logs, remote shells
+viewed through unknown terminal stacks, SSH sessions from minimal clients, and
+any setup where glyph width matters more than visual density.
+
+Use `icons = "unicode"` with `status_style = "compact"` as the default local
+interactive setup. It keeps the existing compact status rendering without
+depending on patched font glyphs.
+
+Use `icons = "nerd"` only after confirming that the terminal profile used for
+amux is configured with a Nerd Font-compatible patched font. Add
+`status_style = "powerline"` only after Powerline separators also render
+correctly.
+
+Color and style-string customization is tracked separately in
+[LAB-114](https://linear.app/weill-labs/issue/LAB-114/configurable-color-themes-and-style-strings).


### PR DESCRIPTION
## Motivation

Nerd Font and Powerline rendering are opt-in human-facing theme layers. Users need clear docs that separate amux glyph emission from terminal font setup, and they need fallback guidance for plain terminals, CI, and remote environments.

## Summary

- Add `docs/themes.md` covering `[theme] icons = "ascii|unicode|nerd"` and `[theme] status_style = "compact|plain|powerline"`.
- Document Nerd Font and Powerline caveats, including Private Use Area glyph rendering failures.
- Document `amux doctor fonts` as a local diagnostic and include text-mode default/Nerd examples.
- Replace the README configuration placeholder with a link to the new theme guide.
- Cross-link LAB-114 for future color/style-string customization.

## Testing

- `go test ./... -timeout 120s` passed before the final docs-only example correction.
- `go test ./test -run TestMouseCommandDragAutomaticallyCopiesSelection -count=5 -timeout 120s` passed after an unrelated integration timeout.
- Final `go test ./... -timeout 120s` reproduced the same `TestMouseCommandDragAutomaticallyCopiesSelection` clipboard timeout in `./test`; the isolated 5x rerun passed, and this PR changes only README/docs.

## Review focus

- Check that documented config names match merged code: `theme.icons`, `theme.status_style`, and `amux doctor fonts`.
- Check the font ownership boundary: amux emits configured glyphs but does not install fonts or mutate terminal settings.
- Check that fallback guidance is conservative for CI, remote shells, and plain terminals.

## Sibling coverage

Covered landed work:

- #761 / LAB-1647: IconSet abstraction and semantic/glyph-free structured APIs.
- #763 / LAB-1649: `[theme] icons` config for `ascii`, `unicode`, and `nerd`.
- #764 / LAB-1650: Nerd icons in pane status metadata.
- #765 / LAB-1651: Powerline status style preset.
- #767 / LAB-1712: `amux doctor fonts` diagnostic. Linear still showed LAB-1652 as Backlog, but the diagnostic command is present on `origin/main` via this landed PR.
- #766 / LAB-1713: Powerline pane names without brackets, reflected in the Powerline text example.

Deferred sections: none. The diagnostic command has landed, so no LAB-1652/doctor section is omitted.

Closes LAB-1653
