### PR TITLE
LAB-1803: Trim styled blank scrollback cells

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -48,4 +48,4 @@ require (
 
 replace github.com/charmbracelet/ultraviolet => github.com/weill-labs/ultraviolet v0.0.0-20260404003102-9344cbfc286f
 
-replace github.com/charmbracelet/x/vt => github.com/weill-labs/x/vt v0.0.0-20260513001905-6adbf8184605
+replace github.com/charmbracelet/x/vt => github.com/weill-labs/x/vt v0.0.0-20260513175146-fc372e8574ca

--- a/go.sum
+++ b/go.sum
@@ -70,8 +70,8 @@ github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcU
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/weill-labs/ultraviolet v0.0.0-20260404003102-9344cbfc286f h1:JMTFuQ/08wrGci+AIUA67OuIMHtJaF369KhWwBel6/g=
 github.com/weill-labs/ultraviolet v0.0.0-20260404003102-9344cbfc286f/go.mod h1:Vo8TffMf0q7Uho/n8e6XpBZvOWtd3g39yX+9P5rRutA=
-github.com/weill-labs/x/vt v0.0.0-20260513001905-6adbf8184605 h1:hDxIKdadQsOsW3SD5sth1NHWJ7KuGRDVCTwf+eudk24=
-github.com/weill-labs/x/vt v0.0.0-20260513001905-6adbf8184605/go.mod h1:u1LOIABor9JqY54oZdktK3TCRrgzP6tzHrDYx1nd3wY=
+github.com/weill-labs/x/vt v0.0.0-20260513175146-fc372e8574ca h1:zHHkdgBgA1XfyHYKjiJgIrV3svzeCgeyzAacVrKTo2Y=
+github.com/weill-labs/x/vt v0.0.0-20260513175146-fc372e8574ca/go.mod h1:u1LOIABor9JqY54oZdktK3TCRrgzP6tzHrDYx1nd3wY=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJuqunuUZ/Dhy/avygyECGrLceyNeo4LiM=
 golang.org/x/crypto v0.49.0 h1:+Ng2ULVvLHnJ/ZFEq4KdcDd/cfjrrjjNSXNzxg0Y4U4=

--- a/internal/mux/emulator_test.go
+++ b/internal/mux/emulator_test.go
@@ -1,6 +1,7 @@
 package mux
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -186,7 +187,7 @@ func BenchmarkVTEmulatorResizePreservationStyledScrollback(b *testing.B) {
 		}
 		emu.Resize(80, 24)
 		emu.Resize(132, 24)
-		if err := emu.Close(); err != nil && err != io.ErrClosedPipe {
+		if err := emu.Close(); err != nil && !errors.Is(err, io.ErrClosedPipe) {
 			b.Fatalf("Close(): %v", err)
 		}
 	}

--- a/internal/mux/emulator_test.go
+++ b/internal/mux/emulator_test.go
@@ -2,6 +2,7 @@ package mux
 
 import (
 	"fmt"
+	"io"
 	"strings"
 	"testing"
 
@@ -171,6 +172,36 @@ func TestVTEmulatorResizeWiderPreservesWideCharContinuations(t *testing.T) {
 				tt.col, cell.Content, cell.Width, tt.wantContent, tt.wantWidth)
 		}
 	}
+}
+
+func BenchmarkVTEmulatorResizePreservationStyledScrollback(b *testing.B) {
+	payload := resizePreservationStyledScrollbackPayload(132, 260)
+
+	b.ReportAllocs()
+	b.SetBytes(int64(len(payload)))
+	for i := 0; i < b.N; i++ {
+		emu := NewVTEmulatorWithDrainAndScrollback(132, 24, 512)
+		if _, err := emu.Write(payload); err != nil {
+			b.Fatalf("Write(): %v", err)
+		}
+		emu.Resize(80, 24)
+		emu.Resize(132, 24)
+		if err := emu.Close(); err != nil && err != io.ErrClosedPipe {
+			b.Fatalf("Close(): %v", err)
+		}
+	}
+}
+
+func resizePreservationStyledScrollbackPayload(width, lines int) []byte {
+	var buf strings.Builder
+	buf.Grow(width * lines)
+	for i := 0; i < lines; i++ {
+		fmt.Fprintf(&buf, "\x1b[48;2;24;28;36mrow-%03d ", i)
+		buf.WriteString(strings.Repeat(" ", max(width-8, 0)))
+		buf.WriteString("\x1b[0m\r\n")
+	}
+	buf.WriteString("PROMPT$ ")
+	return []byte(buf.String())
 }
 
 func TestVTEmulatorCursorPosition(t *testing.T) {

--- a/internal/mux/emulator_test.go
+++ b/internal/mux/emulator_test.go
@@ -194,14 +194,23 @@ func BenchmarkVTEmulatorResizePreservationStyledScrollback(b *testing.B) {
 }
 
 func resizePreservationStyledScrollbackPayload(width, lines int) []byte {
+	const (
+		sgrOpen  = "\x1b[48;2;24;28;36m"
+		sgrReset = "\x1b[0m"
+		prompt   = "PROMPT$ "
+	)
+
 	var buf strings.Builder
-	buf.Grow(width * lines)
+	// Each line: SGR open + visible cells + SGR reset + CRLF.
+	rowBytes := len(sgrOpen) + max(width, len("row-000 ")) + len(sgrReset) + len("\r\n")
+	buf.Grow(rowBytes*lines + len(prompt))
 	for i := 0; i < lines; i++ {
-		fmt.Fprintf(&buf, "\x1b[48;2;24;28;36mrow-%03d ", i)
+		fmt.Fprintf(&buf, "%srow-%03d ", sgrOpen, i)
 		buf.WriteString(strings.Repeat(" ", max(width-8, 0)))
-		buf.WriteString("\x1b[0m\r\n")
+		buf.WriteString(sgrReset)
+		buf.WriteString("\r\n")
 	}
-	buf.WriteString("PROMPT$ ")
+	buf.WriteString(prompt)
 	return []byte(buf.String())
 }
 


### PR DESCRIPTION
## Motivation

LAB-1803's live heap profile reproduced the reported post-LAB-1750 shape. During verification on 2026-05-13, a fresh server heap profile for the installed `d266004` build showed 676.69 MB in-use with `vt.cloneLineInto` retaining 411.63 MB / 60.83%; the issue artifact from 2026-05-13 showed the same post-LAB-1750 shape at 507.70 MB with `cloneLineInto` at 298.41 MB / 58.78%. A pre-LAB-1750 heap artifact from 2026-05-12 showed 300.18 MB total with `cloneLineInto` at 91.16 MB / 30.37%.

`go tool pprof -peek cloneLineInto` pointed at `vt.(*scrollbackRing).push`, not an amux snapshot cache, so the fix targets the vt scrollback clone input instead of adding amux-side memoization.

## Summary

- Add a resize-preservation benchmark that writes full-width styled scrollback rows before shrinking and widening the emulator.
- Pin `github.com/charmbracelet/x/vt` to weill-labs/x commit `fc372e8574ca`, which trims trailing styled blank cells before cloning rows into scrollback.
- Keep `cloneLineInto`'s API unchanged; the fork-side change is tracked in https://github.com/weill-labs/x/pull/15.
- LAB-1794 is already fixed on fork `main` by `6adbf8184605`, so this PR pins a later fork commit rather than cherry-picking the soft-wrap API restoration here.

## Baseline numbers

Hardware: AMD EPYC-Milan Processor, Linux amd64.

| Measurement | Before | After |
| --- | ---: | ---: |
| `BenchmarkVTEmulatorResizePreservationStyledScrollback` bytes/op | ~14.00 MB/op | ~10.16 MB/op |
| `BenchmarkVTEmulatorResizePreservationStyledScrollback` allocs/op | 1518-1519 | 1506-1507 |
| Styled workload heap in-use | 112.13 MB | 48.10 MB |
| Styled workload `vt.cloneLineInto` in-use | 67.62 MB / 60.30% | 5.00 MB / 10.41% |

## Testing

- `go test ./internal/mux -run '^$' -bench BenchmarkVTEmulatorResizePreservationStyledScrollback -benchmem -count=5`
- `go test ./internal/mux -run 'TestRenderWithCursorRoundTripPreserves(SoftWrapForResize|WrappedTrailingSpaces|BlankWrappedSpacesAtCursor|BlankWrappedRowsBeforeHardNewline|PhantomCursorForResize)|TestVTEmulatorResizeShrink' -count=100`
- `go test -race ./internal/mux -timeout 120s -count=10`
- `go test ./... -timeout 180s`
- `go test ./test -run '^TestSwapForward$' -timeout 120s -count=1` after one `go test ./... -timeout 120s` run hit that integration timing flake.
- In `weill-labs/x/vt`: `go test -run 'TestScrollback/trims_trailing_styled_blanks' -count=100`
- In `weill-labs/x/vt`: `go test -run TestScrollback -count=1`
- In `weill-labs/x/vt`: `go test ./...`
- `go test -race ./... -timeout 120s -count=10` was attempted and currently fails outside the touched package set in timing-heavy tests/packages (`internal/cli`, `internal/client`, `internal/dialutil`, `internal/remote`, `internal/server`, and `test`). `internal/mux` passed the same race/count loop.

## Review focus

- Whether the fork-side scrollback trim semantics are the right layer versus amux memoization; profiles showed retained bytes in vt scrollback ring storage.
- Confirming LAB-1750 preserve-output behavior stays intact; the preserve-output regression tests re-pass with `-count=100`.
- Whether to merge https://github.com/weill-labs/x/pull/15 first and then update this PR to the merged fork commit.

Closes LAB-1803.
