### PR TITLE
LAB-1853: Gate renderer snapshot benchmark regressions

### DIFF
--- a/.github/workflows/renderer-benchmark.yml
+++ b/.github/workflows/renderer-benchmark.yml
@@ -1,0 +1,73 @@
+name: Renderer Benchmark Gate
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "internal/client/renderer*.go"
+      - "internal/mux/emulator.go"
+      - ".github/workflows/renderer-benchmark.yml"
+      - "scripts/check-benchmark-regression.py"
+
+permissions:
+  contents: read
+
+env:
+  BENCHMARK_NAME: BenchmarkPublishPaneCaptureFullScrollback
+  REGRESSION_THRESHOLD: "1.25"
+
+jobs:
+  renderer-benchmark:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out PR
+        uses: actions/checkout@v6.0.2
+        with:
+          path: head
+
+      - name: Check out main baseline
+        uses: actions/checkout@v6.0.2
+        with:
+          path: base
+          ref: ${{ github.event.pull_request.base.sha }}
+
+      - uses: actions/setup-go@v6.3.0
+        with:
+          go-version: "1.25"
+          cache-dependency-path: head/go.sum
+
+      - name: Backfill new benchmark on baseline checkout
+        run: |
+          if ! grep -q "$BENCHMARK_NAME" base/internal/client/renderer_bench_test.go; then
+            cp head/internal/client/renderer_bench_test.go base/internal/client/renderer_bench_test.go
+          fi
+
+      - name: Run main baseline benchmark
+        working-directory: base
+        run: |
+          go test ./internal/client -run '^$' -bench "^${BENCHMARK_NAME}$" -benchmem -count=10 -timeout 120s \
+            | tee ../bench-base.txt
+
+      - name: Run PR benchmark
+        working-directory: head
+        run: |
+          go test ./internal/client -run '^$' -bench "^${BENCHMARK_NAME}$" -benchmem -count=10 -timeout 120s \
+            | tee ../bench-head.txt
+
+      - name: Compare against main baseline
+        working-directory: head
+        run: |
+          set -o pipefail
+          python3 scripts/check-benchmark-regression.py \
+            --baseline ../bench-base.txt \
+            --candidate ../bench-head.txt \
+            --benchmark "$BENCHMARK_NAME" \
+            --threshold "$REGRESSION_THRESHOLD" \
+            | tee ../renderer-benchmark-summary.md
+
+      - name: Write benchmark summary
+        if: always()
+        run: |
+          if [[ -f renderer-benchmark-summary.md ]]; then
+            cat renderer-benchmark-summary.md >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/internal/client/renderer_bench_test.go
+++ b/internal/client/renderer_bench_test.go
@@ -119,6 +119,19 @@ func benchScrollbackPayload(paneID uint32, lines int) []byte {
 	return []byte(b.String())
 }
 
+func benchWideScrollbackPayload(paneID uint32, width, lines int) []byte {
+	var b strings.Builder
+	lineWidth := max(1, width-1)
+	for line := 0; line < lines; line++ {
+		prefix := fmt.Sprintf("pane-%d scrollback row %04d ", paneID, line)
+		if len(prefix) > lineWidth {
+			prefix = prefix[:lineWidth]
+		}
+		fmt.Fprintf(&b, "\x1b[3%dm%s%s\x1b[0m\r\n", (int(paneID)+line)%8, prefix, strings.Repeat("x", lineWidth-len(prefix)))
+	}
+	return []byte(b.String())
+}
+
 func benchStyledHistory(paneID uint32, lines int) []proto.StyledLine {
 	history := make([]proto.StyledLine, lines)
 	for line := 0; line < lines; line++ {
@@ -330,6 +343,34 @@ func BenchmarkCapturePaneRenderSnapshotIncrementalScrollback(b *testing.B) {
 			b.Fatalf("write payload: %v", err)
 		}
 		_, state = capturePaneRenderSnapshot(emu, state)
+	}
+}
+
+func BenchmarkPublishPaneCaptureFullScrollback(b *testing.B) {
+	const (
+		width           = 200
+		layoutHeight    = 25
+		scrollbackLines = mux.DefaultScrollbackLines
+		paneID          = 1
+	)
+
+	r := NewWithScrollback(width, layoutHeight+1, scrollbackLines)
+	defer r.Close()
+	r.HandleLayout(benchLayoutSnapshot(1, width, layoutHeight))
+
+	paneContentHeight := mux.PaneContentHeight(layoutHeight)
+	r.HandlePaneOutputInfo(paneID, benchWideScrollbackPayload(paneID, width, scrollbackLines+paneContentHeight), true)
+	if got := len(r.snapshot().paneCaptures[paneID].scrollback); got != scrollbackLines {
+		b.Fatalf("preloaded scrollback lines = %d, want %d", got, scrollbackLines)
+	}
+
+	payload := []byte("renderer actor append\r\n")
+
+	b.SetBytes(int64(len(payload)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		r.HandlePaneOutputInfo(paneID, payload, true)
 	}
 }
 

--- a/scripts/check-benchmark-regression.py
+++ b/scripts/check-benchmark-regression.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+import argparse
+import re
+import statistics
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass
+class BenchSamples:
+    ns_op: list[float]
+    bytes_op: list[float]
+    allocs_op: list[float]
+
+
+def normalize_name(name: str) -> str:
+    return re.sub(r"-\d+$", "", name)
+
+
+def parse_benchmarks(path: Path, benchmark: str) -> BenchSamples:
+    samples = BenchSamples(ns_op=[], bytes_op=[], allocs_op=[])
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if not line.startswith("Benchmark"):
+            continue
+        fields = line.split()
+        if len(fields) < 4 or normalize_name(fields[0]) != benchmark:
+            continue
+        for idx, field in enumerate(fields):
+            if field == "ns/op" and idx > 0:
+                samples.ns_op.append(float(fields[idx - 1]))
+            elif field == "B/op" and idx > 0:
+                samples.bytes_op.append(float(fields[idx - 1]))
+            elif field == "allocs/op" and idx > 0:
+                samples.allocs_op.append(float(fields[idx - 1]))
+    if not samples.ns_op or not samples.allocs_op:
+        raise ValueError(f"{path} has no complete samples for {benchmark}")
+    return samples
+
+
+def median(values: list[float]) -> float:
+    if not values:
+        return 0
+    return statistics.median(values)
+
+
+def ratio(candidate: float, baseline: float) -> float:
+    if baseline == 0:
+        return float("inf") if candidate > 0 else 1
+    return candidate / baseline
+
+
+def fmt(value: float) -> str:
+    if value == float("inf"):
+        return "inf"
+    return f"{value:,.0f}"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Fail when benchmark medians regress past a threshold."
+    )
+    parser.add_argument("--baseline", required=True, type=Path)
+    parser.add_argument("--candidate", required=True, type=Path)
+    parser.add_argument("--benchmark", required=True)
+    parser.add_argument("--threshold", required=True, type=float)
+    args = parser.parse_args()
+
+    baseline = parse_benchmarks(args.baseline, args.benchmark)
+    candidate = parse_benchmarks(args.candidate, args.benchmark)
+
+    base_ns = median(baseline.ns_op)
+    cand_ns = median(candidate.ns_op)
+    base_bytes = median(baseline.bytes_op)
+    cand_bytes = median(candidate.bytes_op)
+    base_allocs = median(baseline.allocs_op)
+    cand_allocs = median(candidate.allocs_op)
+    ns_ratio = ratio(cand_ns, base_ns)
+    allocs_ratio = ratio(cand_allocs, base_allocs)
+
+    print(f"## Renderer benchmark regression check")
+    print()
+    print(f"Benchmark: `{args.benchmark}`")
+    print(
+        f"Threshold: fail when `ns/op` or `allocs/op` exceeds baseline by more than {(args.threshold - 1) * 100:.0f}%"
+    )
+    print()
+    print("| Metric | Main baseline median | PR median | Ratio |")
+    print("| --- | ---: | ---: | ---: |")
+    print(f"| ns/op | {fmt(base_ns)} | {fmt(cand_ns)} | {ns_ratio:.2f}x |")
+    print(
+        f"| B/op | {fmt(base_bytes)} | {fmt(cand_bytes)} | {ratio(cand_bytes, base_bytes):.2f}x |"
+    )
+    print(
+        f"| allocs/op | {fmt(base_allocs)} | {fmt(cand_allocs)} | {allocs_ratio:.2f}x |"
+    )
+
+    failed = ns_ratio > args.threshold or allocs_ratio > args.threshold
+    if failed:
+        print()
+        if ns_ratio > args.threshold:
+            print(f"::error::{args.benchmark} ns/op regressed by {ns_ratio:.2f}x")
+        if allocs_ratio > args.threshold:
+            print(
+                f"::error::{args.benchmark} allocs/op regressed by {allocs_ratio:.2f}x"
+            )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except Exception as exc:
+        print(f"::error::{exc}", file=sys.stderr)
+        raise SystemExit(2)


### PR DESCRIPTION
## Motivation

The renderer actor per-output capture-snapshot path has regressed four times recently without CI catching it. This adds benchmark coverage for the full-scrollback, high-frequency-output case that previously showed up as client lag only after live pprof investigation.

## Summary

- Added `BenchmarkPublishPaneCaptureFullScrollback` for one visible renderer pane at the 5000-row scrollback cap and width 200.
- The benchmark drives `HandlePaneOutputInfo` with a small append per iteration and reports `ns/op`, `B/op`, and `allocs/op` without a PTY or client connection.
- Added a PR-only renderer benchmark gate for changes to `internal/client/renderer*.go` or `internal/mux/emulator.go`.
- The gate compares PR median `ns/op` and `allocs/op` against the main baseline and fails above a documented 25% regression threshold.

## Testing

- `go test ./internal/client -run '^$' -bench '^BenchmarkPublishPaneCaptureFullScrollback$' -benchmem -count=1 -timeout 120s`
- `go test ./internal/client -run '^$' -bench '^BenchmarkPublishPaneCaptureFullScrollback$' -benchmem -count=10 -timeout 120s`
- `go test ./internal/client -count=1 -timeout 120s`
- `python3 scripts/check-benchmark-regression.py --baseline /tmp/lab1853-renderer-benchmark-count10.txt --candidate /tmp/lab1853-renderer-benchmark-count10.txt --benchmark BenchmarkPublishPaneCaptureFullScrollback --threshold 1.25`
- `base=$(mktemp -d /tmp/lab1853-base.XXXXXX); git archive origin/main | tar -x -C "$base"; cp internal/client/renderer_bench_test.go "$base/internal/client/renderer_bench_test.go"; (cd "$base" && go test ./internal/client -run '^$' -bench '^BenchmarkPublishPaneCaptureFullScrollback$' -benchmem -count=3 -timeout 120s | tee /tmp/lab1853-renderer-benchmark-base-count3.txt); python3 scripts/check-benchmark-regression.py --baseline /tmp/lab1853-renderer-benchmark-base-count3.txt --candidate /tmp/lab1853-renderer-benchmark-count10.txt --benchmark BenchmarkPublishPaneCaptureFullScrollback --threshold 1.25`

Attempted `codex review --base origin/main`; it did not return promptly, so I stopped it and completed a manual diff review and simplification pass instead.

## Review focus

- Whether the benchmark setup is the right proxy for the renderer actor hot path: one visible pane, 5000 retained rows, width 200, and small append events through `HandlePaneOutputInfo`.
- Whether the first-run CI baseline backfill is acceptable: the workflow copies the PR benchmark file into the base checkout only when main does not yet contain this benchmark.
- Whether the 25% median threshold on `ns/op` and `allocs/op` is the right initial balance for GitHub runner noise.

## Baseline numbers

Hardware: AMD EPYC-Milan Processor, linux/amd64, Go 1.25.0.

| Benchmark | Count | ns/op median | ns/op range | B/op median | allocs/op median |
| --- | ---: | ---: | ---: | ---: | ---: |
| `BenchmarkPublishPaneCaptureFullScrollback` | 10 | 457,390 | 433,588-482,058 | 619,576 | 168 |

Simulated main-baseline comparison, using `origin/main` plus the new benchmark file because this PR introduces the benchmark, produced `0.93x ns/op`, `1.00x B/op`, and `1.00x allocs/op` versus the PR run.

Closes LAB-1853
