### PR TITLE
LAB-1847: Render zoom as separate list column

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,12 +317,12 @@ The public CLI keeps one command path per concept: target sessions with `-s`, cr
 
 | Command | Description |
 |---------|-------------|
-| `amux list [--no-cwd]` | List panes with metadata (including cwd by default) |
+| `amux list [--no-cwd] [--json]` | List panes with metadata (including cwd by default) |
 | `amux spawn [--auto] [--at <pane>] [--window <name\|id>] [--vertical\|--horizontal] [--root] [--focus] [--name NAME] [--host HOST] [--task TASK] [--color COLOR]` | Create a new pane using default spawn, column-fill auto spawn, or targeted split placement |
 | `amux focus <pane\|direction>` | Focus by name, ID, or direction (left/right/up/down/next) |
 | `amux zoom [pane]` | Toggle zoom on a pane |
 | `amux kill [pane]` | Kill a pane (default: active) |
-| `amux send-keys <pane> [--via pty\|client] [--client <id>] [--wait ready\|ui=input-idle] [--timeout <duration>] [--delay-final <duration>] [--hex] <keys>...` | Send keystrokes to a pane |
+| `amux send-keys (<pane>\|--window <index\|name>) [--via pty\|client] [--client <id>] [--wait ready\|ui=input-idle] [--timeout <duration>] [--delay-final <duration>] [--hex] <keys>...` | Send keystrokes to a pane |
 | `amux broadcast (--panes <pane,pane,...> \| --window <index\|name> \| --match <glob>) [--hex] <keys>...` | Send the same keystrokes to multiple panes |
 | `amux swap <p1> <p2> [--tree]` | Swap two panes, or their root-level groups with `--tree` |
 | `amux swap forward\|backward` | Swap active pane with neighbor |

--- a/internal/cli/cli_commands_layout.go
+++ b/internal/cli/cli_commands_layout.go
@@ -119,7 +119,7 @@ func layoutCLICommands() map[string]commandHandler {
 			return inv.runSessionCommand("kill", args)
 		},
 		"send-keys": func(inv invocation, args []string) int {
-			if handled, exitCode := MaybePrintKeyCommandUsage(inv.runtime.Stdout, inv.runtime.Stderr, args, sendKeysUsage, 2); handled {
+			if handled, exitCode := MaybePrintSendKeysUsage(inv.runtime.Stdout, inv.runtime.Stderr, args); handled {
 				return exitCode
 			}
 			return inv.runSessionCommand("send-keys", args)

--- a/internal/cli/cli_usage.go
+++ b/internal/cli/cli_usage.go
@@ -7,7 +7,7 @@ import (
 )
 
 const (
-	sendKeysUsage     = "usage: amux send-keys <pane> [--via pty|client] [--client <id>] [--wait ready|ui=input-idle] [--timeout <duration>] [--delay-final <duration>] [--hex] <keys>..."
+	sendKeysUsage     = "usage: amux send-keys (<pane>|--window <index|name>) [--via pty|client] [--client <id>] [--wait ready|ui=input-idle] [--timeout <duration>] [--delay-final <duration>] [--hex] <keys>..."
 	mouseUsage        = "usage: amux mouse [--client <id>] [--timeout <duration>] (press <x> <y> | motion <x> <y> | release <x> <y> | click <x> <y> | click <pane> [--status-line] | drag <pane> --to <pane>)"
 	captureUsage      = "usage: amux capture [--client] [pane] [--history <pane>] [--ansi] [--colors]"
 	logUsage          = "usage: amux log <clients|panes>"
@@ -22,7 +22,7 @@ const (
 	disconnectUsage   = "usage: amux disconnect <host>"
 	focusUsage        = "usage: amux focus <pane>"
 	listClientsUsage  = "usage: amux list-clients"
-	listUsage         = "usage: amux list [--no-cwd]"
+	listUsage         = "usage: amux list [--no-cwd] [--json]"
 	listWindowsUsage  = "usage: amux list-windows"
 	reconnectUsage    = "usage: amux reconnect <host>"
 	reloadServerUsage = "usage: amux reload-server"
@@ -147,7 +147,7 @@ func WriteUsage(w io.Writer) {
 Usage:
   amux [-s session]                    Start or attach to amux session
   amux [-s session] new [name]         Start or attach to a named session
-  amux [-s session] list [--no-cwd]    List panes with metadata
+  amux [-s session] list [--no-cwd] [--json]    List panes with metadata
   amux [-s session] status             Show pane/window summary
   amux [-s session] list-clients       List attached clients + client-local UI state
   amux [-s session] log clients        Show recent client attach/detach history
@@ -176,7 +176,7 @@ Usage:
   amux [-s session] capture --colors   Capture border color map
   amux [-s session] connect <host> [--session <name> | --session-per-client]
                                        Connect to a remote amux session and mirror its panes locally
-  amux [-s session] send-keys <pane> [--via pty|client] [--client <id>] [--wait ready|ui=input-idle] [--timeout <duration>] [--delay-final <duration>] [--hex] <keys>...
+  amux [-s session] send-keys (<pane>|--window <index|name>) [--via pty|client] [--client <id>] [--wait ready|ui=input-idle] [--timeout <duration>] [--delay-final <duration>] [--hex] <keys>...
                                        Send keystrokes to a pane
   amux [-s session] mouse [--client <id>] [--timeout <duration>] ...
                                        Simulate mouse input through an attached client

--- a/internal/cli/cli_usage.go
+++ b/internal/cli/cli_usage.go
@@ -137,6 +137,17 @@ func MaybePrintKeyCommandUsage(stdout, stderr io.Writer, args []string, usage st
 	return false, 0
 }
 
+func MaybePrintSendKeysUsage(stdout, stderr io.Writer, args []string) (handled bool, exitCode int) {
+	if handled, exitCode := MaybePrintKeyCommandUsage(stdout, stderr, args, sendKeysUsage, 2); handled {
+		return handled, exitCode
+	}
+	if args[0] == "--window" && len(args) < 3 {
+		fmt.Fprintln(stderr, sendKeysUsage)
+		return true, 1
+	}
+	return false, 0
+}
+
 func PrintUsage() {
 	WriteUsage(os.Stdout)
 }

--- a/internal/cli/main_test.go
+++ b/internal/cli/main_test.go
@@ -433,6 +433,27 @@ func TestMaybePrintKeyCommandUsage(t *testing.T) {
 	}
 }
 
+func TestMaybePrintSendKeysUsageRequiresWindowKeys(t *testing.T) {
+	t.Parallel()
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	handled, exitCode := MaybePrintSendKeysUsage(&stdout, &stderr, []string{"--window", "main"})
+	if !handled {
+		t.Fatal("handled = false, want true")
+	}
+	if exitCode != 1 {
+		t.Fatalf("exitCode = %d, want 1", exitCode)
+	}
+	if got := stdout.String(); got != "" {
+		t.Fatalf("stdout = %q, want empty", got)
+	}
+	if got := stderr.String(); got != sendKeysUsage+"\n" {
+		t.Fatalf("stderr = %q, want %q", got, sendKeysUsage+"\n")
+	}
+}
+
 func TestParseSwapArgs(t *testing.T) {
 	t.Parallel()
 
@@ -944,6 +965,12 @@ func TestRunMainHelpAndUsageErrors(t *testing.T) {
 		{
 			name:       "send-keys usage error stays in dispatch layer",
 			args:       []string{"send-keys", "pane-1"},
+			wantExit:   1,
+			wantStderr: sendKeysUsage + "\n",
+		},
+		{
+			name:       "send-keys window usage error stays in dispatch layer",
+			args:       []string{"send-keys", "--window", "main"},
 			wantExit:   1,
 			wantStderr: sendKeysUsage + "\n",
 		},

--- a/internal/cli/main_usage_test.go
+++ b/internal/cli/main_usage_test.go
@@ -34,7 +34,7 @@ func TestMainSendKeysUsageIncludesWaitReadyFlags(t *testing.T) {
 	if code != 1 {
 		t.Fatalf("exit code = %d, want 1\n%s", code, out)
 	}
-	if !strings.Contains(out, "usage: amux send-keys <pane> [--via pty|client] [--client <id>] [--wait ready|ui=input-idle] [--timeout <duration>] [--delay-final <duration>] [--hex] <keys>...") {
+	if !strings.Contains(out, "usage: amux send-keys (<pane>|--window <index|name>) [--via pty|client] [--client <id>] [--wait ready|ui=input-idle] [--timeout <duration>] [--delay-final <duration>] [--hex] <keys>...") {
 		t.Fatalf("usage output missing via/wait flags:\n%s", out)
 	}
 }
@@ -50,12 +50,12 @@ func TestMainKeyCommandsHelpFlagsPrintUsage(t *testing.T) {
 		{
 			name: "send-keys long help",
 			args: []string{"send-keys", "pane-1", "--help"},
-			want: "usage: amux send-keys <pane> [--via pty|client] [--client <id>] [--wait ready|ui=input-idle] [--timeout <duration>] [--delay-final <duration>] [--hex] <keys>...",
+			want: "usage: amux send-keys (<pane>|--window <index|name>) [--via pty|client] [--client <id>] [--wait ready|ui=input-idle] [--timeout <duration>] [--delay-final <duration>] [--hex] <keys>...",
 		},
 		{
 			name: "send-keys short help",
 			args: []string{"send-keys", "pane-1", "-h"},
-			want: "usage: amux send-keys <pane> [--via pty|client] [--client <id>] [--wait ready|ui=input-idle] [--timeout <duration>] [--delay-final <duration>] [--hex] <keys>...",
+			want: "usage: amux send-keys (<pane>|--window <index|name>) [--via pty|client] [--client <id>] [--wait ready|ui=input-idle] [--timeout <duration>] [--delay-final <duration>] [--hex] <keys>...",
 		},
 	}
 
@@ -297,7 +297,7 @@ func TestMainSendKeysUsageIncludesViaFlags(t *testing.T) {
 	if code != 1 {
 		t.Fatalf("exit code = %d, want 1\n%s", code, out)
 	}
-	if !strings.Contains(out, "usage: amux send-keys <pane> [--via pty|client] [--client <id>] [--wait ready|ui=input-idle] [--timeout <duration>] [--delay-final <duration>] [--hex] <keys>...") {
+	if !strings.Contains(out, "usage: amux send-keys (<pane>|--window <index|name>) [--via pty|client] [--client <id>] [--wait ready|ui=input-idle] [--timeout <duration>] [--delay-final <duration>] [--hex] <keys>...") {
 		t.Fatalf("send-keys usage output missing via flags:\n%s", out)
 	}
 }

--- a/internal/cli/main_usage_test.go
+++ b/internal/cli/main_usage_test.go
@@ -39,6 +39,21 @@ func TestMainSendKeysUsageIncludesWaitReadyFlags(t *testing.T) {
 	}
 }
 
+func TestMainSendKeysWindowUsageRequiresKeys(t *testing.T) {
+	t.Parallel()
+
+	out, code := runHermeticMain(t, "send-keys", "--window", "main")
+	if code != 1 {
+		t.Fatalf("exit code = %d, want 1\n%s", code, out)
+	}
+	if !strings.Contains(out, sendKeysUsage) {
+		t.Fatalf("usage output = %q, want substring %q", out, sendKeysUsage)
+	}
+	if strings.Contains(out, "connecting to server") {
+		t.Fatalf("send-keys --window without keys should not dispatch to the server:\n%s", out)
+	}
+}
+
 func TestMainKeyCommandsHelpFlagsPrintUsage(t *testing.T) {
 	t.Parallel()
 

--- a/internal/server/commands/listing/listing.go
+++ b/internal/server/commands/listing/listing.go
@@ -1,6 +1,7 @@
 package listing
 
 import (
+	"encoding/json"
 	"fmt"
 	"path/filepath"
 	"sort"
@@ -25,7 +26,8 @@ type Context interface {
 }
 
 type ListArgs struct {
-	ShowCwd bool
+	ShowCwd    bool
+	FormatJSON bool
 }
 
 func ParseListArgs(args []string) (ListArgs, error) {
@@ -34,8 +36,10 @@ func ParseListArgs(args []string) (ListArgs, error) {
 		switch arg {
 		case "--no-cwd":
 			parsed.ShowCwd = false
+		case "--json":
+			parsed.FormatJSON = true
 		default:
-			return ListArgs{}, fmt.Errorf("usage: list [--no-cwd]")
+			return ListArgs{}, fmt.Errorf("usage: list [--no-cwd] [--json]")
 		}
 	}
 	return parsed, nil
@@ -49,6 +53,13 @@ func List(ctx Context, args []string) commandpkg.Result {
 	entries, err := ctx.QueryPaneList()
 	if err != nil {
 		return commandpkg.Result{Err: err}
+	}
+	if parsed.FormatJSON {
+		output, err := FormatPaneListJSON(entries)
+		if err != nil {
+			return commandpkg.Result{Err: err}
+		}
+		return commandpkg.Result{Output: output}
 	}
 	return commandpkg.Result{
 		Output: FormatPaneList(entries, ctx.HomeDir(), parsed.ShowCwd),
@@ -80,14 +91,64 @@ func FormatPaneList(entries []PaneEntry, home string, showCwd bool) string {
 
 	var buf strings.Builder
 	if showCwd {
-		fmt.Fprintf(&buf, "%-6s %-20s %-15s %-30s %-9s %-36s %-10s %-12s %s\n", "PANE", "NAME", "HOST", "BRANCH", "IDLE", "CWD", "WINDOW", "TASK", "META")
+		fmt.Fprintf(&buf, "%-6s %-20s %-15s %-30s %-9s %-36s %-10s %-4s %-12s %s\n", "PANE", "NAME", "HOST", "BRANCH", "IDLE", "CWD", "WINDOW", "ZOOM", "TASK", "META")
 	} else {
-		fmt.Fprintf(&buf, "%-6s %-20s %-15s %-30s %-9s %-10s %-12s %s\n", "PANE", "NAME", "HOST", "BRANCH", "IDLE", "WINDOW", "TASK", "META")
+		fmt.Fprintf(&buf, "%-6s %-20s %-15s %-30s %-9s %-10s %-4s %-12s %s\n", "PANE", "NAME", "HOST", "BRANCH", "IDLE", "WINDOW", "ZOOM", "TASK", "META")
 	}
 	for _, entry := range entries {
 		fmt.Fprint(&buf, formatPaneListRow(entry, home, showCwd))
 	}
 	return buf.String()
+}
+
+type PaneListJSONEntry struct {
+	PaneID        uint32               `json:"pane_id"`
+	Name          string               `json:"name"`
+	Host          string               `json:"host"`
+	Branch        string               `json:"branch"`
+	Idle          string               `json:"idle"`
+	Cwd           string               `json:"cwd"`
+	Window        string               `json:"window"`
+	WindowZoomed  bool                 `json:"window_zoomed"`
+	Task          string               `json:"task"`
+	Meta          string               `json:"meta"`
+	KV            map[string]string    `json:"kv,omitempty"`
+	TrackedPRs    []proto.TrackedPR    `json:"tracked_prs,omitempty"`
+	TrackedIssues []proto.TrackedIssue `json:"tracked_issues,omitempty"`
+	Active        bool                 `json:"active"`
+	Lead          bool                 `json:"lead"`
+}
+
+func FormatPaneListJSON(entries []PaneEntry) (string, error) {
+	rows := make([]PaneListJSONEntry, 0, len(entries))
+	for _, entry := range entries {
+		idle := entry.Idle
+		if idle == "" {
+			idle = "--"
+		}
+		rows = append(rows, PaneListJSONEntry{
+			PaneID:        entry.PaneID,
+			Name:          entry.Name,
+			Host:          entry.Host,
+			Branch:        FormatPaneListBranch(entry),
+			Idle:          idle,
+			Cwd:           entry.Cwd,
+			Window:        FormatWindowName(entry.WindowName, entry.WindowZoomed),
+			WindowZoomed:  entry.WindowZoomed,
+			Task:          entry.Task,
+			Meta:          formatPaneListMeta(entry),
+			KV:            entry.KV,
+			TrackedPRs:    entry.TrackedPRs,
+			TrackedIssues: entry.TrackedIssues,
+			Active:        entry.Active,
+			Lead:          entry.Lead,
+		})
+	}
+	data, err := json.MarshalIndent(rows, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	return string(data) + "\n", nil
 }
 
 func FormatPaneListBranch(entry PaneEntry) string {
@@ -99,10 +160,14 @@ func FormatPaneListBranch(entry PaneEntry) string {
 }
 
 func FormatWindowName(name string, zoomed bool) string {
-	if zoomed {
-		return name + "Z"
-	}
 	return name
+}
+
+func FormatWindowZoom(zoomed bool) string {
+	if zoomed {
+		return "Z"
+	}
+	return ""
 }
 
 func formatPaneListRow(entry PaneEntry, home string, showCwd bool) string {
@@ -118,12 +183,13 @@ func formatPaneListRow(entry PaneEntry, home string, showCwd bool) string {
 		idle = "--"
 	}
 	windowName := FormatWindowName(entry.WindowName, entry.WindowZoomed)
+	windowZoom := FormatWindowZoom(entry.WindowZoomed)
 	if showCwd {
-		return fmt.Sprintf("%-6s %-20s %-15s %-30s %-9s %-36s %-10s %-12s %s\n",
-			paneID, entry.Name, entry.Host, branch, idle, FormatListCwd(entry.Cwd, home, ListCwdWidth), windowName, entry.Task, meta)
+		return fmt.Sprintf("%-6s %-20s %-15s %-30s %-9s %-36s %-10s %-4s %-12s %s\n",
+			paneID, entry.Name, entry.Host, branch, idle, FormatListCwd(entry.Cwd, home, ListCwdWidth), windowName, windowZoom, entry.Task, meta)
 	}
-	return fmt.Sprintf("%-6s %-20s %-15s %-30s %-9s %-10s %-12s %s\n",
-		paneID, entry.Name, entry.Host, branch, idle, windowName, entry.Task, meta)
+	return fmt.Sprintf("%-6s %-20s %-15s %-30s %-9s %-10s %-4s %-12s %s\n",
+		paneID, entry.Name, entry.Host, branch, idle, windowName, windowZoom, entry.Task, meta)
 }
 
 func formatPaneListMeta(entry PaneEntry) string {
@@ -290,14 +356,14 @@ type WindowEntry struct {
 
 func FormatWindowList(entries []WindowEntry) string {
 	var output strings.Builder
-	output.WriteString(fmt.Sprintf("%-6s %-20s %-8s\n", "WIN", "NAME", "PANES"))
+	output.WriteString(fmt.Sprintf("%-6s %-20s %-4s %-8s\n", "WIN", "NAME", "ZOOM", "PANES"))
 	for _, entry := range entries {
 		active := " "
 		if entry.Active {
 			active = "*"
 		}
-		output.WriteString(fmt.Sprintf("%-6s %-20s %-8d\n",
-			fmt.Sprintf("%s%d:", active, entry.Index), FormatWindowName(entry.Name, entry.Zoomed), entry.PaneCount))
+		output.WriteString(fmt.Sprintf("%-6s %-20s %-4s %-8d\n",
+			fmt.Sprintf("%s%d:", active, entry.Index), FormatWindowName(entry.Name, entry.Zoomed), FormatWindowZoom(entry.Zoomed), entry.PaneCount))
 	}
 	return output.String()
 }

--- a/internal/server/commands/listing/listing.go
+++ b/internal/server/commands/listing/listing.go
@@ -101,7 +101,7 @@ func FormatPaneList(entries []PaneEntry, home string, showCwd bool) string {
 	return buf.String()
 }
 
-type PaneListJSONEntry struct {
+type paneListJSONEntry struct {
 	PaneID        uint32               `json:"pane_id"`
 	Name          string               `json:"name"`
 	Host          string               `json:"host"`
@@ -120,13 +120,13 @@ type PaneListJSONEntry struct {
 }
 
 func FormatPaneListJSON(entries []PaneEntry) (string, error) {
-	rows := make([]PaneListJSONEntry, 0, len(entries))
+	rows := make([]paneListJSONEntry, 0, len(entries))
 	for _, entry := range entries {
 		idle := entry.Idle
 		if idle == "" {
 			idle = "--"
 		}
-		rows = append(rows, PaneListJSONEntry{
+		rows = append(rows, paneListJSONEntry{
 			PaneID:        entry.PaneID,
 			Name:          entry.Name,
 			Host:          entry.Host,
@@ -159,7 +159,7 @@ func FormatPaneListBranch(entry PaneEntry) string {
 	return branch
 }
 
-func FormatWindowName(name string, zoomed bool) string {
+func FormatWindowName(name string, _ bool) string {
 	return name
 }
 

--- a/internal/server/commands/listing/listing_test.go
+++ b/internal/server/commands/listing/listing_test.go
@@ -1,6 +1,7 @@
 package listing
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 )
@@ -86,7 +87,7 @@ func TestFormatPaneListPreservesPaneNameColumnWhenLeadPresent(t *testing.T) {
 	}
 }
 
-func TestFormatWindowNameAddsZoomMarker(t *testing.T) {
+func TestFormatWindowNameLeavesZoomMarkerOutOfName(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -105,7 +106,7 @@ func TestFormatWindowNameAddsZoomMarker(t *testing.T) {
 			name:   "zoomed window",
 			window: "main",
 			zoomed: true,
-			want:   "mainZ",
+			want:   "main",
 		},
 	}
 
@@ -140,10 +141,120 @@ func TestFormatPaneListMarksZoomedWindow(t *testing.T) {
 		},
 	}, "", false)
 
-	if !strings.Contains(out, "mainZ") {
-		t.Fatalf("zoomed window should include Z marker:\n%s", out)
+	if strings.Contains(out, "mainZ") {
+		t.Fatalf("zoomed window name should not include Z marker:\n%s", out)
 	}
 	if strings.Contains(out, "logsZ") {
 		t.Fatalf("unzoomed window should not include Z marker:\n%s", out)
 	}
+	if !strings.Contains(out, "WINDOW") || !strings.Contains(out, "ZOOM") {
+		t.Fatalf("list should include separate WINDOW and ZOOM headers:\n%s", out)
+	}
+
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	if len(lines) != 3 {
+		t.Fatalf("FormatPaneList() returned %d lines, want 3:\n%s", len(lines), out)
+	}
+	if got := fixedListColumn(t, lines[0], lines[1], "WINDOW", "ZOOM"); got != "main" {
+		t.Fatalf("zoomed row WINDOW column = %q, want main\n%s", got, out)
+	}
+	if got := fixedListColumn(t, lines[0], lines[1], "ZOOM", "TASK"); got != "Z" {
+		t.Fatalf("zoomed row ZOOM column = %q, want Z\n%s", got, out)
+	}
+	if got := fixedListColumn(t, lines[0], lines[2], "WINDOW", "ZOOM"); got != "logs" {
+		t.Fatalf("unzoomed row WINDOW column = %q, want logs\n%s", got, out)
+	}
+	if got := fixedListColumn(t, lines[0], lines[2], "ZOOM", "TASK"); got != "" {
+		t.Fatalf("unzoomed row ZOOM column = %q, want empty\n%s", got, out)
+	}
+}
+
+func TestListJSONIncludesCleanWindowAndZoomedFlag(t *testing.T) {
+	t.Parallel()
+
+	res := List(fakeListContext{entries: []PaneEntry{{
+		PaneID:       1,
+		Name:         "pane-1",
+		Host:         "local",
+		WindowName:   "main",
+		WindowZoomed: true,
+		Task:         "build",
+		Active:       true,
+	}}}, []string{"--json"})
+	if res.Err != nil {
+		t.Fatalf("List(--json) error = %v", res.Err)
+	}
+
+	var rows []map[string]any
+	if err := json.Unmarshal([]byte(res.Output), &rows); err != nil {
+		t.Fatalf("json.Unmarshal(List --json) = %v\n%s", err, res.Output)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("List --json returned %d rows, want 1\n%s", len(rows), res.Output)
+	}
+	if got := rows[0]["window"]; got != "main" {
+		t.Fatalf("json window = %#v, want main\n%s", got, res.Output)
+	}
+	if got := rows[0]["window_zoomed"]; got != true {
+		t.Fatalf("json window_zoomed = %#v, want true\n%s", got, res.Output)
+	}
+}
+
+func fixedListColumn(t *testing.T, header, row, column, nextColumn string) string {
+	t.Helper()
+
+	start := strings.Index(header, column)
+	if start < 0 {
+		t.Fatalf("header missing %q: %q", column, header)
+	}
+	end := len(row)
+	if nextColumn != "" {
+		next := strings.Index(header, nextColumn)
+		if next < 0 {
+			t.Fatalf("header missing next column %q: %q", nextColumn, header)
+		}
+		if next > start {
+			end = min(next, len(row))
+		}
+	}
+	if start >= len(row) {
+		return ""
+	}
+	return strings.TrimSpace(row[start:end])
+}
+
+type fakeListContext struct {
+	entries []PaneEntry
+}
+
+func (f fakeListContext) HomeDir() string {
+	return ""
+}
+
+func (f fakeListContext) BuildVersion() string {
+	return ""
+}
+
+func (f fakeListContext) QueryPaneList() ([]PaneEntry, error) {
+	return f.entries, nil
+}
+
+func (f fakeListContext) QuerySessionStatus() (SessionStatus, error) {
+	return SessionStatus{}, nil
+}
+
+func (f fakeListContext) QueryWindowList() ([]WindowEntry, error) {
+	return nil, nil
+}
+
+func (f fakeListContext) QueryClientList() ([]ClientEntry, error) {
+	return nil, nil
+}
+
+func (f fakeListContext) QueryConnectionLog() ([]ConnectionLogEntry, error) {
+	return nil, nil
+}
+
+func (f fakeListContext) QueryPaneLog() ([]PaneLogEntry, error) {
+	return nil, nil
 }

--- a/internal/server/commands_input.go
+++ b/internal/server/commands_input.go
@@ -22,7 +22,7 @@ const tokenKeyGap = 50 * time.Millisecond
 
 const (
 	broadcastUsage              = "usage: broadcast (--panes <pane,pane,...> | --window <index|name> | --match <glob>) [--hex] <keys>..."
-	sendKeysUsage               = "usage: send-keys <pane> [--via pty|client] [--client <id>] [--wait ready|ui=input-idle] [--timeout <duration>] [--delay-final <duration>] [--hex] <keys>..."
+	sendKeysUsage               = "usage: send-keys (<pane>|--window <index|name>) [--via pty|client] [--client <id>] [--wait ready|ui=input-idle] [--timeout <duration>] [--delay-final <duration>] [--hex] <keys>..."
 	typeKeysUsage               = "usage: type-keys [--wait ui=input-idle] [--timeout <duration>] [--hex] <keys>..."
 	defaultCommandUIWaitTimeout = 5 * time.Second
 )
@@ -93,6 +93,24 @@ type inputCommandContext struct {
 	*CommandContext
 }
 
+type sendKeysTarget struct {
+	paneRef   string
+	windowRef string
+}
+
+func parseSendKeysTarget(args []string) (sendKeysTarget, []string, error) {
+	if len(args) == 0 {
+		return sendKeysTarget{}, nil, errors.New(sendKeysUsage)
+	}
+	if args[0] == "--window" {
+		if len(args) < 2 {
+			return sendKeysTarget{}, nil, errors.New(sendKeysUsage)
+		}
+		return sendKeysTarget{windowRef: args[1]}, args[2:], nil
+	}
+	return sendKeysTarget{paneRef: args[0]}, args[1:], nil
+}
+
 func parseTypeKeysArgs(args []string) (typeKeysOptions, error) {
 	opts := typeKeysOptions{waitTimeout: defaultCommandUIWaitTimeout}
 	timeoutSet := false
@@ -141,10 +159,11 @@ func parseTypeKeysArgs(args []string) (typeKeysOptions, error) {
 }
 
 func (ctx inputCommandContext) SendKeys(actorPaneID uint32, args []string) (string, int, error) {
-	if len(args) < 2 {
-		return "", 0, errors.New(sendKeysUsage)
+	target, optionArgs, err := parseSendKeysTarget(args)
+	if err != nil {
+		return "", 0, err
 	}
-	opts, err := parseSendKeysArgs(args[1:])
+	opts, err := parseSendKeysArgs(optionArgs)
 	if err != nil {
 		return "", 0, err
 	}
@@ -156,14 +175,19 @@ func (ctx inputCommandContext) SendKeys(actorPaneID uint32, args []string) (stri
 		return "", 0, err
 	}
 	applyFinalDelay(chunks, opts.delayFinal)
-	pane, err := ctx.Sess.queryResolvedPaneForActor(actorPaneID, args[0])
+	var pane resolvedPaneRef
+	if target.windowRef != "" {
+		pane, err = ctx.Sess.queryActivePaneForWindow(target.windowRef)
+	} else {
+		pane, err = ctx.Sess.queryResolvedPaneForActor(actorPaneID, target.paneRef)
+	}
 	if err != nil {
 		return "", 0, err
 	}
 	disableAutomaticEnterPacingForIdlePane(chunks, pane.pane)
 	switch opts.waitTarget {
 	case sendKeysWaitReady:
-		if err := waitForPaneReady(ctx.Sess, args[0], pane, waitReadyOptions{timeout: opts.waitTimeout}); err != nil {
+		if err := waitForPaneReady(ctx.Sess, pane.paneName, pane, waitReadyOptions{timeout: opts.waitTimeout}); err != nil {
 			return "", 0, err
 		}
 		if err := enqueueSendKeysInput(ctx.Sess, pane, chunks, opts, nil); err != nil {
@@ -186,7 +210,7 @@ func (ctx inputCommandContext) SendKeys(actorPaneID uint32, args []string) (stri
 }
 
 func cmdSendKeys(ctx *CommandContext) {
-	if len(ctx.Args) > 0 {
+	if len(ctx.Args) > 0 && ctx.Args[0] != "--window" {
 		ref, err := ctx.Sess.queryPaneRef(ctx.Args[0])
 		if err != nil {
 			ctx.replyErr(err.Error())

--- a/internal/server/commands_input_test.go
+++ b/internal/server/commands_input_test.go
@@ -35,7 +35,7 @@ func TestSendKeysCommandUsageIncludesReadyAndVia(t *testing.T) {
 	defer cleanup()
 
 	res := runTestCommand(t, srv, sess, "send-keys", "pane-1")
-	if got := res.cmdErr; got != "usage: send-keys <pane> [--via pty|client] [--client <id>] [--wait ready|ui=input-idle] [--timeout <duration>] [--delay-final <duration>] [--hex] <keys>..." {
+	if got := res.cmdErr; got != "usage: send-keys (<pane>|--window <index|name>) [--via pty|client] [--client <id>] [--wait ready|ui=input-idle] [--timeout <duration>] [--delay-final <duration>] [--hex] <keys>..." {
 		t.Fatalf("send-keys usage error = %q", got)
 	}
 }

--- a/internal/server/list_cwd_test.go
+++ b/internal/server/list_cwd_test.go
@@ -172,7 +172,7 @@ func TestCmdListRejectsUnknownArgs(t *testing.T) {
 	defer cleanup()
 
 	res := runTestCommand(t, srv, sess, "list", "--bogus")
-	if res.cmdErr != "usage: list [--no-cwd]" {
+	if res.cmdErr != "usage: list [--no-cwd] [--json]" {
 		t.Fatalf("cmdErr = %q, want usage", res.cmdErr)
 	}
 }

--- a/internal/server/session_queries.go
+++ b/internal/server/session_queries.go
@@ -270,6 +270,25 @@ func (s *Session) queryResolvedPaneForActor(actorPaneID uint32, ref string) (res
 	})
 }
 
+func (s *Session) queryActivePaneForWindow(ref string) (resolvedPaneRef, error) {
+	return enqueueSessionQuery(s, func(s *Session) (resolvedPaneRef, error) {
+		w := s.resolveWindow(ref)
+		if w == nil {
+			return resolvedPaneRef{}, fmt.Errorf("window %q not found", ref)
+		}
+		if w.ActivePane == nil {
+			return resolvedPaneRef{}, fmt.Errorf("window %q has no active pane", ref)
+		}
+		return resolvedPaneRef{
+			pane:     w.ActivePane,
+			window:   w,
+			paneID:   w.ActivePane.ID,
+			paneName: w.ActivePane.Meta.Name,
+			windowID: w.ID,
+		}, nil
+	})
+}
+
 func (s *Session) queryKillTarget(actorPaneID uint32, ref string) (killTargetSnapshot, error) {
 	return enqueueSessionQuery(s, func(s *Session) (killTargetSnapshot, error) {
 		var pane *mux.Pane

--- a/internal/server/wait_ready_test.go
+++ b/internal/server/wait_ready_test.go
@@ -391,7 +391,7 @@ func TestSendKeysWaitReadyUsage(t *testing.T) {
 	defer cleanup()
 
 	res := runTestCommand(t, srv, sess, "send-keys", "pane-1")
-	if got := res.cmdErr; got != "usage: send-keys <pane> [--via pty|client] [--client <id>] [--wait ready|ui=input-idle] [--timeout <duration>] [--delay-final <duration>] [--hex] <keys>..." {
+	if got := res.cmdErr; got != "usage: send-keys (<pane>|--window <index|name>) [--via pty|client] [--client <id>] [--wait ready|ui=input-idle] [--timeout <duration>] [--delay-final <duration>] [--hex] <keys>..." {
 		t.Fatalf("send-keys usage error = %q", got)
 	}
 }

--- a/test/zoom_test.go
+++ b/test/zoom_test.go
@@ -56,29 +56,50 @@ func TestZoomIndicatorAppearsInWindowListsAndClears(t *testing.T) {
 
 	h.splitH()
 
-	if out := h.runCmd("list"); strings.Contains(out, "window-1Z") {
-		t.Fatalf("unzoomed list should not include zoom marker:\n%s", out)
+	if out := h.runCmd("list"); listZoomColumnForPane(t, out, "pane-1") != "" || strings.Contains(out, "window-1Z") {
+		t.Fatalf("unzoomed list should keep zoom column empty and window name clean:\n%s", out)
 	}
-	if out := h.runCmd("list-windows"); strings.Contains(out, "window-1Z") {
-		t.Fatalf("unzoomed list-windows should not include zoom marker:\n%s", out)
-	}
-
-	h.runCmd("zoom", "pane-1")
-
-	if out := h.runCmd("list"); !strings.Contains(out, "window-1Z") {
-		t.Fatalf("zoomed list should include zoom marker:\n%s", out)
-	}
-	if out := h.runCmd("list-windows"); !strings.Contains(out, "window-1Z") {
-		t.Fatalf("zoomed list-windows should include zoom marker:\n%s", out)
+	if out := h.runCmd("list-windows"); windowListZoomColumnForName(t, out, "window-1") != "" || strings.Contains(out, "window-1Z") {
+		t.Fatalf("unzoomed list-windows should keep zoom column empty and window name clean:\n%s", out)
 	}
 
 	h.runCmd("zoom", "pane-1")
 
-	if out := h.runCmd("list"); strings.Contains(out, "window-1Z") {
-		t.Fatalf("unzoomed list should clear zoom marker:\n%s", out)
+	if out := h.runCmd("list"); listWindowColumnForPane(t, out, "pane-1") != "window-1" || listZoomColumnForPane(t, out, "pane-1") != "Z" || strings.Contains(out, "window-1Z") {
+		t.Fatalf("zoomed list should keep window name clean and show separate zoom marker:\n%s", out)
 	}
-	if out := h.runCmd("list-windows"); strings.Contains(out, "window-1Z") {
-		t.Fatalf("unzoomed list-windows should clear zoom marker:\n%s", out)
+	if out := h.runCmd("list-windows"); windowListZoomColumnForName(t, out, "window-1") != "Z" || strings.Contains(out, "window-1Z") {
+		t.Fatalf("zoomed list-windows should keep window name clean and show separate zoom marker:\n%s", out)
+	}
+
+	h.runCmd("zoom", "pane-1")
+
+	if out := h.runCmd("list"); listZoomColumnForPane(t, out, "pane-1") != "" || strings.Contains(out, "window-1Z") {
+		t.Fatalf("unzoomed list should clear separate zoom marker:\n%s", out)
+	}
+	if out := h.runCmd("list-windows"); windowListZoomColumnForName(t, out, "window-1") != "" || strings.Contains(out, "window-1Z") {
+		t.Fatalf("unzoomed list-windows should clear separate zoom marker:\n%s", out)
+	}
+}
+
+func TestZoomedWindowNameFromListTargetsWindowCommands(t *testing.T) {
+	t.Parallel()
+	h := newServerHarness(t)
+
+	h.splitH()
+	h.runCmd("zoom", "pane-1")
+
+	listOut := h.runCmd("list")
+	windowName := listWindowColumnForPane(t, listOut, "pane-1")
+	if windowName != "window-1" {
+		t.Fatalf("WINDOW column = %q, want window-1\n%s", windowName, listOut)
+	}
+
+	if out := h.runCmd("spawn", "--window", windowName, "--name", "spawned-from-list"); strings.Contains(out, "not found") {
+		t.Fatalf("spawn --window with list window name failed:\n%s\nlist:\n%s", out, listOut)
+	}
+	if out := h.runCmd("send-keys", "--window", windowName, "echo", "Enter"); strings.Contains(out, "not found") || strings.Contains(out, "usage:") {
+		t.Fatalf("send-keys --window with list window name failed:\n%s\nlist:\n%s", out, listOut)
 	}
 }
 
@@ -112,6 +133,69 @@ func TestZoomedWindowJSONFields(t *testing.T) {
 
 	h.runCmd("zoom", "pane-1")
 	assertWindowZoomed("after unzoom", false)
+}
+
+func listWindowColumnForPane(t *testing.T, listOut, paneName string) string {
+	t.Helper()
+	return listColumnForPane(t, listOut, paneName, "WINDOW", "ZOOM")
+}
+
+func listZoomColumnForPane(t *testing.T, listOut, paneName string) string {
+	t.Helper()
+	return listColumnForPane(t, listOut, paneName, "ZOOM", "TASK")
+}
+
+func listColumnForPane(t *testing.T, listOut, paneName, column, nextColumn string) string {
+	t.Helper()
+
+	lines := strings.Split(strings.TrimSpace(listOut), "\n")
+	if len(lines) < 2 {
+		t.Fatalf("list output missing rows:\n%s", listOut)
+	}
+	line := listLineForPane(listOut, paneName)
+	if line == "" {
+		t.Fatalf("list output missing pane %q:\n%s", paneName, listOut)
+	}
+	return fixedWidthColumn(t, lines[0], line, column, nextColumn)
+}
+
+func windowListZoomColumnForName(t *testing.T, listOut, windowName string) string {
+	t.Helper()
+
+	lines := strings.Split(strings.TrimSpace(listOut), "\n")
+	if len(lines) < 2 {
+		t.Fatalf("list-windows output missing rows:\n%s", listOut)
+	}
+	for _, line := range lines[1:] {
+		if fixedWidthColumn(t, lines[0], line, "NAME", "ZOOM") == windowName {
+			return fixedWidthColumn(t, lines[0], line, "ZOOM", "PANES")
+		}
+	}
+	t.Fatalf("list-windows output missing window %q:\n%s", windowName, listOut)
+	return ""
+}
+
+func fixedWidthColumn(t *testing.T, header, row, column, nextColumn string) string {
+	t.Helper()
+
+	start := strings.Index(header, column)
+	if start < 0 {
+		t.Fatalf("header missing %q: %q", column, header)
+	}
+	end := len(row)
+	if nextColumn != "" {
+		next := strings.Index(header, nextColumn)
+		if next < 0 {
+			t.Fatalf("header missing next column %q: %q", nextColumn, header)
+		}
+		if next > start {
+			end = min(next, len(row))
+		}
+	}
+	if start >= len(row) {
+		return ""
+	}
+	return strings.TrimSpace(row[start:end])
 }
 
 func TestZoomSinglePaneFails(t *testing.T) {


### PR DESCRIPTION
## Motivation

`amux list` exposed zoom state by mutating the WINDOW value, so callers that copied that displayed name into window-targeted commands could get `window "...Z" not found`. LAB-1847 keeps the canonical window name round-trippable while preserving visible zoom state.

## Summary

- Keep WINDOW/NAME values clean in `amux list` and `amux list-windows`.
- Add a separate ZOOM column for zoomed windows in tabular output.
- Add `amux list --json` with a top-level `window_zoomed` boolean per row.
- Allow `send-keys --window <index|name>` to target the active pane in a named window, matching the issue's round-trip expectation.

## Testing

- `go test ./internal/server/commands/listing -run 'TestFormatWindowNameLeavesZoomMarkerOutOfName|TestFormatPaneListMarksZoomedWindow|TestListJSONIncludesCleanWindowAndZoomedFlag' -count=100`
- `go test ./internal/server -run 'TestSendKeysCommandUsageIncludesReadyAndVia|TestSendKeysWaitReadyUsage|TestCmdListRejectsUnknownArgs' -count=100`
- `go test ./internal/cli -run 'TestMainSendKeysUsageIncludesWaitReadyFlags|TestMainKeyCommandsHelpFlagsPrintUsage|TestMainSendKeysUsageIncludesViaFlags' -count=100`
- `go test ./internal/cli -run 'TestMaybePrintSendKeysUsageRequiresWindowKeys|TestRunMainHelpAndUsageErrors|TestMainSendKeysWindowUsageRequiresKeys' -count=100`
- `go test ./test -run 'TestZoomIndicatorAppearsInWindowListsAndClears|TestZoomedWindowNameFromListTargetsWindowCommands' -count=100`
- `go test ./... -timeout 120s`

## Review focus

Check the `amux list` column layout and JSON shape, especially that `window` remains canonical while `window_zoomed`/ZOOM carry the display marker. Also check the `send-keys --window` target resolution path because it now resolves a window name to that window's active pane.

Closes LAB-1847
