### PR TITLE
LAB-1760: Default full-session capture to server path

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,10 @@ amux capture --format json
 amux capture --history --format json
 ```
 
+Full-session capture reads server-owned pane state by default and does not
+require an attached interactive client. Use `--client` when you need the
+attached client's displayed view, including client-local overlays.
+
 Returns a JSON object with session metadata, window info, and per-pane state:
 
 ```json

--- a/docs/capture-architecture.md
+++ b/docs/capture-architecture.md
@@ -101,7 +101,7 @@ Roll out the change compatibly:
 1. Before LAB-1644: `amux capture` called client-side rendering and could flicker.
 2. LAB-1644: add server-side single-pane capture as a parallel implementation behind `AMUX_CAPTURE_SERVER=1`.
 3. LAB-1753: flip single-pane capture to server-side by default. `amux capture --client pane-3` opts into the user-perspective behavior. `AMUX_CAPTURE_LEGACY_CLIENT=1` temporarily restores the old single-pane client-forwarded default as an emergency rollback knob during soak.
-4. LAB-1754: flip full-session capture to server-side once the compositor adapter path is ready.
+4. LAB-1760: flip full-session capture to server-side by default using the same `AMUX_CAPTURE_LEGACY_CLIENT=1` emergency rollback knob during soak.
 5. Later: deprecate the redundant `--display` flag, making it equivalent to `--client` without overlay metadata, or keep it as a fast-path alias.
 
 Existing scripts continue working. Most scripts call `amux capture --format json`, which is already a structural read that translates cleanly to server-side capture.

--- a/internal/mux/pane_emulator.go
+++ b/internal/mux/pane_emulator.go
@@ -28,7 +28,7 @@ func (s PaneRenderSnapshot) CellAt(col, row int) (uv.Cell, bool) {
 		return uv.Cell{}, false
 	}
 	idx := row*s.Width + col
-	if idx < 0 || idx >= len(s.ScreenCells) {
+	if idx >= len(s.ScreenCells) {
 		return uv.Cell{}, false
 	}
 	return s.ScreenCells[idx], true

--- a/internal/mux/pane_emulator.go
+++ b/internal/mux/pane_emulator.go
@@ -5,11 +5,33 @@ import (
 	"os"
 	"strings"
 
+	uv "github.com/charmbracelet/ultraviolet"
 	"github.com/weill-labs/amux/internal/proto"
 )
 
 func newPaneEmulator(cols, rows, scrollbackLines int) TerminalEmulator {
 	return NewVTEmulatorWithScrollback(cols, rows, scrollbackLines)
+}
+
+// PaneRenderSnapshot is a consistent copy of a pane's renderable terminal
+// state. It is safe to use after the pane actor has been released.
+type PaneRenderSnapshot struct {
+	CaptureSnapshot
+	Height           int
+	Rendered         string
+	RenderedNoCursor string
+	ScreenCells      []uv.Cell
+}
+
+func (s PaneRenderSnapshot) CellAt(col, row int) (uv.Cell, bool) {
+	if col < 0 || row < 0 || col >= s.Width || row >= s.Height {
+		return uv.Cell{}, false
+	}
+	idx := row*s.Width + col
+	if idx < 0 || idx >= len(s.ScreenCells) {
+		return uv.Cell{}, false
+	}
+	return s.ScreenCells[idx], true
 }
 
 // wireScrollbackCallbacks connects the emulator's scrollback push/clear
@@ -200,35 +222,71 @@ func (p *Pane) TerminalSnapshot() PaneTerminalSnapshot {
 	})
 }
 
+func (p *Pane) captureSnapshotLocked() CaptureSnapshot {
+	baseHistory := p.loadBaseHistory()
+	liveHistory := EmulatorScrollbackHistoryLines(p.emulator, p.loadScrollbackWidths())
+	baseHistory, liveHistory, history := p.captureScrollback(baseHistory, liveHistory)
+	contentRows := EmulatorContentHistoryLines(p.emulator)
+	terminal := p.terminalSnapshot()
+	width, _ := p.emulator.Size()
+	snap := CaptureSnapshot{
+		BaseHistory:    append([]string(nil), baseHistory...),
+		LiveHistory:    append([]CaptureHistoryLine(nil), liveHistory...),
+		History:        history,
+		ContentRows:    append([]CaptureHistoryLine(nil), contentRows...),
+		Content:        captureHistoryLineText(contentRows),
+		Terminal:       terminal.Terminal,
+		Width:          width,
+		CursorCol:      terminal.CursorCol,
+		CursorRow:      terminal.CursorRow,
+		CursorHidden:   terminal.CursorHidden,
+		HasCursorBlock: false,
+	}
+	if blockCol, blockRow, ok := p.emulator.CursorBlockPosition(); ok {
+		snap.CursorBlockCol = blockCol
+		snap.CursorBlockRow = blockRow
+		snap.HasCursorBlock = true
+	}
+	return snap
+}
+
 // CaptureSnapshot returns a consistent plain-text snapshot of retained
 // scrollback, visible screen content, and cursor state.
 func (p *Pane) CaptureSnapshot() CaptureSnapshot {
 	return paneActorValue(p, func() CaptureSnapshot {
-		baseHistory := p.loadBaseHistory()
-		liveHistory := EmulatorScrollbackHistoryLines(p.emulator, p.loadScrollbackWidths())
-		baseHistory, liveHistory, history := p.captureScrollback(baseHistory, liveHistory)
-		contentRows := EmulatorContentHistoryLines(p.emulator)
-		terminal := p.terminalSnapshot()
-		width, _ := p.emulator.Size()
-		snap := CaptureSnapshot{
-			BaseHistory:    append([]string(nil), baseHistory...),
-			LiveHistory:    append([]CaptureHistoryLine(nil), liveHistory...),
-			History:        history,
-			ContentRows:    append([]CaptureHistoryLine(nil), contentRows...),
-			Content:        captureHistoryLineText(contentRows),
-			Terminal:       terminal.Terminal,
-			Width:          width,
-			CursorCol:      terminal.CursorCol,
-			CursorRow:      terminal.CursorRow,
-			CursorHidden:   terminal.CursorHidden,
-			HasCursorBlock: false,
+		return p.captureSnapshotLocked()
+	})
+}
+
+// CaptureRenderSnapshot returns a consistent snapshot of the pane data needed
+// by the full-session compositor.
+func (p *Pane) CaptureRenderSnapshot() PaneRenderSnapshot {
+	return paneActorValue(p, func() PaneRenderSnapshot {
+		snap := p.captureSnapshotLocked()
+		width, height := p.emulator.Size()
+		cells := make([]uv.Cell, width*height)
+		for row := 0; row < height; row++ {
+			for col := 0; col < width; col++ {
+				cell := uv.Cell{Content: " ", Width: 1}
+				if got := p.emulator.CellAt(col, row); got != nil {
+					cell = *got
+				}
+				cells[row*width+col] = cell
+			}
 		}
-		if blockCol, blockRow, ok := p.emulator.CursorBlockPosition(); ok {
-			snap.CursorBlockCol = blockCol
-			snap.CursorBlockRow = blockRow
-			snap.HasCursorBlock = true
+
+		rendered := p.emulator.Render()
+		renderedNoCursor := rendered
+		if snap.HasCursorBlock {
+			renderedNoCursor = p.emulator.RenderWithoutCursorBlock()
 		}
-		return snap
+		return PaneRenderSnapshot{
+			CaptureSnapshot:  snap,
+			Height:           height,
+			Rendered:         rendered,
+			RenderedNoCursor: renderedNoCursor,
+			ScreenCells:      cells,
+		}
 	})
 }
 

--- a/internal/server/capture_forward_test.go
+++ b/internal/server/capture_forward_test.go
@@ -853,7 +853,7 @@ func TestForwardCaptureJSONReturnsSessionShuttingDownWhileWaiting(t *testing.T) 
 func TestForwardCaptureJSONStressUnderPaneOutput(t *testing.T) {
 	t.Parallel()
 
-	srv, sess, cleanup := newCommandTestSession(t)
+	_, sess, cleanup := newCommandTestSession(t)
 	defer cleanup()
 
 	pane1 := newTestPane(sess, 1, "pane-1")
@@ -1002,7 +1002,11 @@ func TestForwardCaptureJSONStressUnderPaneOutput(t *testing.T) {
 			cmdErr string
 		}, 1)
 		go func() {
-			results <- runTestCommand(t, srv, sess, "capture", "--format", "json")
+			resp := sess.forwardCapture([]string{"--format", "json"})
+			results <- struct {
+				output string
+				cmdErr string
+			}{output: resp.CmdOutput, cmdErr: resp.CmdErr}
 		}()
 
 		var responseGate chan struct{}

--- a/internal/server/commands_capture.go
+++ b/internal/server/commands_capture.go
@@ -51,6 +51,16 @@ func captureSinglePaneLocally(ctx *CommandContext, req caputil.Request) *Message
 	return ctx.Sess.capturePaneDirect(caputil.ArgsForRequest(req), target)
 }
 
+func shouldCaptureLocally(req caputil.Request) bool {
+	if req.ClientMode || req.DisplayMode || captureLegacyClientPathEnabled() {
+		return false
+	}
+	if req.PaneRef == "" {
+		return !req.HistoryMode || req.FormatJSON
+	}
+	return !req.HistoryMode
+}
+
 func cmdCapture(ctx *CommandContext) {
 	req := caputil.ParseArgs(ctx.Args)
 	if req.PaneRef != "" {
@@ -65,19 +75,7 @@ func cmdCapture(ctx *CommandContext) {
 			return
 		}
 	}
-	if !req.ClientMode && !req.DisplayMode && !captureLegacyClientPathEnabled() {
-		if req.PaneRef == "" && (!req.HistoryMode || req.FormatJSON) {
-			ctx.applyCommandResult(commandpkg.Result{Message: captureLocally(ctx, ctx.Args)})
-			return
-		}
-		if req.PaneRef == "" {
-			ctx.applyCommandResult(capturecmd.Capture(captureCommandContext{ctx}, ctx.Args))
-			return
-		}
-		if req.HistoryMode {
-			ctx.applyCommandResult(capturecmd.Capture(captureCommandContext{ctx}, ctx.Args))
-			return
-		}
+	if shouldCaptureLocally(req) {
 		ctx.applyCommandResult(commandpkg.Result{Message: captureLocally(ctx, ctx.Args)})
 		return
 	}

--- a/internal/server/commands_capture.go
+++ b/internal/server/commands_capture.go
@@ -31,7 +31,7 @@ func captureLegacyClientPathEnabled() bool {
 func captureLocally(ctx *CommandContext, args []string) *Message {
 	req := caputil.ParseArgs(args)
 	if req.PaneRef == "" {
-		return &Message{Type: MsgTypeCmdResult, CmdErr: "server-side full-session capture is not implemented"}
+		return captureFullSessionLocally(ctx, args)
 	}
 	return captureSinglePaneLocally(ctx, req)
 }
@@ -65,7 +65,19 @@ func cmdCapture(ctx *CommandContext) {
 			return
 		}
 	}
-	if req.PaneRef != "" && !req.ClientMode && !req.DisplayMode && !req.HistoryMode && !captureLegacyClientPathEnabled() {
+	if !req.ClientMode && !req.DisplayMode && !captureLegacyClientPathEnabled() {
+		if req.PaneRef == "" && (!req.HistoryMode || req.FormatJSON) {
+			ctx.applyCommandResult(commandpkg.Result{Message: captureLocally(ctx, ctx.Args)})
+			return
+		}
+		if req.PaneRef == "" {
+			ctx.applyCommandResult(capturecmd.Capture(captureCommandContext{ctx}, ctx.Args))
+			return
+		}
+		if req.HistoryMode {
+			ctx.applyCommandResult(capturecmd.Capture(captureCommandContext{ctx}, ctx.Args))
+			return
+		}
 		ctx.applyCommandResult(commandpkg.Result{Message: captureLocally(ctx, ctx.Args)})
 		return
 	}

--- a/internal/server/commands_capture_test.go
+++ b/internal/server/commands_capture_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"encoding/json"
+	"fmt"
 	"net"
 	"slices"
 	"strings"
@@ -201,6 +202,45 @@ func TestCaptureFullSessionJSONUsesServerPaneMetadataWithoutAttachedClient(t *te
 	}
 	if joined := strings.Join(pane.Content, "\n"); !strings.Contains(joined, "JSON-SERVER-ONE") {
 		t.Fatalf("pane content = %q, want JSON-SERVER-ONE", joined)
+	}
+}
+
+func TestCaptureFullSessionHistoryJSONSeparatesScrollback(t *testing.T) {
+	t.Parallel()
+
+	srv, sess, cleanup := newCommandTestSession(t)
+	defer cleanup()
+	sess.captureTiming.attachMaxRetries = 1
+
+	pane := newStandaloneProxyPane(1, "pane-1")
+	var output strings.Builder
+	for i := 1; i <= 30; i++ {
+		fmt.Fprintf(&output, "SERVER-HISTORY-%02d\r\n", i)
+	}
+	pane.FeedOutput([]byte(output.String()))
+	window := newTestWindowWithPanes(t, sess, 1, "main", pane)
+	setSessionLayoutForTest(t, sess, window.ID, []*mux.Window{window}, pane)
+
+	res := runTestCommand(t, srv, sess, "capture", "--history", "--format", "json")
+	if res.cmdErr != "" {
+		t.Fatalf("capture cmdErr = %q, want empty", res.cmdErr)
+	}
+	var capture proto.CaptureJSON
+	if err := json.Unmarshal([]byte(res.output), &capture); err != nil {
+		t.Fatalf("json.Unmarshal capture output: %v\n%s", err, res.output)
+	}
+	if len(capture.Panes) != 1 {
+		t.Fatalf("capture panes = %d, want 1: %+v", len(capture.Panes), capture.Panes)
+	}
+	paneCapture := capture.Panes[0]
+	if got := strings.Join(paneCapture.History, "\n"); !strings.Contains(got, "SERVER-HISTORY-01") {
+		t.Fatalf("pane history = %q, want SERVER-HISTORY-01; full pane: %+v", got, paneCapture)
+	}
+	if got := strings.Join(paneCapture.Content, "\n"); strings.Contains(got, "SERVER-HISTORY-01") {
+		t.Fatalf("pane content should not contain scrollback history, got %q", got)
+	}
+	if got := strings.Join(paneCapture.Content, "\n"); !strings.Contains(got, "SERVER-HISTORY-30") {
+		t.Fatalf("pane content = %q, want SERVER-HISTORY-30", got)
 	}
 }
 

--- a/internal/server/commands_capture_test.go
+++ b/internal/server/commands_capture_test.go
@@ -10,6 +10,7 @@ import (
 
 	caputil "github.com/weill-labs/amux/internal/capture"
 	"github.com/weill-labs/amux/internal/mux"
+	"github.com/weill-labs/amux/internal/proto"
 )
 
 func TestCaptureDefaultSinglePaneDoesNotSendClientCaptureRequest(t *testing.T) {
@@ -124,6 +125,82 @@ func TestCaptureFullSessionTextUsesServerLayoutWithoutAttachedClient(t *testing.
 		if !strings.Contains(res.output, want) {
 			t.Fatalf("capture output missing %q:\n%s", want, res.output)
 		}
+	}
+}
+
+func TestCaptureFullSessionJSONUsesServerPaneMetadataWithoutAttachedClient(t *testing.T) {
+	t.Parallel()
+
+	srv, sess, cleanup := newCommandTestSession(t)
+	defer cleanup()
+	sess.captureTiming.attachMaxRetries = 1
+
+	pane1 := newStandaloneProxyPane(1, "pane-1")
+	pane2 := newStandaloneProxyPane(2, "pane-2")
+	pane1.FeedOutput([]byte("JSON-SERVER-ONE\r\n"))
+	pane2.FeedOutput([]byte("JSON-SERVER-TWO\r\n"))
+	pane1.Meta.Task = "ship"
+	pane1.Meta.GitBranch = "feature/full-session-capture"
+	pane1.Meta.PR = "1760"
+	pane1.Meta.KV = map[string]string{"issue": "LAB-1760", "owner": "codex"}
+	pane1.Meta.TrackedPRs = []proto.TrackedPR{{Number: 1760, Status: proto.TrackedStatusActive}}
+	pane1.Meta.TrackedIssues = []proto.TrackedIssue{{ID: "LAB-1760", Status: proto.TrackedStatusActive}}
+	window := newTestWindowWithPanes(t, sess, 1, "main", pane1, pane2)
+	setSessionLayoutForTest(t, sess, window.ID, []*mux.Window{window}, pane1, pane2)
+
+	res := runTestCommand(t, srv, sess, "capture", "--format", "json")
+	if res.cmdErr != "" {
+		t.Fatalf("capture cmdErr = %q, want empty", res.cmdErr)
+	}
+	var capture proto.CaptureJSON
+	if err := json.Unmarshal([]byte(res.output), &capture); err != nil {
+		t.Fatalf("json.Unmarshal capture output: %v\n%s", err, res.output)
+	}
+	if capture.Error != nil {
+		t.Fatalf("capture error = %+v, want nil", capture.Error)
+	}
+	if capture.Session != "test-command-queue" {
+		t.Fatalf("capture session = %q, want test-command-queue", capture.Session)
+	}
+	if capture.Window.ID != 1 || capture.Window.Name != "main" || capture.Window.Index != 1 {
+		t.Fatalf("capture window = %+v, want active main window", capture.Window)
+	}
+	if len(capture.Panes) != 2 {
+		t.Fatalf("capture panes = %d, want 2: %+v", len(capture.Panes), capture.Panes)
+	}
+
+	var pane *proto.CapturePane
+	for i := range capture.Panes {
+		if capture.Panes[i].Position == nil {
+			t.Fatalf("pane %s missing position", capture.Panes[i].Name)
+		}
+		if capture.Panes[i].Name == "pane-1" {
+			pane = &capture.Panes[i]
+		}
+	}
+	if pane == nil {
+		t.Fatalf("pane-1 missing from capture: %+v", capture.Panes)
+	}
+	if pane.Task != "ship" || pane.Meta.Task != "ship" {
+		t.Fatalf("pane task fields = top-level %q meta %q, want ship", pane.Task, pane.Meta.Task)
+	}
+	if pane.GitBranch != "feature/full-session-capture" || pane.Meta.GitBranch != "feature/full-session-capture" {
+		t.Fatalf("pane git branch fields = top-level %q meta %q", pane.GitBranch, pane.Meta.GitBranch)
+	}
+	if pane.PR != "1760" || pane.Meta.PR != "1760" {
+		t.Fatalf("pane PR fields = top-level %q meta %q", pane.PR, pane.Meta.PR)
+	}
+	if got := pane.Meta.KV["issue"]; got != "LAB-1760" {
+		t.Fatalf("pane meta issue = %q, want LAB-1760", got)
+	}
+	if len(pane.Meta.TrackedPRs) != 1 || pane.Meta.TrackedPRs[0].Number != 1760 {
+		t.Fatalf("pane tracked PRs = %+v, want PR 1760", pane.Meta.TrackedPRs)
+	}
+	if len(pane.Meta.TrackedIssues) != 1 || pane.Meta.TrackedIssues[0].ID != "LAB-1760" {
+		t.Fatalf("pane tracked issues = %+v, want LAB-1760", pane.Meta.TrackedIssues)
+	}
+	if joined := strings.Join(pane.Content, "\n"); !strings.Contains(joined, "JSON-SERVER-ONE") {
+		t.Fatalf("pane content = %q, want JSON-SERVER-ONE", joined)
 	}
 }
 

--- a/internal/server/commands_capture_test.go
+++ b/internal/server/commands_capture_test.go
@@ -241,6 +241,43 @@ func TestCaptureClientFlagForwardsToAttachedClient(t *testing.T) {
 	}
 }
 
+func TestCaptureClientFlagForwardsFullSessionToAttachedClient(t *testing.T) {
+	t.Parallel()
+
+	srv, sess, cleanup := newCommandTestSession(t)
+	defer cleanup()
+
+	pane := newStandaloneProxyPane(1, "pane-1")
+	pane.FeedOutput([]byte("SERVER-LOCAL\r\n"))
+	window := newTestWindowWithPanes(t, sess, 1, "main", pane)
+	setSessionLayoutForTest(t, sess, window.ID, []*mux.Window{window}, pane)
+
+	captureClient := attachCaptureClientForCommandTest(t, sess)
+	requestCh, errCh := respondToNextCaptureRequest(t, sess, captureClient, "CLIENT-FULL\n")
+
+	res := runTestCommand(t, srv, sess, "capture", "--client")
+	if res.cmdErr != "" {
+		t.Fatalf("capture cmdErr = %q, want empty", res.cmdErr)
+	}
+	if got, want := res.output, "CLIENT-FULL\n"; got != want {
+		t.Fatalf("capture output = %q, want %q", got, want)
+	}
+
+	select {
+	case err := <-errCh:
+		t.Fatalf("reading capture request: %v", err)
+	case msg := <-requestCh:
+		if msg.Type != MsgTypeCaptureRequest {
+			t.Fatalf("message type = %v, want %v", msg.Type, MsgTypeCaptureRequest)
+		}
+		if want := []string{"--client"}; !slices.Equal(msg.CmdArgs, want) {
+			t.Fatalf("capture request args = %v, want %v", msg.CmdArgs, want)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for forwarded capture request")
+	}
+}
+
 func TestCaptureLegacyClientEnvForwardsSinglePaneToAttachedClient(t *testing.T) {
 	t.Setenv("AMUX_CAPTURE_LEGACY_CLIENT", "1")
 
@@ -272,6 +309,43 @@ func TestCaptureLegacyClientEnvForwardsSinglePaneToAttachedClient(t *testing.T) 
 		}
 		if want := []string{"1"}; !slices.Equal(msg.CmdArgs, want) {
 			t.Fatalf("capture request args = %v, want %v", msg.CmdArgs, want)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for forwarded capture request")
+	}
+}
+
+func TestCaptureLegacyClientEnvForwardsFullSessionToAttachedClient(t *testing.T) {
+	t.Setenv("AMUX_CAPTURE_LEGACY_CLIENT", "1")
+
+	srv, sess, cleanup := newCommandTestSession(t)
+	defer cleanup()
+
+	pane := newStandaloneProxyPane(1, "pane-1")
+	pane.FeedOutput([]byte("SERVER-LOCAL\r\n"))
+	window := newTestWindowWithPanes(t, sess, 1, "main", pane)
+	setSessionLayoutForTest(t, sess, window.ID, []*mux.Window{window}, pane)
+
+	captureClient := attachCaptureClientForCommandTest(t, sess)
+	requestCh, errCh := respondToNextCaptureRequest(t, sess, captureClient, "CLIENT-FULL\n")
+
+	res := runTestCommand(t, srv, sess, "capture")
+	if res.cmdErr != "" {
+		t.Fatalf("capture cmdErr = %q, want empty", res.cmdErr)
+	}
+	if got, want := res.output, "CLIENT-FULL\n"; got != want {
+		t.Fatalf("capture output = %q, want %q", got, want)
+	}
+
+	select {
+	case err := <-errCh:
+		t.Fatalf("reading capture request: %v", err)
+	case msg := <-requestCh:
+		if msg.Type != MsgTypeCaptureRequest {
+			t.Fatalf("message type = %v, want %v", msg.Type, MsgTypeCaptureRequest)
+		}
+		if len(msg.CmdArgs) != 0 {
+			t.Fatalf("capture request args = %v, want empty", msg.CmdArgs)
 		}
 	case <-time.After(time.Second):
 		t.Fatal("timeout waiting for forwarded capture request")
@@ -387,11 +461,11 @@ func TestCaptureHistoryPaneUsesServerHistoryPath(t *testing.T) {
 	}
 }
 
-func TestCaptureLocallyRejectsFullSessionDirectCall(t *testing.T) {
+func TestCaptureLocallyRejectsMissingSessionForFullSession(t *testing.T) {
 	t.Parallel()
 
 	res := captureLocally(&CommandContext{}, nil)
-	if got, want := res.CmdErr, "server-side full-session capture is not implemented"; got != want {
+	if got, want := res.CmdErr, "no session"; got != want {
 		t.Fatalf("captureLocally CmdErr = %q, want %q", got, want)
 	}
 }

--- a/internal/server/commands_capture_test.go
+++ b/internal/server/commands_capture_test.go
@@ -326,6 +326,37 @@ func TestCaptureFullSessionDefaultDoesNotSendClientCaptureRequest(t *testing.T) 
 	}
 }
 
+func TestCaptureFullSessionDuringBusyOutputDoesNotRequestClientRepaint(t *testing.T) {
+	t.Parallel()
+
+	srv, sess, cleanup := newCommandTestSession(t)
+	defer cleanup()
+	sess.captureTiming.responseTimeout = 20 * time.Millisecond
+
+	pane := newStandaloneProxyPane(1, "pane-1")
+	window := newTestWindowWithPanes(t, sess, 1, "main", pane)
+	setSessionLayoutForTest(t, sess, window.ID, []*mux.Window{window}, pane)
+	captureClient := attachCaptureClientForCommandTest(t, sess)
+
+	for i := 0; i < 5; i++ {
+		pane.FeedOutput([]byte("BUSY-TUI-FRAME\r\n"))
+		res := runTestCommand(t, srv, sess, "capture")
+		if res.cmdErr != "" {
+			t.Fatalf("capture #%d cmdErr = %q, want empty", i+1, res.cmdErr)
+		}
+		if !strings.Contains(res.output, "BUSY-TUI-FRAME") {
+			t.Fatalf("capture #%d output missing busy pane content:\n%s", i+1, res.output)
+		}
+	}
+
+	if err := captureClient.SetReadDeadline(time.Now().Add(25 * time.Millisecond)); err != nil {
+		t.Fatalf("SetReadDeadline: %v", err)
+	}
+	if msg, err := readMsgOnConn(captureClient); err == nil {
+		t.Fatalf("attached client received %v, want no capture-induced repaint request", msg.Type)
+	}
+}
+
 func TestCaptureHistoryPaneUsesServerHistoryPath(t *testing.T) {
 	t.Parallel()
 

--- a/internal/server/commands_capture_test.go
+++ b/internal/server/commands_capture_test.go
@@ -102,6 +102,31 @@ func TestCaptureDefaultSinglePaneWorksWithoutAttachedClient(t *testing.T) {
 	}
 }
 
+func TestCaptureFullSessionTextUsesServerLayoutWithoutAttachedClient(t *testing.T) {
+	t.Parallel()
+
+	srv, sess, cleanup := newCommandTestSession(t)
+	defer cleanup()
+	sess.captureTiming.attachMaxRetries = 1
+
+	pane1 := newStandaloneProxyPane(1, "pane-1")
+	pane2 := newStandaloneProxyPane(2, "pane-2")
+	pane1.FeedOutput([]byte("LEFT-SERVER\r\n"))
+	pane2.FeedOutput([]byte("RIGHT-SERVER\r\n"))
+	window := newTestWindowWithPanes(t, sess, 1, "main", pane1, pane2)
+	setSessionLayoutForTest(t, sess, window.ID, []*mux.Window{window}, pane1, pane2)
+
+	res := runTestCommand(t, srv, sess, "capture")
+	if res.cmdErr != "" {
+		t.Fatalf("capture cmdErr = %q, want empty", res.cmdErr)
+	}
+	for _, want := range []string{"LEFT-SERVER", "RIGHT-SERVER", "[pane-1]", "[pane-2]", "test-command-queue"} {
+		if !strings.Contains(res.output, want) {
+			t.Fatalf("capture output missing %q:\n%s", want, res.output)
+		}
+	}
+}
+
 func TestCaptureClientFlagForwardsToAttachedClient(t *testing.T) {
 	t.Parallel()
 

--- a/internal/server/commands_capture_test.go
+++ b/internal/server/commands_capture_test.go
@@ -296,11 +296,12 @@ func TestCaptureClientFlagRequiresAttachedClient(t *testing.T) {
 	}
 }
 
-func TestCaptureFullSessionStillForwardsToAttachedClient(t *testing.T) {
+func TestCaptureFullSessionDefaultDoesNotSendClientCaptureRequest(t *testing.T) {
 	t.Parallel()
 
 	srv, sess, cleanup := newCommandTestSession(t)
 	defer cleanup()
+	sess.captureTiming.responseTimeout = 20 * time.Millisecond
 
 	pane := newStandaloneProxyPane(1, "pane-1")
 	pane.FeedOutput([]byte("SERVER-LOCAL\r\n"))
@@ -308,28 +309,20 @@ func TestCaptureFullSessionStillForwardsToAttachedClient(t *testing.T) {
 	setSessionLayoutForTest(t, sess, window.ID, []*mux.Window{window}, pane)
 
 	captureClient := attachCaptureClientForCommandTest(t, sess)
-	requestCh, errCh := respondToNextCaptureRequest(t, sess, captureClient, "CLIENT-FULL\n")
 
 	res := runTestCommand(t, srv, sess, "capture")
 	if res.cmdErr != "" {
 		t.Fatalf("capture cmdErr = %q, want empty", res.cmdErr)
 	}
-	if got, want := res.output, "CLIENT-FULL\n"; got != want {
-		t.Fatalf("capture output = %q, want %q", got, want)
+	if !strings.Contains(res.output, "SERVER-LOCAL") || !strings.Contains(res.output, "[pane-1]") {
+		t.Fatalf("capture output should include server-rendered pane content, got:\n%s", res.output)
 	}
 
-	select {
-	case err := <-errCh:
-		t.Fatalf("reading capture request: %v", err)
-	case msg := <-requestCh:
-		if msg.Type != MsgTypeCaptureRequest {
-			t.Fatalf("message type = %v, want %v", msg.Type, MsgTypeCaptureRequest)
-		}
-		if len(msg.CmdArgs) != 0 {
-			t.Fatalf("capture request args = %v, want empty", msg.CmdArgs)
-		}
-	case <-time.After(time.Second):
-		t.Fatal("timeout waiting for forwarded capture request")
+	if err := captureClient.SetReadDeadline(time.Now().Add(25 * time.Millisecond)); err != nil {
+		t.Fatalf("SetReadDeadline: %v", err)
+	}
+	if msg, err := readMsgOnConn(captureClient); err == nil {
+		t.Fatalf("attached client received %v, want no client capture request", msg.Type)
 	}
 }
 

--- a/internal/server/server_capture_full.go
+++ b/internal/server/server_capture_full.go
@@ -72,10 +72,9 @@ func (s serverFullSessionCapture) buildJSON(req caputil.Request, agentStatus map
 	includeHistory := req.HistoryMode && req.FormatJSON
 	for _, pane := range s.panes {
 		content := append([]string(nil), pane.render.Content...)
+		var history []string
 		if includeHistory {
-			content = make([]string, 0, len(pane.render.History)+len(pane.render.Content))
-			content = append(content, pane.render.History...)
-			content = append(content, pane.render.Content...)
+			history = append([]string(nil), pane.render.History...)
 		}
 		cp := caputil.BuildPane(caputil.PaneInput{
 			ID:            pane.info.ID,
@@ -101,6 +100,7 @@ func (s serverFullSessionCapture) buildJSON(req caputil.Request, agentStatus map
 			),
 			Terminal: caputil.TerminalFromState(pane.render.Terminal),
 			Content:  content,
+			History:  history,
 		}, agentStatus)
 		cp.Position = &proto.CapturePos{
 			X:      pane.position.X,
@@ -118,9 +118,6 @@ type serverPaneData struct {
 }
 
 func (p *serverPaneData) RenderScreen(active bool) string {
-	if p == nil || p.pane == nil {
-		return ""
-	}
 	if !active && p.pane.render.HasCursorBlock {
 		return p.pane.render.RenderedNoCursor
 	}
@@ -128,9 +125,6 @@ func (p *serverPaneData) RenderScreen(active bool) string {
 }
 
 func (p *serverPaneData) CellAt(col, row int, active bool) render.ScreenCell {
-	if p == nil || p.pane == nil {
-		return render.ScreenCell{Char: " ", Width: 1}
-	}
 	cell, ok := p.pane.render.CellAt(col, row)
 	sc := render.CellFromUVValue(cell, ok)
 	if !active && p.pane.render.HasCursorBlock && col == p.pane.render.CursorBlockCol && row == p.pane.render.CursorBlockRow {

--- a/internal/server/server_capture_full.go
+++ b/internal/server/server_capture_full.go
@@ -1,0 +1,320 @@
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+
+	uv "github.com/charmbracelet/ultraviolet"
+	caputil "github.com/weill-labs/amux/internal/capture"
+	"github.com/weill-labs/amux/internal/mux"
+	"github.com/weill-labs/amux/internal/proto"
+	"github.com/weill-labs/amux/internal/render"
+)
+
+type serverFullSessionCapture struct {
+	session      string
+	notice       string
+	width        int
+	height       int
+	root         *mux.LayoutCell
+	activePaneID uint32
+	zoomedPaneID uint32
+	window       proto.CaptureWindow
+	windows      []render.WindowInfo
+	panes        []*serverCapturePane
+	panesByID    map[uint32]*serverCapturePane
+}
+
+type serverCapturePane struct {
+	pane     *mux.Pane
+	info     proto.PaneSnapshot
+	position proto.CapturePos
+	render   mux.PaneRenderSnapshot
+}
+
+func (s serverFullSessionCapture) lookup(paneID uint32) render.PaneData {
+	pane := s.panesByID[paneID]
+	if pane == nil {
+		return nil
+	}
+	return &serverPaneData{pane: pane}
+}
+
+func (s serverFullSessionCapture) agentStatusPanes() []*mux.Pane {
+	panes := make([]*mux.Pane, 0, len(s.panes))
+	for _, pane := range s.panes {
+		if pane.pane != nil {
+			panes = append(panes, pane.pane)
+		}
+	}
+	return panes
+}
+
+func (s serverFullSessionCapture) compositor() *render.Compositor {
+	comp := render.NewCompositor(s.width, s.height, s.session)
+	comp.SetWindows(s.windows)
+	return comp
+}
+
+func (s serverFullSessionCapture) renderANSI() string {
+	return s.compositor().RenderFullWithOverlay(s.root, s.activePaneID, s.lookup, render.OverlayState{Message: s.notice}, false)
+}
+
+func (s serverFullSessionCapture) buildJSON(req caputil.Request, agentStatus map[uint32]proto.PaneAgentStatus) proto.CaptureJSON {
+	capture := proto.CaptureJSON{
+		Session: s.session,
+		Window:  s.window,
+		Width:   s.width,
+		Height:  s.height,
+		Notice:  s.notice,
+		Panes:   make([]proto.CapturePane, 0, len(s.panes)),
+	}
+	includeHistory := req.HistoryMode && req.FormatJSON
+	for _, pane := range s.panes {
+		content := append([]string(nil), pane.render.Content...)
+		if includeHistory {
+			content = make([]string, 0, len(pane.render.History)+len(pane.render.Content))
+			content = append(content, pane.render.History...)
+			content = append(content, pane.render.Content...)
+		}
+		cp := caputil.BuildPane(caputil.PaneInput{
+			ID:            pane.info.ID,
+			Name:          pane.info.Name,
+			Active:        pane.info.ID == s.activePaneID,
+			Lead:          pane.info.Lead,
+			Zoomed:        pane.info.ID == s.zoomedPaneID,
+			Host:          pane.info.Host,
+			Task:          pane.info.Task,
+			Color:         pane.info.Color,
+			ColumnIndex:   pane.info.ColumnIndex,
+			ConnStatus:    pane.info.ConnStatus,
+			GitBranch:     pane.info.GitBranch,
+			PR:            pane.info.PR,
+			KV:            pane.info.KV,
+			TrackedPRs:    pane.info.TrackedPRs,
+			TrackedIssues: pane.info.TrackedIssues,
+			Cursor: caputil.CursorFromState(
+				pane.render.CursorCol,
+				pane.render.CursorRow,
+				pane.render.CursorHidden,
+				pane.render.Terminal,
+			),
+			Terminal: caputil.TerminalFromState(pane.render.Terminal),
+			Content:  content,
+		}, agentStatus)
+		cp.Position = &proto.CapturePos{
+			X:      pane.position.X,
+			Y:      pane.position.Y,
+			Width:  pane.position.Width,
+			Height: pane.position.Height,
+		}
+		capture.Panes = append(capture.Panes, cp)
+	}
+	return capture
+}
+
+type serverPaneData struct {
+	pane *serverCapturePane
+}
+
+func (p *serverPaneData) RenderScreen(active bool) string {
+	if p == nil || p.pane == nil {
+		return ""
+	}
+	if !active && p.pane.render.HasCursorBlock {
+		return p.pane.render.RenderedNoCursor
+	}
+	return p.pane.render.Rendered
+}
+
+func (p *serverPaneData) CellAt(col, row int, active bool) render.ScreenCell {
+	if p == nil || p.pane == nil {
+		return render.ScreenCell{Char: " ", Width: 1}
+	}
+	cell, ok := p.pane.render.CellAt(col, row)
+	sc := render.CellFromUVValue(cell, ok)
+	if !active && p.pane.render.HasCursorBlock && col == p.pane.render.CursorBlockCol && row == p.pane.render.CursorBlockRow {
+		stripServerSnapshotCursorBlock(&sc)
+	}
+	return sc
+}
+
+func stripServerSnapshotCursorBlock(cell *render.ScreenCell) {
+	if cell.Style.Attrs&uv.AttrReverse == 0 {
+		return
+	}
+	if cell.Char != " " && cell.Char != "" {
+		return
+	}
+	cell.Style.Attrs &^= uv.AttrReverse
+}
+
+func (p *serverPaneData) CopyModeOverlay() *proto.ViewportOverlay { return nil }
+func (p *serverPaneData) CursorPos() (col, row int) {
+	return p.pane.render.CursorCol, p.pane.render.CursorRow
+}
+func (p *serverPaneData) CursorHidden() bool { return p.pane.render.CursorHidden }
+func (p *serverPaneData) HasCursorBlock() bool {
+	return p.pane.render.HasCursorBlock
+}
+func (p *serverPaneData) ID() uint32   { return p.pane.info.ID }
+func (p *serverPaneData) Name() string { return p.pane.info.Name }
+func (p *serverPaneData) TrackedPRs() []proto.TrackedPR {
+	return proto.CloneTrackedPRs(p.pane.info.TrackedPRs)
+}
+func (p *serverPaneData) TrackedIssues() []proto.TrackedIssue {
+	return proto.CloneTrackedIssues(p.pane.info.TrackedIssues)
+}
+func (p *serverPaneData) Issue() string {
+	if p.pane.info.KV == nil {
+		return ""
+	}
+	return p.pane.info.KV["issue"]
+}
+func (p *serverPaneData) Host() string           { return p.pane.info.Host }
+func (p *serverPaneData) Task() string           { return p.pane.info.Task }
+func (p *serverPaneData) Color() string          { return p.pane.info.Color }
+func (p *serverPaneData) Idle() bool             { return p.pane.info.Idle }
+func (p *serverPaneData) IsLead() bool           { return p.pane.info.Lead }
+func (p *serverPaneData) ConnStatus() string     { return p.pane.info.ConnStatus }
+func (p *serverPaneData) InCopyMode() bool       { return false }
+func (p *serverPaneData) CopyModeSearch() string { return "" }
+
+func (s *Session) captureFullSessionSnapshot() (serverFullSessionCapture, error) {
+	return enqueueSessionQuery(s, func(s *Session) (serverFullSessionCapture, error) {
+		w := s.activeWindow()
+		if w == nil || w.Root == nil {
+			return serverFullSessionCapture{}, fmt.Errorf("no window")
+		}
+
+		windowIndex := 1
+		for i, candidate := range s.Windows {
+			if candidate != nil && candidate.ID == w.ID {
+				windowIndex = i + 1
+				break
+			}
+		}
+		windowSnap := w.SnapshotWindow(windowIndex)
+		idleSnap := s.snapshotIdleState()
+		paneInfo := make(map[uint32]proto.PaneSnapshot, len(windowSnap.Panes))
+		for _, pane := range windowSnap.Panes {
+			pane.Idle = idleSnap[pane.ID]
+			paneInfo[pane.ID] = pane
+		}
+
+		paneByID := make(map[uint32]*mux.Pane, len(windowSnap.Panes))
+		for _, pane := range w.Panes() {
+			paneByID[pane.ID] = pane
+		}
+
+		root := mux.RebuildLayout(windowSnap.Root)
+		if w.ZoomedPaneID != 0 {
+			root = mux.NewLeafByID(w.ZoomedPaneID, 0, 0, w.Width, w.Height)
+		}
+
+		activePaneID := windowSnap.ActivePaneID
+		panesByID := make(map[uint32]*serverCapturePane)
+		var panes []*serverCapturePane
+		root.Walk(func(cell *mux.LayoutCell) {
+			paneID := cell.CellPaneID()
+			if paneID == 0 {
+				return
+			}
+			pane := paneByID[paneID]
+			info, ok := paneInfo[paneID]
+			if pane == nil || !ok {
+				return
+			}
+			capturePane := &serverCapturePane{
+				pane: pane,
+				info: info,
+				position: proto.CapturePos{
+					X:      cell.X,
+					Y:      cell.Y,
+					Width:  cell.W,
+					Height: cell.H,
+				},
+				render: pane.CaptureRenderSnapshot(),
+			}
+			panes = append(panes, capturePane)
+			panesByID[paneID] = capturePane
+		})
+
+		return serverFullSessionCapture{
+			session:      s.Name,
+			notice:       s.notice,
+			width:        w.Width,
+			height:       w.Height + render.GlobalBarHeight,
+			root:         root,
+			activePaneID: activePaneID,
+			zoomedPaneID: windowSnap.ZoomedPaneID,
+			window: proto.CaptureWindow{
+				ID:     windowSnap.ID,
+				Name:   windowSnap.Name,
+				Index:  windowSnap.Index,
+				Zoomed: windowSnap.Zoomed || windowSnap.ZoomedPaneID != 0,
+			},
+			windows:   serverWindowInfo(s.Windows, s.ActiveWindowID),
+			panes:     panes,
+			panesByID: panesByID,
+		}, nil
+	})
+}
+
+func serverWindowInfo(windows []*mux.Window, activeWindowID uint32) []render.WindowInfo {
+	if len(windows) == 0 {
+		return nil
+	}
+	out := make([]render.WindowInfo, 0, len(windows))
+	for i, window := range windows {
+		if window == nil {
+			continue
+		}
+		out = append(out, render.WindowInfo{
+			Index:    i + 1,
+			Name:     window.Name,
+			IsActive: window.ID == activeWindowID,
+			Panes:    window.PaneCount(),
+			Zoomed:   window.ZoomedPaneID != 0,
+		})
+	}
+	return out
+}
+
+func (s *Session) captureFullSessionDirect(args []string) *Message {
+	req := caputil.ParseArgs(args)
+	if err := caputil.ValidateScreenRequest(req); err != nil {
+		return &Message{Type: MsgTypeCmdResult, CmdErr: err.Error()}
+	}
+	if req.HistoryMode && !req.FormatJSON {
+		return &Message{Type: MsgTypeCmdResult, CmdErr: "--history requires a pane target"}
+	}
+
+	snap, err := s.captureFullSessionSnapshot()
+	if err != nil {
+		if req.FormatJSON {
+			return &Message{Type: MsgTypeCmdResult, CmdOutput: caputil.JSONErrorOutput(false, "state_unavailable", err.Error()) + "\n"}
+		}
+		return &Message{Type: MsgTypeCmdResult, CmdErr: err.Error()}
+	}
+
+	switch {
+	case req.FormatJSON:
+		capture := snap.buildJSON(req, s.captureAgentStatus(snap.agentStatusPanes()))
+		out, _ := json.MarshalIndent(capture, "", "  ")
+		return &Message{Type: MsgTypeCmdResult, CmdOutput: string(out) + "\n"}
+	case req.ColorMap:
+		return &Message{Type: MsgTypeCmdResult, CmdOutput: render.ExtractColorMap(snap.renderANSI(), snap.width, snap.height) + "\n"}
+	case req.IncludeANSI:
+		return &Message{Type: MsgTypeCmdResult, CmdOutput: snap.renderANSI()}
+	default:
+		return &Message{Type: MsgTypeCmdResult, CmdOutput: render.MaterializeGrid(snap.renderANSI(), snap.width, snap.height)}
+	}
+}
+
+func captureFullSessionLocally(ctx *CommandContext, args []string) *Message {
+	if ctx == nil || ctx.Sess == nil {
+		return &Message{Type: MsgTypeCmdResult, CmdErr: "no session"}
+	}
+	return ctx.Sess.captureFullSessionDirect(args)
+}

--- a/test/amux_harness_test.go
+++ b/test/amux_harness_test.go
@@ -548,10 +548,8 @@ func (h *AmuxHarness) captureJSON() proto.CaptureJSON {
 	return captureJSONFor(h.tb, h.runCmd)
 }
 
-// waitForCaptureJSONReady blocks until the inner session can serve a
-// client-backed JSON capture without returning an error object. Outer pane
-// text like "[pane-" can be stale across reloads, so it is not a reliable
-// signal that the re-execed inner client has finished reattaching.
+// waitForCaptureJSONReady blocks until the inner session can serve a JSON
+// capture without returning an error object.
 func (h *AmuxHarness) waitForCaptureJSONReady(timeout time.Duration) proto.CaptureJSON {
 	h.tb.Helper()
 
@@ -579,11 +577,40 @@ func (h *AmuxHarness) waitForCaptureJSONReady(timeout time.Duration) proto.Captu
 	return proto.CaptureJSON{}
 }
 
+func (h *AmuxHarness) waitForClientDisplayCaptureReady(timeout time.Duration) string {
+	h.tb.Helper()
+
+	deadline := time.Now().Add(timeout)
+	ticker := time.NewTicker(25 * time.Millisecond)
+	defer ticker.Stop()
+
+	var last string
+	for time.Now().Before(deadline) {
+		last = strings.TrimSpace(h.runCmd("cursor", "ui"))
+		if _, err := strconv.ParseUint(last, 10, 64); err != nil {
+			<-ticker.C
+			continue
+		}
+
+		last = h.runCmd("capture", "--client")
+		if !isCaptureUnavailable(last) &&
+			!isTransientSessionQueryFailure(last) &&
+			!strings.Contains(last, "capture timed out") &&
+			strings.Contains(last, "[pane-") {
+			return last
+		}
+
+		<-ticker.C
+	}
+
+	h.tb.Fatalf("inner client display capture did not become ready within %v\nlast output:\n%s\nouter:\n%s", timeout, last, h.captureOuter())
+	return ""
+}
+
 // waitForReloadedClient blocks until hot-reload has attached a fresh client.
-// A capture request can still succeed against the pre-reload client if it is
-// issued before the reload disconnect/reattach cycle completes, so first wait
-// for layout generation to advance past the pre-reload value, then require a
-// client-backed JSON capture from the reattached client.
+// Server-side JSON capture can now succeed without a client, so this uses the
+// explicit client display snapshot path to prove that the re-execed client has
+// rendered at least one frame after the reload.
 func (h *AmuxHarness) waitForReloadedClient(afterGen uint64, timeout time.Duration) proto.CaptureJSON {
 	h.tb.Helper()
 
@@ -594,7 +621,8 @@ func (h *AmuxHarness) waitForReloadedClient(afterGen uint64, timeout time.Durati
 	if remaining <= 0 {
 		remaining = time.Millisecond
 	}
-	return h.waitForCaptureJSONReady(remaining)
+	h.waitForClientDisplayCaptureReady(remaining)
+	return h.captureJSON()
 }
 
 // jsonPane finds a pane by name in a CaptureJSON, or fails the test.

--- a/test/capture_json_test.go
+++ b/test/capture_json_test.go
@@ -238,7 +238,7 @@ func TestCaptureJSON_RoundTrip(t *testing.T) {
 
 func TestCaptureJSON_ClientUIState(t *testing.T) {
 	t.Parallel()
-	h := newAmuxHarness(t)
+	h := newAmuxHarness(t, "AMUX_CAPTURE_LEGACY_CLIENT=1")
 
 	h.sendClientKeys("C-a", "q")
 	h.runCmd("wait", "ui", proto.UIEventDisplayPanesShown, "--timeout", "3s")

--- a/test/capture_json_test.go
+++ b/test/capture_json_test.go
@@ -80,7 +80,7 @@ func TestCaptureJSON_FullScreen(t *testing.T) {
 	}
 }
 
-func TestCaptureJSON_FullScreenHistoryPrependsScrollback(t *testing.T) {
+func TestCaptureJSON_FullScreenHistorySeparatesScrollback(t *testing.T) {
 	t.Parallel()
 	h := newServerHarness(t)
 
@@ -96,26 +96,19 @@ func TestCaptureJSON_FullScreenHistoryPrependsScrollback(t *testing.T) {
 	capture := captureJSONWithArgsFor(t, h.runCmd, "capture", "--history", "--format", "json")
 	pane1 := jsonPaneFor(t, capture, "pane-1")
 
-	firstIdx, lastIdx := -1, -1
-	for i, line := range pane1.Content {
-		switch {
-		case firstIdx == -1 && strings.Contains(line, "JSONFULL-01"):
-			firstIdx = i
-		case strings.Contains(line, "JSONFULL-40"):
-			lastIdx = i
-		}
+	history := strings.Join(pane1.History, "\n")
+	content := strings.Join(pane1.Content, "\n")
+	if !strings.Contains(history, "JSONFULL-01") {
+		t.Fatalf("pane-1 history should include off-screen scrollback, got: %v", pane1.History)
 	}
-	if firstIdx == -1 {
-		t.Fatalf("pane-1 content should include off-screen history, got: %v", pane1.Content)
+	if strings.Contains(content, "JSONFULL-01") {
+		t.Fatalf("pane-1 content should not include off-screen scrollback, got: %v", pane1.Content)
 	}
-	if lastIdx == -1 {
+	if !strings.Contains(content, "JSONFULL-40") {
 		t.Fatalf("pane-1 content should include visible viewport lines, got: %v", pane1.Content)
 	}
-	if firstIdx >= lastIdx {
-		t.Fatalf("pane-1 content should prepend history before viewport, got: %v", pane1.Content)
-	}
-	if len(pane1.Content) < 40 {
-		t.Fatalf("pane-1 content should include the emitted history plus viewport, got %d lines", len(pane1.Content))
+	if len(pane1.History)+len(pane1.Content) < 40 {
+		t.Fatalf("pane-1 history plus content should include emitted lines, got history=%d content=%d", len(pane1.History), len(pane1.Content))
 	}
 }
 

--- a/test/capture_test.go
+++ b/test/capture_test.go
@@ -178,8 +178,25 @@ func TestCapturePaneHistoryWithoutAttachedClient(t *testing.T) {
 		t.Fatalf("history capture should work without attached client, got:\n%s\n%s", out, h.diagnosticSnapshot("history capture missing content after detach"))
 	}
 
-	if out := h.runCmd("capture"); !isCaptureUnavailable(out) {
-		t.Fatalf("full-screen capture without client should remain unavailable, got: %s\n%s", out, h.diagnosticSnapshot("unexpected full-screen capture state after pane fallback"))
+	full := h.runCmd("capture")
+	if isCaptureUnavailable(full) {
+		t.Fatalf("full-screen capture without client should use server state, got: %s\n%s", full, h.diagnosticSnapshot("full-screen capture unavailable after detach"))
+	}
+	if !strings.Contains(full, "NOCLIENT-35") || !strings.Contains(full, "[pane-1]") {
+		t.Fatalf("full-screen capture without client should include visible content and pane status, got:\n%s\n%s", full, h.diagnosticSnapshot("full-screen capture missing visible content after detach"))
+	}
+
+	fullJSON := h.runCmd("capture", "--format", "json")
+	var capture proto.CaptureJSON
+	if err := json.Unmarshal([]byte(fullJSON), &capture); err != nil {
+		t.Fatalf("json.Unmarshal full capture: %v\noutput:\n%s", err, fullJSON)
+	}
+	if capture.Error != nil {
+		t.Fatalf("full JSON capture error = %+v, want nil\n%s", capture.Error, h.diagnosticSnapshot("full json capture unavailable after detach"))
+	}
+	pane1 := h.jsonPane(capture, "pane-1")
+	if joined := strings.Join(pane1.Content, "\n"); !strings.Contains(joined, "NOCLIENT-35") {
+		t.Fatalf("full JSON capture should include visible content, got:\n%s\n%s", joined, h.diagnosticSnapshot("full json capture missing visible content after detach"))
 	}
 }
 

--- a/test/hotreload_test.go
+++ b/test/hotreload_test.go
@@ -604,12 +604,10 @@ func TestServerReloadBorderColors(t *testing.T) {
 	ansiBefore := h.captureANSI()
 	colorsBefore := extractBorderColors(pickContentLine(ansiBefore))
 
+	reloadGen := h.generation()
 	h.runCmd("reload-server")
+	h.waitForReloadedClient(reloadGen, 10*time.Second)
 
-	if !h.waitFor("[pane-", 5*time.Second) {
-		screen := h.captureOuter()
-		t.Fatalf("session did not recover after reload\nScreen:\n%s", screen)
-	}
 	if !h.waitForFunc(func(s string) bool {
 		return strings.Contains(s, "[pane-1]") && strings.Contains(s, "[pane-2]")
 	}, 5*time.Second) {
@@ -617,7 +615,9 @@ func TestServerReloadBorderColors(t *testing.T) {
 		t.Fatalf("both panes should be visible after reload\nScreen:\n%s", screen)
 	}
 
-	ansiAfter := h.captureANSI()
+	ansiAfter := waitForOutput(t, 5*time.Second, h.captureANSI, func(out string) bool {
+		return len(extractBorderColors(pickContentLine(out))) > 0
+	})
 	colorsAfter := extractBorderColors(pickContentLine(ansiAfter))
 
 	if len(colorsBefore) == 0 {


### PR DESCRIPTION
## Motivation

Full-session `amux capture` and `amux capture --format json` still depended on an attached rendering client, which made default captures unavailable after detach and could perturb attached clients under load. LAB-1760 completes the server-side default for active-window full-session capture while keeping the explicit client/display path for user-perspective overlays.

## Summary

- Add a server-side full-session capture snapshot that walks the active window layout, snapshots visible pane render state, and renders through the existing compositor.
- Add server-side full-session JSON output using the active window layout, server-owned pane metadata, terminal state, positions, and agent status.
- Route default full-session text/ANSI/colors/JSON capture through the server path, while preserving `--client`, `--display`, and `AMUX_CAPTURE_LEGACY_CLIENT=1` as client-backed paths.
- Update capture and hot-reload tests so server-canonical capture and explicit client-display capture are exercised separately.
- Document the default server-side full-session capture behavior in README and the capture architecture doc.

## Testing

- `go test ./... -timeout 120s`
- `go test ./internal/server -run 'TestCaptureFullSession(TextUsesServerLayoutWithoutAttachedClient|JSONUsesServerPaneMetadataWithoutAttachedClient|DefaultDoesNotSendClientCaptureRequest|DuringBusyOutputDoesNotRequestClientRepaint)|TestCapture(ClientFlagForwardsFullSession|LegacyClientEnvForwardsFullSession|LocallyRejectsMissingSession)|TestForwardCaptureJSONStressUnderPaneOutput' -count=100`
- `go test -race ./internal/server -run TestCaptureFullSessionDuringBusyOutputDoesNotRequestClientRepaint -count=100`
- `go test ./test -run TestCapturePaneHistoryWithoutAttachedClient -count=100 -timeout 900s`
- `go test ./test -run TestServerReloadBorderColors -count=10 -timeout 180s -v`
- `go test ./internal/server -run TestForwardCaptureJSONStressUnderPaneOutput -count=100`
- `git diff --check`

## Review focus

The concurrency choice is snapshot-then-render: the session actor snapshots the active window layout, pane metadata, and each visible pane's render grid, then releases the actor before running the compositor and JSON marshaling. This keeps the compositor off the actor while giving it immutable pane state.

The env-flag decision follows LAB-1753: `AMUX_CAPTURE_LEGACY_CLIENT=1` remains as a temporary rollback knob for the old client-backed capture path. `--client` and `--display` continue to request client display snapshots and preserve overlay semantics; the default server path intentionally does not include client-local overlays.

The main edge cases to review are zoomed-window layout snapshots, full-session `--history --format json`, and ANSI/cell metadata preservation through the server-side `PaneData` adapter.

Closes LAB-1760
