### PR TITLE
LAB-1893: Bound session event-loop wedges

### DIFF
--- a/internal/debugowner/owner_debug.go
+++ b/internal/debugowner/owner_debug.go
@@ -4,10 +4,9 @@ package debugowner
 
 import (
 	"fmt"
-	"runtime"
-	"strconv"
-	"strings"
 	"sync/atomic"
+
+	"github.com/weill-labs/amux/internal/goroutineid"
 )
 
 // Checker records the first mutating goroutine and panics on later mutations
@@ -17,7 +16,7 @@ type Checker struct {
 }
 
 func (c *Checker) Assert(typeName, method string) {
-	gid := currentGoroutineID()
+	gid := goroutineid.Current()
 	if gid == 0 {
 		return
 	}
@@ -35,23 +34,11 @@ func (c *Checker) Assert(typeName, method string) {
 
 // PanicIfCurrent panics when the current goroutine matches the recorded owner.
 func (c *Checker) PanicIfCurrent(typeName, method string) {
-	gid := currentGoroutineID()
+	gid := goroutineid.Current()
 	if gid == 0 {
 		return
 	}
 	if owner := c.owner.Load(); owner != 0 && owner == gid {
 		panic(fmt.Sprintf("%s.%s called from owner goroutine %d", typeName, method, gid))
 	}
-}
-
-func currentGoroutineID() uint64 {
-	var buf [64]byte
-	n := runtime.Stack(buf[:], false)
-	line := strings.TrimPrefix(string(buf[:n]), "goroutine ")
-	field := line
-	if i := strings.IndexByte(line, ' '); i >= 0 {
-		field = line[:i]
-	}
-	gid, _ := strconv.ParseUint(field, 10, 64)
-	return gid
 }

--- a/internal/eventloop/eventloop_test.go
+++ b/internal/eventloop/eventloop_test.go
@@ -3,7 +3,9 @@ package eventloop
 import (
 	"encoding/json"
 	"errors"
+	"strings"
 	"testing"
+	"time"
 )
 
 type counterState struct {
@@ -16,6 +18,43 @@ type addCommand struct {
 
 func (c addCommand) Handle(s *counterState) {
 	s.value += c.delta
+}
+
+type watchdogTestState struct {
+	timeout  time.Duration
+	timedOut chan watchdogTimeoutCall
+}
+
+type watchdogTimeoutCall struct {
+	commandType string
+	started     time.Time
+	elapsed     time.Duration
+	timeout     time.Duration
+	goroutineID uint64
+}
+
+func (s *watchdogTestState) EventLoopWatchdogTimeout() time.Duration {
+	return s.timeout
+}
+
+func (s *watchdogTestState) HandleEventLoopWatchdogTimeout(commandType string, started time.Time, elapsed, timeout time.Duration, goroutineID uint64) {
+	s.timedOut <- watchdogTimeoutCall{
+		commandType: commandType,
+		started:     started,
+		elapsed:     elapsed,
+		timeout:     timeout,
+		goroutineID: goroutineID,
+	}
+}
+
+type blockingWatchdogCommand struct {
+	entered chan struct{}
+	release chan struct{}
+}
+
+func (c blockingWatchdogCommand) Handle(*watchdogTestState) {
+	close(c.entered)
+	<-c.release
 }
 
 func TestFilterMatchesAll(t *testing.T) {
@@ -164,6 +203,66 @@ func TestRunProcessesCommands(t *testing.T) {
 
 	close(stop)
 	<-done
+}
+
+func TestRunWatchdogReportsStuckHandlerAndStopsLoop(t *testing.T) {
+	t.Parallel()
+
+	state := &watchdogTestState{
+		timeout:  20 * time.Millisecond,
+		timedOut: make(chan watchdogTimeoutCall, 1),
+	}
+	queue := make(chan Command[watchdogTestState], 1)
+	stop := make(chan struct{})
+	done := make(chan struct{})
+	release := make(chan struct{})
+	t.Cleanup(func() {
+		close(release)
+		close(stop)
+		<-done
+	})
+
+	go Run(state, queue, stop, done, nil)
+
+	cmd := blockingWatchdogCommand{
+		entered: make(chan struct{}),
+		release: release,
+	}
+	if !Enqueue(queue, stop, cmd) {
+		t.Fatal("Enqueue(blocking command) = false, want true")
+	}
+	select {
+	case <-cmd.entered:
+	case <-time.After(time.Second):
+		t.Fatal("blocking command did not enter Handle")
+	}
+
+	select {
+	case call := <-state.timedOut:
+		if !strings.Contains(call.commandType, "blockingWatchdogCommand") {
+			t.Fatalf("watchdog command type = %q, want blockingWatchdogCommand", call.commandType)
+		}
+		if call.started.IsZero() {
+			t.Fatal("watchdog start time was zero")
+		}
+		if call.elapsed < state.timeout {
+			t.Fatalf("watchdog elapsed = %v, want at least %v", call.elapsed, state.timeout)
+		}
+		if call.timeout != state.timeout {
+			t.Fatalf("watchdog timeout = %v, want %v", call.timeout, state.timeout)
+		}
+		if call.goroutineID == 0 {
+			t.Fatal("watchdog goroutine ID was zero")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("watchdog did not report the stuck handler")
+	}
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("event loop did not stop after watchdog timeout")
+	}
 }
 
 func TestEnqueueReturnsFalseAfterStop(t *testing.T) {

--- a/internal/eventloop/eventloop_test.go
+++ b/internal/eventloop/eventloop_test.go
@@ -22,6 +22,8 @@ func (c addCommand) Handle(s *counterState) {
 
 type watchdogTestState struct {
 	timeout  time.Duration
+	name     string
+	entered  chan struct{}
 	timedOut chan watchdogTimeoutCall
 }
 
@@ -31,29 +33,49 @@ type watchdogTimeoutCall struct {
 	elapsed     time.Duration
 	timeout     time.Duration
 	goroutineID uint64
+	stateName   string
 }
 
 func (s *watchdogTestState) EventLoopWatchdogTimeout() time.Duration {
 	return s.timeout
 }
 
-func (s *watchdogTestState) HandleEventLoopWatchdogTimeout(commandType string, started time.Time, elapsed, timeout time.Duration, goroutineID uint64) {
+func (s *watchdogTestState) EnterEventLoopCommand() {
+	if s.entered == nil {
+		return
+	}
+	select {
+	case s.entered <- struct{}{}:
+	default:
+	}
+}
+
+func (s *watchdogTestState) EventLoopWatchdogSnapshot() WatchdogSnapshot {
+	return WatchdogSnapshot{StateName: s.name}
+}
+
+func (s *watchdogTestState) HandleEventLoopWatchdogTimeout(info WatchdogTimeoutInfo) {
 	s.timedOut <- watchdogTimeoutCall{
-		commandType: commandType,
-		started:     started,
-		elapsed:     elapsed,
-		timeout:     timeout,
-		goroutineID: goroutineID,
+		commandType: info.CommandType,
+		started:     info.Started,
+		elapsed:     info.Elapsed,
+		timeout:     info.Timeout,
+		goroutineID: info.GoroutineID,
+		stateName:   info.StateName,
 	}
 }
 
 type blockingWatchdogCommand struct {
 	entered chan struct{}
 	release chan struct{}
+	rename  string
 }
 
-func (c blockingWatchdogCommand) Handle(*watchdogTestState) {
+func (c blockingWatchdogCommand) Handle(s *watchdogTestState) {
 	close(c.entered)
+	if c.rename != "" {
+		s.name = c.rename
+	}
 	<-c.release
 }
 
@@ -210,6 +232,7 @@ func TestRunWatchdogReportsStuckHandlerAndStopsLoop(t *testing.T) {
 
 	state := &watchdogTestState{
 		timeout:  20 * time.Millisecond,
+		name:     "watchdog-state-before-handle",
 		timedOut: make(chan watchdogTimeoutCall, 1),
 	}
 	queue := make(chan Command[watchdogTestState], 1)
@@ -227,6 +250,7 @@ func TestRunWatchdogReportsStuckHandlerAndStopsLoop(t *testing.T) {
 	cmd := blockingWatchdogCommand{
 		entered: make(chan struct{}),
 		release: release,
+		rename:  "watchdog-state-during-handle",
 	}
 	if !Enqueue(queue, stop, cmd) {
 		t.Fatal("Enqueue(blocking command) = false, want true")
@@ -254,6 +278,9 @@ func TestRunWatchdogReportsStuckHandlerAndStopsLoop(t *testing.T) {
 		if call.goroutineID == 0 {
 			t.Fatal("watchdog goroutine ID was zero")
 		}
+		if call.stateName != "watchdog-state-before-handle" {
+			t.Fatalf("watchdog state name = %q, want pre-handle snapshot", call.stateName)
+		}
 	case <-time.After(time.Second):
 		t.Fatal("watchdog did not report the stuck handler")
 	}
@@ -263,6 +290,29 @@ func TestRunWatchdogReportsStuckHandlerAndStopsLoop(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("event loop did not stop after watchdog timeout")
 	}
+}
+
+func TestRunWatchdogEntersHandlerBeforeFirstCommand(t *testing.T) {
+	t.Parallel()
+
+	state := &watchdogTestState{
+		timeout: 100 * time.Millisecond,
+		entered: make(chan struct{}, 1),
+	}
+	queue := make(chan Command[watchdogTestState], 1)
+	stop := make(chan struct{})
+	done := make(chan struct{})
+
+	go Run(state, queue, stop, done, nil)
+
+	select {
+	case <-state.entered:
+	case <-time.After(time.Second):
+		t.Fatal("watchdog handler did not establish command owner before first command")
+	}
+
+	close(stop)
+	<-done
 }
 
 func TestEnqueueReturnsFalseAfterStop(t *testing.T) {

--- a/internal/eventloop/loop.go
+++ b/internal/eventloop/loop.go
@@ -1,11 +1,18 @@
 package eventloop
 
 import (
+	"bytes"
 	"errors"
+	"fmt"
+	"runtime"
 	"runtime/debug"
+	"strconv"
+	"time"
 )
 
 var ErrStopped = errors.New("event loop stopped")
+
+const DefaultWatchdogTimeout = 30 * time.Second
 
 type Command[S any] interface {
 	Handle(*S)
@@ -13,10 +20,66 @@ type Command[S any] interface {
 
 type LoopHook[S any] func(*S) bool
 
+type watchdogTimeoutProvider interface {
+	EventLoopWatchdogTimeout() time.Duration
+}
+
+type watchdogTimeoutHandler interface {
+	HandleEventLoopWatchdogTimeout(commandType string, started time.Time, elapsed, timeout time.Duration, goroutineID uint64)
+}
+
+type commandEntryHandler interface {
+	EnterEventLoopCommand()
+}
+
+type commandTypeNamer interface {
+	EventLoopCommandType() string
+}
+
+type handleRequest[S any] struct {
+	cmd     Command[S]
+	entered chan handleEntry
+	done    chan struct{}
+}
+
+type handleEntry struct {
+	started     time.Time
+	goroutineID uint64
+}
+
 // Run processes commands serially until stop closes, the queue closes, or the
 // hook returns false.
 func Run[S any](state *S, queue <-chan Command[S], stop <-chan struct{}, done chan<- struct{}, hook LoopHook[S]) {
 	defer close(done)
+	timeout := watchdogTimeout(state)
+	if timeout <= 0 {
+		runInline(state, queue, stop, hook)
+		return
+	}
+
+	handlerRequests := make(chan handleRequest[S])
+	go handleCommands(state, handlerRequests)
+	defer close(handlerRequests)
+
+	for {
+		select {
+		case <-stop:
+			return
+		case cmd, ok := <-queue:
+			if !ok {
+				return
+			}
+			if cmd != nil && !handleWithWatchdog(state, handlerRequests, cmd, timeout) {
+				return
+			}
+			if hook != nil && !hook(state) {
+				return
+			}
+		}
+	}
+}
+
+func runInline[S any](state *S, queue <-chan Command[S], stop <-chan struct{}, hook LoopHook[S]) {
 	for {
 		select {
 		case <-stop:
@@ -26,11 +89,99 @@ func Run[S any](state *S, queue <-chan Command[S], stop <-chan struct{}, done ch
 				return
 			}
 			if cmd != nil {
+				notifyCommandEntry(state)
 				cmd.Handle(state)
 			}
 			if hook != nil && !hook(state) {
 				return
 			}
+		}
+	}
+}
+
+func handleCommands[S any](state *S, requests <-chan handleRequest[S]) {
+	for req := range requests {
+		notifyCommandEntry(state)
+		req.entered <- handleEntry{
+			started:     time.Now(),
+			goroutineID: currentGoroutineID(),
+		}
+		req.cmd.Handle(state)
+		req.done <- struct{}{}
+	}
+}
+
+func notifyCommandEntry[S any](state *S) {
+	if handler, ok := any(state).(commandEntryHandler); ok {
+		handler.EnterEventLoopCommand()
+	}
+}
+
+func handleWithWatchdog[S any](state *S, requests chan<- handleRequest[S], cmd Command[S], timeout time.Duration) bool {
+	entered := make(chan handleEntry, 1)
+	finished := make(chan struct{}, 1)
+	requests <- handleRequest[S]{cmd: cmd, entered: entered, done: finished}
+	entry := <-entered
+
+	timer := time.NewTimer(timeout)
+	defer stopTimer(timer)
+
+	select {
+	case <-finished:
+		return true
+	case <-timer.C:
+		notifyWatchdogTimeout(state, cmd, entry, timeout)
+		return false
+	}
+}
+
+func watchdogTimeout[S any](state *S) time.Duration {
+	timeout := DefaultWatchdogTimeout
+	if provider, ok := any(state).(watchdogTimeoutProvider); ok {
+		configured := provider.EventLoopWatchdogTimeout()
+		switch {
+		case configured < 0:
+			return 0
+		case configured > 0:
+			timeout = configured
+		}
+	}
+	return timeout
+}
+
+func notifyWatchdogTimeout[S any](state *S, cmd Command[S], entry handleEntry, timeout time.Duration) {
+	elapsed := time.Since(entry.started)
+	if handler, ok := any(state).(watchdogTimeoutHandler); ok {
+		handler.HandleEventLoopWatchdogTimeout(commandType(cmd), entry.started, elapsed, timeout, entry.goroutineID)
+	}
+}
+
+func commandType(cmd any) string {
+	if namer, ok := cmd.(commandTypeNamer); ok {
+		return namer.EventLoopCommandType()
+	}
+	return fmt.Sprintf("%T", cmd)
+}
+
+func currentGoroutineID() uint64 {
+	var buf [64]byte
+	n := runtime.Stack(buf[:], false)
+	fields := bytes.Fields(buf[:n])
+	if len(fields) < 2 {
+		return 0
+	}
+	id, err := strconv.ParseUint(string(fields[1]), 10, 64)
+	if err != nil {
+		return 0
+	}
+	return id
+}
+
+func stopTimer(timer *time.Timer) {
+	if !timer.Stop() {
+		select {
+		case <-timer.C:
+		default:
 		}
 	}
 }

--- a/internal/eventloop/loop.go
+++ b/internal/eventloop/loop.go
@@ -12,6 +12,9 @@ import (
 
 var ErrStopped = errors.New("event loop stopped")
 
+// DefaultWatchdogTimeout bounds a single Command.Handle call. A wedged actor
+// should stop loudly and recover through normal daemon restart instead of
+// leaving producers blocked forever.
 const DefaultWatchdogTimeout = 30 * time.Second
 
 type Command[S any] interface {

--- a/internal/eventloop/loop.go
+++ b/internal/eventloop/loop.go
@@ -1,13 +1,12 @@
 package eventloop
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
-	"runtime"
 	"runtime/debug"
-	"strconv"
 	"time"
+
+	"github.com/weill-labs/amux/internal/goroutineid"
 )
 
 var ErrStopped = errors.New("event loop stopped")
@@ -28,7 +27,29 @@ type watchdogTimeoutProvider interface {
 }
 
 type watchdogTimeoutHandler interface {
-	HandleEventLoopWatchdogTimeout(commandType string, started time.Time, elapsed, timeout time.Duration, goroutineID uint64)
+	HandleEventLoopWatchdogTimeout(WatchdogTimeoutInfo)
+}
+
+// WatchdogSnapshot is captured on the command handler goroutine before
+// Command.Handle starts, then reused by the watchdog goroutine if the handler
+// times out.
+type WatchdogSnapshot struct {
+	StateName string
+}
+
+type watchdogSnapshotProvider interface {
+	EventLoopWatchdogSnapshot() WatchdogSnapshot
+}
+
+// WatchdogTimeoutInfo describes a command handler that exceeded the configured
+// watchdog timeout.
+type WatchdogTimeoutInfo struct {
+	CommandType string
+	Started     time.Time
+	Elapsed     time.Duration
+	Timeout     time.Duration
+	GoroutineID uint64
+	StateName   string
 }
 
 type commandEntryHandler interface {
@@ -48,6 +69,8 @@ type handleRequest[S any] struct {
 type handleEntry struct {
 	started     time.Time
 	goroutineID uint64
+	commandType string
+	snapshot    WatchdogSnapshot
 }
 
 // Run processes commands serially until stop closes, the queue closes, or the
@@ -61,7 +84,9 @@ func Run[S any](state *S, queue <-chan Command[S], stop <-chan struct{}, done ch
 	}
 
 	handlerRequests := make(chan handleRequest[S])
-	go handleCommands(state, handlerRequests)
+	handlerReady := make(chan struct{})
+	go handleCommands(state, handlerRequests, handlerReady)
+	<-handlerReady
 	defer close(handlerRequests)
 
 	for {
@@ -83,6 +108,7 @@ func Run[S any](state *S, queue <-chan Command[S], stop <-chan struct{}, done ch
 }
 
 func runInline[S any](state *S, queue <-chan Command[S], stop <-chan struct{}, hook LoopHook[S]) {
+	notifyCommandEntry(state)
 	for {
 		select {
 		case <-stop:
@@ -92,7 +118,6 @@ func runInline[S any](state *S, queue <-chan Command[S], stop <-chan struct{}, h
 				return
 			}
 			if cmd != nil {
-				notifyCommandEntry(state)
 				cmd.Handle(state)
 			}
 			if hook != nil && !hook(state) {
@@ -102,12 +127,15 @@ func runInline[S any](state *S, queue <-chan Command[S], stop <-chan struct{}, h
 	}
 }
 
-func handleCommands[S any](state *S, requests <-chan handleRequest[S]) {
+func handleCommands[S any](state *S, requests <-chan handleRequest[S], ready chan<- struct{}) {
+	notifyCommandEntry(state)
+	close(ready)
 	for req := range requests {
-		notifyCommandEntry(state)
 		req.entered <- handleEntry{
 			started:     time.Now(),
-			goroutineID: currentGoroutineID(),
+			goroutineID: goroutineid.Current(),
+			commandType: commandType(req.cmd),
+			snapshot:    watchdogSnapshot(state),
 		}
 		req.cmd.Handle(state)
 		req.done <- struct{}{}
@@ -133,7 +161,7 @@ func handleWithWatchdog[S any](state *S, requests chan<- handleRequest[S], cmd C
 	case <-finished:
 		return true
 	case <-timer.C:
-		notifyWatchdogTimeout(state, cmd, entry, timeout)
+		notifyWatchdogTimeout(state, entry, timeout)
 		return false
 	}
 }
@@ -152,10 +180,17 @@ func watchdogTimeout[S any](state *S) time.Duration {
 	return timeout
 }
 
-func notifyWatchdogTimeout[S any](state *S, cmd Command[S], entry handleEntry, timeout time.Duration) {
+func notifyWatchdogTimeout[S any](state *S, entry handleEntry, timeout time.Duration) {
 	elapsed := time.Since(entry.started)
 	if handler, ok := any(state).(watchdogTimeoutHandler); ok {
-		handler.HandleEventLoopWatchdogTimeout(commandType(cmd), entry.started, elapsed, timeout, entry.goroutineID)
+		handler.HandleEventLoopWatchdogTimeout(WatchdogTimeoutInfo{
+			CommandType: entry.commandType,
+			Started:     entry.started,
+			Elapsed:     elapsed,
+			Timeout:     timeout,
+			GoroutineID: entry.goroutineID,
+			StateName:   entry.snapshot.StateName,
+		})
 	}
 }
 
@@ -166,18 +201,11 @@ func commandType(cmd any) string {
 	return fmt.Sprintf("%T", cmd)
 }
 
-func currentGoroutineID() uint64 {
-	var buf [64]byte
-	n := runtime.Stack(buf[:], false)
-	fields := bytes.Fields(buf[:n])
-	if len(fields) < 2 {
-		return 0
+func watchdogSnapshot[S any](state *S) WatchdogSnapshot {
+	if provider, ok := any(state).(watchdogSnapshotProvider); ok {
+		return provider.EventLoopWatchdogSnapshot()
 	}
-	id, err := strconv.ParseUint(string(fields[1]), 10, 64)
-	if err != nil {
-		return 0
-	}
-	return id
+	return WatchdogSnapshot{}
 }
 
 func stopTimer(timer *time.Timer) {

--- a/internal/goroutineid/goroutineid.go
+++ b/internal/goroutineid/goroutineid.go
@@ -1,0 +1,24 @@
+package goroutineid
+
+import (
+	"bytes"
+	"runtime"
+	"strconv"
+)
+
+// Current parses the current goroutine ID from runtime.Stack's first line.
+// It is a debug/diagnostic aid only; production logic must not depend on a
+// goroutine ID remaining stable across implementation changes in the runtime.
+func Current() uint64 {
+	var buf [64]byte
+	n := runtime.Stack(buf[:], false)
+	fields := bytes.Fields(buf[:n])
+	if len(fields) < 2 {
+		return 0
+	}
+	id, err := strconv.ParseUint(string(fields[1]), 10, 64)
+	if err != nil {
+		return 0
+	}
+	return id
+}

--- a/internal/remote/manager.go
+++ b/internal/remote/manager.go
@@ -428,6 +428,36 @@ func (m *Manager) RunHostCommand(hostName string, sessionName string, cmdName st
 	return hc.runCommand(cmdName, cmdArgs)
 }
 
+// RemoteHostNames returns configured and connected remote host names without
+// querying individual host actors for connection state.
+func (m *Manager) RemoteHostNames() []string {
+	names, err := enqueueManagerQuery(m, func(m *Manager) ([]string, error) {
+		seen := make(map[string]struct{})
+		names := make([]string, 0, len(m.cfg.Hosts)+len(m.hosts))
+		add := func(name string) {
+			if _, ok := seen[name]; ok {
+				return
+			}
+			seen[name] = struct{}{}
+			names = append(names, name)
+		}
+		for name, host := range m.cfg.Hosts {
+			if host.Type == "local" {
+				continue
+			}
+			add(name)
+		}
+		for name := range m.hosts {
+			add(name)
+		}
+		return names, nil
+	})
+	if err != nil {
+		return nil
+	}
+	return names
+}
+
 // AllHostStatus returns connection states for all configured remote hosts.
 func (m *Manager) AllHostStatus() map[string]ConnState {
 	hosts, err := enqueueManagerQuery(m, func(m *Manager) (map[string]*HostConn, error) {

--- a/internal/remote/manager_test.go
+++ b/internal/remote/manager_test.go
@@ -115,6 +115,29 @@ func TestManagerAllHostStatus(t *testing.T) {
 	}
 }
 
+func TestManagerRemoteHostNames(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{Hosts: map[string]config.Host{
+		"dev":   {Type: "remote", Address: "10.0.0.1"},
+		"prod":  {Type: "remote", Address: "10.0.0.2"},
+		"local": {Type: "local"},
+	}}
+	m := newTestManager(t, cfg, "hash")
+
+	installTestHost(t, m, "adhoc", config.Host{Type: "remote"}, Connected)
+
+	got := m.RemoteHostNames()
+	gotSet := make(map[string]bool, len(got))
+	for _, name := range got {
+		gotSet[name] = true
+	}
+	want := map[string]bool{"dev": true, "prod": true, "adhoc": true}
+	if !reflect.DeepEqual(gotSet, want) {
+		t.Fatalf("RemoteHostNames() = %v, want names %v", got, want)
+	}
+}
+
 func TestManagerConnStatusForPane(t *testing.T) {
 	t.Parallel()
 

--- a/internal/server/paced_input.go
+++ b/internal/server/paced_input.go
@@ -9,7 +9,10 @@ import (
 	"github.com/weill-labs/amux/internal/auditlog"
 )
 
-var errPacedInputClosed = errors.New("paced input queue closed")
+var (
+	errPacedInputClosed       = errors.New("paced input queue closed")
+	errPacedInputBackpressure = errors.New("paced input queue full")
+)
 
 const pacedInputRequestBufferSize = 256
 
@@ -112,8 +115,18 @@ func (q *pacedInputQueue) enqueueAsyncRequest(req pacedInputRequest) error {
 		return errPacedInputClosed
 	case <-q.done:
 		return errPacedInputClosed
+	default:
+	}
+
+	select {
+	case <-q.stop:
+		return errPacedInputClosed
+	case <-q.done:
+		return errPacedInputClosed
 	case q.requests <- req:
 		return nil
+	default:
+		return errPacedInputBackpressure
 	}
 }
 

--- a/internal/server/paced_input_test.go
+++ b/internal/server/paced_input_test.go
@@ -163,6 +163,54 @@ func TestPacedInputQueueAsyncReturnsBeforeBlockedWriteCompletes(t *testing.T) {
 	}
 }
 
+func TestPacedInputQueueAsyncReturnsErrorWhenBufferFull(t *testing.T) {
+	t.Parallel()
+
+	started := make(chan struct{}, 1)
+	release := make(chan struct{})
+
+	q := newPacedInputQueue("test", nil, func(_ uint32, data []byte) error {
+		if string(data) == "blocked" {
+			started <- struct{}{}
+			<-release
+		}
+		return nil
+	})
+	t.Cleanup(func() {
+		close(release)
+		q.close()
+	})
+
+	if err := q.enqueueAsync([]encodedKeyChunk{{data: []byte("blocked")}}); err != nil {
+		t.Fatalf("enqueueAsync(blocked) = %v", err)
+	}
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("blocked write did not start")
+	}
+
+	for i := 0; i < pacedInputRequestBufferSize; i++ {
+		if err := q.enqueueAsync([]encodedKeyChunk{{data: []byte("queued")}}); err != nil {
+			t.Fatalf("enqueueAsync(fill %d) = %v", i, err)
+		}
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- q.enqueueAsync([]encodedKeyChunk{{data: []byte("overflow")}})
+	}()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("enqueueAsync(overflow) error = nil, want backpressure error")
+		}
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("enqueueAsync(overflow) blocked when the queue buffer was full")
+	}
+}
+
 func TestEnqueuePacedPaneInputRetriesShortWrites(t *testing.T) {
 	t.Parallel()
 

--- a/internal/server/pane_ref.go
+++ b/internal/server/pane_ref.go
@@ -6,6 +6,10 @@ import (
 	"github.com/weill-labs/amux/internal/proto"
 )
 
+type remoteHostNamesProvider interface {
+	RemoteHostNames() []string
+}
+
 func (s *Session) queryPaneRef(ref string) (proto.PaneRef, error) {
 	return enqueueSessionQuery(s, func(s *Session) (proto.PaneRef, error) {
 		return s.parsePaneRef(ref)
@@ -32,6 +36,14 @@ func (s *Session) parsePaneRef(ref string) (proto.PaneRef, error) {
 
 func (s *Session) isKnownRemoteHost(hostName string) bool {
 	if s == nil || s.RemoteManager == nil || hostName == "" {
+		return false
+	}
+	if provider, ok := s.RemoteManager.(remoteHostNamesProvider); ok {
+		for _, name := range provider.RemoteHostNames() {
+			if name == hostName {
+				return true
+			}
+		}
 		return false
 	}
 	_, ok := s.RemoteManager.AllHostStatus()[hostName]

--- a/internal/server/pane_ref_test.go
+++ b/internal/server/pane_ref_test.go
@@ -7,6 +7,21 @@ import (
 	"github.com/weill-labs/amux/internal/proto"
 )
 
+type hostNamesPaneTransport struct {
+	stubPaneTransport
+	names                  []string
+	allHostStatusCallCount int
+}
+
+func (t *hostNamesPaneTransport) RemoteHostNames() []string {
+	return append([]string(nil), t.names...)
+}
+
+func (t *hostNamesPaneTransport) AllHostStatus() map[string]proto.ConnState {
+	t.allHostStatusCallCount++
+	return t.stubPaneTransport.AllHostStatus()
+}
+
 func TestQueryPaneRefResolvesKnownHostOnlyRef(t *testing.T) {
 	t.Parallel()
 
@@ -23,6 +38,27 @@ func TestQueryPaneRefResolvesKnownHostOnlyRef(t *testing.T) {
 	}
 	if got != (proto.PaneRef{Host: "builder"}) {
 		t.Fatalf("queryPaneRef(builder) = %#v, want host-only ref", got)
+	}
+}
+
+func TestQueryPaneRefUsesRemoteHostNamesWithoutStatusQuery(t *testing.T) {
+	t.Parallel()
+
+	_, sess, cleanup := newCommandTestSession(t)
+	defer cleanup()
+
+	transport := &hostNamesPaneTransport{names: []string{"builder"}}
+	installTestPaneTransport(t, sess, transport, nil)
+
+	got, err := sess.queryPaneRef("builder")
+	if err != nil {
+		t.Fatalf("queryPaneRef(builder) error = %v", err)
+	}
+	if got != (proto.PaneRef{Host: "builder"}) {
+		t.Fatalf("queryPaneRef(builder) = %#v, want host-only ref", got)
+	}
+	if transport.allHostStatusCallCount != 0 {
+		t.Fatalf("AllHostStatus calls = %d, want 0", transport.allHostStatusCallCount)
 	}
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -85,6 +85,9 @@ type Session struct {
 	// Tests inject short timings here instead of mutating package globals.
 	captureTiming captureTimingConfig
 
+	// Internal event-loop watchdog timing. Zero uses the default 30s timeout.
+	SessionEventWatchdogTimeout time.Duration
+
 	// Remote pane management — nil when no remote transport is configured.
 	RemoteManager   proto.PaneTransport
 	remoteTakeover  PaneTakeoverTransport

--- a/internal/server/session_events_client.go
+++ b/internal/server/session_events_client.go
@@ -78,14 +78,7 @@ func (e liveInputEvent) handle(s *Session) {
 	if e.cc != nil {
 		e.cc.notePredictionEpoch(pane.ID, e.epoch, e.data)
 	}
-	if err := s.enqueueLivePaneInput(pane, e.data); err != nil && !errors.Is(err, errPacedInputClosed) {
-		s.logger.Warn("live input failed",
-			"event", "live_input",
-			"pane_id", pane.ID,
-			"pane_name", pane.Meta.Name,
-			"error", err,
-		)
-	}
+	s.logLiveInputError(pane.ID, pane.Meta.Name, s.enqueueLivePaneInput(pane, e.data))
 }
 
 type liveInputPaneEvent struct {
@@ -103,14 +96,24 @@ func (e liveInputPaneEvent) handle(s *Session) {
 	if e.cc != nil {
 		e.cc.notePredictionEpoch(pane.ID, e.epoch, e.data)
 	}
-	if err := s.enqueueLivePaneInput(pane, e.data); err != nil && !errors.Is(err, errPacedInputClosed) {
-		s.logger.Warn("live input failed",
-			"event", "live_input",
-			"pane_id", pane.ID,
-			"pane_name", pane.Meta.Name,
-			"error", err,
-		)
+	s.logLiveInputError(pane.ID, pane.Meta.Name, s.enqueueLivePaneInput(pane, e.data))
+}
+
+func (s *Session) logLiveInputError(paneID uint32, paneName string, err error) {
+	if err == nil || errors.Is(err, errPacedInputClosed) {
+		return
 	}
+	fields := []any{
+		"event", "live_input",
+		"pane_id", paneID,
+		"pane_name", paneName,
+		"error", err,
+	}
+	if errors.Is(err, errPacedInputBackpressure) {
+		s.logger.Debug("live input backpressure", fields...)
+		return
+	}
+	s.logger.Warn("live input failed", fields...)
 }
 
 func (s *Session) enqueueAttachClient(srv *Server, cc *clientConn, cols, rows int) attachResult {

--- a/internal/server/session_events_layout.go
+++ b/internal/server/session_events_layout.go
@@ -530,6 +530,10 @@ func (s *Session) startEventLoop() {
 	s.sessionEventDone = make(chan struct{})
 	go func() {
 		eventloop.Run(s, s.sessionEvents, s.sessionEventStop, s.sessionEventDone, func(s *Session) bool {
+			// With the watchdog enabled, Command.Handle runs on eventloop's
+			// handler goroutine while this hook runs on the Run goroutine after
+			// each handler completes. Keep hook work limited to serialized
+			// maintenance that does not call debugowner-asserted mutation helpers.
 			// Keep the active input target in sync with actor-owned focus/window
 			// state so the common input path can avoid a round-trip through the
 			// session queue.
@@ -553,16 +557,20 @@ func (s *Session) EventLoopWatchdogTimeout() time.Duration {
 	return s.SessionEventWatchdogTimeout
 }
 
-func (s *Session) HandleEventLoopWatchdogTimeout(commandType string, started time.Time, elapsed, timeout time.Duration, goroutineID uint64) {
+func (s *Session) EventLoopWatchdogSnapshot() eventloop.WatchdogSnapshot {
+	return eventloop.WatchdogSnapshot{StateName: s.Name}
+}
+
+func (s *Session) HandleEventLoopWatchdogTimeout(info eventloop.WatchdogTimeoutInfo) {
 	if s.logger != nil {
 		s.logger.Error("session event loop handler timed out",
 			"event", "event_loop_watchdog",
-			"session", s.Name,
-			"command_type", commandType,
-			"handler_started_at", started.Format(time.RFC3339Nano),
-			"elapsed", elapsed.String(),
-			"timeout", timeout.String(),
-			"goroutine_id", goroutineID,
+			"session", info.StateName,
+			"command_type", info.CommandType,
+			"handler_started_at", info.Started.Format(time.RFC3339Nano),
+			"elapsed", info.Elapsed.String(),
+			"timeout", info.Timeout.String(),
+			"goroutine_id", info.GoroutineID,
 		)
 	}
 	closeStopSignal(s.sessionEventStop)

--- a/internal/server/session_events_layout.go
+++ b/internal/server/session_events_layout.go
@@ -29,6 +29,10 @@ func (c sessionEventCommand) Handle(s *Session) {
 	c.sessionAction.handle(s)
 }
 
+func (c sessionEventCommand) EventLoopCommandType() string {
+	return fmt.Sprintf("%T", c.sessionAction)
+}
+
 type commandMutationResult struct {
 	output          string
 	err             error
@@ -525,7 +529,6 @@ func (s *Session) startEventLoop() {
 	s.sessionEventStop = make(chan struct{})
 	s.sessionEventDone = make(chan struct{})
 	go func() {
-		s.eventLoopOwner.Assert("server.Session", "eventLoop")
 		eventloop.Run(s, s.sessionEvents, s.sessionEventStop, s.sessionEventDone, func(s *Session) bool {
 			// Keep the active input target in sync with actor-owned focus/window
 			// state so the common input path can avoid a round-trip through the
@@ -540,6 +543,29 @@ func (s *Session) startEventLoop() {
 			return false
 		})
 	}()
+}
+
+func (s *Session) EnterEventLoopCommand() {
+	s.eventLoopOwner.Assert("server.Session", "eventLoop")
+}
+
+func (s *Session) EventLoopWatchdogTimeout() time.Duration {
+	return s.SessionEventWatchdogTimeout
+}
+
+func (s *Session) HandleEventLoopWatchdogTimeout(commandType string, started time.Time, elapsed, timeout time.Duration, goroutineID uint64) {
+	if s.logger != nil {
+		s.logger.Error("session event loop handler timed out",
+			"event", "event_loop_watchdog",
+			"session", s.Name,
+			"command_type", commandType,
+			"handler_started_at", started.Format(time.RFC3339Nano),
+			"elapsed", elapsed.String(),
+			"timeout", timeout.String(),
+			"goroutine_id", goroutineID,
+		)
+	}
+	closeStopSignal(s.sessionEventStop)
 }
 
 func (s *Session) stopEventLoop() {

--- a/internal/server/session_events_layout.go
+++ b/internal/server/session_events_layout.go
@@ -566,6 +566,9 @@ func (s *Session) HandleEventLoopWatchdogTimeout(commandType string, started tim
 		)
 	}
 	closeStopSignal(s.sessionEventStop)
+	if s.exitServer != nil {
+		go s.exitServer.Shutdown()
+	}
 }
 
 func (s *Session) stopEventLoop() {

--- a/internal/server/session_events_test.go
+++ b/internal/server/session_events_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/weill-labs/amux/internal/auditlog"
+	"github.com/weill-labs/amux/internal/eventloop"
 	"github.com/weill-labs/amux/internal/mux"
 	"github.com/weill-labs/amux/internal/proto"
 	"github.com/weill-labs/amux/internal/render"
@@ -353,6 +354,18 @@ func TestSessionWatchdogTimeoutConfigUsesSessionOverride(t *testing.T) {
 	}
 }
 
+func TestSessionWatchdogSnapshotCapturesSessionName(t *testing.T) {
+	t.Parallel()
+
+	sess := &Session{Name: "snapshot-before-handle"}
+	got := sess.EventLoopWatchdogSnapshot()
+	sess.Name = "snapshot-during-handle"
+
+	if got.StateName != "snapshot-before-handle" {
+		t.Fatalf("EventLoopWatchdogSnapshot().StateName = %q, want pre-handle session name", got.StateName)
+	}
+}
+
 func TestSessionWatchdogTimeoutClosesStopAndShutsDownServer(t *testing.T) {
 	t.Parallel()
 
@@ -365,7 +378,14 @@ func TestSessionWatchdogTimeoutClosesStopAndShutsDownServer(t *testing.T) {
 		exitServer:       srv,
 	}
 
-	sess.HandleEventLoopWatchdogTimeout("server.liveInputEvent", time.Now(), 31*time.Second, 30*time.Second, 123)
+	sess.HandleEventLoopWatchdogTimeout(eventloop.WatchdogTimeoutInfo{
+		CommandType: "server.liveInputEvent",
+		Started:     time.Now(),
+		Elapsed:     31 * time.Second,
+		Timeout:     30 * time.Second,
+		GoroutineID: 123,
+		StateName:   "watchdog-timeout-test",
+	})
 
 	select {
 	case <-sess.sessionEventStop:

--- a/internal/server/session_events_test.go
+++ b/internal/server/session_events_test.go
@@ -334,6 +334,72 @@ func TestEnqueueLiveInputPaneResolvesFreshSessionPane(t *testing.T) {
 	}
 }
 
+func TestLiveInputEventDoesNotBlockWhenPacedInputQueueIsFull(t *testing.T) {
+	t.Parallel()
+
+	sess := newSession("test-live-input-queue-full")
+	stopCrashCheckpointLoop(t, sess)
+	t.Cleanup(func() {
+		stopSessionBackgroundLoops(t, sess)
+	})
+
+	started := make(chan struct{}, 1)
+	release := make(chan struct{})
+	t.Cleanup(func() {
+		close(release)
+	})
+
+	pane := mustSetupSinglePaneSession(t, sess, func(data []byte) (int, error) {
+		if string(data) == "blocked" {
+			started <- struct{}{}
+			<-release
+		}
+		return len(data), nil
+	})
+
+	_, err := enqueueSessionQuery(sess, func(sess *Session) (struct{}, error) {
+		return struct{}{}, sess.enqueueLivePaneInput(pane, []byte("blocked"))
+	})
+	if err != nil {
+		t.Fatalf("enqueueLivePaneInput(blocked) = %v", err)
+	}
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("blocked pane write did not start")
+	}
+
+	queue := mustSessionQuery(t, sess, func(sess *Session) *pacedInputQueue {
+		return sess.ensureInputRouter().paneQueues[pane.ID].queue
+	})
+	for i := 0; i < pacedInputRequestBufferSize; i++ {
+		if err := queue.enqueueAsync([]encodedKeyChunk{{data: []byte("queued")}}); err != nil {
+			t.Fatalf("enqueueAsync(fill %d) = %v", i, err)
+		}
+	}
+
+	if !sess.enqueueEvent(liveInputEvent{data: []byte("overflow")}) {
+		t.Fatal("enqueueEvent(liveInputEvent) = false, want true")
+	}
+
+	actorReady := make(chan error, 1)
+	go func() {
+		_, err := enqueueSessionQuery(sess, func(*Session) (struct{}, error) {
+			return struct{}{}, nil
+		})
+		actorReady <- err
+	}()
+
+	select {
+	case err := <-actorReady:
+		if err != nil {
+			t.Fatalf("session actor returned error after live input: %v", err)
+		}
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("liveInputEvent blocked the session actor on a full paced input queue")
+	}
+}
+
 func TestResetCommandBroadcastsClearedHistoryAndBlankScreen(t *testing.T) {
 	t.Parallel()
 

--- a/internal/server/session_events_test.go
+++ b/internal/server/session_events_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/weill-labs/amux/internal/auditlog"
 	"github.com/weill-labs/amux/internal/mux"
 	"github.com/weill-labs/amux/internal/proto"
 	"github.com/weill-labs/amux/internal/render"
@@ -331,6 +332,51 @@ func TestEnqueueLiveInputPaneResolvesFreshSessionPane(t *testing.T) {
 		}
 	case <-time.After(time.Second):
 		t.Fatal("targeted live input did not reach the fresh-session pane")
+	}
+}
+
+func TestSessionEventCommandReportsActionType(t *testing.T) {
+	t.Parallel()
+
+	got := (sessionEventCommand{sessionAction: liveInputEvent{}}).EventLoopCommandType()
+	if !strings.Contains(got, "liveInputEvent") {
+		t.Fatalf("EventLoopCommandType() = %q, want liveInputEvent", got)
+	}
+}
+
+func TestSessionWatchdogTimeoutConfigUsesSessionOverride(t *testing.T) {
+	t.Parallel()
+
+	sess := &Session{SessionEventWatchdogTimeout: 75 * time.Millisecond}
+	if got := sess.EventLoopWatchdogTimeout(); got != 75*time.Millisecond {
+		t.Fatalf("EventLoopWatchdogTimeout() = %v, want 75ms", got)
+	}
+}
+
+func TestSessionWatchdogTimeoutClosesStopAndShutsDownServer(t *testing.T) {
+	t.Parallel()
+
+	shutdownDone := make(chan struct{})
+	srv := &Server{shutdownDone: shutdownDone}
+	sess := &Session{
+		Name:             "watchdog-timeout-test",
+		logger:           auditlog.Discard(),
+		sessionEventStop: make(chan struct{}),
+		exitServer:       srv,
+	}
+
+	sess.HandleEventLoopWatchdogTimeout("server.liveInputEvent", time.Now(), 31*time.Second, 30*time.Second, 123)
+
+	select {
+	case <-sess.sessionEventStop:
+	case <-time.After(time.Second):
+		t.Fatal("watchdog timeout did not close sessionEventStop")
+	}
+
+	select {
+	case <-shutdownDone:
+	case <-time.After(time.Second):
+		t.Fatal("watchdog timeout did not trigger server shutdown")
 	}
 }
 

--- a/internal/server/session_events_test.go
+++ b/internal/server/session_events_test.go
@@ -466,6 +466,46 @@ func TestLiveInputEventDoesNotBlockWhenPacedInputQueueIsFull(t *testing.T) {
 	}
 }
 
+func TestLogLiveInputErrorDowngradesBackpressure(t *testing.T) {
+	t.Parallel()
+
+	logger, buf := newAuditTestLogger()
+	sess := &Session{logger: logger}
+
+	sess.logLiveInputError(7, "pane-7", errPacedInputBackpressure)
+
+	records := parseAuditRecords(t, buf)
+	if len(records) != 1 {
+		t.Fatalf("log record count = %d, want 1", len(records))
+	}
+	if records[0]["msg"] != "live input backpressure" {
+		t.Fatalf("log msg = %v, want live input backpressure", records[0]["msg"])
+	}
+	if records[0]["event"] != "live_input" {
+		t.Fatalf("log event = %v, want live_input", records[0]["event"])
+	}
+}
+
+func TestLogLiveInputErrorWarnsUnexpectedFailures(t *testing.T) {
+	t.Parallel()
+
+	logger, buf := newAuditTestLogger()
+	sess := &Session{logger: logger}
+
+	sess.logLiveInputError(7, "pane-7", errors.New("write failed"))
+
+	records := parseAuditRecords(t, buf)
+	if len(records) != 1 {
+		t.Fatalf("log record count = %d, want 1", len(records))
+	}
+	if records[0]["msg"] != "live input failed" {
+		t.Fatalf("log msg = %v, want live input failed", records[0]["msg"])
+	}
+	if records[0]["event"] != "live_input" {
+		t.Fatalf("log event = %v, want live_input", records[0]["event"])
+	}
+}
+
 func TestResetCommandBroadcastsClearedHistoryAndBlankScreen(t *testing.T) {
 	t.Parallel()
 

--- a/test/crash_recovery_test.go
+++ b/test/crash_recovery_test.go
@@ -504,6 +504,7 @@ func startServerForSession(t *testing.T, session, home string) *ServerHarness {
 	env := upsertEnv(cmd.Env, "HOME", home)
 	env = upsertEnv(env, "AMUX_LOG_DIR", logDir)
 	env = append(env, "AMUX_READY_FD=3", "AMUX_SHUTDOWN_FD=4", "AMUX_NO_WATCH=1", "AMUX_EXIT_UNATTACHED=1", "AMUX_DISABLE_META_REFRESH=1")
+	env = applyHarnessShellEnv(t, env)
 
 	// Per-test cover dir
 	var coverDir string


### PR DESCRIPTION
## Motivation

The production `main` session wedged with the server still alive but every session command hanging behind the single session actor. The load-bearing hypothesis is confirmed: disassembly of the running binary shows `eventloop.Run +0xef` at `0x8ac72f`, immediately after the indirect `CALL CX` to `cmd.Handle(state)`, and the goroutine dump stack above that frame is `liveInputEvent.handle -> enqueueLivePaneInput -> pacedInputQueue.enqueueAsyncRequest`.

## Summary

- Add a configurable `eventloop` watchdog with a 30s default for a single `Command.Handle` call. On timeout it reports command type, handler start time, elapsed time, timeout, and handler goroutine ID.
- Wire session watchdog timeouts to log `event_loop_watchdog`, close the session event loop stop channel, and ask the owning server to shut down so the next attach can recover through normal startup.
- Fix the identified root cause: live input no longer blocks the session actor when a pane's paced input queue is full; `enqueueAsync` returns a backpressure error instead of parking in the actor.
- Add regressions for the watchdog, session watchdog callbacks, saturated async paced input, and `liveInputEvent` actor progress under saturated pane-input backpressure.
- Reuse the harness shell wrapper on crash-recovery restarts so integration tests do not inherit ambient zsh first-run prompts in temp homes.

Fixed: the observed `liveInputEvent` -> `pacedInputQueue.enqueueAsyncRequest` actor wedge path.

Guarded: future handlers that run longer than the watchdog threshold now fail loudly and force session/server recovery instead of silently blocking producers forever.

Deferred: context-aware `Enqueue`/`EnqueueQuery` cancellation and a pprof-backed `_diag` command remain follow-up scope.

## Testing

- `go test ./internal/eventloop -run TestRunWatchdogReportsStuckHandlerAndStopsLoop -count=100 -timeout 30s`
- `go test ./internal/server -run 'TestSessionEventCommandReportsActionType|TestSessionWatchdogTimeoutConfigUsesSessionOverride|TestSessionWatchdogTimeoutClosesStopAndShutsDownServer|TestPacedInputQueueAsyncReturnsErrorWhenBufferFull|TestLiveInputEventDoesNotBlockWhenPacedInputQueueIsFull' -count=100 -timeout 60s`
- `go test -race ./internal/eventloop -count=10 -timeout 60s`
- `go test ./test -run TestCrashRecovery_ -count=1 -timeout 120s`
- `go test ./test -run TestPaneMetaSurvivesCrashRecovery -count=1 -timeout 120s`
- `go test ./test -run TestMetaSetSetsTaskAndBranch -count=1 -timeout 120s`
- `go test ./internal/eventloop ./internal/server ./test -timeout 120s`
- `go test ./... -timeout 120s`

Not run: `make install` or live throwaway-session watchdog verification, because replacing the installed binary would hot-reload live sessions and the request explicitly said not to restart live sessions during testing.

## Review focus

Please look closely at the watchdog worker/timeout semantics in `internal/eventloop/loop.go`, especially that state remains serialized through one handler worker and that a timed-out handler cannot keep producers blocked on `done`.

Also review the live-input backpressure tradeoff: once a pane input queue already has 256 pending async chunks behind a blocked writer, new live input is rejected/logged instead of wedging the session actor.

Closes LAB-1893
