### PR TITLE
LAB-1857: Reuse screen-cell snapshots incrementally

### DIFF
--- a/internal/client/renderer_bench_test.go
+++ b/internal/client/renderer_bench_test.go
@@ -315,7 +315,7 @@ func BenchmarkCapturePaneRenderSnapshotStyledScrollback1KB(b *testing.B) {
 		if _, err := emu.Write(payload); err != nil {
 			b.Fatalf("write payload: %v", err)
 		}
-		_, _, _ = capturePaneRenderSnapshot(emu, paneScrollbackSnapshotState{})
+		_, _, _ = capturePaneRenderSnapshot(emu, paneRenderSnapshotState{})
 	}
 }
 
@@ -332,7 +332,7 @@ func BenchmarkCapturePaneRenderSnapshotIncrementalScrollback(b *testing.B) {
 		b.Fatalf("preload scrollback: %v", err)
 	}
 
-	_, state, _ := capturePaneRenderSnapshot(emu, paneScrollbackSnapshotState{})
+	_, state, _ := capturePaneRenderSnapshot(emu, paneRenderSnapshotState{})
 	payload := []byte("incremental scrollback append\r\n")
 
 	b.SetBytes(int64(len(payload)))
@@ -386,7 +386,7 @@ func BenchmarkCapturePaneRenderSnapshotRender(b *testing.B) {
 		b.Fatalf("preload screen: %v", err)
 	}
 
-	_, state, _ := capturePaneRenderSnapshot(emu, paneScrollbackSnapshotState{})
+	_, state, _ := capturePaneRenderSnapshot(emu, paneRenderSnapshotState{})
 	payload := []byte("\x1b[1;1H\x1b[1;2H")
 
 	b.SetBytes(int64(len(payload)))
@@ -414,14 +414,14 @@ func BenchmarkCapturePaneRenderSnapshotScreenCells(b *testing.B) {
 		b.ResetTimer()
 		for b.Loop() {
 			emu.changedRows = changedRows
-			_, _, _ = capturePaneRenderSnapshot(emu, paneScrollbackSnapshotState{})
+			_, _, _ = capturePaneRenderSnapshot(emu, paneRenderSnapshotState{})
 		}
 	})
 
 	b.Run("incremental", func(b *testing.B) {
 		emu := benchScreenCaptureEmulator(width, height)
 		emu.changedRows = benchScreenRows(height)
-		_, state, _ := capturePaneRenderSnapshot(emu, paneScrollbackSnapshotState{})
+		_, state, _ := capturePaneRenderSnapshot(emu, paneRenderSnapshotState{})
 		changedRow := []int{height / 2}
 
 		b.SetBytes(int64(width * height))

--- a/internal/client/renderer_bench_test.go
+++ b/internal/client/renderer_bench_test.go
@@ -406,45 +406,52 @@ func BenchmarkCapturePaneRenderSnapshotScreenCells(b *testing.B) {
 		height = 48
 	)
 
-	payload := []byte("\x1b[Hscreen cell update")
-
 	b.Run("full", func(b *testing.B) {
-		emu := mux.NewVTEmulatorWithScrollback(width, height, mux.DefaultScrollbackLines)
-		defer emu.Close()
-		if _, err := emu.Write(benchScrollbackPayload(1, height)); err != nil {
-			b.Fatalf("preload screen: %v", err)
-		}
-
-		b.SetBytes(int64(len(payload)))
+		emu := benchScreenCaptureEmulator(width, height)
+		changedRows := benchScreenRows(height)
+		b.SetBytes(int64(width * height))
 		b.ReportAllocs()
 		b.ResetTimer()
 		for b.Loop() {
-			if _, err := emu.Write(payload); err != nil {
-				b.Fatalf("write payload: %v", err)
-			}
+			emu.changedRows = changedRows
 			_, _, _ = capturePaneRenderSnapshot(emu, paneScrollbackSnapshotState{})
 		}
 	})
 
 	b.Run("incremental", func(b *testing.B) {
-		emu := mux.NewVTEmulatorWithScrollback(width, height, mux.DefaultScrollbackLines)
-		defer emu.Close()
-		if _, err := emu.Write(benchScrollbackPayload(1, height)); err != nil {
-			b.Fatalf("preload screen: %v", err)
-		}
-
+		emu := benchScreenCaptureEmulator(width, height)
+		emu.changedRows = benchScreenRows(height)
 		_, state, _ := capturePaneRenderSnapshot(emu, paneScrollbackSnapshotState{})
+		changedRow := []int{height / 2}
 
-		b.SetBytes(int64(len(payload)))
+		b.SetBytes(int64(width * height))
 		b.ReportAllocs()
 		b.ResetTimer()
 		for b.Loop() {
-			if _, err := emu.Write(payload); err != nil {
-				b.Fatalf("write payload: %v", err)
-			}
+			emu.screen[height/2] = "updated row"
+			emu.changedRows = changedRow
 			_, state, _ = capturePaneRenderSnapshot(emu, state)
 		}
 	})
+}
+
+func benchScreenCaptureEmulator(width, height int) *captureSnapshotFakeEmulator {
+	emu := newCaptureSnapshotFakeEmulator(nil, 0)
+	emu.width = width
+	emu.height = height
+	emu.screen = make([]string, height)
+	for row := range emu.screen {
+		emu.screen[row] = fmt.Sprintf("screen row %03d", row)
+	}
+	return emu
+}
+
+func benchScreenRows(height int) []int {
+	rows := make([]int, height)
+	for row := range rows {
+		rows[row] = row
+	}
+	return rows
 }
 
 func BenchmarkCaptureJSON(b *testing.B) {

--- a/internal/client/renderer_bench_test.go
+++ b/internal/client/renderer_bench_test.go
@@ -400,6 +400,53 @@ func BenchmarkCapturePaneRenderSnapshotRender(b *testing.B) {
 	}
 }
 
+func BenchmarkCapturePaneRenderSnapshotScreenCells(b *testing.B) {
+	const (
+		width  = 160
+		height = 48
+	)
+
+	payload := []byte("\x1b[Hscreen cell update")
+
+	b.Run("full", func(b *testing.B) {
+		emu := mux.NewVTEmulatorWithScrollback(width, height, mux.DefaultScrollbackLines)
+		defer emu.Close()
+		if _, err := emu.Write(benchScrollbackPayload(1, height)); err != nil {
+			b.Fatalf("preload screen: %v", err)
+		}
+
+		b.SetBytes(int64(len(payload)))
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			if _, err := emu.Write(payload); err != nil {
+				b.Fatalf("write payload: %v", err)
+			}
+			_, _, _ = capturePaneRenderSnapshot(emu, paneScrollbackSnapshotState{})
+		}
+	})
+
+	b.Run("incremental", func(b *testing.B) {
+		emu := mux.NewVTEmulatorWithScrollback(width, height, mux.DefaultScrollbackLines)
+		defer emu.Close()
+		if _, err := emu.Write(benchScrollbackPayload(1, height)); err != nil {
+			b.Fatalf("preload screen: %v", err)
+		}
+
+		_, state, _ := capturePaneRenderSnapshot(emu, paneScrollbackSnapshotState{})
+
+		b.SetBytes(int64(len(payload)))
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			if _, err := emu.Write(payload); err != nil {
+				b.Fatalf("write payload: %v", err)
+			}
+			_, state, _ = capturePaneRenderSnapshot(emu, state)
+		}
+	})
+}
+
 func BenchmarkCaptureJSON(b *testing.B) {
 	for _, panes := range []int{2, 4, 8, 16} {
 		b.Run(fmt.Sprintf("panes_%d", panes), func(b *testing.B) {

--- a/internal/client/renderer_capture_snapshot.go
+++ b/internal/client/renderer_capture_snapshot.go
@@ -27,7 +27,7 @@ type paneRenderSnapshot struct {
 	hasCursorBlock   bool
 }
 
-type paneScrollbackSnapshotState struct {
+type paneRenderSnapshotState struct {
 	scrollbackLen    int
 	scrollbackPushed uint64
 	scrollback       []paneBufferLine
@@ -44,7 +44,7 @@ type paneScrollbackSnapshotState struct {
 	hasCursorBlock   bool
 }
 
-func capturePaneRenderSnapshot(emu mux.TerminalEmulator, prev paneScrollbackSnapshotState) (paneRenderSnapshot, paneScrollbackSnapshotState, bool) {
+func capturePaneRenderSnapshot(emu mux.TerminalEmulator, prev paneRenderSnapshotState) (paneRenderSnapshot, paneRenderSnapshotState, bool) {
 	width, height := emu.Size()
 	cursorCol, cursorRow := emu.CursorPosition()
 	scrollbackState := captureScrollbackSnapshot(emu, prev)
@@ -81,7 +81,7 @@ func capturePaneRenderSnapshot(emu mux.TerminalEmulator, prev paneScrollbackSnap
 	return snap, state, screenChanged
 }
 
-func captureRenderedSnapshot(emu mux.TerminalEmulator, prev paneScrollbackSnapshotState, width, height int, screenChanged bool, cursorBlockCol, cursorBlockRow int, hasCursorBlock bool) (rendered, renderedNoCursor string) {
+func captureRenderedSnapshot(emu mux.TerminalEmulator, prev paneRenderSnapshotState, width, height int, screenChanged bool, cursorBlockCol, cursorBlockRow int, hasCursorBlock bool) (rendered, renderedNoCursor string) {
 	renderCacheValid := prev.renderedValid && prev.renderWidth == width && prev.renderHeight == height
 	cursorBlockChanged := prev.hasCursorBlock != hasCursorBlock ||
 		(hasCursorBlock && (prev.cursorBlockCol != cursorBlockCol || prev.cursorBlockRow != cursorBlockRow))
@@ -109,21 +109,21 @@ func renderWithoutCursorBlockSnapshot(emu mux.TerminalEmulator) string {
 	return rendered
 }
 
-func captureScrollbackSnapshot(emu mux.TerminalEmulator, prev paneScrollbackSnapshotState) paneScrollbackSnapshotState {
+func captureScrollbackSnapshot(emu mux.TerminalEmulator, prev paneRenderSnapshotState) paneRenderSnapshotState {
 	curLen := emu.ScrollbackLen()
 	curPushed := emu.ScrollbackPushed()
 	scrollback, ok := extendScrollbackSnapshot(emu, prev, curLen, curPushed)
 	if !ok {
 		scrollback = rebuildScrollbackSnapshot(emu, curLen)
 	}
-	return paneScrollbackSnapshotState{
+	return paneRenderSnapshotState{
 		scrollbackLen:    curLen,
 		scrollbackPushed: curPushed,
 		scrollback:       scrollback,
 	}
 }
 
-func extendScrollbackSnapshot(emu mux.TerminalEmulator, prev paneScrollbackSnapshotState, curLen int, curPushed uint64) ([]paneBufferLine, bool) {
+func extendScrollbackSnapshot(emu mux.TerminalEmulator, prev paneRenderSnapshotState, curLen int, curPushed uint64) ([]paneBufferLine, bool) {
 	if prev.scrollback == nil || len(prev.scrollback) != prev.scrollbackLen || curPushed < prev.scrollbackPushed {
 		return nil, false
 	}
@@ -160,21 +160,21 @@ func rebuildScrollbackSnapshot(emu mux.TerminalEmulator, scrollbackLen int) []pa
 	return scrollback
 }
 
-func captureScreenSnapshot(emu mux.TerminalEmulator, prev paneScrollbackSnapshotState, width, height int) (paneScrollbackSnapshotState, bool) {
+func captureScreenSnapshot(emu mux.TerminalEmulator, prev paneRenderSnapshotState, width, height int) (paneRenderSnapshotState, bool) {
 	changedRows := emu.DrainScreenChangeRows()
 	screen, ok := extendScreenSnapshot(emu, prev, width, height, changedRows)
 	screenChanged := len(changedRows) != 0 || !ok
 	if !ok {
 		screen = rebuildScreenSnapshot(emu, width, height)
 	}
-	return paneScrollbackSnapshotState{
+	return paneRenderSnapshotState{
 		screenWidth:  width,
 		screenHeight: height,
 		screen:       screen,
 	}, screenChanged
 }
 
-func extendScreenSnapshot(emu mux.TerminalEmulator, prev paneScrollbackSnapshotState, width, height int, changedRows []int) ([]paneBufferLine, bool) {
+func extendScreenSnapshot(emu mux.TerminalEmulator, prev paneRenderSnapshotState, width, height int, changedRows []int) ([]paneBufferLine, bool) {
 	if prev.screen == nil || prev.screenWidth != width || prev.screenHeight != height || len(prev.screen) != height {
 		return nil, false
 	}
@@ -207,8 +207,8 @@ func captureScreenLine(emu mux.TerminalEmulator, row, width int) paneBufferLine 
 	}
 }
 
-func mergePaneSnapshotState(scrollbackState, screenState paneScrollbackSnapshotState) paneScrollbackSnapshotState {
-	return paneScrollbackSnapshotState{
+func mergePaneSnapshotState(scrollbackState, screenState paneRenderSnapshotState) paneRenderSnapshotState {
+	return paneRenderSnapshotState{
 		scrollbackLen:    scrollbackState.scrollbackLen,
 		scrollbackPushed: scrollbackState.scrollbackPushed,
 		scrollback:       scrollbackState.scrollback,

--- a/internal/client/renderer_capture_snapshot.go
+++ b/internal/client/renderer_capture_snapshot.go
@@ -31,6 +31,9 @@ type paneScrollbackSnapshotState struct {
 	scrollbackLen    int
 	scrollbackPushed uint64
 	scrollback       []paneBufferLine
+	screenWidth      int
+	screenHeight     int
+	screen           []paneBufferLine
 	renderWidth      int
 	renderHeight     int
 	rendered         string
@@ -44,16 +47,8 @@ type paneScrollbackSnapshotState struct {
 func capturePaneRenderSnapshot(emu mux.TerminalEmulator, prev paneScrollbackSnapshotState) (paneRenderSnapshot, paneScrollbackSnapshotState, bool) {
 	width, height := emu.Size()
 	cursorCol, cursorRow := emu.CursorPosition()
-	screenChanged := emu.DrainScreenChanges()
 	scrollbackState := captureScrollbackSnapshot(emu, prev)
-
-	screen := make([]paneBufferLine, height)
-	for row := 0; row < height; row++ {
-		screen[row] = paneBufferLine{
-			text:  emu.ScreenLineText(row),
-			cells: captureScreenCells(emu, row, width),
-		}
-	}
+	screenState, screenChanged := captureScreenSnapshot(emu, prev, width, height)
 
 	cursorBlockCol, cursorBlockRow, hasCursorBlock := emu.CursorBlockPosition()
 	rendered, renderedNoCursor := captureRenderedSnapshot(emu, prev, width, height, screenChanged, cursorBlockCol, cursorBlockRow, hasCursorBlock)
@@ -67,22 +62,23 @@ func capturePaneRenderSnapshot(emu mux.TerminalEmulator, prev paneScrollbackSnap
 		rendered:         rendered,
 		renderedNoCursor: renderedNoCursor,
 		scrollback:       scrollbackState.scrollback,
-		screen:           screen,
+		screen:           screenState.screen,
 	}
 	if hasCursorBlock {
 		snap.cursorBlockCol = cursorBlockCol
 		snap.cursorBlockRow = cursorBlockRow
 		snap.hasCursorBlock = true
 	}
-	scrollbackState.renderWidth = width
-	scrollbackState.renderHeight = height
-	scrollbackState.rendered = rendered
-	scrollbackState.renderedNoCursor = renderedNoCursor
-	scrollbackState.renderedValid = true
-	scrollbackState.cursorBlockCol = cursorBlockCol
-	scrollbackState.cursorBlockRow = cursorBlockRow
-	scrollbackState.hasCursorBlock = hasCursorBlock
-	return snap, scrollbackState, screenChanged
+	state := mergePaneSnapshotState(scrollbackState, screenState)
+	state.renderWidth = width
+	state.renderHeight = height
+	state.rendered = rendered
+	state.renderedNoCursor = renderedNoCursor
+	state.renderedValid = true
+	state.cursorBlockCol = cursorBlockCol
+	state.cursorBlockRow = cursorBlockRow
+	state.hasCursorBlock = hasCursorBlock
+	return snap, state, screenChanged
 }
 
 func captureRenderedSnapshot(emu mux.TerminalEmulator, prev paneScrollbackSnapshotState, width, height int, screenChanged bool, cursorBlockCol, cursorBlockRow int, hasCursorBlock bool) (rendered, renderedNoCursor string) {
@@ -162,6 +158,64 @@ func rebuildScrollbackSnapshot(emu mux.TerminalEmulator, scrollbackLen int) []pa
 		}
 	}
 	return scrollback
+}
+
+func captureScreenSnapshot(emu mux.TerminalEmulator, prev paneScrollbackSnapshotState, width, height int) (paneScrollbackSnapshotState, bool) {
+	changedRows := emu.DrainScreenChangeRows()
+	screen, ok := extendScreenSnapshot(emu, prev, width, height, changedRows)
+	screenChanged := len(changedRows) != 0 || !ok
+	if !ok {
+		screen = rebuildScreenSnapshot(emu, width, height)
+	}
+	return paneScrollbackSnapshotState{
+		screenWidth:  width,
+		screenHeight: height,
+		screen:       screen,
+	}, screenChanged
+}
+
+func extendScreenSnapshot(emu mux.TerminalEmulator, prev paneScrollbackSnapshotState, width, height int, changedRows []int) ([]paneBufferLine, bool) {
+	if prev.screen == nil || prev.screenWidth != width || prev.screenHeight != height || len(prev.screen) != height {
+		return nil, false
+	}
+	if len(changedRows) == 0 {
+		return prev.screen, true
+	}
+
+	screen := append([]paneBufferLine(nil), prev.screen...)
+	for _, row := range changedRows {
+		if row < 0 || row >= height {
+			return nil, false
+		}
+		screen[row] = captureScreenLine(emu, row, width)
+	}
+	return screen, true
+}
+
+func rebuildScreenSnapshot(emu mux.TerminalEmulator, width, height int) []paneBufferLine {
+	screen := make([]paneBufferLine, height)
+	for row := range screen {
+		screen[row] = captureScreenLine(emu, row, width)
+	}
+	return screen
+}
+
+func captureScreenLine(emu mux.TerminalEmulator, row, width int) paneBufferLine {
+	return paneBufferLine{
+		text:  emu.ScreenLineText(row),
+		cells: captureScreenCells(emu, row, width),
+	}
+}
+
+func mergePaneSnapshotState(scrollbackState, screenState paneScrollbackSnapshotState) paneScrollbackSnapshotState {
+	return paneScrollbackSnapshotState{
+		scrollbackLen:    scrollbackState.scrollbackLen,
+		scrollbackPushed: scrollbackState.scrollbackPushed,
+		scrollback:       scrollbackState.scrollback,
+		screenWidth:      screenState.screenWidth,
+		screenHeight:     screenState.screenHeight,
+		screen:           screenState.screen,
+	}
 }
 
 func cloneTerminalState(state proto.TerminalState) proto.TerminalState {

--- a/internal/client/renderer_capture_snapshot_test.go
+++ b/internal/client/renderer_capture_snapshot_test.go
@@ -135,8 +135,8 @@ func (e *captureSnapshotFakeEmulator) screenANSI() string {
 	return strings.Join(e.screen, "\n")
 }
 
-func scrollbackState(lines []string, pushed uint64) paneScrollbackSnapshotState {
-	return paneScrollbackSnapshotState{
+func scrollbackState(lines []string, pushed uint64) paneRenderSnapshotState {
+	return paneRenderSnapshotState{
 		scrollbackLen:    len(lines),
 		scrollbackPushed: pushed,
 		scrollback:       paneBufferLines(lines),
@@ -168,7 +168,7 @@ func TestCapturePaneRenderSnapshotIncrementalScrollback(t *testing.T) {
 
 	tests := []struct {
 		name       string
-		prev       paneScrollbackSnapshotState
+		prev       paneRenderSnapshotState
 		lines      []string
 		pushed     uint64
 		wantLines  []string
@@ -268,7 +268,7 @@ func TestCapturePaneRenderSnapshotReusesRenderedANSIWhenScreenUnchanged(t *testi
 	emu.screen = []string{"cached", "screen"}
 	emu.screenChanged = true
 
-	first, state, screenChanged := capturePaneRenderSnapshot(emu, paneScrollbackSnapshotState{})
+	first, state, screenChanged := capturePaneRenderSnapshot(emu, paneRenderSnapshotState{})
 	if !screenChanged {
 		t.Fatal("initial capture should report drained screen changes")
 	}
@@ -304,7 +304,7 @@ func TestCapturePaneRenderSnapshotCachesCursorlessANSI(t *testing.T) {
 	emu.cursorBlockCol = 1
 	emu.cursorBlockRow = 0
 
-	first, state, _ := capturePaneRenderSnapshot(emu, paneScrollbackSnapshotState{})
+	first, state, _ := capturePaneRenderSnapshot(emu, paneRenderSnapshotState{})
 	if !first.hasCursorBlock {
 		t.Fatal("snapshot should record cursor block metadata")
 	}
@@ -454,7 +454,7 @@ func TestCapturePaneRenderSnapshotIncrementalScreenCells(t *testing.T) {
 			emu.height = 2
 			emu.screen = append([]string(nil), tt.firstScreen...)
 			emu.changedRows = []int{0, 1}
-			first, state, _ := capturePaneRenderSnapshot(emu, paneScrollbackSnapshotState{})
+			first, state, _ := capturePaneRenderSnapshot(emu, paneRenderSnapshotState{})
 
 			emu.width = tt.width
 			emu.height = tt.height

--- a/internal/client/renderer_capture_snapshot_test.go
+++ b/internal/client/renderer_capture_snapshot_test.go
@@ -404,6 +404,7 @@ func TestCapturePaneRenderSnapshotIncrementalScreenCells(t *testing.T) {
 		wantReadRows   []int
 		wantCellReads  []screenCellRead
 		wantReusedRows []int
+		wantChanged    bool
 	}{
 		{
 			name:           "no change reuses previous screen rows",
@@ -423,6 +424,7 @@ func TestCapturePaneRenderSnapshotIncrementalScreenCells(t *testing.T) {
 			wantReadRows:   []int{1},
 			wantCellReads:  screenCellReads([]int{1}, 4),
 			wantReusedRows: []int{0},
+			wantChanged:    true,
 		},
 		{
 			name:          "full change rebuilds all screen rows",
@@ -433,6 +435,7 @@ func TestCapturePaneRenderSnapshotIncrementalScreenCells(t *testing.T) {
 			height:        2,
 			wantReadRows:  []int{0, 1},
 			wantCellReads: screenCellReads([]int{0, 1}, 4),
+			wantChanged:   true,
 		},
 		{
 			name:          "shape mismatch falls back to full screen rebuild",
@@ -442,6 +445,7 @@ func TestCapturePaneRenderSnapshotIncrementalScreenCells(t *testing.T) {
 			height:        3,
 			wantReadRows:  []int{0, 1, 2},
 			wantCellReads: screenCellReads([]int{0, 1, 2}, 5),
+			wantChanged:   true,
 		},
 	}
 
@@ -462,10 +466,13 @@ func TestCapturePaneRenderSnapshotIncrementalScreenCells(t *testing.T) {
 			emu.changedRows = append([]int(nil), tt.changedRows...)
 			emu.screenReads = nil
 			emu.cellReads = nil
-			second, _, _ := capturePaneRenderSnapshot(emu, state)
+			second, _, changed := capturePaneRenderSnapshot(emu, state)
 
 			if got := paneRenderSnapshotLines(second.screen); !slices.Equal(got, tt.secondScreen) {
 				t.Fatalf("snapshot screen = %#v, want %#v", got, tt.secondScreen)
+			}
+			if changed != tt.wantChanged {
+				t.Fatalf("screenChanged = %v, want %v", changed, tt.wantChanged)
 			}
 			if !slices.Equal(emu.screenReads, tt.wantReadRows) {
 				t.Fatalf("ScreenLineText reads = %#v, want %#v", emu.screenReads, tt.wantReadRows)

--- a/internal/client/renderer_capture_snapshot_test.go
+++ b/internal/client/renderer_capture_snapshot_test.go
@@ -3,6 +3,7 @@ package client
 import (
 	"fmt"
 	"io"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -20,11 +21,20 @@ type captureSnapshotFakeEmulator struct {
 	pushed              uint64
 	screenChanged       bool
 	lineReads           []int
+	screenReads         []int
+	cellReads           []screenCellRead
+	changedRows         []int
 	renderCalls         int
 	renderNoCursorCalls int
 	hasCursorBlock      bool
 	cursorBlockCol      int
 	cursorBlockRow      int
+	cell                uv.Cell
+}
+
+type screenCellRead struct {
+	row int
+	col int
 }
 
 func newCaptureSnapshotFakeEmulator(lines []string, pushed uint64) *captureSnapshotFakeEmulator {
@@ -34,14 +44,30 @@ func newCaptureSnapshotFakeEmulator(lines []string, pushed uint64) *captureSnaps
 		scrollback: append([]string(nil), lines...),
 		screen:     []string{"screen-0", "screen-1"},
 		pushed:     pushed,
+		cell:       uv.Cell{Content: "x", Width: 1},
 	}
 }
 
 func (e *captureSnapshotFakeEmulator) Write(data []byte) (int, error) { return len(data), nil }
-func (e *captureSnapshotFakeEmulator) DrainScreenChanges() bool {
-	changed := e.screenChanged
+func (e *captureSnapshotFakeEmulator) DrainScreenChangeRows() []int {
+	if e.changedRows != nil {
+		rows := e.changedRows
+		e.changedRows = nil
+		e.screenChanged = false
+		return rows
+	}
+	if !e.screenChanged {
+		return nil
+	}
 	e.screenChanged = false
-	return changed
+	rows := make([]int, e.height)
+	for row := range rows {
+		rows[row] = row
+	}
+	return rows
+}
+func (e *captureSnapshotFakeEmulator) DrainScreenChanges() bool {
+	return len(e.DrainScreenChangeRows()) != 0
 }
 func (e *captureSnapshotFakeEmulator) Read([]byte) (int, error) { return 0, io.EOF }
 func (e *captureSnapshotFakeEmulator) Close() error             { return nil }
@@ -85,6 +111,7 @@ func (e *captureSnapshotFakeEmulator) CursorBlockPosition() (int, int, bool) {
 	return e.cursorBlockCol, e.cursorBlockRow, e.hasCursorBlock
 }
 func (e *captureSnapshotFakeEmulator) ScreenLineText(y int) string {
+	e.screenReads = append(e.screenReads, y)
 	if y < 0 || y >= len(e.screen) {
 		return ""
 	}
@@ -92,8 +119,11 @@ func (e *captureSnapshotFakeEmulator) ScreenLineText(y int) string {
 }
 func (e *captureSnapshotFakeEmulator) LineWrapped(int) bool       { return false }
 func (e *captureSnapshotFakeEmulator) ScreenContains(string) bool { return false }
-func (e *captureSnapshotFakeEmulator) CellAt(int, int) *uv.Cell   { return nil }
-func (e *captureSnapshotFakeEmulator) IsAltScreen() bool          { return false }
+func (e *captureSnapshotFakeEmulator) CellAt(col, row int) *uv.Cell {
+	e.cellReads = append(e.cellReads, screenCellRead{row: row, col: col})
+	return &e.cell
+}
+func (e *captureSnapshotFakeEmulator) IsAltScreen() bool { return false }
 func (e *captureSnapshotFakeEmulator) MouseProtocol() mux.MouseProtocol {
 	return mux.MouseProtocol{}
 }
@@ -344,15 +374,112 @@ func equalStrings(a, b []string) bool {
 }
 
 func equalInts(a, b []int) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i := range a {
-		if a[i] != b[i] {
-			return false
+	return slices.Equal(a, b)
+}
+
+func sameScreenCellsBacking(a, b paneBufferLine) bool {
+	return len(a.cells) > 0 && len(b.cells) > 0 && &a.cells[0] == &b.cells[0]
+}
+
+func screenCellReads(rows []int, width int) []screenCellRead {
+	reads := make([]screenCellRead, 0, len(rows)*width)
+	for _, row := range rows {
+		for col := 0; col < width; col++ {
+			reads = append(reads, screenCellRead{row: row, col: col})
 		}
 	}
-	return true
+	return reads
+}
+
+func TestCapturePaneRenderSnapshotIncrementalScreenCells(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		firstScreen    []string
+		secondScreen   []string
+		changedRows    []int
+		width          int
+		height         int
+		wantReadRows   []int
+		wantCellReads  []screenCellRead
+		wantReusedRows []int
+	}{
+		{
+			name:           "no change reuses previous screen rows",
+			firstScreen:    []string{"top", "bottom"},
+			secondScreen:   []string{"top", "bottom"},
+			width:          4,
+			height:         2,
+			wantReusedRows: []int{0, 1},
+		},
+		{
+			name:           "partial change rebuilds only touched rows",
+			firstScreen:    []string{"top", "bottom"},
+			secondScreen:   []string{"top", "changed"},
+			changedRows:    []int{1},
+			width:          4,
+			height:         2,
+			wantReadRows:   []int{1},
+			wantCellReads:  screenCellReads([]int{1}, 4),
+			wantReusedRows: []int{0},
+		},
+		{
+			name:          "full change rebuilds all screen rows",
+			firstScreen:   []string{"top", "bottom"},
+			secondScreen:  []string{"changed-top", "changed-bottom"},
+			changedRows:   []int{0, 1},
+			width:         4,
+			height:        2,
+			wantReadRows:  []int{0, 1},
+			wantCellReads: screenCellReads([]int{0, 1}, 4),
+		},
+		{
+			name:          "shape mismatch falls back to full screen rebuild",
+			firstScreen:   []string{"top", "bottom"},
+			secondScreen:  []string{"new-top", "new-bottom", "new-tail"},
+			width:         5,
+			height:        3,
+			wantReadRows:  []int{0, 1, 2},
+			wantCellReads: screenCellReads([]int{0, 1, 2}, 5),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			emu := newCaptureSnapshotFakeEmulator(nil, 0)
+			emu.width = 4
+			emu.height = 2
+			emu.screen = append([]string(nil), tt.firstScreen...)
+			emu.changedRows = []int{0, 1}
+			first, state, _ := capturePaneRenderSnapshot(emu, paneScrollbackSnapshotState{})
+
+			emu.width = tt.width
+			emu.height = tt.height
+			emu.screen = append([]string(nil), tt.secondScreen...)
+			emu.changedRows = append([]int(nil), tt.changedRows...)
+			emu.screenReads = nil
+			emu.cellReads = nil
+			second, _, _ := capturePaneRenderSnapshot(emu, state)
+
+			if got := paneRenderSnapshotLines(second.screen); !slices.Equal(got, tt.secondScreen) {
+				t.Fatalf("snapshot screen = %#v, want %#v", got, tt.secondScreen)
+			}
+			if !slices.Equal(emu.screenReads, tt.wantReadRows) {
+				t.Fatalf("ScreenLineText reads = %#v, want %#v", emu.screenReads, tt.wantReadRows)
+			}
+			if !slices.Equal(emu.cellReads, tt.wantCellReads) {
+				t.Fatalf("CellAt reads = %#v, want %#v", emu.cellReads, tt.wantCellReads)
+			}
+			for _, row := range tt.wantReusedRows {
+				if !sameScreenCellsBacking(second.screen[row], first.screen[row]) {
+					t.Fatalf("screen row %d did not reuse previous cells backing array", row)
+				}
+			}
+		})
+	}
 }
 
 func TestHandleCaptureRequestDoesNotWaitForRendererActor(t *testing.T) {

--- a/internal/client/renderer_state.go
+++ b/internal/client/renderer_state.go
@@ -145,8 +145,8 @@ func prunePaneRenderSnapshots(src map[uint32]paneRenderSnapshot, panes map[uint3
 	return dst
 }
 
-func prunePaneScrollbackSnapshotStates(src map[uint32]paneScrollbackSnapshotState, panes map[uint32]proto.PaneSnapshot) map[uint32]paneScrollbackSnapshotState {
-	dst := make(map[uint32]paneScrollbackSnapshotState, len(src))
+func prunePaneRenderSnapshotStates(src map[uint32]paneRenderSnapshotState, panes map[uint32]proto.PaneSnapshot) map[uint32]paneRenderSnapshotState {
+	dst := make(map[uint32]paneRenderSnapshotState, len(src))
 	for paneID, snap := range src {
 		if _, ok := panes[paneID]; ok {
 			dst[paneID] = snap
@@ -163,7 +163,7 @@ type rendererCommand struct {
 type rendererActorState struct {
 	snapshot          *rendererSnapshot
 	emulators         map[uint32]mux.TerminalEmulator
-	paneScrollbacks   map[uint32]paneScrollbackSnapshotState
+	paneCaptureStates map[uint32]paneRenderSnapshotState
 	pendingPaneOutput map[uint32]*paneOutputBuffer
 	compositor        *render.Compositor
 }
@@ -285,16 +285,16 @@ func (st *rendererActorState) warmVisiblePanes(snap *rendererSnapshot, emulators
 
 func (st *rendererActorState) refreshPaneCaptures(snap *rendererSnapshot, emulators map[uint32]mux.TerminalEmulator) {
 	captures := prunePaneRenderSnapshots(snap.paneCaptures, snap.paneInfo)
-	scrollbacks := prunePaneScrollbackSnapshotStates(st.paneScrollbacks, snap.paneInfo)
+	captureStates := prunePaneRenderSnapshotStates(st.paneCaptureStates, snap.paneInfo)
 	for paneID, emu := range emulators {
 		if _, ok := snap.paneInfo[paneID]; !ok || emu == nil {
 			continue
 		}
-		capture, state, _ := capturePaneRenderSnapshot(emu, scrollbacks[paneID])
+		capture, state, _ := capturePaneRenderSnapshot(emu, captureStates[paneID])
 		captures[paneID] = capture
-		scrollbacks[paneID] = state
+		captureStates[paneID] = state
 	}
-	st.paneScrollbacks = scrollbacks
+	st.paneCaptureStates = captureStates
 	snap.paneCaptures = captures
 }
 
@@ -305,9 +305,9 @@ func (r *Renderer) publishPaneCapture(st *rendererActorState, paneID uint32) boo
 	}
 	next := *st.snapshot
 	next.paneCaptures = clonePaneRenderSnapshots(st.snapshot.paneCaptures)
-	capture, state, screenChanged := capturePaneRenderSnapshot(emu, st.paneScrollbacks[paneID])
+	capture, state, screenChanged := capturePaneRenderSnapshot(emu, st.paneCaptureStates[paneID])
 	next.paneCaptures[paneID] = capture
-	st.paneScrollbacks[paneID] = state
+	st.paneCaptureStates[paneID] = state
 	st.snapshot = &next
 	r.publishSnapshot(&next)
 	return screenChanged
@@ -335,7 +335,7 @@ func (r *Renderer) actorLoop(initial *rendererSnapshot, compositor *render.Compo
 	state := &rendererActorState{
 		snapshot:          initial,
 		emulators:         make(map[uint32]mux.TerminalEmulator),
-		paneScrollbacks:   make(map[uint32]paneScrollbackSnapshotState),
+		paneCaptureStates: make(map[uint32]paneRenderSnapshotState),
 		pendingPaneOutput: make(map[uint32]*paneOutputBuffer),
 		compositor:        compositor,
 	}

--- a/internal/mux/emulator.go
+++ b/internal/mux/emulator.go
@@ -26,6 +26,10 @@ type TerminalEmulator interface {
 	// drain and clears the emulator's internal touched state.
 	DrainScreenChanges() bool
 
+	// DrainScreenChangeRows returns changed screen rows since the last drain
+	// and clears the emulator's internal touched state.
+	DrainScreenChangeRows() []int
+
 	// Read returns terminal responses (DA queries, cursor reports, etc.).
 	// These must be drained and written back to the PTY so the shell
 	// receives the expected replies. Go's io.Pipe is unbuffered — if
@@ -186,45 +190,56 @@ func (v *vtEmulator) Write(data []byte) (int, error) {
 }
 
 func (v *vtEmulator) DrainScreenChanges() bool {
+	return len(v.DrainScreenChangeRows()) != 0
+}
+
+func (v *vtEmulator) DrainScreenChangeRows() []int {
 	w, h := v.Size()
 	if w <= 0 || h <= 0 {
-		return false
+		return nil
 	}
-	probe := touchedScreenProbe{
-		bounds: uv.Rect(0, 0, w, h),
+	probe := touchedScreenRowsProbe{
+		bounds:  uv.Rect(0, 0, w, h),
+		lastRow: -1,
 	}
 	v.emu.Draw(&probe, probe.bounds)
-	return probe.changed
+	return probe.rows
 }
 
 func (v *vtEmulator) Read(p []byte) (int, error) {
 	return v.emu.Read(p)
 }
 
-type touchedScreenProbe struct {
+type touchedScreenRowsProbe struct {
 	bounds  uv.Rectangle
-	changed bool
+	lastRow int
+	rows    []int
 }
 
-func (p *touchedScreenProbe) Bounds() uv.Rectangle {
+func (p *touchedScreenRowsProbe) Bounds() uv.Rectangle {
 	return p.bounds
 }
 
-func (p *touchedScreenProbe) CellAt(x, y int) *uv.Cell {
+func (p *touchedScreenRowsProbe) CellAt(x, y int) *uv.Cell {
 	if x < p.bounds.Min.X || x >= p.bounds.Max.X || y < p.bounds.Min.Y || y >= p.bounds.Max.Y {
 		return nil
 	}
 	return &uv.EmptyCell
 }
 
-func (p *touchedScreenProbe) SetCell(x, y int, c *uv.Cell) {
+func (p *touchedScreenRowsProbe) SetCell(x, y int, c *uv.Cell) {
 	if x < p.bounds.Min.X || x >= p.bounds.Max.X || y < p.bounds.Min.Y || y >= p.bounds.Max.Y {
 		return
 	}
-	p.changed = true
+	row := y - p.bounds.Min.Y
+	if row < 0 || row >= p.bounds.Dy() || row == p.lastRow {
+		return
+	}
+	p.lastRow = row
+	p.rows = append(p.rows, row)
 }
 
-func (p *touchedScreenProbe) WidthMethod() uv.WidthMethod {
+func (p *touchedScreenRowsProbe) WidthMethod() uv.WidthMethod {
 	return ansi.GraphemeWidth
 }
 

--- a/internal/mux/emulator.go
+++ b/internal/mux/emulator.go
@@ -235,6 +235,12 @@ func (p *touchedScreenRowsProbe) SetCell(x, y int, c *uv.Cell) {
 	if row < 0 || row >= p.bounds.Dy() || row == p.lastRow {
 		return
 	}
+	for _, recorded := range p.rows {
+		if recorded == row {
+			p.lastRow = row
+			return
+		}
+	}
 	p.lastRow = row
 	p.rows = append(p.rows, row)
 }

--- a/internal/mux/emulator_test.go
+++ b/internal/mux/emulator_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"slices"
 	"strings"
 	"testing"
 
@@ -93,6 +94,23 @@ func TestVTEmulatorRespectsScrollbackLimitUnderFlood(t *testing.T) {
 		if got[i] != want[i] {
 			t.Fatalf("scrollback[%d] = %q, want %q; full scrollback=%#v", i, got[i], want[i], got)
 		}
+	}
+}
+
+func TestVTEmulatorDrainScreenChangeRows(t *testing.T) {
+	t.Parallel()
+
+	emu := NewVTEmulatorWithDrainAndScrollback(8, 3, DefaultScrollbackLines)
+	if got, want := emu.DrainScreenChangeRows(), []int{0, 1, 2}; !slices.Equal(got, want) {
+		t.Fatalf("initial DrainScreenChangeRows() = %v, want %v", got, want)
+	}
+
+	mustWrite(t, emu, []byte("\x1b[2;3HX"))
+	if got, want := emu.DrainScreenChangeRows(), []int{1}; !slices.Equal(got, want) {
+		t.Fatalf("DrainScreenChangeRows() after row update = %v, want %v", got, want)
+	}
+	if got := emu.DrainScreenChangeRows(); len(got) != 0 {
+		t.Fatalf("DrainScreenChangeRows() after drain = %v, want none", got)
 	}
 }
 

--- a/internal/mux/emulator_test.go
+++ b/internal/mux/emulator_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	uv "github.com/charmbracelet/ultraviolet"
 	"github.com/charmbracelet/x/ansi"
 	"github.com/weill-labs/amux/internal/mouse"
 )
@@ -111,6 +112,22 @@ func TestVTEmulatorDrainScreenChangeRows(t *testing.T) {
 	}
 	if got := emu.DrainScreenChangeRows(); len(got) != 0 {
 		t.Fatalf("DrainScreenChangeRows() after drain = %v, want none", got)
+	}
+}
+
+func TestTouchedScreenRowsProbeDeduplicatesNonconsecutiveRows(t *testing.T) {
+	t.Parallel()
+
+	probe := touchedScreenRowsProbe{
+		bounds:  uv.Rect(0, 0, 8, 3),
+		lastRow: -1,
+	}
+	probe.SetCell(0, 1, &uv.EmptyCell)
+	probe.SetCell(0, 2, &uv.EmptyCell)
+	probe.SetCell(1, 1, &uv.EmptyCell)
+
+	if got, want := probe.rows, []int{1, 2}; !slices.Equal(got, want) {
+		t.Fatalf("rows = %v, want %v", got, want)
 	}
 }
 


### PR DESCRIPTION
## Motivation

`capturePaneRenderSnapshot` rebuilt every visible screen row's cell slice on each pane-output publish. After LAB-1833 removed the full scrollback rebuild, `captureScreenCells` was the next capture-path allocation source on the renderer actor.

## Summary

- Add row-level `DrainScreenChangeRows()` reporting to the mux terminal emulator wrapper.
- Reuse previous screen row snapshots when no rows changed and rebuild only touched rows when the shape is stable.
- Fall back to a full screen rebuild on cold start, size changes, or impossible dirty-row data.
- Keep `emu.Render()` unchanged; LAB-1858 is handling rendered ANSI caching separately in PR #789.

## Testing

- `go test ./internal/client -run '^(TestCapturePaneRenderSnapshotIncrementalScreenCells|TestCapturePaneRenderSnapshotIncrementalScrollback|TestHandleCaptureRequestDoesNotWaitForRendererActor)$' -count=100`
- `go test ./internal/mux -run '^TestVTEmulatorDrainScreenChangeRows$' -count=100`
- `go test ./internal/client -run 'Display|display|CaptureRequest_DisplayFlag' -count=1`
- `go test ./test -run 'Display|display|CaptureDisplay|RenderDiff' -count=1 -timeout 120s`
- `SHELL=/usr/bin/bash go test ./internal/client ./internal/mux ./internal/render ./internal/server ./test -timeout 120s`
- `SHELL=/usr/bin/bash go test -race ./internal/client -run '^(TestCapturePaneRenderSnapshotIncrementalScreenCells|TestCapturePaneRenderSnapshotIncrementalScrollback|TestHandleCaptureRequestDoesNotWaitForRendererActor|TestCaptureDisplayDoesNotWaitForRendererActor)$' -count=10`
- `SHELL=/usr/bin/bash go test -race ./internal/mux -run '^TestVTEmulatorDrainScreenChangeRows$' -count=10`
- `go test ./internal/client -run '^$' -bench '^BenchmarkCapturePaneRenderSnapshotScreenCells$' -benchmem -count=5`
- `make install`
- `curl -s --max-time 30 --unix-socket /tmp/amux-1000/main.client.3892582.pprof 'http://amux/debug/pprof/profile?seconds=20' -o /tmp/lab-1857-after.pprof`
- `go tool pprof -top -cum -nodecount=200 -nodefraction=0 /tmp/lab-1857-after.pprof`

Local note: running the full package slice without overriding `SHELL` exposed unrelated harness noise from zsh's first-run prompt in crash-recovery tests. With `SHELL=/usr/bin/bash`, the requested package slice passed.

## Review focus

- Check that draining screen rows inside `publishPaneCapture` still preserves the LAB-1634 actor-free capture invariant while returning the same screen-changed signal previously supplied by `DrainScreenChanges()`.
- Check fallback behavior for cold starts, pane resizes, and out-of-range dirty rows.
- Check the LAB-1858 overlap in `capturePaneRenderSnapshot`; PR #789 touches the same function and whichever PR lands second will need to rebase.

## Baseline numbers

Hardware: AMD EPYC-Milan Processor, linux/amd64, Go 1.25.0.

### Benchmark

`go test ./internal/client -run '^$' -bench '^BenchmarkCapturePaneRenderSnapshotScreenCells$' -benchmem -count=5`

| Benchmark | ns/op range | B/op range | allocs/op | Change |
| --- | ---: | ---: | ---: | ---: |
| `full` | 260063-623766 | 1507635-1631094 | 50 | baseline |
| `incremental` | 5791-9770 | 34314-36734 | 3 | 16.7x fewer allocs/op |

### Live client pprof

| Profile | Total samples | `actorLoop` cum | `publishPaneCapture` cum | `capturePaneRenderSnapshot` cum | `captureScreenCells` cum |
| --- | ---: | ---: | ---: | ---: | ---: |
| Original lag baseline (`/tmp/lab-scrollback-lag.pprof`) | 14.97s | 8.90s | 6.87s | 7.11s | 1.05s |
| Pre-LAB-1857 reference (`/tmp/lab-scrollback-postfix.pprof`) | 1.18s | 0.79s | 0.29s | 0.29s | 0.07s |
| After (`/tmp/lab-1857-after.pprof`) | 0.17s | 0.03s | 0 samples | 0 samples | 0 samples |

The after profile was captured from the live `main` client after `make install`; the workload was light, but `captureScreenCells` had no samples across the 20s profile, below 1% of one core.

Closes LAB-1857
