### PR TITLE
LAB-1654: Cap vt parser buffer

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -48,4 +48,4 @@ require (
 
 replace github.com/charmbracelet/ultraviolet => github.com/weill-labs/ultraviolet v0.0.0-20260404003102-9344cbfc286f
 
-replace github.com/charmbracelet/x/vt => github.com/weill-labs/x/vt v0.0.0-20260513175146-fc372e8574ca
+replace github.com/charmbracelet/x/vt => github.com/weill-labs/x/vt v0.0.0-20260514062200-6ca40b8a9268

--- a/go.sum
+++ b/go.sum
@@ -70,8 +70,8 @@ github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcU
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/weill-labs/ultraviolet v0.0.0-20260404003102-9344cbfc286f h1:JMTFuQ/08wrGci+AIUA67OuIMHtJaF369KhWwBel6/g=
 github.com/weill-labs/ultraviolet v0.0.0-20260404003102-9344cbfc286f/go.mod h1:Vo8TffMf0q7Uho/n8e6XpBZvOWtd3g39yX+9P5rRutA=
-github.com/weill-labs/x/vt v0.0.0-20260513175146-fc372e8574ca h1:zHHkdgBgA1XfyHYKjiJgIrV3svzeCgeyzAacVrKTo2Y=
-github.com/weill-labs/x/vt v0.0.0-20260513175146-fc372e8574ca/go.mod h1:u1LOIABor9JqY54oZdktK3TCRrgzP6tzHrDYx1nd3wY=
+github.com/weill-labs/x/vt v0.0.0-20260514062200-6ca40b8a9268 h1:eK1uv22omrKrgMBmfZud6F9jknE7yVQvSsWZrTyubZg=
+github.com/weill-labs/x/vt v0.0.0-20260514062200-6ca40b8a9268/go.mod h1:u1LOIABor9JqY54oZdktK3TCRrgzP6tzHrDYx1nd3wY=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJuqunuUZ/Dhy/avygyECGrLceyNeo4LiM=
 golang.org/x/crypto v0.49.0 h1:+Ng2ULVvLHnJ/ZFEq4KdcDd/cfjrrjjNSXNzxg0Y4U4=

--- a/internal/mux/emulator_bench_test.go
+++ b/internal/mux/emulator_bench_test.go
@@ -47,6 +47,42 @@ func BenchmarkEmulatorWrite(b *testing.B) {
 	}
 }
 
+var benchmarkParserBufferWorkloadSink []TerminalEmulator
+
+func BenchmarkPaneParserDataBufferWorkload(b *testing.B) {
+	const (
+		panes       = 16
+		chunkSize   = 1024
+		chunkCount  = 60
+		paneWidth   = 120
+		paneHeight  = 40
+		payloadSize = chunkSize * chunkCount
+	)
+
+	payload := realisticTerminalPayload(payloadSize)
+	chunks := make([][]byte, 0, chunkCount)
+	for offset := 0; offset < len(payload); offset += chunkSize {
+		chunks = append(chunks, payload[offset:offset+chunkSize])
+	}
+
+	b.SetBytes(int64(panes * payloadSize))
+	b.ReportAllocs()
+	for b.Loop() {
+		emulators := make([]TerminalEmulator, panes)
+		for pane := range panes {
+			emu := NewVTEmulatorWithScrollback(paneWidth, paneHeight, DefaultScrollbackLines)
+			for _, chunk := range chunks {
+				mustWrite(b, emu, chunk)
+			}
+			emulators[pane] = emu
+		}
+		for _, emu := range emulators {
+			_ = emu.Close()
+		}
+		benchmarkParserBufferWorkloadSink = emulators
+	}
+}
+
 func BenchmarkEmulatorRender(b *testing.B) {
 	emu := NewVTEmulatorWithDrain(80, 24)
 


### PR DESCRIPTION
## Motivation

After the encoder and history-memory reductions landed, the live amux server heap showed `github.com/charmbracelet/x/ansi.(*Parser).SetDataSize` as the largest fixed parser cost. The 30-minute pre-fix pprof window confirmed this was a per-emulator allocation from the vt fork's 4 MiB parser data buffer, not output-volume growth.

## Summary

- Add `BenchmarkPaneParserDataBufferWorkload`, a 16-pane benchmark that feeds 60 seconds of 1 KiB/s styled output through the amux pane emulator boundary.
- Pin `github.com/charmbracelet/x/vt` to `github.com/weill-labs/x/vt v0.0.0-20260514062200-6ca40b8a9268`.
- Pull in the vt fork fix from weill-labs/x#16, which caps each emulator parser data buffer at 128 KiB instead of 4 MiB.

Underlying vt fix: https://github.com/weill-labs/x/pull/16, commit `6ca40b8a926893024c116d710bfb4f3c4df84cc9`.

## Investigation

1. `Parser.SetDataSize` in `github.com/charmbracelet/x/ansi` eagerly assigns `p.data = make([]byte, size)`. With a positive size it is a fixed bounded buffer; it is not lazy, and it does not grow to max-seen input. Only `size <= 0` switches the parser into unlimited `append` mode.
2. In `/home/cweill/github/weill-labs/x/vt`, the only production `SetDataSize` call is `NewEmulator` setting `1024 * 1024 * 4`. The parser is a passive consumer of the size; vt owns the active policy.
3. `vt.Emulator` has a `parser *ansi.Parser` field, and `NewEmulator` allocates a new parser per emulator. `NewSafeEmulator` wraps a new `Emulator`, so there is no shared parser across panes.
4. Live pprof over 30 minutes showed fixed per-emulator residence:
   - `2026-05-14 05:49:52 UTC`: `SetDataSize` = 132.04 MB / 15.70% of 841.27 MB heap.
   - `2026-05-14 06:19:52 UTC`: `SetDataSize` = 136.05 MB / 15.39% of 884.08 MB heap.
   - The 4 MiB delta matches one additional emulator-sized buffer, not unbounded growth.

Chosen path: Path A, implemented in the vt fork as a simple cap reduction. Pooling was not justified because the allocation is fixed at emulator construction, not transient per write, and adding shared parser lifecycle state would create synchronization complexity without addressing a growing buffer.

## Baseline numbers

Hardware: AMD EPYC-Milan Processor, 8 vCPU, Linux 6.8, Go 1.25.0.

Benchmark command: `go test ./internal/mux -run '^$' -bench BenchmarkPaneParserDataBufferWorkload -benchmem -benchtime=1x -count=10`

| Version | Representative B/op | Range observed | allocs/op |
| -- | --: | --: | --: |
| Before, vt `fc372e8` 4 MiB parser buffer | 170,185,792 | 170,185,792-170,202,560 | 24,003-24,024 |
| After, vt `6ca40b8` 128 KiB parser buffer | 105,174,080 | 105,174,080-105,185,312 | 24,003-24,017 |

Live pprof acceptance snapshot after `make install` and hot reload on the same 28-pane `main` server:

| Snapshot | Total inuse heap | `Parser.SetDataSize` | Share |
| -- | --: | --: | --: |
| Before fix, 2026-05-14 06:19:52 UTC | 884.08 MB | 136.05 MB | 15.39% |
| After fix, 2026-05-14 06:39:02 UTC | 100.66 MB | 3.39 MB | 3.37% |

## Testing

- In `/home/cweill/github/weill-labs/x/vt`: `go test -run TestNewEmulatorCapsParserDataBuffer -count=100`
- In `/home/cweill/github/weill-labs/x/vt`: `go test ./... -count=1`
- In amux before and after the vt pin: `go test ./internal/mux -run '^$' -bench BenchmarkPaneParserDataBufferWorkload -benchmem -benchtime=1x -count=10`
- In amux: `go test ./internal/server -run 'TestRespawnCommandRestartsLocalPaneInPlace' -count=100 -timeout 120s`
- In amux: `go test -race ./... -timeout 300s`
- In amux after dependency update: `go_vulncheck ./...`
- Live pprof: `curl -s --unix-socket /tmp/amux-1000/main.pprof http://x/debug/pprof/heap`

Repeated full-suite note: `go test ./... -timeout 120s -count=10` exceeded package timeout in existing long-running `internal/reload` and `internal/remote` repeats. Those named slices passed with `-count=10 -timeout 300s`. Broader full-suite repeats also exposed unrelated integration flakes in `test/` (`TestMouseHorizontalBorderDrag`, `TestReloadServer`, and metadata/repeat cases); each named failure passed when rerun directly. The parser-bound packages and race suite passed.

## Review focus

Review the cross-repo dependency pin and the 128 KiB vt parser buffer cap. The main tradeoff is truncating OSC/DCS/SOS/PM/APC parser payload data above 128 KiB, which is already bounded today at 4 MiB; amux does not render large inline payloads, and this avoids parser pooling or shared state.

Closes LAB-1654
