### PR TITLE
LAB-1854: Prune stale client pprof sockets

### DIFF
--- a/internal/client/pprof.go
+++ b/internal/client/pprof.go
@@ -74,6 +74,7 @@ func newPprofEndpoint(session string, pid int) (*pprofEndpoint, error) {
 		}
 		_ = os.Remove(sockPath)
 	}
+	pruneDeadClientPprofSockets(session, sockPath)
 
 	listener, err := net.Listen("unix", sockPath)
 	if err != nil {
@@ -121,6 +122,24 @@ func publishPprofAlias(aliasPath, sockPath string) error {
 		return err
 	}
 	return nil
+}
+
+func pruneDeadClientPprofSockets(session, skipPath string) {
+	matches, err := filepath.Glob(clientPprofSocketGlob(session))
+	if err != nil {
+		return
+	}
+	for _, path := range matches {
+		if path == skipPath {
+			continue
+		}
+		conn, err := dialutil.DialUnixStaleProbe(path)
+		if err != nil {
+			_ = os.Remove(path)
+			continue
+		}
+		conn.Close()
+	}
 }
 
 func aliasPointsToSocket(aliasPath, sockPath string) bool {

--- a/internal/client/pprof_test.go
+++ b/internal/client/pprof_test.go
@@ -185,3 +185,54 @@ func TestPromoteFallbackPprofAliasRemovesDeadSockets(t *testing.T) {
 		t.Fatalf("alias should be removed when only stale candidates remain, stat err = %v", err)
 	}
 }
+
+func TestNewPprofEndpointPrunesDeadSiblingSocketsAndKeepsLiveOnes(t *testing.T) {
+	t.Parallel()
+
+	session := fmt.Sprintf("cpps-%d", time.Now().UnixNano())
+	aliasPath := PprofSocketPath(session)
+	_ = os.Remove(aliasPath)
+	t.Cleanup(func() { _ = os.Remove(aliasPath) })
+
+	live, err := newPprofEndpoint(session, 7777)
+	if err != nil {
+		t.Fatalf("newPprofEndpoint(live): %v", err)
+	}
+	defer live.close()
+
+	stalePath := PprofProcessSocketPath(session, 8888)
+	leaveStalePprofSocket(t, stalePath)
+
+	newest, err := newPprofEndpoint(session, 9999)
+	if err != nil {
+		t.Fatalf("newPprofEndpoint(newest): %v", err)
+	}
+	defer newest.close()
+
+	if _, err := os.Stat(stalePath); !os.IsNotExist(err) {
+		t.Fatalf("stale sibling socket should be pruned, stat err = %v", err)
+	}
+	if _, err := os.Stat(live.sockPath); err != nil {
+		t.Fatalf("live sibling socket should be preserved, stat err = %v", err)
+	}
+	if got, err := os.Readlink(aliasPath); err != nil {
+		t.Fatalf("Readlink(%q): %v", aliasPath, err)
+	} else if got != newest.sockPath {
+		t.Fatalf("alias target = %q, want newest socket %q", got, newest.sockPath)
+	}
+}
+
+func leaveStalePprofSocket(t *testing.T, sockPath string) {
+	t.Helper()
+
+	_ = os.Remove(sockPath)
+	ln, err := net.ListenUnix("unix", &net.UnixAddr{Name: sockPath, Net: "unix"})
+	if err != nil {
+		t.Fatalf("ListenUnix(%q): %v", sockPath, err)
+	}
+	ln.SetUnlinkOnClose(false)
+	if err := ln.Close(); err != nil {
+		t.Fatalf("Close(%q): %v", sockPath, err)
+	}
+	t.Cleanup(func() { _ = os.Remove(sockPath) })
+}

--- a/internal/client/pprof_test.go
+++ b/internal/client/pprof_test.go
@@ -203,6 +203,12 @@ func TestNewPprofEndpointPrunesDeadSiblingSocketsAndKeepsLiveOnes(t *testing.T) 
 	stalePath := PprofProcessSocketPath(session, 8888)
 	leaveStalePprofSocket(t, stalePath)
 
+	pruneDeadClientPprofSockets("[", "")
+	pruneDeadClientPprofSockets(session, stalePath)
+	if _, err := os.Stat(stalePath); err != nil {
+		t.Fatalf("skip path should be preserved before startup pruning, stat err = %v", err)
+	}
+
 	newest, err := newPprofEndpoint(session, 9999)
 	if err != nil {
 		t.Fatalf("newPprofEndpoint(newest): %v", err)

--- a/test/debug_test.go
+++ b/test/debug_test.go
@@ -138,13 +138,7 @@ func TestDebugClientCommandsUseInteractiveClientPprofEndpoint(t *testing.T) {
 	t.Parallel()
 
 	h := newServerHarness(t)
-	configPath := filepath.Join(h.home, ".config", "amux", "config.toml")
-	if err := os.MkdirAll(filepath.Dir(configPath), 0755); err != nil {
-		t.Fatalf("MkdirAll(%q): %v", filepath.Dir(configPath), err)
-	}
-	if err := os.WriteFile(configPath, []byte("[debug]\npprof = true\n"), 0644); err != nil {
-		t.Fatalf("WriteFile(%q): %v", configPath, err)
-	}
+	writeDebugPprofConfig(t, h)
 
 	pty := newPTYClientHarness(t, h)
 	if _, err := os.Lstat(client.PprofSocketPath(h.session)); err != nil {
@@ -177,6 +171,90 @@ func TestDebugClientCommandsUseInteractiveClientPprofEndpoint(t *testing.T) {
 	if !pty.waitExited(5 * time.Second) {
 		t.Fatal("interactive client did not exit after detach")
 	}
+}
+
+func TestDebugClientProfileUsesNewestClientAndPrunesStaleSocket(t *testing.T) {
+	t.Parallel()
+
+	h := newServerHarness(t)
+	writeDebugPprofConfig(t, h)
+
+	stalePath := client.PprofProcessSocketPath(h.session, 999999)
+	leaveStaleUnixSocket(t, stalePath)
+
+	aliasPath := client.PprofSocketPath(h.session)
+	_ = os.Remove(aliasPath)
+	if err := os.Symlink(stalePath, aliasPath); err != nil {
+		t.Fatalf("Symlink(%q, %q): %v", stalePath, aliasPath, err)
+	}
+	t.Cleanup(func() { _ = os.Remove(aliasPath) })
+
+	ptyA := newPTYClientHarness(t, h)
+	ptyB := newPTYClientHarness(t, h)
+	clientASocket := client.PprofProcessSocketPath(h.session, ptyA.cmd.Process.Pid)
+	clientBSocket := client.PprofProcessSocketPath(h.session, ptyB.cmd.Process.Pid)
+
+	ptyA.detach()
+	if !ptyA.waitExited(5 * time.Second) {
+		t.Fatal("first interactive client did not exit after detach")
+	}
+	if _, err := os.Stat(clientASocket); !os.IsNotExist(err) {
+		t.Fatalf("first client socket should be removed after detach, stat err = %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	profileCmd := h.commandWithContext(ctx, "debug", "client-profile", "--duration", "1s")
+	profileOut, err := profileCmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("debug client-profile: %v\n%s", err, profileOut)
+	}
+	if len(profileOut) < 2 || profileOut[0] != 0x1f || profileOut[1] != 0x8b {
+		t.Fatalf("client profile output should start with gzip magic, got % x", profileOut[:min(8, len(profileOut))])
+	}
+	if got, err := os.Readlink(aliasPath); err != nil {
+		t.Fatalf("Readlink(%q): %v", aliasPath, err)
+	} else if got != clientBSocket {
+		t.Fatalf("client pprof alias = %q, want newest client socket %q", got, clientBSocket)
+	}
+	if _, err := os.Stat(stalePath); !os.IsNotExist(err) {
+		t.Fatalf("stale client socket should be pruned on client startup, stat err = %v", err)
+	}
+
+	ptyB.detach()
+	if !ptyB.waitExited(5 * time.Second) {
+		t.Fatal("second interactive client did not exit after detach")
+	}
+}
+
+func writeDebugPprofConfig(t *testing.T, h *ServerHarness) {
+	t.Helper()
+
+	configPath := filepath.Join(h.home, ".config", "amux", "config.toml")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0755); err != nil {
+		t.Fatalf("MkdirAll(%q): %v", filepath.Dir(configPath), err)
+	}
+	if err := os.WriteFile(configPath, []byte("[debug]\npprof = true\n"), 0644); err != nil {
+		t.Fatalf("WriteFile(%q): %v", configPath, err)
+	}
+}
+
+func leaveStaleUnixSocket(t *testing.T, sockPath string) {
+	t.Helper()
+
+	if err := os.MkdirAll(filepath.Dir(sockPath), 0700); err != nil {
+		t.Fatalf("MkdirAll(%q): %v", filepath.Dir(sockPath), err)
+	}
+	_ = os.Remove(sockPath)
+	ln, err := net.ListenUnix("unix", &net.UnixAddr{Name: sockPath, Net: "unix"})
+	if err != nil {
+		t.Fatalf("ListenUnix(%q): %v", sockPath, err)
+	}
+	ln.SetUnlinkOnClose(false)
+	if err := ln.Close(); err != nil {
+		t.Fatalf("Close(%q): %v", sockPath, err)
+	}
+	t.Cleanup(func() { _ = os.Remove(sockPath) })
 }
 
 func min(a, b int) int {


### PR DESCRIPTION
## Motivation

The client pprof alias already relinks to the latest live client, but PID-suffixed client pprof sockets left behind by crashed clients can still accumulate under `/tmp/amux-$UID/`. LAB-1854 calls for the debug client commands to keep working after stale client endpoints and for dead PID sockets to be cleaned up.

## Summary

- Use approach A: keep the existing atomic `<session>.client.pprof` alias relink design because the CLI already resolves through that alias and the client pprof path already publishes it on startup.
- Prune dead `<session>.client.*.pprof` sockets on client pprof startup by probing each sibling socket and removing only endpoints that no longer accept a Unix connection.
- Add an integration regression covering stale alias + stale PID socket, two live clients, first-client detach cleanup, and `amux debug client-profile --duration 1s` resolving to the newest live client.
- Add direct client pprof unit coverage for startup pruning so patch coverage sees the helper behavior.

## Testing

- `go test ./test -run TestDebugClientProfileUsesNewestClientAndPrunesStaleSocket -count=1 -timeout 120s` (failed before the production fix because the stale PID socket remained)
- `go test ./test -run TestDebugClientProfileUsesNewestClientAndPrunesStaleSocket -count=100 -timeout 1800s`
- `go test ./internal/client -run TestNewPprofEndpointPrunesDeadSiblingSocketsAndKeepsLiveOnes -count=100 -timeout 120s`
- `go test ./internal/client -run 'Test(PprofEndpointServesAndPromotesLatestClientAlias|NewPprofEndpointRejectsInvalidInputs|NewPprofEndpointRejectsLiveExistingSocket|NewPprofEndpointFailsWhenAliasCannotBePublished|PromoteFallbackPprofAliasRemovesDeadSockets)' -count=100 -timeout 120s`
- `go test ./internal/client -timeout 120s`
- `go test ./internal/client ./internal/cli ./internal/server ./test -timeout 120s` failed locally in unrelated `test` package cases after the three internal packages passed. The first failure mode was zsh's first-run prompt in hermetic HOME for crash-recovery tests; rerunning those with `SHELL=/bin/sh` passed. A later full `test` package run hit unrelated metadata/timeout failures outside this diff.
- `go test ./test -run TestDebugClient -count=1 -timeout 120s`

## Review focus

Review the startup pruning behavior in `internal/client/pprof.go`: it intentionally uses the same Unix stale-probe pattern as existing pprof cleanup and skips the new socket path so concurrent live clients are preserved.

Closes LAB-1854
