### PR TITLE
LAB-1879: Reduce compositor row copy overhead

### DIFF
--- a/.github/workflows/renderer-benchmark.yml
+++ b/.github/workflows/renderer-benchmark.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - "internal/client/renderer*.go"
+      - "internal/render/**"
       - "internal/mux/emulator.go"
       - ".github/workflows/renderer-benchmark.yml"
       - "scripts/check-benchmark-regression.py"
@@ -13,12 +14,21 @@ permissions:
   contents: read
 
 env:
-  BENCHMARK_NAME: BenchmarkPublishPaneCaptureFullScrollback
   REGRESSION_THRESHOLD: "1.25"
 
 jobs:
   renderer-benchmark:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - package: ./internal/client
+            benchmark: BenchmarkPublishPaneCaptureFullScrollback
+            file: internal/client/renderer_bench_test.go
+          - package: ./internal/render
+            benchmark: BenchmarkCompositorDirtyPaneRepresentative
+            file: internal/render/compositor_bench_test.go
     steps:
       - name: Check out PR
         uses: actions/checkout@v6.0.2
@@ -37,25 +47,36 @@ jobs:
           cache-dependency-path: head/go.sum
 
       - name: Backfill new benchmark on baseline checkout
+        env:
+          BENCHMARK_NAME: ${{ matrix.benchmark }}
+          BENCHMARK_FILE: ${{ matrix.file }}
         run: |
-          if ! grep -q "$BENCHMARK_NAME" base/internal/client/renderer_bench_test.go; then
-            cp head/internal/client/renderer_bench_test.go base/internal/client/renderer_bench_test.go
+          if ! grep -q "$BENCHMARK_NAME" "base/$BENCHMARK_FILE"; then
+            cp "head/$BENCHMARK_FILE" "base/$BENCHMARK_FILE"
           fi
 
       - name: Run main baseline benchmark
         working-directory: base
+        env:
+          BENCHMARK_NAME: ${{ matrix.benchmark }}
+          BENCHMARK_PACKAGE: ${{ matrix.package }}
         run: |
-          go test ./internal/client -run '^$' -bench "^${BENCHMARK_NAME}$" -benchmem -count=10 -timeout 120s \
+          go test "$BENCHMARK_PACKAGE" -run '^$' -bench "^${BENCHMARK_NAME}$" -benchmem -count=10 -timeout 120s \
             | tee ../bench-base.txt
 
       - name: Run PR benchmark
         working-directory: head
+        env:
+          BENCHMARK_NAME: ${{ matrix.benchmark }}
+          BENCHMARK_PACKAGE: ${{ matrix.package }}
         run: |
-          go test ./internal/client -run '^$' -bench "^${BENCHMARK_NAME}$" -benchmem -count=10 -timeout 120s \
+          go test "$BENCHMARK_PACKAGE" -run '^$' -bench "^${BENCHMARK_NAME}$" -benchmem -count=10 -timeout 120s \
             | tee ../bench-head.txt
 
       - name: Compare against main baseline
         working-directory: head
+        env:
+          BENCHMARK_NAME: ${{ matrix.benchmark }}
         run: |
           set -o pipefail
           python3 scripts/check-benchmark-regression.py \

--- a/internal/render/compositor_bench_test.go
+++ b/internal/render/compositor_bench_test.go
@@ -201,9 +201,10 @@ func BenchmarkCompositorDirtyPaneRepresentative(b *testing.B) {
 	lookup := func(id uint32) PaneData { return paneDataMap[id] }
 
 	dirtyPaneID := paneIDs[0]
+	dirtyCell := root.FindByPaneID(dirtyPaneID)
 	dirtyPanes := map[uint32]struct{}{dirtyPaneID: {}}
 	dirtyCellsA := paneDataMap[dirtyPaneID].cells
-	dirtyCellsB := benchScreenCellGrid(root.FindByPaneID(dirtyPaneID).W, mux.PaneContentHeight(root.FindByPaneID(dirtyPaneID).H), "y")
+	dirtyCellsB := benchScreenCellGrid(dirtyCell.W, mux.PaneContentHeight(dirtyCell.H), "y")
 
 	comp := NewCompositor(width, layoutH+GlobalBarHeight, "bench")
 	comp.RenderDiffWithOverlayDirty(root, paneIDs[0], lookup, OverlayState{}, dirtyPanes, true)

--- a/internal/render/compositor_bench_test.go
+++ b/internal/render/compositor_bench_test.go
@@ -179,6 +179,65 @@ func BenchmarkRenderDiffDirtyPanes(b *testing.B) {
 	}
 }
 
+func BenchmarkCompositorDirtyPaneRepresentative(b *testing.B) {
+	const (
+		width   = 240
+		layoutH = 80
+		panes   = 20
+	)
+
+	root, paneIDs := benchLayoutTree(panes, width, layoutH)
+	paneDataMap := make(map[uint32]*styledPaneData, panes)
+	root.Walk(func(c *mux.LayoutCell) {
+		pid := c.CellPaneID()
+		paneDataMap[pid] = &styledPaneData{
+			fakePaneData: fakePaneData{
+				id:   pid,
+				name: fmt.Sprintf("pane-%d", pid),
+			},
+			cells: benchScreenCellGrid(c.W, mux.PaneContentHeight(c.H), "x"),
+		}
+	})
+	lookup := func(id uint32) PaneData { return paneDataMap[id] }
+
+	dirtyPaneID := paneIDs[0]
+	dirtyPanes := map[uint32]struct{}{dirtyPaneID: {}}
+	dirtyCellsA := paneDataMap[dirtyPaneID].cells
+	dirtyCellsB := benchScreenCellGrid(root.FindByPaneID(dirtyPaneID).W, mux.PaneContentHeight(root.FindByPaneID(dirtyPaneID).H), "y")
+
+	comp := NewCompositor(width, layoutH+GlobalBarHeight, "bench")
+	comp.RenderDiffWithOverlayDirty(root, paneIDs[0], lookup, OverlayState{}, dirtyPanes, true)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if i%2 == 0 {
+			paneDataMap[dirtyPaneID].cells = dirtyCellsB
+		} else {
+			paneDataMap[dirtyPaneID].cells = dirtyCellsA
+		}
+		comp.RenderDiffWithOverlayDirty(root, paneIDs[0], lookup, OverlayState{}, dirtyPanes, false)
+	}
+}
+
+func benchScreenCellGrid(w, h int, fill string) [][]ScreenCell {
+	rows := make([][]ScreenCell, h)
+	for row := range rows {
+		rows[row] = make([]ScreenCell, w)
+		for col := range rows[row] {
+			ch := fill
+			if col%17 == 0 {
+				ch = "$"
+			}
+			if col%23 == 0 {
+				ch = " "
+			}
+			rows[row][col] = ScreenCell{Char: ch, Width: 1}
+		}
+	}
+	return rows
+}
+
 func BenchmarkClipLine(b *testing.B) {
 	for _, width := range []int{40, 80, 200} {
 		b.Run(fmt.Sprintf("width_%d", width), func(b *testing.B) {

--- a/internal/render/compositor_test.go
+++ b/internal/render/compositor_test.go
@@ -877,6 +877,7 @@ func TestRenderDiffWithOverlayDirtySkipsCleanPaneCellReads(t *testing.T) {
 }
 
 func TestBuildPaneContentCellsDoesNotAllocateRowBuffer(t *testing.T) {
+	// Not parallel: testing.AllocsPerRun panics when called after t.Parallel.
 	const (
 		width  = 80
 		height = 3

--- a/internal/render/compositor_test.go
+++ b/internal/render/compositor_test.go
@@ -876,6 +876,33 @@ func TestRenderDiffWithOverlayDirtySkipsCleanPaneCellReads(t *testing.T) {
 	}
 }
 
+func TestBuildPaneContentCellsDoesNotAllocateRowBuffer(t *testing.T) {
+	const (
+		width  = 80
+		height = 3
+	)
+	rows := make([][]ScreenCell, height)
+	for row := range rows {
+		rows[row] = make([]ScreenCell, width)
+		for col := range rows[row] {
+			rows[row][col] = ScreenCell{Char: " ", Width: 1}
+		}
+	}
+	pane := &styledPaneData{
+		fakePaneData: fakePaneData{id: 1, name: "pane-1"},
+		cells:        rows,
+	}
+	cell := mux.NewLeaf(&mux.Pane{ID: 1, Meta: mux.PaneMeta{Name: "pane-1"}}, 0, 0, width, height+mux.StatusLineRows)
+	grid := NewScreenGrid(width, height+mux.StatusLineRows)
+
+	allocs := testing.AllocsPerRun(1000, func() {
+		buildPaneContentCells(grid, cell, 0, true, pane, nil)
+	})
+	if allocs > 0 {
+		t.Fatalf("buildPaneContentCells allocated %.2f times per row; want no per-row buffer allocation", allocs)
+	}
+}
+
 func TestRenderDiffWithOverlayDirtySuppressesStableEmptyFrame(t *testing.T) {
 	t.Parallel()
 

--- a/internal/render/screen.go
+++ b/internal/render/screen.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode/utf8"
 
 	uv "github.com/charmbracelet/ultraviolet"
 	"github.com/charmbracelet/x/ansi"
@@ -427,9 +428,38 @@ func (c *Compositor) buildGridWithOverlayDirty(
 // rendered row collapses them into a single grapheme cluster. Re-pack the row
 // before diffing so RenderDiff matches the RenderFull path.
 func buildPaneContentCells(g *ScreenGrid, cell *mux.LayoutCell, row int, active bool, pd PaneData, copyOverlay *proto.ViewportOverlay) {
-	rowCells := paneContentRowCells(cell.W, row, active, pd, copyOverlay)
-	for col, sc := range rowCells {
-		g.Set(cell.X+col, cell.Y+mux.StatusLineRows+row, sc)
+	y := cell.Y + mux.StatusLineRows + row
+	for col := 0; col < cell.W; col++ {
+		g.Set(cell.X+col, y, ScreenCell{Char: " ", Width: 1})
+	}
+
+	dstCol := 0
+	for srcCol := 0; srcCol < cell.W && dstCol < cell.W; {
+		sc := paneContentCellAt(row, srcCol, active, pd, copyOverlay)
+		if sc.Width == 0 && sc.Char == " " {
+			srcCol++
+			continue
+		}
+
+		rendered, renderedWidth, nextSrc := compactRowCell(cell.W, row, active, pd, copyOverlay, srcCol, sc)
+		if renderedWidth <= 0 {
+			renderedWidth = 1
+		}
+		if renderedWidth > cell.W-dstCol {
+			break
+		}
+
+		g.Set(cell.X+dstCol, y, rendered)
+		for i := 1; i < renderedWidth && dstCol+i < cell.W; i++ {
+			g.Set(cell.X+dstCol+i, y, ScreenCell{
+				Link:  rendered.Link,
+				Style: rendered.Style,
+				Width: 0,
+			})
+		}
+
+		dstCol += renderedWidth
+		srcCol = nextSrc
 	}
 }
 
@@ -512,6 +542,9 @@ func compactRowCell(width, row int, active bool, pd PaneData, copyOverlay *proto
 		if next.Char == " " || !merged.Style.Equal(&next.Style) || !merged.Link.Equal(&next.Link) {
 			break
 		}
+		if asciiCellsCannotMerge(candidate, next.Char) {
+			break
+		}
 
 		concat := candidate + next.Char
 		cluster, clusterWidth := ansi.FirstGraphemeCluster(concat, ansi.GraphemeWidth)
@@ -540,6 +573,11 @@ func compactRowCell(width, row int, active bool, pd PaneData, copyOverlay *proto
 	}
 
 	return merged, mergedWidth, nextSrc
+}
+
+func asciiCellsCannotMerge(candidate, next string) bool {
+	return len(candidate) == 1 && candidate[0] < utf8.RuneSelf &&
+		len(next) == 1 && next[0] < utf8.RuneSelf
 }
 
 type emittedCellState struct {

--- a/internal/render/screen.go
+++ b/internal/render/screen.go
@@ -434,14 +434,15 @@ func buildPaneContentCells(g *ScreenGrid, cell *mux.LayoutCell, row int, active 
 	}
 
 	dstCol := 0
+	var lookahead paneContentLookahead
 	for srcCol := 0; srcCol < cell.W && dstCol < cell.W; {
-		sc := paneContentCellAt(row, srcCol, active, pd, copyOverlay)
+		sc := paneContentCellAtWithLookahead(row, srcCol, active, pd, copyOverlay, &lookahead)
 		if sc.Width == 0 && sc.Char == " " {
 			srcCol++
 			continue
 		}
 
-		rendered, renderedWidth, nextSrc := compactRowCell(cell.W, row, active, pd, copyOverlay, srcCol, sc)
+		rendered, renderedWidth, nextSrc := compactRowCell(cell.W, row, active, pd, copyOverlay, srcCol, sc, &lookahead)
 		if renderedWidth <= 0 {
 			renderedWidth = 1
 		}
@@ -488,14 +489,15 @@ func paneContentRowCells(width, row int, active bool, pd PaneData, copyOverlay *
 	}
 
 	dstCol := 0
+	var lookahead paneContentLookahead
 	for srcCol := 0; srcCol < width && dstCol < width; {
-		sc := paneContentCellAt(row, srcCol, active, pd, copyOverlay)
+		sc := paneContentCellAtWithLookahead(row, srcCol, active, pd, copyOverlay, &lookahead)
 		if sc.Width == 0 && sc.Char == " " {
 			srcCol++
 			continue
 		}
 
-		rendered, renderedWidth, nextSrc := compactRowCell(width, row, active, pd, copyOverlay, srcCol, sc)
+		rendered, renderedWidth, nextSrc := compactRowCell(width, row, active, pd, copyOverlay, srcCol, sc, &lookahead)
 		if renderedWidth <= 0 {
 			renderedWidth = 1
 		}
@@ -522,7 +524,21 @@ func paneContentCellAt(row, col int, active bool, pd PaneData, copyOverlay *prot
 	return applyCopyModeOverlay(pd.CellAt(col, row, active), copyOverlay, col, row)
 }
 
-func compactRowCell(width, row int, active bool, pd PaneData, copyOverlay *proto.ViewportOverlay, srcCol int, base ScreenCell) (ScreenCell, int, int) {
+type paneContentLookahead struct {
+	col  int
+	cell ScreenCell
+	ok   bool
+}
+
+func paneContentCellAtWithLookahead(row, col int, active bool, pd PaneData, copyOverlay *proto.ViewportOverlay, lookahead *paneContentLookahead) ScreenCell {
+	if lookahead != nil && lookahead.ok && lookahead.col == col {
+		lookahead.ok = false
+		return lookahead.cell
+	}
+	return paneContentCellAt(row, col, active, pd, copyOverlay)
+}
+
+func compactRowCell(width, row int, active bool, pd PaneData, copyOverlay *proto.ViewportOverlay, srcCol int, base ScreenCell, lookahead *paneContentLookahead) (ScreenCell, int, int) {
 	baseWidth := base.Width
 	if baseWidth <= 0 {
 		baseWidth = 1
@@ -540,9 +556,11 @@ func compactRowCell(width, row int, active bool, pd PaneData, copyOverlay *proto
 			continue
 		}
 		if next.Char == " " || !merged.Style.Equal(&next.Style) || !merged.Link.Equal(&next.Link) {
+			storePaneContentLookahead(lookahead, nextSrc, next)
 			break
 		}
 		if asciiCellsCannotMerge(candidate, next.Char) {
+			storePaneContentLookahead(lookahead, nextSrc, next)
 			break
 		}
 
@@ -555,6 +573,7 @@ func compactRowCell(width, row int, active bool, pd PaneData, copyOverlay *proto
 			zwjConcat := candidate + "\u200d" + next.Char
 			cluster, clusterWidth = ansi.FirstGraphemeCluster(zwjConcat, ansi.GraphemeWidth)
 			if cluster != zwjConcat {
+				storePaneContentLookahead(lookahead, nextSrc, next)
 				break
 			}
 			concat = zwjConcat
@@ -573,6 +592,15 @@ func compactRowCell(width, row int, active bool, pd PaneData, copyOverlay *proto
 	}
 
 	return merged, mergedWidth, nextSrc
+}
+
+func storePaneContentLookahead(lookahead *paneContentLookahead, col int, cell ScreenCell) {
+	if lookahead == nil {
+		return
+	}
+	lookahead.col = col
+	lookahead.cell = cell
+	lookahead.ok = true
 }
 
 func asciiCellsCannotMerge(candidate, next string) bool {

--- a/internal/render/screen_test.go
+++ b/internal/render/screen_test.go
@@ -892,7 +892,7 @@ func TestCompactRowCell_DoesNotMergeUnrelatedCells(t *testing.T) {
 	pd := &emuPaneData{emu: paneEmu, cursorHidden: true}
 
 	base := pd.CellAt(0, 0, true)
-	got, gotWidth, nextSrc := compactRowCell(4, 0, true, pd, nil, 0, base)
+	got, gotWidth, nextSrc := compactRowCell(4, 0, true, pd, nil, 0, base, nil)
 
 	if got.Char != "A" || got.Width != 1 {
 		t.Fatalf("compactRowCell() = %+v, want single-cell A", got)


### PR DESCRIPTION
## Motivation

LAB-1879 investigates the renderer-actor CPU regression after LAB-1833/LAB-1857/LAB-1858. The supplied profile showed the compositor consuming 3.55s of a 20.11s client profile, with most time under row-buffer construction, cell copies, and grapheme compaction.

Investigation note: https://linear.app/weill-labs/issue/LAB-1879/compositor-is-now-top-renderer-actor-consumer-after-lab-183318571858#comment-05432690

## Summary

- Add a representative dirty-pane compositor benchmark and include it in the renderer benchmark CI gate.
- Stream pane content rows directly into the destination `ScreenGrid` instead of allocating a row buffer and copying it into place.
- Add a regression guard that fails if row composition reintroduces per-row allocations.
- Avoid unnecessary grapheme parsing for adjacent unrelated ASCII cells, and reuse a one-cell lookahead when compaction already fetched the next source cell.

## Testing

- `go test ./internal/render -run '^TestBuildPaneContentCellsDoesNotAllocateRowBuffer$' -count=1` (confirmed red before production changes)
- `go test ./internal/render -run '^(TestBuildPaneContentCellsDoesNotAllocateRowBuffer|TestPaneContentRowCellsAppliesCopyModeOverlay|TestRenderDiffWithOverlayDirtySkipsCleanPaneCellReads|TestRenderDiffWithOverlayDirtyMatchesFullRenderAfterShorterRecompose|TestRenderDiffWithOverlayDirtyClearsVacatedCellsAfterShorterLine|TestRenderDiffWithOverlayDirtyMatchesFullRenderWithPaneLabelsOnParallelPath|TestCompactRowCell_DoesNotMergeUnrelatedCells)$' -count=100`
- `go test ./internal/render -count=1 -timeout 120s`
- `SHELL=/usr/bin/bash go test ./internal/render ./internal/client ./test -timeout 120s`
- `go test -race ./internal/render -run '^(TestBuildPaneContentCellsDoesNotAllocateRowBuffer|TestPaneContentRowCellsAppliesCopyModeOverlay|TestRenderDiffWithOverlayDirtySkipsCleanPaneCellReads|TestRenderDiffWithOverlayDirtyMatchesFullRenderAfterShorterRecompose|TestRenderDiffWithOverlayDirtyClearsVacatedCellsAfterShorterLine|TestRenderDiffWithOverlayDirtyMatchesFullRenderWithPaneLabelsOnParallelPath|TestCompactRowCell_DoesNotMergeUnrelatedCells)$' -count=10 -timeout 120s`
- `SHELL=/usr/bin/bash go test -race ./internal/client -run 'RenderDiff|Dirty' -count=10 -timeout 120s`
- `go test ./internal/render -run '^$' -bench '^BenchmarkCompositorDirtyPaneRepresentative$' -benchmem -count=10 -timeout 120s`
- `go test ./internal/client -run '^$' -bench '^BenchmarkPublishPaneCaptureFullScrollback$' -benchmem -count=3 -timeout 120s`
- `make install`
- `amux debug client-profile --duration 20s > /tmp/lab1879-after-live2.pprof`
- `go tool pprof -top -cum -nodecount=30 /tmp/lab1879-after-live2.pprof`

The integration slice is run with `SHELL=/usr/bin/bash` because the default zsh environment can trigger known first-run prompt behavior in the harness.

## Baseline numbers

Hardware: AMD EPYC-Milan Processor, linux/amd64, Go 1.25.0.

| Measurement | Before | After |
| --- | ---: | ---: |
| `BenchmarkCompositorDirtyPaneRepresentative` | 1.92-2.07 ms/op | 1.20-1.81 ms/op |
| Benchmark bytes/op | 4,683,193-4,683,195 | 4,618,036-4,618,043 |
| Benchmark allocs/op | 1,173 | 138 |
| 20s client profile total samples | 8.02s | 990ms |
| `RenderDiffWithOverlayDirtyStats` cumulative | 3.55s | 330ms |
| `buildGridWithOverlayDirty` cumulative | 2.49s | 250ms |
| `composePane` cumulative | 2.52s | 220ms |
| `buildPaneContentCells` cumulative | 2.43s | 220ms |
| `paneContentCellAt` cumulative | 1.39s | 110ms |
| `compactRowCell` cumulative | 1.18s | 170ms |

Profile inputs: before `/tmp/lab-scrollback-postfix2.pprof`, after `/tmp/lab1879-after-live2.pprof`.

## Review focus

Please focus on the equivalence of direct grid writes versus the previous row-buffer path, especially wide/continuation cells and copy-mode overlays. The benchmark CI threshold is intentionally coarse enough for runner noise while still catching the allocation regression that caused this hotspot.

Closes LAB-1879
