### PR TITLE
LAB-1833: Reuse scrollback snapshots incrementally

### DIFF
--- a/docs/incremental-scrollback-snapshot.md
+++ b/docs/incremental-scrollback-snapshot.md
@@ -1,0 +1,90 @@
+# Incremental Scrollback Capture Snapshot
+
+## Problem
+
+`publishPaneCapture` runs on the renderer actor for every pane-output event.
+Today it calls `capturePaneRenderSnapshot`, which rebuilds the full text
+scrollback by walking every retained row with `ScrollbackLineText`. On a
+5000-line scrollback this makes the actor spend measurable CPU on capture-only
+state even when no capture request is active.
+
+The captured profile for LAB-1833 shows `capturePaneRenderSnapshot` at 7.11s
+cumulative out of 14.97s total samples, with `ScrollbackLineText` alone at
+3.63s cumulative. The per-output render path does not consume
+`paneRenderSnapshot.scrollback`; only capture snapshot readers do.
+
+## VT Scrollback Invariants
+
+The project imports `github.com/charmbracelet/x/vt`, replaced by
+`github.com/weill-labs/x/vt v0.0.0-20260514062200-6ca40b8a9268`.
+
+The fork's `Scrollback` uses `scrollbackRing`:
+
+- `Push` appends a line at the logical back.
+- When the ring is full, `Push` overwrites the oldest slot and advances
+  `start`, so logical trimming happens at the front.
+- `Line(0)` returns the oldest line and `Line(Len()-1)` returns the most recent
+  line.
+- `SetMaxLines` keeps the newest `min(currentLen, maxLines)` rows.
+- `Clear` resets the ring to empty.
+
+The fork exposes `ScrollbackPush(count, width)` and `ScrollbackClear()`
+callbacks, but it does not expose a cumulative pushed counter. amux already
+sets these callbacks in `mux.(*vtEmulator)`, so LAB-1833 can add a small
+counter in the mux wrapper without changing the vt fork.
+
+## Design
+
+Add `ScrollbackPushed() uint64` to `mux.TerminalEmulator`.
+`mux.(*vtEmulator)` increments this counter from the vt `ScrollbackPush`
+callback by the callback's `count`. `Reset` and vt `ScrollbackClear` reset the
+retained scrollback, but they do not reset this counter; the renderer can model
+a clear as all previous rows being trimmed while the cumulative push count stays
+monotonic.
+
+The renderer actor keeps one incremental scrollback state per pane:
+
+- previous scrollback length
+- previous cumulative pushed counter
+- previous immutable `[]paneBufferLine` text snapshot
+
+On each pane snapshot publish:
+
+1. Read `curLen := emu.ScrollbackLen()`.
+2. Read `curPushed := emu.ScrollbackPushed()`.
+3. Compute `appended := curPushed - prevPushed`.
+4. Compute `trimmed := (prevLen + appended) - curLen`.
+5. If `appended == 0 && trimmed == 0`, reuse the previous slice header.
+6. Otherwise reslice away `trimmed` front rows and append only the `appended`
+   newest rows from the emulator.
+
+The newest appended rows are read from indices
+`curLen - appended` through `curLen - 1`.
+
+## Safety
+
+`paneBufferLine.text` is a Go string, so the copied scrollback text is immutable.
+Existing snapshot cloning already shallow-copies `paneRenderSnapshot` values and
+documents that `scrollback` and `screen` slices are immutable after capture.
+Tail-sharing the previous scrollback slice with `prev[trimmed:]` preserves that
+contract.
+
+The cold-start path performs the existing full rebuild. The implementation also
+falls back to a full rebuild if counters move backwards, if trim math is
+negative, if the previous slice is missing, or if the previous slice length does
+not match the recorded previous length. These cases should not happen during
+normal actor-owned emulator updates, but the fallback keeps capture correctness
+ahead of optimization.
+
+## Test Plan
+
+- Unit-test the incremental builder for cold start, no-change, appended-only,
+  trimmed-only, appended-and-trimmed, and defensive fallback.
+- Unit-test `ScrollbackPushed()` on `vtEmulator`: it starts at zero, never
+  decreases, and increments by the number of rows pushed into scrollback.
+- Benchmark a full 5000-line scrollback followed by a one-line append per
+  snapshot.
+- Re-run the actor-free capture invariant test for
+  `TestHandleCaptureRequestDoesNotWaitForRendererActor`.
+- Verify touched client and mux tests with `-count=100`, targeted race runs,
+  and the requested package slice.

--- a/internal/client/renderer_bench_test.go
+++ b/internal/client/renderer_bench_test.go
@@ -298,11 +298,39 @@ func BenchmarkCapturePaneRenderSnapshotStyledScrollback1KB(b *testing.B) {
 	b.SetBytes(payloadSize)
 	b.ReportAllocs()
 	b.ResetTimer()
+	var state paneScrollbackSnapshotState
 	for b.Loop() {
 		if _, err := emu.Write(payload); err != nil {
 			b.Fatalf("write payload: %v", err)
 		}
-		_ = capturePaneRenderSnapshot(emu)
+		_, state = capturePaneRenderSnapshot(emu, state)
+	}
+}
+
+func BenchmarkCapturePaneRenderSnapshotIncrementalScrollback(b *testing.B) {
+	const (
+		width           = 80
+		height          = 24
+		scrollbackLines = 5000
+	)
+
+	emu := mux.NewVTEmulatorWithScrollback(width, height, scrollbackLines)
+	defer emu.Close()
+	if _, err := emu.Write(benchScrollbackPayload(1, scrollbackLines+height)); err != nil {
+		b.Fatalf("preload scrollback: %v", err)
+	}
+
+	_, state := capturePaneRenderSnapshot(emu, paneScrollbackSnapshotState{})
+	payload := []byte("incremental scrollback append\r\n")
+
+	b.SetBytes(int64(len(payload)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		if _, err := emu.Write(payload); err != nil {
+			b.Fatalf("write payload: %v", err)
+		}
+		_, state = capturePaneRenderSnapshot(emu, state)
 	}
 }
 

--- a/internal/client/renderer_bench_test.go
+++ b/internal/client/renderer_bench_test.go
@@ -298,12 +298,11 @@ func BenchmarkCapturePaneRenderSnapshotStyledScrollback1KB(b *testing.B) {
 	b.SetBytes(payloadSize)
 	b.ReportAllocs()
 	b.ResetTimer()
-	var state paneScrollbackSnapshotState
 	for b.Loop() {
 		if _, err := emu.Write(payload); err != nil {
 			b.Fatalf("write payload: %v", err)
 		}
-		_, state = capturePaneRenderSnapshot(emu, state)
+		_, _ = capturePaneRenderSnapshot(emu, paneScrollbackSnapshotState{})
 	}
 }
 

--- a/internal/client/renderer_capture_snapshot.go
+++ b/internal/client/renderer_capture_snapshot.go
@@ -27,13 +27,50 @@ type paneRenderSnapshot struct {
 	hasCursorBlock   bool
 }
 
-func capturePaneRenderSnapshot(emu mux.TerminalEmulator) paneRenderSnapshot {
+type paneScrollbackSnapshotState struct {
+	scrollbackLen    int
+	scrollbackPushed uint64
+	scrollback       []paneBufferLine
+}
+
+func capturePaneRenderSnapshot(emu mux.TerminalEmulator, prev paneScrollbackSnapshotState) (paneRenderSnapshot, paneScrollbackSnapshotState) {
 	width, height := emu.Size()
 	cursorCol, cursorRow := emu.CursorPosition()
-	scrollback := make([]paneBufferLine, emu.ScrollbackLen())
-	for row := range scrollback {
-		scrollback[row] = paneBufferLine{
-			text: emu.ScrollbackLineText(row),
+	curScrollbackLen := emu.ScrollbackLen()
+	curScrollbackPushed := emu.ScrollbackPushed()
+
+	scrollback := prev.scrollback
+	rebuildScrollback := prev.scrollback == nil ||
+		len(prev.scrollback) != prev.scrollbackLen ||
+		curScrollbackPushed < prev.scrollbackPushed
+	if !rebuildScrollback {
+		appended64 := curScrollbackPushed - prev.scrollbackPushed
+		if appended64 > uint64(curScrollbackLen) {
+			rebuildScrollback = true
+		} else {
+			appended := int(appended64)
+			trimmed := prev.scrollbackLen + appended - curScrollbackLen
+			if trimmed < 0 || trimmed > len(prev.scrollback) {
+				rebuildScrollback = true
+			} else if appended == 0 && trimmed == 0 {
+				scrollback = prev.scrollback
+			} else {
+				scrollback = prev.scrollback[trimmed:]
+				start := curScrollbackLen - appended
+				for row := start; row < curScrollbackLen; row++ {
+					scrollback = append(scrollback, paneBufferLine{
+						text: emu.ScrollbackLineText(row),
+					})
+				}
+			}
+		}
+	}
+	if rebuildScrollback {
+		scrollback = make([]paneBufferLine, curScrollbackLen)
+		for row := range scrollback {
+			scrollback[row] = paneBufferLine{
+				text: emu.ScrollbackLineText(row),
+			}
 		}
 	}
 
@@ -64,7 +101,11 @@ func capturePaneRenderSnapshot(emu mux.TerminalEmulator) paneRenderSnapshot {
 		snap.hasCursorBlock = true
 		snap.renderedNoCursor = emu.RenderWithoutCursorBlock()
 	}
-	return snap
+	return snap, paneScrollbackSnapshotState{
+		scrollbackLen:    curScrollbackLen,
+		scrollbackPushed: curScrollbackPushed,
+		scrollback:       scrollback,
+	}
 }
 
 func cloneTerminalState(state proto.TerminalState) proto.TerminalState {

--- a/internal/client/renderer_capture_snapshot.go
+++ b/internal/client/renderer_capture_snapshot.go
@@ -36,43 +36,7 @@ type paneScrollbackSnapshotState struct {
 func capturePaneRenderSnapshot(emu mux.TerminalEmulator, prev paneScrollbackSnapshotState) (paneRenderSnapshot, paneScrollbackSnapshotState) {
 	width, height := emu.Size()
 	cursorCol, cursorRow := emu.CursorPosition()
-	curScrollbackLen := emu.ScrollbackLen()
-	curScrollbackPushed := emu.ScrollbackPushed()
-
-	scrollback := prev.scrollback
-	rebuildScrollback := prev.scrollback == nil ||
-		len(prev.scrollback) != prev.scrollbackLen ||
-		curScrollbackPushed < prev.scrollbackPushed
-	if !rebuildScrollback {
-		appended64 := curScrollbackPushed - prev.scrollbackPushed
-		if appended64 > uint64(curScrollbackLen) {
-			rebuildScrollback = true
-		} else {
-			appended := int(appended64)
-			trimmed := prev.scrollbackLen + appended - curScrollbackLen
-			if trimmed < 0 || trimmed > len(prev.scrollback) {
-				rebuildScrollback = true
-			} else if appended == 0 && trimmed == 0 {
-				scrollback = prev.scrollback
-			} else {
-				scrollback = prev.scrollback[trimmed:]
-				start := curScrollbackLen - appended
-				for row := start; row < curScrollbackLen; row++ {
-					scrollback = append(scrollback, paneBufferLine{
-						text: emu.ScrollbackLineText(row),
-					})
-				}
-			}
-		}
-	}
-	if rebuildScrollback {
-		scrollback = make([]paneBufferLine, curScrollbackLen)
-		for row := range scrollback {
-			scrollback[row] = paneBufferLine{
-				text: emu.ScrollbackLineText(row),
-			}
-		}
-	}
+	scrollbackState := captureScrollbackSnapshot(emu, prev)
 
 	screen := make([]paneBufferLine, height)
 	for row := 0; row < height; row++ {
@@ -92,7 +56,7 @@ func capturePaneRenderSnapshot(emu mux.TerminalEmulator, prev paneScrollbackSnap
 		terminal:         cloneTerminalState(emu.TerminalState()),
 		rendered:         rendered,
 		renderedNoCursor: rendered,
-		scrollback:       scrollback,
+		scrollback:       scrollbackState.scrollback,
 		screen:           screen,
 	}
 	if col, row, ok := emu.CursorBlockPosition(); ok {
@@ -101,11 +65,58 @@ func capturePaneRenderSnapshot(emu mux.TerminalEmulator, prev paneScrollbackSnap
 		snap.hasCursorBlock = true
 		snap.renderedNoCursor = emu.RenderWithoutCursorBlock()
 	}
-	return snap, paneScrollbackSnapshotState{
-		scrollbackLen:    curScrollbackLen,
-		scrollbackPushed: curScrollbackPushed,
+	return snap, scrollbackState
+}
+
+func captureScrollbackSnapshot(emu mux.TerminalEmulator, prev paneScrollbackSnapshotState) paneScrollbackSnapshotState {
+	curLen := emu.ScrollbackLen()
+	curPushed := emu.ScrollbackPushed()
+	scrollback, ok := extendScrollbackSnapshot(emu, prev, curLen, curPushed)
+	if !ok {
+		scrollback = rebuildScrollbackSnapshot(emu, curLen)
+	}
+	return paneScrollbackSnapshotState{
+		scrollbackLen:    curLen,
+		scrollbackPushed: curPushed,
 		scrollback:       scrollback,
 	}
+}
+
+func extendScrollbackSnapshot(emu mux.TerminalEmulator, prev paneScrollbackSnapshotState, curLen int, curPushed uint64) ([]paneBufferLine, bool) {
+	if prev.scrollback == nil || len(prev.scrollback) != prev.scrollbackLen || curPushed < prev.scrollbackPushed {
+		return nil, false
+	}
+	appended64 := curPushed - prev.scrollbackPushed
+	if appended64 > uint64(curLen) {
+		return nil, false
+	}
+	appended := int(appended64)
+	trimmed := prev.scrollbackLen + appended - curLen
+	if trimmed < 0 || trimmed > len(prev.scrollback) {
+		return nil, false
+	}
+	if appended == 0 && trimmed == 0 {
+		return prev.scrollback, true
+	}
+
+	scrollback := prev.scrollback[trimmed:]
+	start := curLen - appended
+	for row := start; row < curLen; row++ {
+		scrollback = append(scrollback, paneBufferLine{
+			text: emu.ScrollbackLineText(row),
+		})
+	}
+	return scrollback, true
+}
+
+func rebuildScrollbackSnapshot(emu mux.TerminalEmulator, scrollbackLen int) []paneBufferLine {
+	scrollback := make([]paneBufferLine, scrollbackLen)
+	for row := range scrollback {
+		scrollback[row] = paneBufferLine{
+			text: emu.ScrollbackLineText(row),
+		}
+	}
+	return scrollback
 }
 
 func cloneTerminalState(state proto.TerminalState) proto.TerminalState {

--- a/internal/client/renderer_capture_snapshot_test.go
+++ b/internal/client/renderer_capture_snapshot_test.go
@@ -1,13 +1,228 @@
 package client
 
 import (
+	"io"
 	"strings"
 	"testing"
 	"time"
 
+	uv "github.com/charmbracelet/ultraviolet"
+	"github.com/weill-labs/amux/internal/mouse"
 	"github.com/weill-labs/amux/internal/mux"
 	"github.com/weill-labs/amux/internal/proto"
 )
+
+type captureSnapshotFakeEmulator struct {
+	width, height int
+	scrollback    []string
+	screen        []string
+	pushed        uint64
+	lineReads     []int
+}
+
+func newCaptureSnapshotFakeEmulator(lines []string, pushed uint64) *captureSnapshotFakeEmulator {
+	return &captureSnapshotFakeEmulator{
+		width:      4,
+		height:     2,
+		scrollback: append([]string(nil), lines...),
+		screen:     []string{"screen-0", "screen-1"},
+		pushed:     pushed,
+	}
+}
+
+func (e *captureSnapshotFakeEmulator) Write(data []byte) (int, error) { return len(data), nil }
+func (e *captureSnapshotFakeEmulator) DrainScreenChanges() bool       { return false }
+func (e *captureSnapshotFakeEmulator) Read([]byte) (int, error)       { return 0, io.EOF }
+func (e *captureSnapshotFakeEmulator) Close() error                   { return nil }
+func (e *captureSnapshotFakeEmulator) Render() string                 { return strings.Join(e.screen, "\n") }
+func (e *captureSnapshotFakeEmulator) Resize(width, height int)       { e.width, e.height = width, height }
+func (e *captureSnapshotFakeEmulator) Size() (int, int)               { return e.width, e.height }
+func (e *captureSnapshotFakeEmulator) Reset()                         {}
+func (e *captureSnapshotFakeEmulator) CursorPosition() (int, int)     { return 0, 0 }
+func (e *captureSnapshotFakeEmulator) CursorPhantom() bool            { return false }
+func (e *captureSnapshotFakeEmulator) CursorHidden() bool             { return false }
+func (e *captureSnapshotFakeEmulator) TerminalState() mux.TerminalState {
+	return mux.TerminalState{}
+}
+func (e *captureSnapshotFakeEmulator) ScrollbackLen() int { return len(e.scrollback) }
+func (e *captureSnapshotFakeEmulator) ScrollbackPushed() uint64 {
+	return e.pushed
+}
+func (e *captureSnapshotFakeEmulator) ScrollbackLineText(y int) string {
+	e.lineReads = append(e.lineReads, y)
+	if y < 0 || y >= len(e.scrollback) {
+		return ""
+	}
+	return e.scrollback[y]
+}
+func (e *captureSnapshotFakeEmulator) ScrollbackCellAt(int, int) (uv.Cell, bool) {
+	return uv.Cell{}, false
+}
+func (e *captureSnapshotFakeEmulator) RenderWithoutCursorBlock() string {
+	return e.Render()
+}
+func (e *captureSnapshotFakeEmulator) HasCursorBlock() bool { return false }
+func (e *captureSnapshotFakeEmulator) CursorBlockPosition() (int, int, bool) {
+	return 0, 0, false
+}
+func (e *captureSnapshotFakeEmulator) ScreenLineText(y int) string {
+	if y < 0 || y >= len(e.screen) {
+		return ""
+	}
+	return e.screen[y]
+}
+func (e *captureSnapshotFakeEmulator) LineWrapped(int) bool       { return false }
+func (e *captureSnapshotFakeEmulator) ScreenContains(string) bool { return false }
+func (e *captureSnapshotFakeEmulator) CellAt(int, int) *uv.Cell   { return nil }
+func (e *captureSnapshotFakeEmulator) IsAltScreen() bool          { return false }
+func (e *captureSnapshotFakeEmulator) MouseProtocol() mux.MouseProtocol {
+	return mux.MouseProtocol{}
+}
+func (e *captureSnapshotFakeEmulator) EncodeMouse(mouse.Event, int, int) []byte {
+	return nil
+}
+
+func scrollbackState(lines []string, pushed uint64) paneScrollbackSnapshotState {
+	return paneScrollbackSnapshotState{
+		scrollbackLen:    len(lines),
+		scrollbackPushed: pushed,
+		scrollback:       paneBufferLines(lines),
+	}
+}
+
+func paneBufferLines(lines []string) []paneBufferLine {
+	out := make([]paneBufferLine, len(lines))
+	for i, line := range lines {
+		out[i] = paneBufferLine{text: line}
+	}
+	return out
+}
+
+func sameScrollbackBacking(a, b []paneBufferLine) bool {
+	return len(a) > 0 && len(b) > 0 && &a[0] == &b[0]
+}
+
+func TestCapturePaneRenderSnapshotIncrementalScrollback(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		prev       paneScrollbackSnapshotState
+		lines      []string
+		pushed     uint64
+		wantLines  []string
+		wantReads  []int
+		wantReuse  bool
+		wantPushed uint64
+	}{
+		{
+			name:       "cold start rebuilds all scrollback",
+			lines:      []string{"a", "b", "c"},
+			pushed:     3,
+			wantLines:  []string{"a", "b", "c"},
+			wantReads:  []int{0, 1, 2},
+			wantPushed: 3,
+		},
+		{
+			name:       "no change reuses previous slice",
+			prev:       scrollbackState([]string{"a", "b"}, 2),
+			lines:      []string{"a", "b"},
+			pushed:     2,
+			wantLines:  []string{"a", "b"},
+			wantReuse:  true,
+			wantPushed: 2,
+		},
+		{
+			name:       "appended rows read only new tail rows",
+			prev:       scrollbackState([]string{"a", "b"}, 2),
+			lines:      []string{"a", "b", "c", "d"},
+			pushed:     4,
+			wantLines:  []string{"a", "b", "c", "d"},
+			wantReads:  []int{2, 3},
+			wantPushed: 4,
+		},
+		{
+			name:       "trimmed rows drop from previous front without reads",
+			prev:       scrollbackState([]string{"a", "b", "c", "d"}, 4),
+			lines:      []string{"c", "d"},
+			pushed:     4,
+			wantLines:  []string{"c", "d"},
+			wantReads:  nil,
+			wantReuse:  true,
+			wantPushed: 4,
+		},
+		{
+			name:       "appended and trimmed rows reuse tail then append new rows",
+			prev:       scrollbackState([]string{"a", "b", "c"}, 3),
+			lines:      []string{"c", "d", "e"},
+			pushed:     5,
+			wantLines:  []string{"c", "d", "e"},
+			wantReads:  []int{1, 2},
+			wantPushed: 5,
+		},
+		{
+			name:       "counter mismatch falls back to full rebuild",
+			prev:       scrollbackState([]string{"a", "b"}, 4),
+			lines:      []string{"x", "y"},
+			pushed:     1,
+			wantLines:  []string{"x", "y"},
+			wantReads:  []int{0, 1},
+			wantPushed: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			emu := newCaptureSnapshotFakeEmulator(tt.lines, tt.pushed)
+			snap, state := capturePaneRenderSnapshot(emu, tt.prev)
+
+			if got := paneRenderSnapshotLines(snap.scrollback); !equalStrings(got, tt.wantLines) {
+				t.Fatalf("snapshot scrollback = %#v, want %#v", got, tt.wantLines)
+			}
+			if got := paneRenderSnapshotLines(state.scrollback); !equalStrings(got, tt.wantLines) {
+				t.Fatalf("state scrollback = %#v, want %#v", got, tt.wantLines)
+			}
+			if !equalInts(emu.lineReads, tt.wantReads) {
+				t.Fatalf("ScrollbackLineText reads = %#v, want %#v", emu.lineReads, tt.wantReads)
+			}
+			if state.scrollbackLen != len(tt.wantLines) {
+				t.Fatalf("state scrollbackLen = %d, want %d", state.scrollbackLen, len(tt.wantLines))
+			}
+			if state.scrollbackPushed != tt.wantPushed {
+				t.Fatalf("state scrollbackPushed = %d, want %d", state.scrollbackPushed, tt.wantPushed)
+			}
+			if tt.wantReuse && !sameScrollbackBacking(snap.scrollback, tt.prev.scrollback) {
+				t.Fatal("snapshot did not reuse previous scrollback backing array")
+			}
+		})
+	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func equalInts(a, b []int) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
 
 func TestHandleCaptureRequestDoesNotWaitForRendererActor(t *testing.T) {
 	t.Parallel()

--- a/internal/client/renderer_capture_snapshot_test.go
+++ b/internal/client/renderer_capture_snapshot_test.go
@@ -99,7 +99,15 @@ func paneBufferLines(lines []string) []paneBufferLine {
 }
 
 func sameScrollbackBacking(a, b []paneBufferLine) bool {
-	return len(a) > 0 && len(b) > 0 && &a[0] == &b[0]
+	if len(a) == 0 || len(b) == 0 {
+		return false
+	}
+	for i := range b {
+		if &a[0] == &b[i] {
+			return true
+		}
+	}
+	return false
 }
 
 func TestCapturePaneRenderSnapshotIncrementalScrollback(t *testing.T) {

--- a/internal/client/renderer_state.go
+++ b/internal/client/renderer_state.go
@@ -145,6 +145,16 @@ func prunePaneRenderSnapshots(src map[uint32]paneRenderSnapshot, panes map[uint3
 	return dst
 }
 
+func prunePaneScrollbackSnapshotStates(src map[uint32]paneScrollbackSnapshotState, panes map[uint32]proto.PaneSnapshot) map[uint32]paneScrollbackSnapshotState {
+	dst := make(map[uint32]paneScrollbackSnapshotState, len(src))
+	for paneID, snap := range src {
+		if _, ok := panes[paneID]; ok {
+			dst[paneID] = snap
+		}
+	}
+	return dst
+}
+
 type rendererCommand struct {
 	run  func(*rendererActorState)
 	done chan struct{}
@@ -153,6 +163,7 @@ type rendererCommand struct {
 type rendererActorState struct {
 	snapshot          *rendererSnapshot
 	emulators         map[uint32]mux.TerminalEmulator
+	paneScrollbacks   map[uint32]paneScrollbackSnapshotState
 	pendingPaneOutput map[uint32]*paneOutputBuffer
 	compositor        *render.Compositor
 }
@@ -274,12 +285,16 @@ func (st *rendererActorState) warmVisiblePanes(snap *rendererSnapshot, emulators
 
 func (st *rendererActorState) refreshPaneCaptures(snap *rendererSnapshot, emulators map[uint32]mux.TerminalEmulator) {
 	captures := prunePaneRenderSnapshots(snap.paneCaptures, snap.paneInfo)
+	scrollbacks := prunePaneScrollbackSnapshotStates(st.paneScrollbacks, snap.paneInfo)
 	for paneID, emu := range emulators {
 		if _, ok := snap.paneInfo[paneID]; !ok || emu == nil {
 			continue
 		}
-		captures[paneID] = capturePaneRenderSnapshot(emu)
+		capture, state := capturePaneRenderSnapshot(emu, scrollbacks[paneID])
+		captures[paneID] = capture
+		scrollbacks[paneID] = state
 	}
+	st.paneScrollbacks = scrollbacks
 	snap.paneCaptures = captures
 }
 
@@ -290,7 +305,9 @@ func (r *Renderer) publishPaneCapture(st *rendererActorState, paneID uint32) {
 	}
 	next := *st.snapshot
 	next.paneCaptures = clonePaneRenderSnapshots(st.snapshot.paneCaptures)
-	next.paneCaptures[paneID] = capturePaneRenderSnapshot(emu)
+	capture, state := capturePaneRenderSnapshot(emu, st.paneScrollbacks[paneID])
+	next.paneCaptures[paneID] = capture
+	st.paneScrollbacks[paneID] = state
 	st.snapshot = &next
 	r.publishSnapshot(&next)
 }
@@ -317,6 +334,7 @@ func (r *Renderer) actorLoop(initial *rendererSnapshot, compositor *render.Compo
 	state := &rendererActorState{
 		snapshot:          initial,
 		emulators:         make(map[uint32]mux.TerminalEmulator),
+		paneScrollbacks:   make(map[uint32]paneScrollbackSnapshotState),
 		pendingPaneOutput: make(map[uint32]*paneOutputBuffer),
 		compositor:        compositor,
 	}

--- a/internal/mux/emulator.go
+++ b/internal/mux/emulator.go
@@ -64,6 +64,10 @@ type TerminalEmulator interface {
 	// ScrollbackLen returns the number of lines in the scrollback buffer.
 	ScrollbackLen() int
 
+	// ScrollbackPushed returns the cumulative number of lines pushed into
+	// retained scrollback during this emulator's lifetime.
+	ScrollbackPushed() uint64
+
 	// ScrollbackLineText returns the plain text of scrollback line y (0=oldest).
 	ScrollbackLineText(y int) string
 
@@ -124,6 +128,7 @@ type vtEmulator struct {
 	cursorHidden      atomic.Bool
 	altScreen         atomic.Bool
 	mouseFlags        atomic.Uint32
+	scrollbackPushed  atomic.Uint64
 	scrollbackPushFn  func(count, width int)
 	scrollbackClearFn func()
 	scrollbackLimit   int
@@ -160,6 +165,9 @@ func NewVTEmulatorWithScrollback(width, height, scrollbackLines int) TerminalEmu
 			v.setMouseMode(mode, false)
 		},
 		ScrollbackPush: func(count, width int) {
+			if count > 0 {
+				v.scrollbackPushed.Add(uint64(count))
+			}
 			if v.scrollbackPushFn != nil {
 				v.scrollbackPushFn(count, width)
 			}
@@ -310,6 +318,10 @@ func (v *vtEmulator) TerminalState() TerminalState {
 
 func (v *vtEmulator) ScrollbackLen() int {
 	return v.emu.ScrollbackLen()
+}
+
+func (v *vtEmulator) ScrollbackPushed() uint64 {
+	return v.scrollbackPushed.Load()
 }
 
 func (v *vtEmulator) ScrollbackLineText(y int) string {

--- a/internal/mux/emulator_test.go
+++ b/internal/mux/emulator_test.go
@@ -96,6 +96,59 @@ func TestVTEmulatorRespectsScrollbackLimitUnderFlood(t *testing.T) {
 	}
 }
 
+func TestVTEmulatorScrollbackPushedCountsOverflowRows(t *testing.T) {
+	t.Parallel()
+
+	emu := NewVTEmulatorWithDrainAndScrollback(20, 2, 3)
+	if got := emu.ScrollbackPushed(); got != 0 {
+		t.Fatalf("initial ScrollbackPushed() = %d, want 0", got)
+	}
+
+	for i := 1; i <= 4; i++ {
+		mustWrite(t, emu, []byte(fmt.Sprintf("line-%02d\r\n", i)))
+	}
+	before := emu.ScrollbackPushed()
+	if before != 3 {
+		t.Fatalf("ScrollbackPushed() after 4 lines = %d, want 3", before)
+	}
+	if got := emu.ScrollbackLen(); got != 3 {
+		t.Fatalf("ScrollbackLen() after 4 lines = %d, want capped 3", got)
+	}
+
+	for i := 5; i <= 6; i++ {
+		mustWrite(t, emu, []byte(fmt.Sprintf("line-%02d\r\n", i)))
+	}
+	after := emu.ScrollbackPushed()
+	if after < before {
+		t.Fatalf("ScrollbackPushed() decreased from %d to %d", before, after)
+	}
+	if got := after - before; got != 2 {
+		t.Fatalf("ScrollbackPushed() delta = %d, want 2", got)
+	}
+}
+
+func TestVTEmulatorScrollbackPushedSurvivesScrollbackClear(t *testing.T) {
+	t.Parallel()
+
+	emu := NewVTEmulatorWithDrainAndScrollback(20, 2, 5)
+	for i := 1; i <= 4; i++ {
+		mustWrite(t, emu, []byte(fmt.Sprintf("line-%02d\r\n", i)))
+	}
+	before := emu.ScrollbackPushed()
+	if before == 0 {
+		t.Fatal("expected scrollback pushes before clear")
+	}
+
+	mustWrite(t, emu, []byte("\x1b[3J"))
+
+	if got := emu.ScrollbackLen(); got != 0 {
+		t.Fatalf("ScrollbackLen() after clear = %d, want 0", got)
+	}
+	if got := emu.ScrollbackPushed(); got != before {
+		t.Fatalf("ScrollbackPushed() after clear = %d, want %d", got, before)
+	}
+}
+
 func TestVTEmulatorResizeWiderReflowsVisibleRows(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Motivation

Client rendering was lagging because `publishPaneCapture -> capturePaneRenderSnapshot` rebuilt full text scrollback on every PTY output event. The live baseline profile had `capturePaneRenderSnapshot` at 7.11s cumulative out of 14.97s samples (47.49%), with `ScrollbackLineText` at 3.63s cumulative.

## Summary

- Add a monotonic `ScrollbackPushed()` counter to `mux.TerminalEmulator`, backed by the existing vt `ScrollbackPush` callback.
- Keep per-pane scrollback snapshot state on the renderer actor and reuse previous text snapshots when no rows changed.
- Append only newly pushed scrollback rows and drop front-trimmed rows by reslicing the previous immutable snapshot.
- Fall back to a full rebuild on cold start or counter/math mismatch.
- Document the vt scrollback invariants and test plan in `docs/incremental-scrollback-snapshot.md`.

## Baseline numbers

Hardware: AMD EPYC-Milan Processor, linux/amd64.

### Live client pprof

| Profile | Total samples | `capturePaneRenderSnapshot` cum | `publishPaneCapture` cum | `ScrollbackLineText` cum |
| --- | ---: | ---: | ---: | ---: |
| Before (`/tmp/lab-scrollback-lag.pprof`) | 14.97s | 7.11s (47.49%) | 6.87s (45.89%) | 3.63s (24.25%) |
| After (`/tmp/lab-1833-after.pprof`) | 1.48s | 0.06s (4.05%) | 0.06s (4.05%) | 0 samples |

The after profile was captured from the live `main` client after `make install`. The session was less CPU-hot than the original repro, but the target function dropped below the requested 5% threshold.

### Benchmarks

`go test ./internal/client -run '^$' -bench 'BenchmarkCapturePaneRenderSnapshot(StyledScrollback1KB|IncrementalScrollback)$' -benchmem -count=5`

| Benchmark | ns/op range | B/op range | allocs/op range |
| --- | ---: | ---: | ---: |
| `BenchmarkCapturePaneRenderSnapshotStyledScrollback1KB` | 2223402-2395475 | 1063968-1066998 | 18862-18904 |
| `BenchmarkCapturePaneRenderSnapshotIncrementalScrollback` | 147210-157678 | 243850-243883 | 88 |

## Testing

- `go test ./internal/client -run 'TestCapturePaneRenderSnapshotIncrementalScrollback|TestHandleCaptureRequestDoesNotWaitForRendererActor|TestClientRendererHandleCaptureRequestHistoryJSONPrependsScrollback|TestRendererHandleCaptureRequestHistoryJSONWithoutBootstrapHistory|TestPaneBufferSnapshot' -count=100`
- `go test ./internal/mux -run 'TestVTEmulatorScrollbackPushed|TestVTEmulatorResetClearsScreenScrollbackAndModes' -count=100`
- `go test ./internal/client ./internal/mux ./internal/render ./internal/server ./test -timeout 120s`
- `go test -race ./internal/client -run 'TestCapturePaneRenderSnapshotIncrementalScrollback|TestHandleCaptureRequestDoesNotWaitForRendererActor|TestClientRendererHandleCaptureRequestHistoryJSONPrependsScrollback|TestRendererHandleCaptureRequestHistoryJSONWithoutBootstrapHistory|TestPaneBufferSnapshot' -count=10`
- `go test -race ./internal/mux -run 'TestVTEmulatorScrollbackPushed|TestVTEmulatorResetClearsScreenScrollbackAndModes' -count=10`
- `go test -race ./internal/mux -count=10`
- `go test -race ./internal/client`
- `go test -race ./internal/client -run TestRenderCoalescedPrioritizesActivePaneOutputAfterLocalInput -count=10`
- `go test -race ./internal/client -run TestReadAttachBootstrapAppliesZoomedReplayBeforeReturn -count=10`
- `go test ./internal/client -run 'TestCapturePaneRenderSnapshotIncrementalScrollback|TestHandleCaptureRequestDoesNotWaitForRendererActor|TestClientRendererHandleCaptureRequestHistoryJSONPrependsScrollback|TestRendererHandleCaptureRequestHistoryJSONWithoutBootstrapHistory|TestPaneBufferSnapshot'`
- `go test ./internal/client -run '^$' -bench 'BenchmarkCapturePaneRenderSnapshot(StyledScrollback1KB|IncrementalScrollback)$' -benchmem -count=5`
- `make install`
- `amux debug client-profile --duration 20s > /tmp/lab-1833-after.pprof`
- `go tool pprof -top -cum -nodecount=30 /tmp/lab-scrollback-lag.pprof`
- `go tool pprof -top -cum -nodecount=200 -nodefraction=0 /tmp/lab-1833-after.pprof`

Attempted `go test -race ./internal/client ./internal/mux -count=10`; the combined run was killed after several minutes, and a package-wide client retry surfaced two timing-sensitive tests. Both client failures passed in isolation under `-race -count=10`; the full single client race pass and full mux `-race -count=10` pass are listed above.

## Review focus

- Confirm the scrollback counter should remain monotonic across `ESC[3J`/reset so trims are represented by length changes, not counter resets.
- Check the slice tail-sharing safety: snapshot lines are immutable text, and appends only write beyond the previous visible slice length.
- Check the fallback conditions for stale state, counter regression, and impossible trim math.

Closes LAB-1833
