### PR TITLE
LAB-1642: Gate precise SGR diff state

### DIFF
--- a/internal/render/compositor.go
+++ b/internal/render/compositor.go
@@ -1,6 +1,7 @@
 package render
 
 import (
+	"os"
 	"strconv"
 	"strings"
 	"sync/atomic"
@@ -49,6 +50,7 @@ type Compositor struct {
 	prevGridSnap      atomic.Pointer[ScreenGrid]
 	prevGridLayoutKey string
 	prevCursor        cursorRenderState
+	lastEmittedCell   emittedCellState
 	colorProfile      termenv.Profile
 	iconSet           IconSet
 	statusStyle       string
@@ -76,12 +78,13 @@ func (c *Compositor) SetWindows(windows []WindowInfo) {
 // NewCompositor creates a compositor for the given terminal dimensions.
 func NewCompositor(width, height int, sessionName string) *Compositor {
 	return &Compositor{
-		width:        width,
-		height:       height,
-		sessionName:  sessionName,
-		colorProfile: defaultColorProfile,
-		iconSet:      DefaultIconSet(),
-		statusStyle:  config.StatusStyleCompact,
+		width:           width,
+		height:          height,
+		sessionName:     sessionName,
+		lastEmittedCell: defaultEmittedCellState(),
+		colorProfile:    defaultColorProfile,
+		iconSet:         DefaultIconSet(),
+		statusStyle:     config.StatusStyleCompact,
 	}
 }
 
@@ -304,6 +307,10 @@ func (c *Compositor) RenderDiffWithOverlayDirtyStats(
 	layoutHeight := c.layoutHeightForHelpBar(overlay.HelpBar)
 	layoutKey := c.layoutReuseKey(root, activePaneID, layoutHeight)
 	newGrid, panesComposited := c.buildGridWithOverlayDirty(root, activePaneID, lookup, overlay, dirtyPanes, fullRedraw)
+	firstFrame := c.prevGrid == nil
+	if firstFrame {
+		c.resetLastEmittedCell()
+	}
 	changes := DiffGrid(c.prevGrid, newGrid)
 	c.prevGrid = newGrid
 	c.publishPrevGridSnapshot(newGrid)
@@ -325,15 +332,16 @@ func (c *Compositor) RenderDiffWithOverlayDirtyStats(
 	if len(changes) > 0 || !nextCursor.visible {
 		buf.WriteString(HideCursor)
 	}
-	// Reset all styles before emitting diffs. The terminal retains the
-	// "current style" from the previous frame's last cell write (typically
-	// the global bar with bg=surface0). Without a reset, EmitDiff's first
-	// StyleDiff(nil → cell) only sets the needed attributes, leaving stale
-	// bg/fg from the prior frame to bleed into content cells.
-	if len(changes) > 0 {
-		buf.WriteString(Reset)
+	if preciseSGREnabled() {
+		buf.WriteString(emitDiffWithProfileState(changes, c.colorProfile, &c.lastEmittedCell, false))
+	} else {
+		// Legacy soak path: keep the exact blanket-reset prefix until the
+		// precise SGR state machine becomes the default.
+		if len(changes) > 0 {
+			buf.WriteString(Reset)
+		}
+		buf.WriteString(emitDiffWithProfile(changes, c.colorProfile))
 	}
-	buf.WriteString(emitDiffWithProfile(changes, c.colorProfile))
 
 	// Position cursor.
 	c.renderCursorTransition(&buf, nextCursor, len(changes) > 0)
@@ -354,6 +362,15 @@ func (c *Compositor) clearPrevGrid() {
 	c.prevGridSnap.Store(nil)
 	c.prevGridLayoutKey = ""
 	c.prevCursor = cursorRenderState{}
+	c.resetLastEmittedCell()
+}
+
+func (c *Compositor) resetLastEmittedCell() {
+	c.lastEmittedCell = defaultEmittedCellState()
+}
+
+func preciseSGREnabled() bool {
+	return os.Getenv("AMUX_PRECISE_SGR") == "1"
 }
 
 func (c *Compositor) publishPrevGridSnapshot(g *ScreenGrid) {

--- a/internal/render/compositor.go
+++ b/internal/render/compositor.go
@@ -9,6 +9,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/charmbracelet/lipgloss"
+	uv "github.com/charmbracelet/ultraviolet"
 	"github.com/charmbracelet/x/ansi"
 	"github.com/mattn/go-runewidth"
 	"github.com/muesli/termenv"
@@ -51,6 +52,7 @@ type Compositor struct {
 	prevGridLayoutKey string
 	prevCursor        cursorRenderState
 	lastEmittedCell   emittedCellState
+	preciseSGR        bool
 	colorProfile      termenv.Profile
 	iconSet           IconSet
 	statusStyle       string
@@ -82,6 +84,7 @@ func NewCompositor(width, height int, sessionName string) *Compositor {
 		height:          height,
 		sessionName:     sessionName,
 		lastEmittedCell: defaultEmittedCellState(),
+		preciseSGR:      preciseSGREnabled(),
 		colorProfile:    defaultColorProfile,
 		iconSet:         DefaultIconSet(),
 		statusStyle:     config.StatusStyleCompact,
@@ -332,7 +335,7 @@ func (c *Compositor) RenderDiffWithOverlayDirtyStats(
 	if len(changes) > 0 || !nextCursor.visible {
 		buf.WriteString(HideCursor)
 	}
-	if preciseSGREnabled() {
+	if c.preciseSGR {
 		buf.WriteString(emitDiffWithProfileState(changes, c.colorProfile, &c.lastEmittedCell, false))
 	} else {
 		// Legacy soak path: keep the exact blanket-reset prefix until the
@@ -345,6 +348,9 @@ func (c *Compositor) RenderDiffWithOverlayDirtyStats(
 
 	// Position cursor.
 	c.renderCursorTransition(&buf, nextCursor, len(changes) > 0)
+	if c.preciseSGR && nextCursor.visible && nextCursor.positioned {
+		c.resetLastEmittedStyle()
+	}
 
 	return buf.String(), RenderStats{
 		CellsDiffed:     len(changes),
@@ -367,6 +373,12 @@ func (c *Compositor) clearPrevGrid() {
 
 func (c *Compositor) resetLastEmittedCell() {
 	c.lastEmittedCell = defaultEmittedCellState()
+}
+
+func (c *Compositor) resetLastEmittedStyle() {
+	// SGR reset restores only text style; OSC-8 hyperlink state is independent.
+	c.lastEmittedCell.hasStyle = true
+	c.lastEmittedCell.style = uv.Style{}
 }
 
 func preciseSGREnabled() bool {

--- a/internal/render/compositor_test.go
+++ b/internal/render/compositor_test.go
@@ -392,6 +392,40 @@ func TestRenderDiffPreciseSGRResizeResetsEmitState(t *testing.T) {
 	}
 }
 
+func TestRenderDiffPreciseSGRCursorResetInvalidatesEmitState(t *testing.T) {
+	t.Setenv("AMUX_PRECISE_SGR", "1")
+
+	const (
+		width  = 8
+		height = 3
+	)
+	redBG := uv.Style{Bg: ansi.RGBColor{R: 1, G: 2, B: 3}}
+	pane := &styledPaneData{
+		fakePaneData: fakePaneData{id: 1, name: "pane-1"},
+		cells: [][]ScreenCell{{
+			{Char: "A", Width: 1},
+		}},
+	}
+	root := mux.NewLeafByID(1, 0, 0, width, height-GlobalBarHeight)
+	lookup := func(paneID uint32) PaneData { return pane }
+	c := newTestCompositor(width, height, "lab-1642")
+
+	c.RenderDiffWithOverlayDirty(root, 1, lookup, OverlayState{}, nil, true)
+	pane.cells = [][]ScreenCell{{
+		{Char: "B", Width: 1, Style: redBG},
+	}}
+	c.RenderDiffWithOverlayDirty(root, 1, lookup, OverlayState{}, map[uint32]struct{}{1: {}}, false)
+	pane.cells = [][]ScreenCell{{
+		{Char: "C", Width: 1, Style: redBG},
+	}}
+	third := c.RenderDiffWithOverlayDirty(root, 1, lookup, OverlayState{}, map[uint32]struct{}{1: {}}, false)
+
+	firstCellPrefix := prefixBeforeFirstPrintable(third)
+	if !strings.Contains(firstCellPrefix, "48;2;1;2;3") {
+		t.Fatalf("third-frame first cell prefix = %q, want bg SGR after cursor reset in diff %q", firstCellPrefix, third)
+	}
+}
+
 func TestRenderDiffLegacyKeepsBlanketResetWhenPreciseSGRDisabled(t *testing.T) {
 	t.Setenv("AMUX_PRECISE_SGR", "0")
 

--- a/internal/render/compositor_test.go
+++ b/internal/render/compositor_test.go
@@ -334,7 +334,7 @@ func TestRenderDiffPreciseSGRDropsBlanketResetForSingleBGChange(t *testing.T) {
 	if strings.Contains(second, Reset) {
 		t.Fatalf("precise SGR diff contains blanket reset: %q", second)
 	}
-	if !strings.Contains(second, "\x1b[48;2;1;2;3m") {
+	if !strings.Contains(second, "48;2;1;2;3") {
 		t.Fatalf("precise SGR diff = %q, want changed cell bg SGR", second)
 	}
 }

--- a/internal/render/compositor_test.go
+++ b/internal/render/compositor_test.go
@@ -91,6 +91,18 @@ func (f *fakePaneData) CopyModeOverlay() *proto.ViewportOverlay {
 	return f.copyOverlay
 }
 
+type styledPaneData struct {
+	fakePaneData
+	cells [][]ScreenCell
+}
+
+func (s *styledPaneData) CellAt(col, row int, active bool) ScreenCell {
+	if row < 0 || row >= len(s.cells) || col < 0 || col >= len(s.cells[row]) {
+		return ScreenCell{Char: " ", Width: 1}
+	}
+	return s.cells[row][col]
+}
+
 type countingPaneData struct {
 	base      *fakePaneData
 	cellReads *int
@@ -295,6 +307,120 @@ func TestRenderDiffRepaintsMovedPaneHeaders(t *testing.T) {
 	}
 }
 
+func TestRenderDiffPreciseSGRDropsBlanketResetForSingleBGChange(t *testing.T) {
+	t.Setenv("AMUX_PRECISE_SGR", "1")
+
+	const (
+		width  = 8
+		height = 3
+	)
+	redBG := uv.Style{Bg: ansi.RGBColor{R: 1, G: 2, B: 3}}
+	pane := &styledPaneData{
+		fakePaneData: fakePaneData{id: 1, name: "pane-1", cursorHidden: true},
+		cells: [][]ScreenCell{{
+			{Char: "A", Width: 1},
+		}},
+	}
+	root := mux.NewLeafByID(1, 0, 0, width, height-GlobalBarHeight)
+	lookup := func(paneID uint32) PaneData { return pane }
+	c := newTestCompositor(width, height, "lab-1642")
+
+	c.RenderDiffWithOverlayDirty(root, 1, lookup, OverlayState{}, nil, true)
+	pane.cells = [][]ScreenCell{{
+		{Char: "B", Width: 1, Style: redBG},
+	}}
+	second := c.RenderDiffWithOverlayDirty(root, 1, lookup, OverlayState{}, map[uint32]struct{}{1: {}}, false)
+
+	if strings.Contains(second, Reset) {
+		t.Fatalf("precise SGR diff contains blanket reset: %q", second)
+	}
+	if !strings.Contains(second, "\x1b[48;2;1;2;3m") {
+		t.Fatalf("precise SGR diff = %q, want changed cell bg SGR", second)
+	}
+}
+
+func TestRenderDiffPreciseSGRStartsFromLastEmittedState(t *testing.T) {
+	t.Setenv("AMUX_PRECISE_SGR", "1")
+
+	const (
+		width  = 8
+		height = 3
+	)
+	pane := &styledPaneData{
+		fakePaneData: fakePaneData{id: 1, name: "pane-1", cursorHidden: true},
+		cells: [][]ScreenCell{{
+			{Char: "A", Width: 1},
+		}},
+	}
+	root := mux.NewLeafByID(1, 0, 0, width, height-GlobalBarHeight)
+	lookup := func(paneID uint32) PaneData { return pane }
+	c := newTestCompositor(width, height, "lab-1642")
+
+	c.RenderDiffWithOverlayDirty(root, 1, lookup, OverlayState{}, nil, true)
+	lastStyle := c.prevGrid.Get(width-1, height-1).Style
+	pane.cells = [][]ScreenCell{{
+		{Char: "Z", Width: 1, Style: lastStyle},
+	}}
+	second := c.RenderDiffWithOverlayDirty(root, 1, lookup, OverlayState{}, map[uint32]struct{}{1: {}}, false)
+
+	firstCellPrefix := prefixBeforeFirstPrintable(second)
+	if strings.Contains(firstCellPrefix, surface0BGParams()) {
+		t.Fatalf("first changed cell redundantly emitted bg SGR in prefix %q of diff %q", firstCellPrefix, second)
+	}
+}
+
+func TestRenderDiffPreciseSGRResizeResetsEmitState(t *testing.T) {
+	t.Setenv("AMUX_PRECISE_SGR", "1")
+
+	const height = 1
+	pane := &styledPaneData{
+		fakePaneData: fakePaneData{id: 1, name: "pane-1", cursorHidden: true},
+	}
+	lookup := func(paneID uint32) PaneData { return pane }
+	c := newTestCompositor(20, height, "lab-1642")
+
+	c.RenderDiffWithOverlayDirty(mux.NewLeafByID(1, 0, 0, 20, 0), 1, lookup, OverlayState{}, nil, true)
+	c.Resize(21, height)
+	second := c.RenderDiffWithOverlayDirty(mux.NewLeafByID(1, 0, 0, 21, 0), 1, lookup, OverlayState{}, nil, true)
+
+	if strings.Contains(second, Reset) {
+		t.Fatalf("precise SGR post-resize diff contains blanket reset: %q", second)
+	}
+	firstCellPrefix := prefixBeforeFirstPrintable(second)
+	if !strings.Contains(firstCellPrefix, surface0BGParams()) {
+		t.Fatalf("post-resize first cell prefix = %q, want fresh bg SGR in diff %q", firstCellPrefix, second)
+	}
+}
+
+func TestRenderDiffLegacyKeepsBlanketResetWhenPreciseSGRDisabled(t *testing.T) {
+	t.Setenv("AMUX_PRECISE_SGR", "0")
+
+	const (
+		width  = 8
+		height = 3
+	)
+	redBG := uv.Style{Bg: ansi.RGBColor{R: 1, G: 2, B: 3}}
+	pane := &styledPaneData{
+		fakePaneData: fakePaneData{id: 1, name: "pane-1", cursorHidden: true},
+		cells: [][]ScreenCell{{
+			{Char: "A", Width: 1},
+		}},
+	}
+	root := mux.NewLeafByID(1, 0, 0, width, height-GlobalBarHeight)
+	lookup := func(paneID uint32) PaneData { return pane }
+	c := newTestCompositor(width, height, "lab-1642")
+
+	c.RenderDiffWithOverlayDirty(root, 1, lookup, OverlayState{}, nil, true)
+	pane.cells = [][]ScreenCell{{
+		{Char: "B", Width: 1, Style: redBG},
+	}}
+	second := c.RenderDiffWithOverlayDirty(root, 1, lookup, OverlayState{}, map[uint32]struct{}{1: {}}, false)
+
+	if !strings.Contains(second, Reset) {
+		t.Fatalf("legacy diff = %q, want blanket reset while precise SGR is disabled", second)
+	}
+}
+
 type screenPos struct {
 	row int
 	col int
@@ -380,6 +506,26 @@ func parseCUPHeaderDraws(stream string) map[string][]screenPos {
 		draws[header] = append(draws[header], pos)
 	}
 	return draws
+}
+
+func prefixBeforeFirstPrintable(stream string) string {
+	for i := 0; i < len(stream); {
+		if stream[i] == '\x1b' {
+			if next := skipANSISequence(stream, i); next > i {
+				i = next
+				continue
+			}
+		}
+		if stream[i] >= ' ' {
+			return stream[:i]
+		}
+		i++
+	}
+	return stream
+}
+
+func surface0BGParams() string {
+	return strings.TrimSuffix(strings.TrimPrefix(bgHexSequence(config.Surface0Hex, termenv.TrueColor), "\x1b["), "m")
 }
 
 func lab1610PaneData() map[uint32]*fakePaneData {

--- a/internal/render/screen.go
+++ b/internal/render/screen.go
@@ -177,13 +177,17 @@ func EmitDiff(changes []CellChange) string {
 }
 
 func emitDiffWithProfile(changes []CellChange, profile termenv.Profile) string {
+	var state emittedCellState
+	return emitDiffWithProfileState(changes, profile, &state, true)
+}
+
+func emitDiffWithProfileState(changes []CellChange, profile termenv.Profile, state *emittedCellState, closeHyperlink bool) string {
 	if len(changes) == 0 {
 		return ""
 	}
 	var buf strings.Builder
 	buf.Grow(len(changes) * 8)
 
-	var state emittedCellState
 	expectX, expectY := -1, -1
 
 	for _, ch := range changes {
@@ -213,7 +217,9 @@ func emitDiffWithProfile(changes []CellChange, profile termenv.Profile) string {
 		}
 		expectX = ch.X + w
 	}
-	state.closeHyperlink(&buf)
+	if closeHyperlink {
+		state.closeHyperlink(&buf)
+	}
 	return buf.String()
 }
 
@@ -540,6 +546,10 @@ type emittedCellState struct {
 	hasStyle bool
 	style    uv.Style
 	link     uv.Link
+}
+
+func defaultEmittedCellState() emittedCellState {
+	return emittedCellState{hasStyle: true}
 }
 
 func (s *emittedCellState) stylePtr() *uv.Style {


### PR DESCRIPTION
## Motivation

The diff renderer currently emits a blanket `\x1b[m` reset before every changed frame to defend against stale terminal SGR state. LAB-1642 tracks the tmux-style fix: carry the last emitted cell state across frames so the precise path can drop that reset without losing style correctness.

## Summary

- Added `AMUX_PRECISE_SGR=1` as the initial soak flag for the precise diff path.
- Persisted the compositor's last emitted cell style/link state across diff frames, following the existing `prevCursor` lifecycle pattern.
- Reset the persisted emit state on first-frame paint, resize, and `ClearPrevGrid` through the existing previous-grid reset path.
- Invalidated precise SGR style state after the visible-cursor positioning reset, while preserving OSC-8 hyperlink state.
- Cached the rollout flag on `Compositor` construction so render frames do not re-read the environment.
- Kept the legacy default path on the existing blanket reset behavior for this PR.
- Added regression coverage for single-cell bg changes, CUP-jump ordering from last emitted state, resize reset behavior, visible-cursor reset invalidation, and the legacy flag-disabled path.

## Testing

- Before implementation: `go test ./internal/render -run 'TestRenderDiffPreciseSGR|TestRenderDiffLegacyKeeps' -count=1` failed the three precise-SGR regressions against current main.
- Before cursor-reset fix: `go test ./internal/render -run TestRenderDiffPreciseSGRCursorResetInvalidatesEmitState -count=1` failed because frame 3 skipped the bg SGR after cursor Reset.
- After implementation: `go test ./internal/render -run 'TestRenderDiffPreciseSGR|TestRenderDiffLegacyKeeps' -count=100`
- `go test ./internal/render -count=1`
- `go test ./test -run 'Test(LastWindowKeybinding|NewWindowKeybinding|NextPrevWindow|NextPrevWindowCLI|OnlyActivePaneBordersColored|SelectWindowByNumber|SelectWindowCLI|WindowPaneIsolation)$' -count=1 -timeout 120s`
- `go test ./test -timeout 300s`
- `go test ./internal/mux -run 'TestGitBranch/git_repo_returns_branch' -count=1`
- `go test ./internal/mux -count=1`
- `go test ./... -timeout 300s`
- After review fix and rebase onto `origin/main`: `go test ./internal/render -run 'TestRenderDiffPreciseSGR|TestRenderDiffLegacyKeeps' -count=100`
- After review fix and rebase onto `origin/main`: `go test ./internal/render -count=1`
- After review fix and rebase onto `origin/main`: `go test ./... -timeout 300s`
- Remote SSH CI flake check: `go test -count=3 -parallel 2 -timeout 360s ./test/ -run TestRemotePaneViaSSHAutoDeploy`

Note: `go test ./... -timeout 120s` exceeded the local 120s package timeout in `./test`; the listed targeted window slice passed at 57s, `./test -timeout 300s` passed at 212s, and the final repo-wide 300s run passed. One repo-wide 300s run also hit an unrelated transient `git init -b test-branch` broken pipe in `internal/mux`, which passed on targeted and package reruns. After the review-fix push, the first CI `test` run timed out in `TestRemotePaneViaSSHAutoDeploy`; the exact test passed locally under the CI shape and the failed CI job passed on rerun.

## Review focus

- Confirm the legacy branch is byte-compatible for the default soak path.
- Check the precise path's `emittedCellState` lifecycle: first frame, resize, and `ClearPrevGrid` all reset to default state.
- Check the visible-cursor transition: cursor positioning still writes Reset, and precise mode clears only tracked SGR style afterward so the next diff starts from terminal default style.
- Check hyperlink state handling: the precise path leaves link state threaded across frames; cursor Reset invalidates style only because SGR Reset does not close OSC-8 hyperlinks.
- Coordinate with LAB-1691 if that PR also edits `internal/render/screen.go`.

## Rollout plan

- PR 1: this change, precise SGR behind `AMUX_PRECISE_SGR=1`; default remains the legacy blanket-reset path.
- PR 2 after soak: flip the default and add `AMUX_LEGACY_BLANKET_RESET=1` as the emergency rollback flag.
- PR 3 after the second soak: remove the legacy path and rollout flag.

Refs LAB-1642.