### PR TITLE
LAB-1802: Show zoom indicators for zoomed windows

### DIFF
--- a/internal/client/chooser.go
+++ b/internal/client/chooser.go
@@ -433,7 +433,7 @@ func chooserListHeight(screenH int) int {
 }
 
 func chooserWindowFilterValue(ws proto.WindowSnapshot, includePanes bool) string {
-	parts := []string{strconv.Itoa(ws.Index), ws.Name}
+	parts := []string{strconv.Itoa(ws.Index), chooserWindowName(ws)}
 	if includePanes {
 		for _, ps := range ws.Panes {
 			parts = append(parts, chooserPaneFilterTerms(ps)...)
@@ -465,7 +465,14 @@ func formatChooserWindowRow(ws proto.WindowSnapshot, active bool) string {
 	if active {
 		marker = "*"
 	}
-	return marker + " " + strconv.Itoa(ws.Index) + ":" + ws.Name + " (" + strconv.Itoa(len(ws.Panes)) + " panes)"
+	return marker + " " + strconv.Itoa(ws.Index) + ":" + chooserWindowName(ws) + " (" + strconv.Itoa(len(ws.Panes)) + " panes)"
+}
+
+func chooserWindowName(ws proto.WindowSnapshot) string {
+	if ws.Zoomed || ws.ZoomedPaneID != 0 {
+		return ws.Name + "Z"
+	}
+	return ws.Name
 }
 
 func formatChooserPaneRow(ps proto.PaneSnapshot, active bool) string {

--- a/internal/client/mouse.go
+++ b/internal/client/mouse.go
@@ -515,6 +515,7 @@ func globalBarWindowInfos(cr *ClientRenderer) []render.WindowInfo {
 			Name:     ws.Name,
 			IsActive: ws.ID == activeWindowID,
 			Panes:    len(ws.Panes),
+			Zoomed:   ws.Zoomed || ws.ZoomedPaneID != 0,
 		}
 	}
 	return infos

--- a/internal/client/renderer.go
+++ b/internal/client/renderer.go
@@ -449,7 +449,7 @@ func (r *Renderer) captureJSONValueWithHistory(agentStatus map[uint32]proto.Pane
 	for _, ws := range snap.windows {
 		if ws.ID == snap.activeWinID {
 			capture.Window = proto.CaptureWindow{
-				ID: ws.ID, Name: ws.Name, Index: ws.Index,
+				ID: ws.ID, Name: ws.Name, Index: ws.Index, Zoomed: ws.Zoomed || ws.ZoomedPaneID != 0,
 			}
 			break
 		}

--- a/internal/client/renderer_capture_snapshot.go
+++ b/internal/client/renderer_capture_snapshot.go
@@ -127,6 +127,7 @@ func windowInfoFromSnapshot(windows []proto.WindowSnapshot, activeWinID uint32) 
 			Name:     ws.Name,
 			IsActive: ws.ID == activeWinID,
 			Panes:    len(ws.Panes),
+			Zoomed:   ws.Zoomed || ws.ZoomedPaneID != 0,
 		}
 	}
 	return out

--- a/internal/mux/snapshot.go
+++ b/internal/mux/snapshot.go
@@ -48,6 +48,7 @@ func (w *Window) SnapshotWindow(index int) proto.WindowSnapshot {
 		Name:         w.Name,
 		Index:        index,
 		ActivePaneID: activePaneID,
+		Zoomed:       zoomedPaneID != 0,
 		ZoomedPaneID: zoomedPaneID,
 		LeadPaneID:   leadPaneID,
 		Root:         root,

--- a/internal/proto/types.go
+++ b/internal/proto/types.go
@@ -28,6 +28,7 @@ type WindowSnapshot struct {
 	Name         string         `json:"name"`
 	Index        int            `json:"index"` // 1-based display order
 	ActivePaneID uint32         `json:"active_pane_id"`
+	Zoomed       bool           `json:"zoomed"`
 	ZoomedPaneID uint32         `json:"zoomed_pane_id"`
 	LeadPaneID   uint32         `json:"lead_pane_id,omitempty"`
 	Root         CellSnapshot   `json:"root"`
@@ -87,9 +88,10 @@ type CaptureUI struct {
 
 // CaptureWindow identifies the captured window.
 type CaptureWindow struct {
-	ID    uint32 `json:"id"`
-	Name  string `json:"name"`
-	Index int    `json:"index"`
+	ID     uint32 `json:"id"`
+	Name   string `json:"name"`
+	Index  int    `json:"index"`
+	Zoomed bool   `json:"zoomed"`
 }
 
 // CaptureMeta holds user-managed pane metadata for JSON capture.

--- a/internal/render/compositor.go
+++ b/internal/render/compositor.go
@@ -21,6 +21,7 @@ type WindowInfo struct {
 	Name     string
 	IsActive bool
 	Panes    int
+	Zoomed   bool
 }
 
 // RenderStats captures lightweight render counters alongside ANSI output.

--- a/internal/render/overlay_status_test.go
+++ b/internal/render/overlay_status_test.go
@@ -1097,6 +1097,25 @@ func TestBuildGlobalBarCellsColorsActiveTab(t *testing.T) {
 	}
 }
 
+func TestBuildGlobalBarWindowTabsMarksZoomedWindow(t *testing.T) {
+	t.Parallel()
+
+	tabs := buildGlobalBarWindowTabs([]WindowInfo{
+		{Index: 1, Name: "main", IsActive: true, Zoomed: true},
+		{Index: 2, Name: "logs", IsActive: false},
+	})
+
+	if len(tabs) != 2 {
+		t.Fatalf("buildGlobalBarWindowTabs returned %d tabs, want 2", len(tabs))
+	}
+	if got := tabs[0].display; got != "1:mainZ" {
+		t.Fatalf("zoomed tab display = %q, want %q", got, "1:mainZ")
+	}
+	if got := tabs[1].display; got != "2:logs" {
+		t.Fatalf("unzoomed tab display = %q, want %q", got, "2:logs")
+	}
+}
+
 func TestBuildGlobalBarCellsPowerline(t *testing.T) {
 	t.Parallel()
 

--- a/internal/render/statusbar.go
+++ b/internal/render/statusbar.go
@@ -731,7 +731,7 @@ func buildGlobalBarWindowTabs(windows []WindowInfo) []globalBarWindowTab {
 	tabs := make([]globalBarWindowTab, 0, len(windows))
 	col := globalBarTitlePrefixVisibleWidth
 	for _, w := range windows {
-		label := strconv.Itoa(w.Index) + ":" + w.Name
+		label := strconv.Itoa(w.Index) + ":" + globalBarWindowName(w)
 		display := label
 
 		width := utf8.RuneCountInString(display)
@@ -744,6 +744,13 @@ func buildGlobalBarWindowTabs(windows []WindowInfo) []globalBarWindowTab {
 		col += width + 1
 	}
 	return tabs
+}
+
+func globalBarWindowName(window WindowInfo) string {
+	if window.Zoomed {
+		return window.Name + "Z"
+	}
+	return window.Name
 }
 
 func globalBarTabColorHex(window WindowInfo) string {

--- a/internal/server/commands/listing/listing.go
+++ b/internal/server/commands/listing/listing.go
@@ -60,6 +60,7 @@ type PaneEntry struct {
 	Name          string
 	Host          string
 	WindowName    string
+	WindowZoomed  bool
 	Task          string
 	Cwd           string
 	GitBranch     string
@@ -97,6 +98,13 @@ func FormatPaneListBranch(entry PaneEntry) string {
 	return branch
 }
 
+func FormatWindowName(name string, zoomed bool) string {
+	if zoomed {
+		return name + "Z"
+	}
+	return name
+}
+
 func formatPaneListRow(entry PaneEntry, home string, showCwd bool) string {
 	active := " "
 	if entry.Active {
@@ -109,12 +117,13 @@ func formatPaneListRow(entry PaneEntry, home string, showCwd bool) string {
 	if idle == "" {
 		idle = "--"
 	}
+	windowName := FormatWindowName(entry.WindowName, entry.WindowZoomed)
 	if showCwd {
 		return fmt.Sprintf("%-6s %-20s %-15s %-30s %-9s %-36s %-10s %-12s %s\n",
-			paneID, entry.Name, entry.Host, branch, idle, FormatListCwd(entry.Cwd, home, ListCwdWidth), entry.WindowName, entry.Task, meta)
+			paneID, entry.Name, entry.Host, branch, idle, FormatListCwd(entry.Cwd, home, ListCwdWidth), windowName, entry.Task, meta)
 	}
 	return fmt.Sprintf("%-6s %-20s %-15s %-30s %-9s %-10s %-12s %s\n",
-		paneID, entry.Name, entry.Host, branch, idle, entry.WindowName, entry.Task, meta)
+		paneID, entry.Name, entry.Host, branch, idle, windowName, entry.Task, meta)
 }
 
 func formatPaneListMeta(entry PaneEntry) string {
@@ -276,6 +285,7 @@ type WindowEntry struct {
 	Name      string
 	PaneCount int
 	Active    bool
+	Zoomed    bool
 }
 
 func FormatWindowList(entries []WindowEntry) string {
@@ -287,7 +297,7 @@ func FormatWindowList(entries []WindowEntry) string {
 			active = "*"
 		}
 		output.WriteString(fmt.Sprintf("%-6s %-20s %-8d\n",
-			fmt.Sprintf("%s%d:", active, entry.Index), entry.Name, entry.PaneCount))
+			fmt.Sprintf("%s%d:", active, entry.Index), FormatWindowName(entry.Name, entry.Zoomed), entry.PaneCount))
 	}
 	return output.String()
 }

--- a/internal/server/commands/listing/listing_test.go
+++ b/internal/server/commands/listing/listing_test.go
@@ -85,3 +85,65 @@ func TestFormatPaneListPreservesPaneNameColumnWhenLeadPresent(t *testing.T) {
 		t.Fatalf("row should include lead metadata, got: %q", lines[1])
 	}
 }
+
+func TestFormatWindowNameAddsZoomMarker(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		window string
+		zoomed bool
+		want   string
+	}{
+		{
+			name:   "normal window",
+			window: "main",
+			zoomed: false,
+			want:   "main",
+		},
+		{
+			name:   "zoomed window",
+			window: "main",
+			zoomed: true,
+			want:   "mainZ",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := FormatWindowName(tt.window, tt.zoomed); got != tt.want {
+				t.Fatalf("FormatWindowName(%q, %v) = %q, want %q", tt.window, tt.zoomed, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFormatPaneListMarksZoomedWindow(t *testing.T) {
+	t.Parallel()
+
+	out := FormatPaneList([]PaneEntry{
+		{
+			PaneID:       1,
+			Name:         "pane-1",
+			Host:         "local",
+			WindowName:   "main",
+			WindowZoomed: true,
+		},
+		{
+			PaneID:     2,
+			Name:       "pane-2",
+			Host:       "local",
+			WindowName: "logs",
+		},
+	}, "", false)
+
+	if !strings.Contains(out, "mainZ") {
+		t.Fatalf("zoomed window should include Z marker:\n%s", out)
+	}
+	if strings.Contains(out, "logsZ") {
+		t.Fatalf("unzoomed window should not include Z marker:\n%s", out)
+	}
+}

--- a/internal/server/commands_listing.go
+++ b/internal/server/commands_listing.go
@@ -12,6 +12,7 @@ func toListingPaneEntry(entry paneListEntry) listingcmd.PaneEntry {
 		Name:          entry.name,
 		Host:          entry.host,
 		WindowName:    entry.windowName,
+		WindowZoomed:  entry.windowZoomed,
 		Task:          entry.task,
 		Cwd:           entry.cwd,
 		GitBranch:     entry.gitBranch,
@@ -49,6 +50,7 @@ func toListingWindowEntries(entries []windowListEntry) []listingcmd.WindowEntry 
 			Name:      entry.name,
 			PaneCount: entry.paneCount,
 			Active:    entry.active,
+			Zoomed:    entry.zoomed,
 		})
 	}
 	return out

--- a/internal/server/session_queries.go
+++ b/internal/server/session_queries.go
@@ -32,20 +32,21 @@ type killTargetSnapshot struct {
 }
 
 type paneListEntry struct {
-	paneID     uint32
-	name       string
-	host       string
-	windowName string
-	task       string
-	cwd        string
-	gitBranch  string
-	idle       string
-	pr         string
-	kv         map[string]string
-	prs        []proto.TrackedPR
-	issues     []proto.TrackedIssue
-	active     bool
-	lead       bool
+	paneID       uint32
+	name         string
+	host         string
+	windowName   string
+	windowZoomed bool
+	task         string
+	cwd          string
+	gitBranch    string
+	idle         string
+	pr           string
+	kv           map[string]string
+	prs          []proto.TrackedPR
+	issues       []proto.TrackedIssue
+	active       bool
+	lead         bool
 }
 
 type sessionStatusSnapshot struct {
@@ -59,6 +60,7 @@ type windowListEntry struct {
 	name      string
 	paneCount int
 	active    bool
+	zoomed    bool
 }
 
 type clientListEntry struct {
@@ -321,6 +323,7 @@ func (s *Session) queryPaneList() ([]paneListEntry, error) {
 			default:
 				if pw := s.findWindowByPaneID(p.ID); pw != nil {
 					entry.windowName = pw.Name
+					entry.windowZoomed = pw.ZoomedPaneID != 0
 					entry.lead = pw.LeadPaneID == p.ID
 				}
 			}
@@ -381,6 +384,7 @@ func (s *Session) queryWindowList() ([]windowListEntry, error) {
 				name:      w.Name,
 				paneCount: w.PaneCount(),
 				active:    w.ID == s.ActiveWindowID,
+				zoomed:    w.ZoomedPaneID != 0,
 			})
 		}
 		return entries, nil

--- a/test/zoom_test.go
+++ b/test/zoom_test.go
@@ -56,28 +56,28 @@ func TestZoomIndicatorAppearsInWindowListsAndClears(t *testing.T) {
 
 	h.splitH()
 
-	if out := h.runCmd("list"); strings.Contains(out, "mainZ") {
+	if out := h.runCmd("list"); strings.Contains(out, "window-1Z") {
 		t.Fatalf("unzoomed list should not include zoom marker:\n%s", out)
 	}
-	if out := h.runCmd("list-windows"); strings.Contains(out, "mainZ") {
+	if out := h.runCmd("list-windows"); strings.Contains(out, "window-1Z") {
 		t.Fatalf("unzoomed list-windows should not include zoom marker:\n%s", out)
 	}
 
 	h.runCmd("zoom", "pane-1")
 
-	if out := h.runCmd("list"); !strings.Contains(out, "mainZ") {
+	if out := h.runCmd("list"); !strings.Contains(out, "window-1Z") {
 		t.Fatalf("zoomed list should include zoom marker:\n%s", out)
 	}
-	if out := h.runCmd("list-windows"); !strings.Contains(out, "mainZ") {
+	if out := h.runCmd("list-windows"); !strings.Contains(out, "window-1Z") {
 		t.Fatalf("zoomed list-windows should include zoom marker:\n%s", out)
 	}
 
 	h.runCmd("zoom", "pane-1")
 
-	if out := h.runCmd("list"); strings.Contains(out, "mainZ") {
+	if out := h.runCmd("list"); strings.Contains(out, "window-1Z") {
 		t.Fatalf("unzoomed list should clear zoom marker:\n%s", out)
 	}
-	if out := h.runCmd("list-windows"); strings.Contains(out, "mainZ") {
+	if out := h.runCmd("list-windows"); strings.Contains(out, "window-1Z") {
 		t.Fatalf("unzoomed list-windows should clear zoom marker:\n%s", out)
 	}
 }

--- a/test/zoom_test.go
+++ b/test/zoom_test.go
@@ -50,6 +50,70 @@ func TestZoomToggle(t *testing.T) {
 	})
 }
 
+func TestZoomIndicatorAppearsInWindowListsAndClears(t *testing.T) {
+	t.Parallel()
+	h := newServerHarness(t)
+
+	h.splitH()
+
+	if out := h.runCmd("list"); strings.Contains(out, "mainZ") {
+		t.Fatalf("unzoomed list should not include zoom marker:\n%s", out)
+	}
+	if out := h.runCmd("list-windows"); strings.Contains(out, "mainZ") {
+		t.Fatalf("unzoomed list-windows should not include zoom marker:\n%s", out)
+	}
+
+	h.runCmd("zoom", "pane-1")
+
+	if out := h.runCmd("list"); !strings.Contains(out, "mainZ") {
+		t.Fatalf("zoomed list should include zoom marker:\n%s", out)
+	}
+	if out := h.runCmd("list-windows"); !strings.Contains(out, "mainZ") {
+		t.Fatalf("zoomed list-windows should include zoom marker:\n%s", out)
+	}
+
+	h.runCmd("zoom", "pane-1")
+
+	if out := h.runCmd("list"); strings.Contains(out, "mainZ") {
+		t.Fatalf("unzoomed list should clear zoom marker:\n%s", out)
+	}
+	if out := h.runCmd("list-windows"); strings.Contains(out, "mainZ") {
+		t.Fatalf("unzoomed list-windows should clear zoom marker:\n%s", out)
+	}
+}
+
+func TestZoomedWindowJSONFields(t *testing.T) {
+	t.Parallel()
+	h := newServerHarness(t)
+
+	h.splitH()
+
+	assertWindowZoomed := func(label string, want bool) {
+		t.Helper()
+
+		layout := h.layoutSnapshot()
+		if len(layout.Windows) != 1 {
+			t.Fatalf("%s: layout has %d windows, want 1", label, len(layout.Windows))
+		}
+		if got := layout.Windows[0].Zoomed; got != want {
+			t.Fatalf("%s: layout window zoomed = %v, want %v\nlayout: %+v", label, got, want, layout.Windows[0])
+		}
+
+		capture := h.captureJSON()
+		if got := capture.Window.Zoomed; got != want {
+			t.Fatalf("%s: capture window zoomed = %v, want %v\ncapture: %+v", label, got, want, capture.Window)
+		}
+	}
+
+	assertWindowZoomed("before zoom", false)
+
+	h.runCmd("zoom", "pane-1")
+	assertWindowZoomed("after zoom", true)
+
+	h.runCmd("zoom", "pane-1")
+	assertWindowZoomed("after unzoom", false)
+}
+
 func TestZoomSinglePaneFails(t *testing.T) {
 	t.Parallel()
 	h := newServerHarness(t)


### PR DESCRIPTION
## Motivation

A zoomed window currently looks like a normal multi-pane window in listings and structured output. tmux exposes this state with a familiar `Z` marker, and LAB-1802 asks amux to surface the same affordance so users and tooling can distinguish zoomed windows quickly.

## Summary

- Add a `Z` suffix to rendered window names when `Window.ZoomedPaneID` is set.
- Surface the marker in `amux list`, `amux list-windows`, global window tabs, and chooser window rows.
- Add `zoomed: bool` to window snapshots and capture window JSON while preserving existing `zoomed_pane_id` fields.

## Testing

- `go test ./internal/server/commands/listing ./internal/render ./test -run 'TestFormatWindowNameAddsZoomMarker|TestFormatPaneListMarksZoomedWindow|TestBuildGlobalBarWindowTabsMarksZoomedWindow|TestZoomIndicatorAppearsInWindowListsAndClears|TestZoomedWindowJSONFields'`
- `go test ./internal/server/commands/listing -run 'TestFormatWindowNameAddsZoomMarker|TestFormatPaneListMarksZoomedWindow' -count=100`
- `go test ./internal/render -run TestBuildGlobalBarWindowTabsMarksZoomedWindow -count=100`
- `go test ./test -run 'TestZoomIndicatorAppearsInWindowListsAndClears|TestZoomedWindowJSONFields' -count=100 -timeout 300s`
- `go test ./internal/server/commands/listing ./internal/server ./internal/proto ./internal/mux ./internal/client ./internal/render ./test -timeout 120s`
- `go test ./... -timeout 120s`

## Review focus

Check the decision to keep `amux list` table columns unchanged by appending tmux's single-character `Z` marker to the window display name. Also check the `zoomed` JSON field placement on both `WindowSnapshot` and `CaptureWindow` for downstream compatibility.

Closes LAB-1802
