### PR TITLE
LAB-1911: Transfer display snapshot grid ownership

### DIFF
--- a/internal/render/compositor.go
+++ b/internal/render/compositor.go
@@ -46,7 +46,10 @@ type Compositor struct {
 	cachedBorderRoot *mux.LayoutCell
 	cachedBorderH    int
 
-	// Previous frame's grid for diff rendering. Nil forces full paint.
+	// Previous frame's grid for diff rendering. Nil forces full paint. Once a
+	// grid is assigned here it is immutable: dirty rendering must clone it
+	// before composing the next frame, allowing prevGridSnap to publish the
+	// same owned grid without a second full-cell copy.
 	prevGrid          *ScreenGrid
 	prevGridSnap      atomic.Pointer[ScreenGrid]
 	prevGridLayoutKey string
@@ -386,11 +389,7 @@ func preciseSGREnabled() bool {
 }
 
 func (c *Compositor) publishPrevGridSnapshot(g *ScreenGrid) {
-	if g == nil {
-		c.prevGridSnap.Store(nil)
-		return
-	}
-	c.prevGridSnap.Store(g.Clone())
+	c.prevGridSnap.Store(g)
 }
 
 func (c *Compositor) layoutReuseKey(root *mux.LayoutCell, activePaneID uint32, layoutHeight int) string {

--- a/internal/render/compositor_snapshot_test.go
+++ b/internal/render/compositor_snapshot_test.go
@@ -1,24 +1,24 @@
 package render
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/weill-labs/amux/internal/config"
 	"github.com/weill-labs/amux/internal/mux"
 )
 
-func TestRenderDiffPublishesPrevGridSnapshot(t *testing.T) {
+func TestRenderDiffPublishesOwnedPrevGridSnapshot(t *testing.T) {
 	t.Parallel()
 
 	comp := NewCompositor(20, 6, "test")
 	root := mux.NewLeaf(&mux.Pane{ID: 1}, 0, 0, 20, 5)
+	screen := "snapshot row\n\n\n"
 	lookup := func(uint32) PaneData {
 		return &statusPaneData{
 			id:     1,
 			name:   "pane-1",
 			color:  config.TextColorHex,
-			screen: "snapshot row\n\n\n",
+			screen: screen,
 		}
 	}
 
@@ -28,16 +28,33 @@ func TestRenderDiffPublishesPrevGridSnapshot(t *testing.T) {
 	if snap == nil {
 		t.Fatal("RenderDiff should publish a prevGrid snapshot")
 	}
-	if snap == comp.prevGrid {
-		t.Fatal("published snapshot should be a clone, not the mutable prevGrid pointer")
+	if snap != comp.prevGrid {
+		t.Fatal("published snapshot should own the rendered prevGrid pointer without cloning")
 	}
-	if got, want := gridToText(snap), gridToText(comp.prevGrid); got != want {
+	firstSnapshotText := gridToText(snap)
+	if got, want := firstSnapshotText, gridToText(comp.prevGrid); got != want {
 		t.Fatalf("published snapshot text mismatch:\n--- got ---\n%s\n--- want ---\n%s", got, want)
 	}
 
-	comp.prevGrid.Set(0, 1, ScreenCell{Char: "X", Width: 1})
-	if got := gridToText(snap); strings.Contains(got, "Xnapshot row") {
-		t.Fatalf("published snapshot changed after prevGrid mutation:\n%s", got)
+	screen = "updated row\n\n\n"
+	comp.RenderDiffWithOverlayDirtyStats(root, 1, lookup, OverlayState{}, map[uint32]struct{}{1: {}}, false)
+	if got := gridToText(snap); got != firstSnapshotText {
+		t.Fatalf("previous published snapshot changed after next render:\n--- got ---\n%s\n--- want ---\n%s", got, firstSnapshotText)
+	}
+	if next := comp.prevGridSnap.Load(); next == nil || next == snap {
+		t.Fatal("next render should publish the newly rendered grid")
+	}
+}
+
+func TestPublishPrevGridSnapshotDoesNotAllocate(t *testing.T) {
+	comp := NewCompositor(80, 24, "test")
+	grid := NewScreenGrid(80, 24)
+
+	allocs := testing.AllocsPerRun(1000, func() {
+		comp.publishPrevGridSnapshot(grid)
+	})
+	if allocs > 0 {
+		t.Fatalf("publishPrevGridSnapshot allocated %.2f times; want ownership transfer without allocation", allocs)
 	}
 }
 
@@ -89,7 +106,6 @@ func TestPrevGridTextRectCropsPublishedSnapshot(t *testing.T) {
 	}
 
 	comp.publishPrevGridSnapshot(grid)
-	grid.Set(1, 1, ScreenCell{Char: "X", Width: 1})
 
 	if got, want := comp.PrevGridTextRect(1, 1, 3, 2), "hij\nnop"; got != want {
 		t.Fatalf("PrevGridTextRect() = %q, want %q", got, want)

--- a/internal/render/compositor_snapshot_test.go
+++ b/internal/render/compositor_snapshot_test.go
@@ -47,6 +47,7 @@ func TestRenderDiffPublishesOwnedPrevGridSnapshot(t *testing.T) {
 }
 
 func TestPublishPrevGridSnapshotDoesNotAllocate(t *testing.T) {
+	// Not parallel: testing.AllocsPerRun panics when called after t.Parallel.
 	comp := NewCompositor(80, 24, "test")
 	grid := NewScreenGrid(80, 24)
 

--- a/internal/render/screen.go
+++ b/internal/render/screen.go
@@ -370,6 +370,8 @@ func (c *Compositor) buildGridWithOverlayDirty(
 		return c.buildGridWithOverlay(root, activePaneID, lookup, overlay)
 	}
 
+	// prevGrid may be published concurrently for display capture. Clone before
+	// applying dirty-pane updates so previously published frames stay immutable.
 	g := c.prevGrid.Clone()
 	g.Debug = c.debug
 


### PR DESCRIPTION
## Motivation

Display snapshot publication cloned every rendered ScreenGrid before storing it for client-side capture. The allocation profile showed ScreenGrid.Clone as the dominant cumulative alloc-space source, with the publication clone adding churn without changing the rendered frame.

## Summary

- Publish the rendered prevGrid directly through the atomic display snapshot pointer.
- Document the ownership invariant: once a grid becomes prevGrid it is immutable, and dirty rendering clones it before applying the next frame.
- Update snapshot tests to assert ownership transfer, previous-frame immutability across the next render, and zero allocations in snapshot publication.

## Testing

- go test ./internal/render -run 'TestRenderDiffPublishesOwnedPrevGridSnapshot|TestPublishPrevGridSnapshotDoesNotAllocate|TestPrevGridTextRectCropsPublishedSnapshot' -count=100
- go test ./internal/client -run 'TestCaptureDisplay|TestHandleCaptureRequest_DisplayFlag|TestDisplayPanesOverlayDisplayOnly|TestCaptureDisplayShowsPaneDragOverlay' -count=100
- go test -race ./internal/render -run 'TestRenderDiffPublishesOwnedPrevGridSnapshot|TestPrevGridTextRectCropsPublishedSnapshot' -count=20
- go test -race ./internal/client -run 'TestCaptureDisplayDoesNotWaitForRendererActor|TestHandleCaptureRequest_DisplayFlag|TestDisplayPanesOverlayDisplayOnly' -count=10
- go test ./internal/render -run '^$' -bench '^BenchmarkCompositorDirtyPaneRepresentative$' -benchmem -memprofile /tmp/lab-1911-before.mem -count=5
- go test ./internal/render -run '^$' -bench '^BenchmarkCompositorDirtyPaneRepresentative$' -benchmem -memprofile /tmp/lab-1911-after.mem -count=5
- go test ./internal/render ./internal/client
- go test ./test -run '^TestParallelAudit$' -count=1
- go test ./test -run 'TestDisplayPanesZoomedOnlyShowsVisiblePane|TestMouseStatusLineDragAtWindowBoundaryCreatesRootSplit' -count=1 -timeout 120s
- go test ./test -run 'TestMetaSetStoresArbitraryMetadataAndProjectsReservedKeys|TestCopyModeClipboardLargeUTF8RoundTripsPaste' -count=1 -timeout 120s

Full `go test ./... -timeout 120s` was run twice locally. Both runs failed in different unrelated integration tests; all failed tests passed when rerun directly. First run: `TestDisplayPanesZoomedOnlyShowsVisiblePane`, `TestMouseStatusLineDragAtWindowBoundaryCreatesRootSplit`, plus the branch-owned parallel audit issue that is now fixed. Second run: `TestMetaSetStoresArbitraryMetadataAndProjectsReservedKeys`, `TestCopyModeClipboardLargeUTF8RoundTripsPaste`.

## Baseline numbers

Hardware: AMD EPYC-Milan Processor, linux/amd64.

| Benchmark | Before | After |
| --- | ---: | ---: |
| BenchmarkCompositorDirtyPaneRepresentative B/op | 4,618,039-4,618,047 | 2,438,884-2,438,900 |
| BenchmarkCompositorDirtyPaneRepresentative allocs/op | 138 | 136 |
| pprof alloc_space publishPrevGridSnapshot | 3,752.10 MB cumulative | not present |

## Review focus

Please check the ownership invariant around `prevGrid`, `prevGridSnap`, and the dirty-render clone boundary. The key assumption is that no production path mutates a grid after assigning it to `prevGrid`.

Closes LAB-1911
