### PR TITLE
LAB-1762: Preserve zoomed pane size during background spawns

### DIFF
--- a/internal/mux/window.go
+++ b/internal/mux/window.go
@@ -36,6 +36,10 @@ type SplitOptions struct {
 	TreatLeadPaneAsWindowRef bool
 }
 
+func (w *Window) shouldKeepZoomedPaneSize(paneID uint32, opts SplitOptions) bool {
+	return opts.KeepFocus && w.ZoomedPaneID != 0 && paneID == w.ZoomedPaneID
+}
+
 // NewWindow creates a window with a single pane.
 func NewWindow(pane *Pane, width, height int) *Window {
 	root := NewLeaf(pane, 0, 0, width, height)
@@ -150,8 +154,7 @@ func (w *Window) splitRootTargetWithOptions(targetRoot, parent *LayoutCell, pare
 	}
 	w.Root.FixOffsets()
 
-	w.resizePTYs()
-	w.restoreZoomedPaneSize()
+	w.resizePTYsPreservingZoomedPaneSize()
 
 	if !opts.KeepFocus {
 		w.setActive(newPane)
@@ -219,15 +222,14 @@ func (w *Window) splitCellWithOptions(cell *LayoutCell, dir SplitDir, newPane *P
 	} else if len(cell.Children) > 0 {
 		existingCell = cell.Children[0]
 	}
-	if existingCell != nil && existingCell.Pane != nil {
+	if existingCell != nil && existingCell.Pane != nil && !w.shouldKeepZoomedPaneSize(existingCell.Pane.ID, opts) {
 		if err := existingCell.Pane.Resize(existingCell.W, PaneContentHeight(existingCell.H)); err != nil {
 			return nil, err
 		}
 	}
 
 	w.Root.FixOffsets()
-	w.resizePTYs()
-	w.restoreZoomedPaneSize()
+	w.resizePTYsPreservingZoomedPaneSize()
 	if !opts.KeepFocus {
 		w.setActive(newPane)
 	}
@@ -344,8 +346,7 @@ func (w *Window) MovePaneIntoSplit(paneID, targetPaneID uint32, dir SplitDir, in
 	}
 
 	w.Root.FixOffsets()
-	w.resizePTYs()
-	w.restoreZoomedPaneSize()
+	w.resizePTYsPreservingZoomedPaneSize()
 	w.restoreActivePaneByID(activePaneID, sourcePane)
 	return nil
 }
@@ -851,8 +852,7 @@ func (w *Window) ReplacePane(oldPaneID uint32, replacement *Pane) error {
 		return err
 	}
 	cell.Pane = replacement
-	w.finishTreeMutation()
-	w.restoreZoomedPaneSize()
+	w.finishTreeMutationPreservingZoomedPaneSize()
 	if w.ActivePane != nil && w.ActivePane.ID == oldPaneID {
 		w.setActive(replacement)
 	}

--- a/internal/mux/window_resize.go
+++ b/internal/mux/window_resize.go
@@ -166,6 +166,17 @@ func (w *Window) ResizePane(paneID uint32, direction string, delta int) bool {
 // redistributed evenly. Returns true if the layout changed.
 func (w *Window) Equalize(widths, heights bool) bool {
 	w.assertOwner("Equalize")
+	return w.equalizeWithOptions(widths, heights, SplitOptions{})
+}
+
+// EqualizeWithOptions rebalances the window layout with explicit focus/zoom
+// behavior control.
+func (w *Window) EqualizeWithOptions(widths, heights bool, opts SplitOptions) bool {
+	w.assertOwner("EqualizeWithOptions")
+	return w.equalizeWithOptions(widths, heights, opts)
+}
+
+func (w *Window) equalizeWithOptions(widths, heights bool, opts SplitOptions) bool {
 	if w.Root == nil || (!widths && !heights) {
 		return false
 	}
@@ -193,7 +204,7 @@ func (w *Window) Equalize(widths, heights bool) bool {
 		return false
 	}
 
-	if w.ZoomedPaneID != 0 {
+	if w.ZoomedPaneID != 0 && !opts.KeepFocus {
 		if err := w.Unzoom(); err != nil {
 			return false
 		}
@@ -212,7 +223,11 @@ func (w *Window) Equalize(widths, heights bool) bool {
 	}
 
 	w.Root.FixOffsets()
-	w.resizePTYs()
+	if opts.KeepFocus {
+		w.resizePTYsPreservingZoomedPaneSize()
+	} else {
+		w.resizePTYs()
+	}
 	return true
 }
 

--- a/internal/mux/window_resize.go
+++ b/internal/mux/window_resize.go
@@ -17,8 +17,7 @@ func (w *Window) Resize(width, height int) {
 	w.Height = height
 	w.Root.ResizeAll(width, height)
 
-	w.resizePTYs()
-	w.restoreZoomedPaneSize()
+	w.resizePTYsPreservingZoomedPaneSize()
 }
 
 // ResizeBorder moves a border at position (x, y) by delta cells.
@@ -471,11 +470,28 @@ func transferAxisSize(grower, donor *LayoutCell, axis SplitDir, needed int, grow
 
 // resizePTYs resizes all pane PTYs to match their layout cell dimensions.
 func (w *Window) resizePTYs() {
+	w.resizePTYsExcept(0)
+}
+
+func (w *Window) resizePTYsExcept(excludedPaneID uint32) {
 	w.Root.Walk(func(c *LayoutCell) {
-		if c.Pane != nil {
-			_ = c.Pane.Resize(c.W, PaneContentHeight(c.H))
+		if c.Pane == nil {
+			return
 		}
+		if excludedPaneID != 0 && c.Pane.ID == excludedPaneID {
+			return
+		}
+		_ = c.Pane.Resize(c.W, PaneContentHeight(c.H))
 	})
+}
+
+func (w *Window) resizePTYsPreservingZoomedPaneSize() {
+	if w.ZoomedPaneID == 0 {
+		w.resizePTYs()
+		return
+	}
+	w.resizePTYsExcept(w.ZoomedPaneID)
+	w.restoreZoomedPaneSize()
 }
 
 func (w *Window) restoreZoomedPaneSize() {

--- a/internal/mux/window_spiral.go
+++ b/internal/mux/window_spiral.go
@@ -129,6 +129,11 @@ func (w *Window) finishTreeMutation() {
 	w.resizePTYs()
 }
 
+func (w *Window) finishTreeMutationPreservingZoomedPaneSize() {
+	w.Root.FixOffsets()
+	w.resizePTYsPreservingZoomedPaneSize()
+}
+
 // MovePaneToColumn reparents paneID into the logical column selected by
 // targetPaneID, appending the moved pane to the bottom of that column.
 func (w *Window) MovePaneToColumn(paneID, targetPaneID uint32) error {
@@ -298,8 +303,7 @@ func (w *Window) splitSubtreeRootWithOptions(root *LayoutCell, dir SplitDir, new
 		w.equalizeAnchoredLeadColumns()
 	}
 	w.Root.FixOffsets()
-	w.resizePTYs()
-	w.restoreZoomedPaneSize()
+	w.resizePTYsPreservingZoomedPaneSize()
 	if !opts.KeepFocus {
 		w.setActive(newPane)
 	}

--- a/internal/mux/window_zoom_resize_test.go
+++ b/internal/mux/window_zoom_resize_test.go
@@ -1,0 +1,139 @@
+package mux
+
+import (
+	"fmt"
+	"testing"
+)
+
+type recordedResize struct {
+	cols int
+	rows int
+}
+
+func (r recordedResize) String() string {
+	return fmt.Sprintf("%dx%d", r.cols, r.rows)
+}
+
+type resizeRecordingEmulator struct {
+	TerminalEmulator
+	cols    int
+	rows    int
+	changes []recordedResize
+}
+
+func newResizeRecordingPane(id uint32, cols, rows int) (*Pane, *resizeRecordingEmulator) {
+	emu := &resizeRecordingEmulator{
+		TerminalEmulator: NewVTEmulatorWithScrollback(cols, rows, DefaultScrollbackLines),
+		cols:             cols,
+		rows:             rows,
+	}
+	return &Pane{
+		ID:       id,
+		Meta:     PaneMeta{Name: fmt.Sprintf(PaneNameFormat, id), Host: DefaultHost},
+		emulator: emu,
+	}, emu
+}
+
+func (r *resizeRecordingEmulator) Resize(cols, rows int) {
+	if r.cols != cols || r.rows != rows {
+		r.changes = append(r.changes, recordedResize{cols: cols, rows: rows})
+	}
+	r.cols = cols
+	r.rows = rows
+	r.TerminalEmulator.Resize(cols, rows)
+}
+
+func (r *resizeRecordingEmulator) Size() (int, int) {
+	return r.cols, r.rows
+}
+
+func (r *resizeRecordingEmulator) reset() {
+	r.changes = nil
+}
+
+func TestZoomPreservingMutationsDoNotResizeZoomedPaneToHiddenCell(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		mutate func(t *testing.T, w *Window, p3 *Pane)
+	}{
+		{
+			name: "split active pane",
+			mutate: func(t *testing.T, w *Window, p3 *Pane) {
+				t.Helper()
+				if _, err := w.SplitWithOptions(SplitVertical, p3, SplitOptions{KeepFocus: true}); err != nil {
+					t.Fatalf("SplitWithOptions: %v", err)
+				}
+			},
+		},
+		{
+			name: "split root",
+			mutate: func(t *testing.T, w *Window, p3 *Pane) {
+				t.Helper()
+				if _, err := w.SplitRootWithOptions(SplitVertical, p3, SplitOptions{KeepFocus: true}); err != nil {
+					t.Fatalf("SplitRootWithOptions: %v", err)
+				}
+			},
+		},
+		{
+			name: "split subtree root",
+			mutate: func(t *testing.T, w *Window, p3 *Pane) {
+				t.Helper()
+				if _, err := w.splitSubtreeRootWithOptions(w.Root, SplitVertical, p3, false, SplitOptions{KeepFocus: true}); err != nil {
+					t.Fatalf("splitSubtreeRootWithOptions: %v", err)
+				}
+			},
+		},
+		{
+			name: "replace hidden pane",
+			mutate: func(t *testing.T, w *Window, p3 *Pane) {
+				t.Helper()
+				if err := w.ReplacePane(2, p3); err != nil {
+					t.Fatalf("ReplacePane: %v", err)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			p1, recorder := newResizeRecordingPane(1, 80, 23)
+			p2, _ := newResizeRecordingPane(2, 80, 23)
+			p3, _ := newResizeRecordingPane(3, 80, 23)
+			w := NewWindow(p1, 80, 24)
+			if _, err := w.SplitRoot(SplitHorizontal, p2); err != nil {
+				t.Fatalf("SplitRoot setup: %v", err)
+			}
+			if err := w.Zoom(p1.ID); err != nil {
+				t.Fatalf("Zoom setup: %v", err)
+			}
+			recorder.reset()
+
+			tt.mutate(t, w, p3)
+
+			fullSize := recordedResize{cols: w.Width, rows: PaneContentHeight(w.Height)}
+			for _, got := range recorder.changes {
+				if got != fullSize {
+					t.Fatalf("zoomed pane resize history = %v, want no hidden-cell resize; full size is %s", recorder.changes, fullSize)
+				}
+			}
+			if w.ZoomedPaneID != p1.ID {
+				t.Fatalf("ZoomedPaneID = %d, want %d", w.ZoomedPaneID, p1.ID)
+			}
+			if w.ActivePane != p1 {
+				t.Fatalf("active pane = %v, want pane-1", w.ActivePane)
+			}
+			cell3 := w.Root.FindPane(p3.ID)
+			if cell3 == nil {
+				t.Fatal("pane-3 should be present in the layout")
+			}
+			if cols, rows := p3.EmulatorSize(); cols != cell3.W || rows != PaneContentHeight(cell3.H) {
+				t.Fatalf("new pane size = %dx%d, want %dx%d", cols, rows, cell3.W, PaneContentHeight(cell3.H))
+			}
+		})
+	}
+}

--- a/internal/server/commands_layout.go
+++ b/internal/server/commands_layout.go
@@ -306,7 +306,7 @@ func placeCreatedPaneInWindow(w *mux.Window, placement createPanePlacement, snap
 				return err
 			}
 		}
-		w.Equalize(true, true)
+		w.EqualizeWithOptions(true, true, opts)
 		return nil
 	default:
 		return fmt.Errorf("unknown create-pane placement: %d", placement)

--- a/internal/server/spawn_auto_command_test.go
+++ b/internal/server/spawn_auto_command_test.go
@@ -83,6 +83,56 @@ func TestCommandSpawnAutoAppendsToShortestUnderfilledColumnAndEqualizes(t *testi
 	}
 }
 
+func TestCommandSpawnAutoKeepsZoomAndFocus(t *testing.T) {
+	t.Parallel()
+
+	srv, sess, cleanup := newCommandTestSession(t)
+	defer cleanup()
+
+	p1 := newTestPane(sess, 1, "pane-1")
+	p2 := newTestPane(sess, 2, "pane-2")
+	p3 := newTestPane(sess, 3, "pane-3")
+	w := mux.NewWindow(p1, 80, 23)
+	w.ID = 1
+	w.Name = "main"
+	if _, err := w.SplitPaneWithOptions(p1.ID, mux.SplitHorizontal, p2, mux.SplitOptions{}); err != nil {
+		t.Fatalf("Split pane-1 horizontally: %v", err)
+	}
+	if _, err := w.SplitRoot(mux.SplitVertical, p3); err != nil {
+		t.Fatalf("SplitRoot pane-3: %v", err)
+	}
+	if err := w.Zoom(p1.ID); err != nil {
+		t.Fatalf("Zoom pane-1: %v", err)
+	}
+	setSessionLayoutForTest(t, sess, w.ID, []*mux.Window{w}, p1, p2, p3)
+
+	res := runTestCommand(t, srv, sess, "spawn", "--auto", "--name", "worker-4")
+	if res.cmdErr != "" {
+		t.Fatalf("spawn --auto failed: %s", res.cmdErr)
+	}
+
+	state := mustSessionQuery(t, sess, func(sess *Session) struct {
+		activeID uint32
+		zoomedID uint32
+		hasPane  bool
+	} {
+		w := sess.activeWindow()
+		p4, err := sess.findPaneByRef("worker-4")
+		return struct {
+			activeID uint32
+			zoomedID uint32
+			hasPane  bool
+		}{
+			activeID: w.ActivePane.ID,
+			zoomedID: w.ZoomedPaneID,
+			hasPane:  err == nil && w.Root.FindPane(p4.ID) != nil,
+		}
+	})
+	if state.activeID != p1.ID || state.zoomedID != p1.ID || !state.hasPane {
+		t.Fatalf("state after spawn --auto = %+v, want active pane-1, zoomed pane-1, worker present", state)
+	}
+}
+
 func TestCommandSpawnAutoRootSplitsWhenColumnsAreFull(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Motivation
Background pane creation while a pane is zoomed preserved focus/zoom metadata, but the layout resize pass still sent the zoomed pane through its hidden layout-cell size before restoring fullscreen. Fullscreen TUIs could observe that intermediate SIGWINCH and redraw at the wrong size.

## Summary
- Add a zoom-preserving PTY resize path that skips the zoomed pane during hidden layout resize passes and keeps it at fullscreen size.
- Use the zoom-aware path for split/root/subtree mutations, pane replacement, and terminal window resize restoration.
- Preserve zoom/focus for `spawn --auto` by adding an equalize option used by the background spawn path.
- Add regressions for hidden-cell resize history and `spawn --auto` zoom preservation.

## Testing
- `go test ./internal/mux -run '^TestZoomPreservingMutationsDoNotResizeZoomedPaneToHiddenCell$' -count=100`
- `go test ./internal/server -run '^TestCommandSpawnAutoKeepsZoomAndFocus$' -count=100`
- `go test ./internal/mux -count=1`
- `go test ./internal/server -count=1`
- `go test ./internal/reload -run 'TestWatchBinaryInstallScriptSequence' -count=1 -timeout 180s`
- `go test ./... -timeout 300s`

Note: `go test ./... -timeout 120s` was also attempted, but the repo-wide run exceeded 120s in existing `internal/reload`/`test` long-running install/build tests. The isolated reload test and the full suite with a 300s timeout passed.

## Review focus
- Check that zoom-preserving resize paths only apply where callers intentionally keep zoom/focus.
- Check `EqualizeWithOptions` does not change standalone `equalize` command behavior.
- Check the regression test proves the zoomed pane never receives a hidden layout-cell resize.

Closes LAB-1762