### PR TITLE
LAB-1859: Use rounded Powerline separators

### DIFF
--- a/internal/cli/main_doctor_fonts_test.go
+++ b/internal/cli/main_doctor_fonts_test.go
@@ -31,8 +31,8 @@ func TestMainDoctorFontsPrintsIconDiagnostic(t *testing.T) {
 		`icons = "nerd"`,
 		`status_style = "powerline"`,
 		"powerline:",
-		"right=\ue0b0",
-		"left=\ue0b2",
+		"right=\ue0b4",
+		"left=\ue0b6",
 	} {
 		if !strings.Contains(output, want) {
 			t.Fatalf("doctor fonts output missing %q:\n%s", want, output)

--- a/internal/render/statusbar.go
+++ b/internal/render/statusbar.go
@@ -25,8 +25,8 @@ const (
 )
 
 const (
-	powerlineRightSeparator = "\ue0b0" // Nerd Font Powerline right-pointing solid separator.
-	powerlineLeftSeparator  = "\ue0b2" // Nerd Font Powerline left-pointing solid separator.
+	powerlineRightSeparator = "\ue0b4" // Nerd Font Powerline right rounded separator.
+	powerlineLeftSeparator  = "\ue0b6" // Nerd Font Powerline left rounded separator.
 )
 
 // PowerlineSeparators returns the glyphs used by the Powerline status style.

--- a/test/harness_test.go
+++ b/test/harness_test.go
@@ -526,7 +526,9 @@ func extractBorderColors(line string) []string {
 // Matches the structural pattern: " amux │ ... panes │ HH:MM "
 func isGlobalBar(line string) bool {
 	return strings.Contains(line, " amux ") &&
-		(strings.Contains(line, "panes │") || strings.Contains(line, "panes "))
+		(strings.Contains(line, "panes │") ||
+			strings.Contains(line, "panes ") ||
+			strings.Contains(line, "panes "))
 }
 
 // hasWindowTab returns true if the global bar contains a tab for the given

--- a/test/testdata/status_style_powerline.golden
+++ b/test/testdata/status_style_powerline.golden
@@ -1,5 +1,5 @@
-● pane-1#42, LAB-1651@gpubuild
+● pane-1#42, LAB-1651@gpubuild
 
 
 
- amux  SESSION          1 panes  ? help  00:00
+ amux  SESSION          1 panes  ? help  00:00


### PR DESCRIPTION
## Motivation

The Powerline status preset used sharp triangular transitions for pane headers and the global status line. LAB-1859 asks for the softer rounded Powerline edges while keeping the existing preset and config surface unchanged.

## Summary

- Hard-replaced the Powerline preset separators from `U+E0B0`/`U+E0B2` to `U+E0B4`/`U+E0B6`.
- Updated the Powerline status golden to show rounded pane-header and global-bar transitions.
- Kept the golden-frame extractor compatible with both the previous and new left separator so older structural captures are still recognized.

Design note: this uses approach 1 from the brief. The sharp glyph constants were only used by the Powerline preset and its tests, so adding a new config option would add surface area without a current second consumer.

Golden diff:

```diff
-● pane-1#42, LAB-1651@gpubuild
+● pane-1#42, LAB-1651@gpubuild

- amux  SESSION          1 panes  ? help  00:00
+ amux  SESSION          1 panes  ? help  00:00
```

## Testing

- `go test ./test -run TestStatusStyleGoldenOutputs -count=100`
- `go test ./internal/cli -run '^TestMainDoctorFontsPrintsIconDiagnostic$' -count=100`
- `go test ./internal/render -run 'TestBuildPowerlineStatusCellsUsesSeparatorColorTransitions|TestRenderPaneStatusPowerlineFullANSI|TestBuildGlobalBarCellsPowerline|TestRenderGlobalBarPowerlineFullANSI|TestPowerlineStatusHelpers' -count=100`
- `go test ./internal/render -run TestGolden`
- `go test ./internal/render ./internal/config ./test -timeout 60s` was attempted, but the local full `./test` package run is unstable in this worker on unrelated integration tests. The failing tests varied across runs (`TestMetaSetStoresArbitraryMetadataAndProjectsReservedKeys`, `TestCaptureJSONIncludesPaneMetaKV`, `TestCrashRecovery_PreservesHistoryCapture`, and `TestWatchPRCIScriptPassesWhenRequiredChecksSucceed`); each isolated rerun passed with `SHELL=/bin/bash`.

## Review focus

Check that the hard replacement is acceptable for the existing Powerline preset and that the golden output reflects the desired rounded `U+E0B4`/`U+E0B6` transitions in both pane headers and the global status line.

Closes LAB-1859
