### PR TITLE
LAB-1858: Cache rendered capture ANSI between screen changes

### DIFF
--- a/internal/client/renderer.go
+++ b/internal/client/renderer.go
@@ -176,7 +176,7 @@ func (r *Renderer) HandlePaneOutput(paneID uint32, data []byte) bool {
 			if emu := st.emulators[paneID]; emu != nil {
 				st.warmPaneOutput(paneID, st.emulators)
 				_, _ = emu.Write(data)
-				r.publishPaneCapture(st, paneID)
+				_ = r.publishPaneCapture(st, paneID)
 				return false
 			}
 			st.bufferPaneOutput(paneID, data)
@@ -188,7 +188,7 @@ func (r *Renderer) HandlePaneOutput(paneID uint32, data []byte) bool {
 		}
 		st.warmPaneOutput(paneID, st.emulators)
 		_, _ = emu.Write(data)
-		r.publishPaneCapture(st, paneID)
+		_ = r.publishPaneCapture(st, paneID)
 		return true
 	})
 }
@@ -223,7 +223,7 @@ func (r *Renderer) HandlePaneOutputInfo(paneID uint32, data []byte, trackCursor 
 			if emu := st.emulators[paneID]; emu != nil {
 				st.warmPaneOutput(paneID, st.emulators)
 				_, _ = emu.Write(data)
-				r.publishPaneCapture(st, paneID)
+				_ = r.publishPaneCapture(st, paneID)
 				return paneOutputRenderInfo{}
 			}
 			st.bufferPaneOutput(paneID, data)
@@ -245,11 +245,10 @@ func (r *Renderer) HandlePaneOutputInfo(paneID uint32, data []byte, trackCursor 
 		info := paneOutputRenderInfo{
 			paneVisible: true,
 		}
-		info.screenChanged = emu.DrainScreenChanges()
 		if trackCursor {
 			info.cursorChanged = before != captureTerminalCursorState(emu)
 		}
-		r.publishPaneCapture(st, paneID)
+		info.screenChanged = r.publishPaneCapture(st, paneID)
 		return info
 	})
 }
@@ -537,7 +536,7 @@ func (r *Renderer) capturePaneTextFromActor(paneID uint32, includeANSI bool) str
 			return ""
 		}
 		st.warmPaneOutput(paneID, st.emulators)
-		r.publishPaneCapture(st, paneID)
+		_ = r.publishPaneCapture(st, paneID)
 		if includeANSI {
 			return filterRenderedANSI(emu.Render(), st.snapshot.capabilities)
 		}
@@ -562,7 +561,7 @@ func (r *Renderer) capturePaneValueFromActor(paneID uint32, agentStatus map[uint
 	r.withActor(func(st *rendererActorState) {
 		pane, ok = r.buildCapturePane(st, st.snapshot, paneID, agentStatus, false, nil)
 		if ok {
-			r.publishPaneCapture(st, paneID)
+			_ = r.publishPaneCapture(st, paneID)
 		}
 	})
 	return pane, ok

--- a/internal/client/renderer.go
+++ b/internal/client/renderer.go
@@ -176,7 +176,7 @@ func (r *Renderer) HandlePaneOutput(paneID uint32, data []byte) bool {
 			if emu := st.emulators[paneID]; emu != nil {
 				st.warmPaneOutput(paneID, st.emulators)
 				_, _ = emu.Write(data)
-				_ = r.publishPaneCapture(st, paneID)
+				r.publishPaneCapture(st, paneID)
 				return false
 			}
 			st.bufferPaneOutput(paneID, data)
@@ -188,7 +188,7 @@ func (r *Renderer) HandlePaneOutput(paneID uint32, data []byte) bool {
 		}
 		st.warmPaneOutput(paneID, st.emulators)
 		_, _ = emu.Write(data)
-		_ = r.publishPaneCapture(st, paneID)
+		r.publishPaneCapture(st, paneID)
 		return true
 	})
 }
@@ -223,7 +223,7 @@ func (r *Renderer) HandlePaneOutputInfo(paneID uint32, data []byte, trackCursor 
 			if emu := st.emulators[paneID]; emu != nil {
 				st.warmPaneOutput(paneID, st.emulators)
 				_, _ = emu.Write(data)
-				_ = r.publishPaneCapture(st, paneID)
+				r.publishPaneCapture(st, paneID)
 				return paneOutputRenderInfo{}
 			}
 			st.bufferPaneOutput(paneID, data)
@@ -536,7 +536,7 @@ func (r *Renderer) capturePaneTextFromActor(paneID uint32, includeANSI bool) str
 			return ""
 		}
 		st.warmPaneOutput(paneID, st.emulators)
-		_ = r.publishPaneCapture(st, paneID)
+		r.publishPaneCapture(st, paneID)
 		if includeANSI {
 			return filterRenderedANSI(emu.Render(), st.snapshot.capabilities)
 		}
@@ -561,7 +561,7 @@ func (r *Renderer) capturePaneValueFromActor(paneID uint32, agentStatus map[uint
 	r.withActor(func(st *rendererActorState) {
 		pane, ok = r.buildCapturePane(st, st.snapshot, paneID, agentStatus, false, nil)
 		if ok {
-			_ = r.publishPaneCapture(st, paneID)
+			r.publishPaneCapture(st, paneID)
 		}
 	})
 	return pane, ok

--- a/internal/client/renderer_bench_test.go
+++ b/internal/client/renderer_bench_test.go
@@ -365,12 +365,38 @@ func BenchmarkPublishPaneCaptureFullScrollback(b *testing.B) {
 	}
 
 	payload := []byte("renderer actor append\r\n")
-
 	b.SetBytes(int64(len(payload)))
 	b.ReportAllocs()
 	b.ResetTimer()
 	for b.Loop() {
 		r.HandlePaneOutputInfo(paneID, payload, true)
+	}
+}
+
+func BenchmarkCapturePaneRenderSnapshotRender(b *testing.B) {
+	const (
+		width           = 80
+		height          = 24
+		scrollbackLines = mux.DefaultScrollbackLines
+	)
+
+	emu := mux.NewVTEmulatorWithScrollback(width, height, scrollbackLines)
+	defer emu.Close()
+	if _, err := emu.Write(benchScrollbackPayload(1, height)); err != nil {
+		b.Fatalf("preload screen: %v", err)
+	}
+
+	_, state := capturePaneRenderSnapshot(emu, paneScrollbackSnapshotState{})
+	payload := []byte("\x1b[1;1H\x1b[1;2H")
+
+	b.SetBytes(int64(len(payload)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		if _, err := emu.Write(payload); err != nil {
+			b.Fatalf("write payload: %v", err)
+		}
+		_, state = capturePaneRenderSnapshot(emu, state)
 	}
 }
 

--- a/internal/client/renderer_bench_test.go
+++ b/internal/client/renderer_bench_test.go
@@ -315,7 +315,7 @@ func BenchmarkCapturePaneRenderSnapshotStyledScrollback1KB(b *testing.B) {
 		if _, err := emu.Write(payload); err != nil {
 			b.Fatalf("write payload: %v", err)
 		}
-		_, _ = capturePaneRenderSnapshot(emu, paneScrollbackSnapshotState{})
+		_, _, _ = capturePaneRenderSnapshot(emu, paneScrollbackSnapshotState{})
 	}
 }
 
@@ -332,7 +332,7 @@ func BenchmarkCapturePaneRenderSnapshotIncrementalScrollback(b *testing.B) {
 		b.Fatalf("preload scrollback: %v", err)
 	}
 
-	_, state := capturePaneRenderSnapshot(emu, paneScrollbackSnapshotState{})
+	_, state, _ := capturePaneRenderSnapshot(emu, paneScrollbackSnapshotState{})
 	payload := []byte("incremental scrollback append\r\n")
 
 	b.SetBytes(int64(len(payload)))
@@ -342,7 +342,7 @@ func BenchmarkCapturePaneRenderSnapshotIncrementalScrollback(b *testing.B) {
 		if _, err := emu.Write(payload); err != nil {
 			b.Fatalf("write payload: %v", err)
 		}
-		_, state = capturePaneRenderSnapshot(emu, state)
+		_, state, _ = capturePaneRenderSnapshot(emu, state)
 	}
 }
 
@@ -386,7 +386,7 @@ func BenchmarkCapturePaneRenderSnapshotRender(b *testing.B) {
 		b.Fatalf("preload screen: %v", err)
 	}
 
-	_, state := capturePaneRenderSnapshot(emu, paneScrollbackSnapshotState{})
+	_, state, _ := capturePaneRenderSnapshot(emu, paneScrollbackSnapshotState{})
 	payload := []byte("\x1b[1;1H\x1b[1;2H")
 
 	b.SetBytes(int64(len(payload)))
@@ -396,7 +396,7 @@ func BenchmarkCapturePaneRenderSnapshotRender(b *testing.B) {
 		if _, err := emu.Write(payload); err != nil {
 			b.Fatalf("write payload: %v", err)
 		}
-		_, state = capturePaneRenderSnapshot(emu, state)
+		_, state, _ = capturePaneRenderSnapshot(emu, state)
 	}
 }
 

--- a/internal/client/renderer_capture_snapshot.go
+++ b/internal/client/renderer_capture_snapshot.go
@@ -39,10 +39,9 @@ type paneScrollbackSnapshotState struct {
 	cursorBlockCol   int
 	cursorBlockRow   int
 	hasCursorBlock   bool
-	screenChanged    bool
 }
 
-func capturePaneRenderSnapshot(emu mux.TerminalEmulator, prev paneScrollbackSnapshotState) (paneRenderSnapshot, paneScrollbackSnapshotState) {
+func capturePaneRenderSnapshot(emu mux.TerminalEmulator, prev paneScrollbackSnapshotState) (paneRenderSnapshot, paneScrollbackSnapshotState, bool) {
 	width, height := emu.Size()
 	cursorCol, cursorRow := emu.CursorPosition()
 	screenChanged := emu.DrainScreenChanges()
@@ -83,13 +82,14 @@ func capturePaneRenderSnapshot(emu mux.TerminalEmulator, prev paneScrollbackSnap
 	scrollbackState.cursorBlockCol = cursorBlockCol
 	scrollbackState.cursorBlockRow = cursorBlockRow
 	scrollbackState.hasCursorBlock = hasCursorBlock
-	scrollbackState.screenChanged = screenChanged
-	return snap, scrollbackState
+	return snap, scrollbackState, screenChanged
 }
 
 func captureRenderedSnapshot(emu mux.TerminalEmulator, prev paneScrollbackSnapshotState, width, height int, screenChanged bool, cursorBlockCol, cursorBlockRow int, hasCursorBlock bool) (rendered, renderedNoCursor string) {
 	renderCacheValid := prev.renderedValid && prev.renderWidth == width && prev.renderHeight == height
-	if !renderCacheValid || screenChanged {
+	cursorBlockChanged := prev.hasCursorBlock != hasCursorBlock ||
+		(hasCursorBlock && (prev.cursorBlockCol != cursorBlockCol || prev.cursorBlockRow != cursorBlockRow))
+	if !renderCacheValid || screenChanged || cursorBlockChanged {
 		rendered = emu.Render()
 		renderedNoCursor = rendered
 		if hasCursorBlock {
@@ -102,10 +102,7 @@ func captureRenderedSnapshot(emu mux.TerminalEmulator, prev paneScrollbackSnapsh
 	if !hasCursorBlock {
 		return rendered, rendered
 	}
-	if prev.hasCursorBlock && prev.cursorBlockCol == cursorBlockCol && prev.cursorBlockRow == cursorBlockRow {
-		return rendered, prev.renderedNoCursor
-	}
-	return rendered, renderWithoutCursorBlockSnapshot(emu)
+	return rendered, prev.renderedNoCursor
 }
 
 func renderWithoutCursorBlockSnapshot(emu mux.TerminalEmulator) string {

--- a/internal/client/renderer_capture_snapshot.go
+++ b/internal/client/renderer_capture_snapshot.go
@@ -31,11 +31,21 @@ type paneScrollbackSnapshotState struct {
 	scrollbackLen    int
 	scrollbackPushed uint64
 	scrollback       []paneBufferLine
+	renderWidth      int
+	renderHeight     int
+	rendered         string
+	renderedNoCursor string
+	renderedValid    bool
+	cursorBlockCol   int
+	cursorBlockRow   int
+	hasCursorBlock   bool
+	screenChanged    bool
 }
 
 func capturePaneRenderSnapshot(emu mux.TerminalEmulator, prev paneScrollbackSnapshotState) (paneRenderSnapshot, paneScrollbackSnapshotState) {
 	width, height := emu.Size()
 	cursorCol, cursorRow := emu.CursorPosition()
+	screenChanged := emu.DrainScreenChanges()
 	scrollbackState := captureScrollbackSnapshot(emu, prev)
 
 	screen := make([]paneBufferLine, height)
@@ -46,7 +56,8 @@ func capturePaneRenderSnapshot(emu mux.TerminalEmulator, prev paneScrollbackSnap
 		}
 	}
 
-	rendered := emu.Render()
+	cursorBlockCol, cursorBlockRow, hasCursorBlock := emu.CursorBlockPosition()
+	rendered, renderedNoCursor := captureRenderedSnapshot(emu, prev, width, height, screenChanged, cursorBlockCol, cursorBlockRow, hasCursorBlock)
 	snap := paneRenderSnapshot{
 		width:            width,
 		height:           height,
@@ -55,17 +66,54 @@ func capturePaneRenderSnapshot(emu mux.TerminalEmulator, prev paneScrollbackSnap
 		cursorHidden:     emu.CursorHidden(),
 		terminal:         cloneTerminalState(emu.TerminalState()),
 		rendered:         rendered,
-		renderedNoCursor: rendered,
+		renderedNoCursor: renderedNoCursor,
 		scrollback:       scrollbackState.scrollback,
 		screen:           screen,
 	}
-	if col, row, ok := emu.CursorBlockPosition(); ok {
-		snap.cursorBlockCol = col
-		snap.cursorBlockRow = row
+	if hasCursorBlock {
+		snap.cursorBlockCol = cursorBlockCol
+		snap.cursorBlockRow = cursorBlockRow
 		snap.hasCursorBlock = true
-		snap.renderedNoCursor = emu.RenderWithoutCursorBlock()
 	}
+	scrollbackState.renderWidth = width
+	scrollbackState.renderHeight = height
+	scrollbackState.rendered = rendered
+	scrollbackState.renderedNoCursor = renderedNoCursor
+	scrollbackState.renderedValid = true
+	scrollbackState.cursorBlockCol = cursorBlockCol
+	scrollbackState.cursorBlockRow = cursorBlockRow
+	scrollbackState.hasCursorBlock = hasCursorBlock
+	scrollbackState.screenChanged = screenChanged
 	return snap, scrollbackState
+}
+
+func captureRenderedSnapshot(emu mux.TerminalEmulator, prev paneScrollbackSnapshotState, width, height int, screenChanged bool, cursorBlockCol, cursorBlockRow int, hasCursorBlock bool) (rendered, renderedNoCursor string) {
+	renderCacheValid := prev.renderedValid && prev.renderWidth == width && prev.renderHeight == height
+	if !renderCacheValid || screenChanged {
+		rendered = emu.Render()
+		renderedNoCursor = rendered
+		if hasCursorBlock {
+			renderedNoCursor = renderWithoutCursorBlockSnapshot(emu)
+		}
+		return rendered, renderedNoCursor
+	}
+
+	rendered = prev.rendered
+	if !hasCursorBlock {
+		return rendered, rendered
+	}
+	if prev.hasCursorBlock && prev.cursorBlockCol == cursorBlockCol && prev.cursorBlockRow == cursorBlockRow {
+		return rendered, prev.renderedNoCursor
+	}
+	return rendered, renderWithoutCursorBlockSnapshot(emu)
+}
+
+func renderWithoutCursorBlockSnapshot(emu mux.TerminalEmulator) string {
+	rendered := emu.RenderWithoutCursorBlock()
+	// RenderWithoutCursorBlock temporarily edits emulator cells. Clear that
+	// internal touched state so the next snapshot only sees real PTY changes.
+	emu.DrainScreenChanges()
+	return rendered
 }
 
 func captureScrollbackSnapshot(emu mux.TerminalEmulator, prev paneScrollbackSnapshotState) paneScrollbackSnapshotState {

--- a/internal/client/renderer_capture_snapshot_test.go
+++ b/internal/client/renderer_capture_snapshot_test.go
@@ -38,9 +38,12 @@ func (e *captureSnapshotFakeEmulator) DrainScreenChanges() bool {
 	e.screenChanged = false
 	return changed
 }
-func (e *captureSnapshotFakeEmulator) Read([]byte) (int, error)   { return 0, io.EOF }
-func (e *captureSnapshotFakeEmulator) Close() error               { return nil }
-func (e *captureSnapshotFakeEmulator) Render() string             { e.renderCalls++; return strings.Join(e.screen, "\n") }
+func (e *captureSnapshotFakeEmulator) Read([]byte) (int, error) { return 0, io.EOF }
+func (e *captureSnapshotFakeEmulator) Close() error             { return nil }
+func (e *captureSnapshotFakeEmulator) Render() string {
+	e.renderCalls++
+	return strings.Join(e.screen, "\n")
+}
 func (e *captureSnapshotFakeEmulator) Resize(width, height int)   { e.width, e.height = width, height }
 func (e *captureSnapshotFakeEmulator) Size() (int, int)           { return e.width, e.height }
 func (e *captureSnapshotFakeEmulator) Reset()                     {}

--- a/internal/client/renderer_capture_snapshot_test.go
+++ b/internal/client/renderer_capture_snapshot_test.go
@@ -17,7 +17,9 @@ type captureSnapshotFakeEmulator struct {
 	scrollback    []string
 	screen        []string
 	pushed        uint64
+	screenChanged bool
 	lineReads     []int
+	renderCalls   int
 }
 
 func newCaptureSnapshotFakeEmulator(lines []string, pushed uint64) *captureSnapshotFakeEmulator {
@@ -31,16 +33,20 @@ func newCaptureSnapshotFakeEmulator(lines []string, pushed uint64) *captureSnaps
 }
 
 func (e *captureSnapshotFakeEmulator) Write(data []byte) (int, error) { return len(data), nil }
-func (e *captureSnapshotFakeEmulator) DrainScreenChanges() bool       { return false }
-func (e *captureSnapshotFakeEmulator) Read([]byte) (int, error)       { return 0, io.EOF }
-func (e *captureSnapshotFakeEmulator) Close() error                   { return nil }
-func (e *captureSnapshotFakeEmulator) Render() string                 { return strings.Join(e.screen, "\n") }
-func (e *captureSnapshotFakeEmulator) Resize(width, height int)       { e.width, e.height = width, height }
-func (e *captureSnapshotFakeEmulator) Size() (int, int)               { return e.width, e.height }
-func (e *captureSnapshotFakeEmulator) Reset()                         {}
-func (e *captureSnapshotFakeEmulator) CursorPosition() (int, int)     { return 0, 0 }
-func (e *captureSnapshotFakeEmulator) CursorPhantom() bool            { return false }
-func (e *captureSnapshotFakeEmulator) CursorHidden() bool             { return false }
+func (e *captureSnapshotFakeEmulator) DrainScreenChanges() bool {
+	changed := e.screenChanged
+	e.screenChanged = false
+	return changed
+}
+func (e *captureSnapshotFakeEmulator) Read([]byte) (int, error)   { return 0, io.EOF }
+func (e *captureSnapshotFakeEmulator) Close() error               { return nil }
+func (e *captureSnapshotFakeEmulator) Render() string             { e.renderCalls++; return strings.Join(e.screen, "\n") }
+func (e *captureSnapshotFakeEmulator) Resize(width, height int)   { e.width, e.height = width, height }
+func (e *captureSnapshotFakeEmulator) Size() (int, int)           { return e.width, e.height }
+func (e *captureSnapshotFakeEmulator) Reset()                     {}
+func (e *captureSnapshotFakeEmulator) CursorPosition() (int, int) { return 0, 0 }
+func (e *captureSnapshotFakeEmulator) CursorPhantom() bool        { return false }
+func (e *captureSnapshotFakeEmulator) CursorHidden() bool         { return false }
 func (e *captureSnapshotFakeEmulator) TerminalState() mux.TerminalState {
 	return mux.TerminalState{}
 }
@@ -205,6 +211,33 @@ func TestCapturePaneRenderSnapshotIncrementalScrollback(t *testing.T) {
 				t.Fatal("snapshot did not reuse previous scrollback backing array")
 			}
 		})
+	}
+}
+
+func TestCapturePaneRenderSnapshotReusesRenderedANSIWhenScreenUnchanged(t *testing.T) {
+	t.Parallel()
+
+	emu := newCaptureSnapshotFakeEmulator(nil, 0)
+	emu.screen = []string{"cached", "screen"}
+	emu.screenChanged = true
+
+	first, state := capturePaneRenderSnapshot(emu, paneScrollbackSnapshotState{})
+	if got, want := emu.renderCalls, 1; got != want {
+		t.Fatalf("initial Render calls = %d, want %d", got, want)
+	}
+
+	emu.renderCalls = 0
+	emu.screenChanged = false
+	second, _ := capturePaneRenderSnapshot(emu, state)
+
+	if got := emu.renderCalls; got != 0 {
+		t.Fatalf("Render calls after unchanged screen = %d, want 0", got)
+	}
+	if second.rendered != first.rendered {
+		t.Fatalf("rendered ANSI changed after unchanged screen: got %q, want %q", second.rendered, first.rendered)
+	}
+	if second.renderedNoCursor != first.renderedNoCursor {
+		t.Fatalf("cursorless ANSI changed after unchanged screen: got %q, want %q", second.renderedNoCursor, first.renderedNoCursor)
 	}
 }
 

--- a/internal/client/renderer_capture_snapshot_test.go
+++ b/internal/client/renderer_capture_snapshot_test.go
@@ -47,7 +47,11 @@ func (e *captureSnapshotFakeEmulator) Read([]byte) (int, error) { return 0, io.E
 func (e *captureSnapshotFakeEmulator) Close() error             { return nil }
 func (e *captureSnapshotFakeEmulator) Render() string {
 	e.renderCalls++
-	return strings.Join(e.screen, "\n")
+	rendered := e.screenANSI()
+	if e.hasCursorBlock {
+		rendered = fmt.Sprintf("%s|cursor:%d,%d", rendered, e.cursorBlockCol, e.cursorBlockRow)
+	}
+	return rendered
 }
 func (e *captureSnapshotFakeEmulator) Resize(width, height int)   { e.width, e.height = width, height }
 func (e *captureSnapshotFakeEmulator) Size() (int, int)           { return e.width, e.height }
@@ -74,7 +78,7 @@ func (e *captureSnapshotFakeEmulator) ScrollbackCellAt(int, int) (uv.Cell, bool)
 }
 func (e *captureSnapshotFakeEmulator) RenderWithoutCursorBlock() string {
 	e.renderNoCursorCalls++
-	return fmt.Sprintf("%s|cursorless:%d,%d", strings.Join(e.screen, "\n"), e.cursorBlockCol, e.cursorBlockRow)
+	return fmt.Sprintf("%s|cursorless:%d,%d", e.screenANSI(), e.cursorBlockCol, e.cursorBlockRow)
 }
 func (e *captureSnapshotFakeEmulator) HasCursorBlock() bool { return e.hasCursorBlock }
 func (e *captureSnapshotFakeEmulator) CursorBlockPosition() (int, int, bool) {
@@ -95,6 +99,10 @@ func (e *captureSnapshotFakeEmulator) MouseProtocol() mux.MouseProtocol {
 }
 func (e *captureSnapshotFakeEmulator) EncodeMouse(mouse.Event, int, int) []byte {
 	return nil
+}
+
+func (e *captureSnapshotFakeEmulator) screenANSI() string {
+	return strings.Join(e.screen, "\n")
 }
 
 func scrollbackState(lines []string, pushed uint64) paneScrollbackSnapshotState {
@@ -199,7 +207,7 @@ func TestCapturePaneRenderSnapshotIncrementalScrollback(t *testing.T) {
 			t.Parallel()
 
 			emu := newCaptureSnapshotFakeEmulator(tt.lines, tt.pushed)
-			snap, state := capturePaneRenderSnapshot(emu, tt.prev)
+			snap, state, _ := capturePaneRenderSnapshot(emu, tt.prev)
 
 			if got := paneRenderSnapshotLines(snap.scrollback); !equalStrings(got, tt.wantLines) {
 				t.Fatalf("snapshot scrollback = %#v, want %#v", got, tt.wantLines)
@@ -230,14 +238,20 @@ func TestCapturePaneRenderSnapshotReusesRenderedANSIWhenScreenUnchanged(t *testi
 	emu.screen = []string{"cached", "screen"}
 	emu.screenChanged = true
 
-	first, state := capturePaneRenderSnapshot(emu, paneScrollbackSnapshotState{})
+	first, state, screenChanged := capturePaneRenderSnapshot(emu, paneScrollbackSnapshotState{})
+	if !screenChanged {
+		t.Fatal("initial capture should report drained screen changes")
+	}
 	if got, want := emu.renderCalls, 1; got != want {
 		t.Fatalf("initial Render calls = %d, want %d", got, want)
 	}
 
 	emu.renderCalls = 0
 	emu.screenChanged = false
-	second, _ := capturePaneRenderSnapshot(emu, state)
+	second, _, screenChanged := capturePaneRenderSnapshot(emu, state)
+	if screenChanged {
+		t.Fatal("unchanged capture should not report screen changes")
+	}
 
 	if got := emu.renderCalls; got != 0 {
 		t.Fatalf("Render calls after unchanged screen = %d, want 0", got)
@@ -260,7 +274,7 @@ func TestCapturePaneRenderSnapshotCachesCursorlessANSI(t *testing.T) {
 	emu.cursorBlockCol = 1
 	emu.cursorBlockRow = 0
 
-	first, state := capturePaneRenderSnapshot(emu, paneScrollbackSnapshotState{})
+	first, state, _ := capturePaneRenderSnapshot(emu, paneScrollbackSnapshotState{})
 	if !first.hasCursorBlock {
 		t.Fatal("snapshot should record cursor block metadata")
 	}
@@ -277,7 +291,7 @@ func TestCapturePaneRenderSnapshotCachesCursorlessANSI(t *testing.T) {
 	emu.renderCalls = 0
 	emu.renderNoCursorCalls = 0
 	emu.screenChanged = false
-	second, state := capturePaneRenderSnapshot(emu, state)
+	second, state, _ := capturePaneRenderSnapshot(emu, state)
 	if got := emu.renderCalls; got != 0 {
 		t.Fatalf("same cursor-block Render calls = %d, want 0", got)
 	}
@@ -289,12 +303,15 @@ func TestCapturePaneRenderSnapshotCachesCursorlessANSI(t *testing.T) {
 	}
 
 	emu.cursorBlockCol = 2
-	third, _ := capturePaneRenderSnapshot(emu, state)
-	if got := emu.renderCalls; got != 0 {
-		t.Fatalf("moved cursor-block Render calls = %d, want 0", got)
+	third, _, _ := capturePaneRenderSnapshot(emu, state)
+	if got, want := emu.renderCalls, 1; got != want {
+		t.Fatalf("moved cursor-block Render calls = %d, want %d", got, want)
 	}
 	if got, want := emu.renderNoCursorCalls, 1; got != want {
 		t.Fatalf("moved cursor-block RenderWithoutCursorBlock calls = %d, want %d", got, want)
+	}
+	if third.rendered == second.rendered {
+		t.Fatalf("moved cursor block should refresh rendered ANSI, got %q", third.rendered)
 	}
 	if third.renderedNoCursor == second.renderedNoCursor {
 		t.Fatalf("moved cursor block should refresh cursorless ANSI, got %q", third.renderedNoCursor)

--- a/internal/client/renderer_capture_snapshot_test.go
+++ b/internal/client/renderer_capture_snapshot_test.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"fmt"
 	"io"
 	"strings"
 	"testing"
@@ -13,13 +14,17 @@ import (
 )
 
 type captureSnapshotFakeEmulator struct {
-	width, height int
-	scrollback    []string
-	screen        []string
-	pushed        uint64
-	screenChanged bool
-	lineReads     []int
-	renderCalls   int
+	width, height       int
+	scrollback          []string
+	screen              []string
+	pushed              uint64
+	screenChanged       bool
+	lineReads           []int
+	renderCalls         int
+	renderNoCursorCalls int
+	hasCursorBlock      bool
+	cursorBlockCol      int
+	cursorBlockRow      int
 }
 
 func newCaptureSnapshotFakeEmulator(lines []string, pushed uint64) *captureSnapshotFakeEmulator {
@@ -68,11 +73,12 @@ func (e *captureSnapshotFakeEmulator) ScrollbackCellAt(int, int) (uv.Cell, bool)
 	return uv.Cell{}, false
 }
 func (e *captureSnapshotFakeEmulator) RenderWithoutCursorBlock() string {
-	return e.Render()
+	e.renderNoCursorCalls++
+	return fmt.Sprintf("%s|cursorless:%d,%d", strings.Join(e.screen, "\n"), e.cursorBlockCol, e.cursorBlockRow)
 }
-func (e *captureSnapshotFakeEmulator) HasCursorBlock() bool { return false }
+func (e *captureSnapshotFakeEmulator) HasCursorBlock() bool { return e.hasCursorBlock }
 func (e *captureSnapshotFakeEmulator) CursorBlockPosition() (int, int, bool) {
-	return 0, 0, false
+	return e.cursorBlockCol, e.cursorBlockRow, e.hasCursorBlock
 }
 func (e *captureSnapshotFakeEmulator) ScreenLineText(y int) string {
 	if y < 0 || y >= len(e.screen) {
@@ -242,6 +248,70 @@ func TestCapturePaneRenderSnapshotReusesRenderedANSIWhenScreenUnchanged(t *testi
 	if second.renderedNoCursor != first.renderedNoCursor {
 		t.Fatalf("cursorless ANSI changed after unchanged screen: got %q, want %q", second.renderedNoCursor, first.renderedNoCursor)
 	}
+}
+
+func TestCapturePaneRenderSnapshotCachesCursorlessANSI(t *testing.T) {
+	t.Parallel()
+
+	emu := newCaptureSnapshotFakeEmulator(nil, 0)
+	emu.screen = []string{"cursor", "screen"}
+	emu.screenChanged = true
+	emu.hasCursorBlock = true
+	emu.cursorBlockCol = 1
+	emu.cursorBlockRow = 0
+
+	first, state := capturePaneRenderSnapshot(emu, paneScrollbackSnapshotState{})
+	if !first.hasCursorBlock {
+		t.Fatal("snapshot should record cursor block metadata")
+	}
+	if first.cursorBlockCol != 1 || first.cursorBlockRow != 0 {
+		t.Fatalf("cursor block position = %d,%d, want 1,0", first.cursorBlockCol, first.cursorBlockRow)
+	}
+	if got, want := emu.renderCalls, 1; got != want {
+		t.Fatalf("initial Render calls = %d, want %d", got, want)
+	}
+	if got, want := emu.renderNoCursorCalls, 1; got != want {
+		t.Fatalf("initial RenderWithoutCursorBlock calls = %d, want %d", got, want)
+	}
+
+	emu.renderCalls = 0
+	emu.renderNoCursorCalls = 0
+	emu.screenChanged = false
+	second, state := capturePaneRenderSnapshot(emu, state)
+	if got := emu.renderCalls; got != 0 {
+		t.Fatalf("same cursor-block Render calls = %d, want 0", got)
+	}
+	if got := emu.renderNoCursorCalls; got != 0 {
+		t.Fatalf("same cursor-block RenderWithoutCursorBlock calls = %d, want 0", got)
+	}
+	if second.renderedNoCursor != first.renderedNoCursor {
+		t.Fatalf("cursorless ANSI was not reused: got %q, want %q", second.renderedNoCursor, first.renderedNoCursor)
+	}
+
+	emu.cursorBlockCol = 2
+	third, _ := capturePaneRenderSnapshot(emu, state)
+	if got := emu.renderCalls; got != 0 {
+		t.Fatalf("moved cursor-block Render calls = %d, want 0", got)
+	}
+	if got, want := emu.renderNoCursorCalls, 1; got != want {
+		t.Fatalf("moved cursor-block RenderWithoutCursorBlock calls = %d, want %d", got, want)
+	}
+	if third.renderedNoCursor == second.renderedNoCursor {
+		t.Fatalf("moved cursor block should refresh cursorless ANSI, got %q", third.renderedNoCursor)
+	}
+}
+
+func TestPublishPaneCaptureMissingEmulatorReportsNoScreenChange(t *testing.T) {
+	t.Parallel()
+
+	r := NewWithScrollback(20, 4, 100)
+	t.Cleanup(r.Close)
+
+	r.withActor(func(st *rendererActorState) {
+		if got := r.publishPaneCapture(st, 42); got {
+			t.Fatal("missing emulator publish should not report screen changes")
+		}
+	})
 }
 
 func equalStrings(a, b []string) bool {

--- a/internal/client/renderer_state.go
+++ b/internal/client/renderer_state.go
@@ -298,10 +298,10 @@ func (st *rendererActorState) refreshPaneCaptures(snap *rendererSnapshot, emulat
 	snap.paneCaptures = captures
 }
 
-func (r *Renderer) publishPaneCapture(st *rendererActorState, paneID uint32) {
+func (r *Renderer) publishPaneCapture(st *rendererActorState, paneID uint32) bool {
 	emu := st.emulators[paneID]
 	if emu == nil {
-		return
+		return false
 	}
 	next := *st.snapshot
 	next.paneCaptures = clonePaneRenderSnapshots(st.snapshot.paneCaptures)
@@ -310,6 +310,7 @@ func (r *Renderer) publishPaneCapture(st *rendererActorState, paneID uint32) {
 	st.paneScrollbacks[paneID] = state
 	st.snapshot = &next
 	r.publishSnapshot(&next)
+	return state.screenChanged
 }
 
 func (r *Renderer) loadSnapshot() *rendererSnapshot {

--- a/internal/client/renderer_state.go
+++ b/internal/client/renderer_state.go
@@ -290,7 +290,7 @@ func (st *rendererActorState) refreshPaneCaptures(snap *rendererSnapshot, emulat
 		if _, ok := snap.paneInfo[paneID]; !ok || emu == nil {
 			continue
 		}
-		capture, state := capturePaneRenderSnapshot(emu, scrollbacks[paneID])
+		capture, state, _ := capturePaneRenderSnapshot(emu, scrollbacks[paneID])
 		captures[paneID] = capture
 		scrollbacks[paneID] = state
 	}
@@ -305,12 +305,12 @@ func (r *Renderer) publishPaneCapture(st *rendererActorState, paneID uint32) boo
 	}
 	next := *st.snapshot
 	next.paneCaptures = clonePaneRenderSnapshots(st.snapshot.paneCaptures)
-	capture, state := capturePaneRenderSnapshot(emu, st.paneScrollbacks[paneID])
+	capture, state, screenChanged := capturePaneRenderSnapshot(emu, st.paneScrollbacks[paneID])
 	next.paneCaptures[paneID] = capture
 	st.paneScrollbacks[paneID] = state
 	st.snapshot = &next
 	r.publishSnapshot(&next)
-	return state.screenChanged
+	return screenChanged
 }
 
 func (r *Renderer) loadSnapshot() *rendererSnapshot {


### PR DESCRIPTION
## Motivation

After LAB-1833, the client renderer actor still spent time rendering full ANSI pane strings inside `capturePaneRenderSnapshot` for every pane-output publish. The post-fix profile showed `emu.Render()` at 110ms and `RenderWithoutCursorBlock()` at 100ms on that per-output path.

## Summary

- Add a rendered-ANSI cache to the existing per-pane capture snapshot state.
- Move the emulator `DrainScreenChanges()` check into snapshot capture and return that result through `publishPaneCapture`, so the render loop keeps the same dirty-pane behavior while the snapshot code can decide whether ANSI must be refreshed.
- Reuse `rendered` and `renderedNoCursor` when pane output only changes cursor/metadata and the screen dimensions are unchanged.
- Refresh ANSI when screen cells changed, dimensions changed, or cursor-block stripping needs a new cursorless render.
- Preserve the LAB-1634 invariant: `--ansi`, `--display`, JSON/text capture, and snapshot-backed composition still read frozen snapshot data off-actor. The snapshot continues to carry `rendered` and `renderedNoCursor`; this change only changes when those strings are recomputed.

## Testing

- `go test ./internal/client -run 'Test(CapturePaneRenderSnapshot(ReusesRenderedANSIWhenScreenUnchanged|CachesCursorlessANSI|IncrementalScrollback)|PublishPaneCaptureMissingEmulatorReportsNoScreenChange|HandleCaptureRequestDoesNotWaitForRendererActor|CaptureDisplayDoesNotWaitForRendererActor|CaptureDisplaySnapshotEdgeCases|PaneCaptureMissingWarmSnapshotReturnsBlank|CapturePaneTextActorFallbackUsesCurrentCapabilities)$' -count=100`
- `go test -race ./internal/client -run 'Test(CapturePaneRenderSnapshot(ReusesRenderedANSIWhenScreenUnchanged|CachesCursorlessANSI|IncrementalScrollback)|PublishPaneCaptureMissingEmulatorReportsNoScreenChange|HandleCaptureRequestDoesNotWaitForRendererActor|CaptureDisplayDoesNotWaitForRendererActor|CaptureDisplaySnapshotEdgeCases|PaneCaptureMissingWarmSnapshotReturnsBlank|CapturePaneTextActorFallbackUsesCurrentCapabilities)$' -count=10`
- `go test ./internal/client -count=1`
- `go test -race ./internal/client -count=1`
- `go test ./test -run 'TestCapturePaneANSI_PreservesStyleAfterSGRReset|TestGolden' -count=1 -timeout 120s`
- `go test ./internal/render -count=1`
- `go test ./internal/client -run 'TestClientRendererHandleCaptureRequest|TestCapturePaneText|TestCaptureDisplay' -count=1`
- `SHELL=/bin/bash go test ./test -timeout 120s`
- `SHELL=/bin/bash go test ./... -timeout 120s`
- `go test ./internal/client -run '^$' -bench 'BenchmarkCapturePaneRenderSnapshot(Render|IncrementalScrollback|StyledScrollback1KB)$' -benchmem -count=5`
- `go test ./internal/client -run '^$' -bench '^BenchmarkCapturePaneRenderSnapshotRender$' -benchtime=3s -cpuprofile /tmp/lab1858-after-bench.pprof -benchmem`
- `go test ./internal/client -coverprofile=/tmp/lab1858-client.cover.out && go run ./cmd/diffcoverage --base origin/main --module github.com/weill-labs/amux --profile /tmp/lab1858-client.cover.out --target 70`
- `make install`
- `amux debug client-profile --duration 20s > /tmp/lab1858-after-live.pprof`
- `go tool pprof -list 'capturePaneRenderSnapshot' /tmp/lab-scrollback-postfix.pprof`
- `go tool pprof -list 'capturePaneRenderSnapshot' /tmp/lab1858-after-live.pprof`

Note: plain `go test ./... -timeout 120s` under this zsh environment fails on `origin/main` too because `TestCrashRecovery_PreservesHistoryCapture` captures `zsh-newuser-install` first-run text from an empty temp HOME. The bash-shell full-suite run above passed.

## Review focus

- Check the invalidation rules in `captureRenderedSnapshot`: first render, screen changed, pane size changed, and cursor-block movement.
- Check the moved dirty-screen drain: `HandlePaneOutputInfo` now receives `screenChanged` from `publishPaneCapture` instead of draining separately.
- Check that `renderWithoutCursorBlockSnapshot` clears only touched state caused by temporary cursor-block stripping, so cursor-block panes do not become permanently dirty.

## Baseline numbers

Hardware: AMD EPYC-Milan Processor, linux/amd64.

### Benchmark

`go test ./internal/client -run '^$' -bench '^BenchmarkCapturePaneRenderSnapshotRender$' -benchtime=3s -cpuprofile ... -benchmem`

| Build | ns/op | B/op | allocs/op | Capture snapshot cum | `emu.Render()` cum |
| --- | ---: | ---: | ---: | ---: | ---: |
| Before (`4d72d6d`, red test baseline) | 506346 | 245522 | 132 | 1.79s | 0.74s |
| After (`c7c9246`) | 358682 | 240166 | 53 | 2.37s | 0 samples in capture path |

### Live client pprof

| Profile | Total samples | `capturePaneRenderSnapshot` cum | `emu.Render()` line | `RenderWithoutCursorBlock()` line |
| --- | ---: | ---: | ---: | ---: |
| Before (`/tmp/lab-scrollback-postfix.pprof`) | 1.18s | 0.29s (24.58%) | 110ms | 100ms |
| After (`/tmp/lab1858-after-live.pprof`) | 250ms | 0 samples | 0 samples | 0 samples |

The after live profile was captured after `make install` in the same active amux environment. Total client CPU was lower than the earlier LAB-1833 profile, but the target functions disappeared from the sampled actor path.

Closes LAB-1858
