### PR TITLE
LAB-1908: Make pane ANSI capture lazy

### DIFF
--- a/internal/client/renderer_capture_snapshot.go
+++ b/internal/client/renderer_capture_snapshot.go
@@ -12,19 +12,17 @@ import (
 )
 
 type paneRenderSnapshot struct {
-	width            int
-	height           int
-	cursorCol        int
-	cursorRow        int
-	cursorHidden     bool
-	terminal         proto.TerminalState
-	rendered         string
-	renderedNoCursor string
-	scrollback       []paneBufferLine
-	screen           []paneBufferLine
-	cursorBlockCol   int
-	cursorBlockRow   int
-	hasCursorBlock   bool
+	width          int
+	height         int
+	cursorCol      int
+	cursorRow      int
+	cursorHidden   bool
+	terminal       proto.TerminalState
+	scrollback     []paneBufferLine
+	screen         []paneBufferLine
+	cursorBlockCol int
+	cursorBlockRow int
+	hasCursorBlock bool
 }
 
 type paneRenderSnapshotState struct {
@@ -34,11 +32,6 @@ type paneRenderSnapshotState struct {
 	screenWidth      int
 	screenHeight     int
 	screen           []paneBufferLine
-	renderWidth      int
-	renderHeight     int
-	rendered         string
-	renderedNoCursor string
-	renderedValid    bool
 	cursorBlockCol   int
 	cursorBlockRow   int
 	hasCursorBlock   bool
@@ -71,34 +64,6 @@ func capturePaneRenderSnapshot(emu mux.TerminalEmulator, prev paneRenderSnapshot
 	state.cursorBlockRow = cursorBlockRow
 	state.hasCursorBlock = hasCursorBlock
 	return snap, state, screenChanged
-}
-
-func captureRenderedSnapshot(emu mux.TerminalEmulator, prev paneRenderSnapshotState, width, height int, screenChanged bool, cursorBlockCol, cursorBlockRow int, hasCursorBlock bool) (rendered, renderedNoCursor string) {
-	renderCacheValid := prev.renderedValid && prev.renderWidth == width && prev.renderHeight == height
-	cursorBlockChanged := prev.hasCursorBlock != hasCursorBlock ||
-		(hasCursorBlock && (prev.cursorBlockCol != cursorBlockCol || prev.cursorBlockRow != cursorBlockRow))
-	if !renderCacheValid || screenChanged || cursorBlockChanged {
-		rendered = emu.Render()
-		renderedNoCursor = rendered
-		if hasCursorBlock {
-			renderedNoCursor = renderWithoutCursorBlockSnapshot(emu)
-		}
-		return rendered, renderedNoCursor
-	}
-
-	rendered = prev.rendered
-	if !hasCursorBlock {
-		return rendered, rendered
-	}
-	return rendered, prev.renderedNoCursor
-}
-
-func renderWithoutCursorBlockSnapshot(emu mux.TerminalEmulator) string {
-	rendered := emu.RenderWithoutCursorBlock()
-	// RenderWithoutCursorBlock temporarily edits emulator cells. Clear that
-	// internal touched state so the next snapshot only sees real PTY changes.
-	emu.DrainScreenChanges()
-	return rendered
 }
 
 func captureScrollbackSnapshot(emu mux.TerminalEmulator, prev paneRenderSnapshotState) paneRenderSnapshotState {
@@ -220,14 +185,11 @@ func emptyPaneRenderSnapshot(width, height int) paneRenderSnapshot {
 		height = 0
 	}
 	screen := make([]paneBufferLine, height)
-	rendered := strings.Repeat("\n", max(0, height-1))
 	return paneRenderSnapshot{
-		width:            width,
-		height:           height,
-		cursorHidden:     true,
-		rendered:         rendered,
-		renderedNoCursor: rendered,
-		screen:           screen,
+		width:        width,
+		height:       height,
+		cursorHidden: true,
+		screen:       screen,
 	}
 }
 

--- a/internal/client/renderer_capture_snapshot.go
+++ b/internal/client/renderer_capture_snapshot.go
@@ -51,18 +51,15 @@ func capturePaneRenderSnapshot(emu mux.TerminalEmulator, prev paneRenderSnapshot
 	screenState, screenChanged := captureScreenSnapshot(emu, prev, width, height)
 
 	cursorBlockCol, cursorBlockRow, hasCursorBlock := emu.CursorBlockPosition()
-	rendered, renderedNoCursor := captureRenderedSnapshot(emu, prev, width, height, screenChanged, cursorBlockCol, cursorBlockRow, hasCursorBlock)
 	snap := paneRenderSnapshot{
-		width:            width,
-		height:           height,
-		cursorCol:        cursorCol,
-		cursorRow:        cursorRow,
-		cursorHidden:     emu.CursorHidden(),
-		terminal:         cloneTerminalState(emu.TerminalState()),
-		rendered:         rendered,
-		renderedNoCursor: renderedNoCursor,
-		scrollback:       scrollbackState.scrollback,
-		screen:           screenState.screen,
+		width:        width,
+		height:       height,
+		cursorCol:    cursorCol,
+		cursorRow:    cursorRow,
+		cursorHidden: emu.CursorHidden(),
+		terminal:     cloneTerminalState(emu.TerminalState()),
+		scrollback:   scrollbackState.scrollback,
+		screen:       screenState.screen,
 	}
 	if hasCursorBlock {
 		snap.cursorBlockCol = cursorBlockCol
@@ -70,11 +67,6 @@ func capturePaneRenderSnapshot(emu mux.TerminalEmulator, prev paneRenderSnapshot
 		snap.hasCursorBlock = true
 	}
 	state := mergePaneSnapshotState(scrollbackState, screenState)
-	state.renderWidth = width
-	state.renderHeight = height
-	state.rendered = rendered
-	state.renderedNoCursor = renderedNoCursor
-	state.renderedValid = true
 	state.cursorBlockCol = cursorBlockCol
 	state.cursorBlockRow = cursorBlockRow
 	state.hasCursorBlock = hasCursorBlock
@@ -328,11 +320,7 @@ type snapshotPaneData struct {
 }
 
 func (p *snapshotPaneData) RenderScreen(active bool) string {
-	rendered := p.pane.rendered
-	if !active && p.pane.hasCursorBlock {
-		rendered = p.pane.renderedNoCursor
-	}
-	return filterRenderedANSI(rendered, p.caps)
+	return renderPaneSnapshotANSI(p.pane, active, p.caps)
 }
 
 func (p *snapshotPaneData) CellAt(col, row int, active bool) render.ScreenCell {
@@ -387,7 +375,12 @@ func (p *snapshotPaneData) CopyModeSearch() string {
 }
 
 func (p paneRenderSnapshot) ansiString(caps proto.ClientCapabilities) string {
-	return filterRenderedANSI(p.rendered, caps)
+	return renderPaneSnapshotANSI(p, true, caps)
+}
+
+func renderPaneSnapshotANSI(pane paneRenderSnapshot, active bool, caps proto.ClientCapabilities) string {
+	data := snapshotPaneData{pane: pane, caps: caps}
+	return filterRenderedANSI(render.RenderPaneViewportANSI(pane.width, pane.height, active, &data), caps)
 }
 
 func (p paneRenderSnapshot) textString() string {

--- a/internal/client/renderer_capture_snapshot_test.go
+++ b/internal/client/renderer_capture_snapshot_test.go
@@ -660,7 +660,7 @@ func TestPaneCaptureMissingWarmSnapshotReturnsBlank(t *testing.T) {
 	if len(pane.screen) != pane.height {
 		t.Fatalf("screen lines = %d, want %d", len(pane.screen), pane.height)
 	}
-	if got, want := pane.rendered, "\n\n\n"; got != want {
+	if got, want := render.MaterializeGrid(pane.ansiString(proto.ClientCapabilities{}), pane.width, pane.height), "\n\n\n"; got != want {
 		t.Fatalf("rendered blank pane = %q, want %q", got, want)
 	}
 	if !pane.cursorHidden {

--- a/internal/client/renderer_capture_snapshot_test.go
+++ b/internal/client/renderer_capture_snapshot_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/weill-labs/amux/internal/mouse"
 	"github.com/weill-labs/amux/internal/mux"
 	"github.com/weill-labs/amux/internal/proto"
+	"github.com/weill-labs/amux/internal/render"
 )
 
 type captureSnapshotFakeEmulator struct {
@@ -261,90 +262,110 @@ func TestCapturePaneRenderSnapshotIncrementalScrollback(t *testing.T) {
 	}
 }
 
-func TestCapturePaneRenderSnapshotReusesRenderedANSIWhenScreenUnchanged(t *testing.T) {
+func TestCapturePaneRenderSnapshotSkipsRenderedANSIOnPublish(t *testing.T) {
 	t.Parallel()
 
 	emu := newCaptureSnapshotFakeEmulator(nil, 0)
 	emu.screen = []string{"cached", "screen"}
 	emu.screenChanged = true
-
-	first, state, screenChanged := capturePaneRenderSnapshot(emu, paneRenderSnapshotState{})
-	if !screenChanged {
-		t.Fatal("initial capture should report drained screen changes")
-	}
-	if got, want := emu.renderCalls, 1; got != want {
-		t.Fatalf("initial Render calls = %d, want %d", got, want)
-	}
-
-	emu.renderCalls = 0
-	emu.screenChanged = false
-	second, _, screenChanged := capturePaneRenderSnapshot(emu, state)
-	if screenChanged {
-		t.Fatal("unchanged capture should not report screen changes")
-	}
-
-	if got := emu.renderCalls; got != 0 {
-		t.Fatalf("Render calls after unchanged screen = %d, want 0", got)
-	}
-	if second.rendered != first.rendered {
-		t.Fatalf("rendered ANSI changed after unchanged screen: got %q, want %q", second.rendered, first.rendered)
-	}
-	if second.renderedNoCursor != first.renderedNoCursor {
-		t.Fatalf("cursorless ANSI changed after unchanged screen: got %q, want %q", second.renderedNoCursor, first.renderedNoCursor)
-	}
-}
-
-func TestCapturePaneRenderSnapshotCachesCursorlessANSI(t *testing.T) {
-	t.Parallel()
-
-	emu := newCaptureSnapshotFakeEmulator(nil, 0)
-	emu.screen = []string{"cursor", "screen"}
-	emu.screenChanged = true
 	emu.hasCursorBlock = true
 	emu.cursorBlockCol = 1
 	emu.cursorBlockRow = 0
 
-	first, state, _ := capturePaneRenderSnapshot(emu, paneRenderSnapshotState{})
-	if !first.hasCursorBlock {
+	snap, state, screenChanged := capturePaneRenderSnapshot(emu, paneRenderSnapshotState{})
+	if !screenChanged {
+		t.Fatal("initial capture should report drained screen changes")
+	}
+	if !snap.hasCursorBlock {
 		t.Fatal("snapshot should record cursor block metadata")
 	}
-	if first.cursorBlockCol != 1 || first.cursorBlockRow != 0 {
-		t.Fatalf("cursor block position = %d,%d, want 1,0", first.cursorBlockCol, first.cursorBlockRow)
+	if snap.cursorBlockCol != 1 || snap.cursorBlockRow != 0 {
+		t.Fatalf("cursor block position = %d,%d, want 1,0", snap.cursorBlockCol, snap.cursorBlockRow)
 	}
-	if got, want := emu.renderCalls, 1; got != want {
-		t.Fatalf("initial Render calls = %d, want %d", got, want)
+	if got := emu.renderCalls; got != 0 {
+		t.Fatalf("initial Render calls = %d, want 0", got)
 	}
-	if got, want := emu.renderNoCursorCalls, 1; got != want {
-		t.Fatalf("initial RenderWithoutCursorBlock calls = %d, want %d", got, want)
+	if got := emu.renderNoCursorCalls; got != 0 {
+		t.Fatalf("initial RenderWithoutCursorBlock calls = %d, want 0", got)
 	}
 
 	emu.renderCalls = 0
 	emu.renderNoCursorCalls = 0
 	emu.screenChanged = false
-	second, state, _ := capturePaneRenderSnapshot(emu, state)
+	_, _, screenChanged = capturePaneRenderSnapshot(emu, state)
+	if screenChanged {
+		t.Fatal("unchanged capture should not report screen changes")
+	}
 	if got := emu.renderCalls; got != 0 {
-		t.Fatalf("same cursor-block Render calls = %d, want 0", got)
+		t.Fatalf("Render calls after unchanged screen = %d, want 0", got)
 	}
 	if got := emu.renderNoCursorCalls; got != 0 {
-		t.Fatalf("same cursor-block RenderWithoutCursorBlock calls = %d, want 0", got)
+		t.Fatalf("RenderWithoutCursorBlock calls after unchanged screen = %d, want 0", got)
 	}
-	if second.renderedNoCursor != first.renderedNoCursor {
-		t.Fatalf("cursorless ANSI was not reused: got %q, want %q", second.renderedNoCursor, first.renderedNoCursor)
+}
+
+func TestPaneRenderSnapshotANSIStringUsesCapturedCells(t *testing.T) {
+	t.Parallel()
+
+	snap := paneRenderSnapshot{
+		width:  4,
+		height: 2,
+		screen: []paneBufferLine{
+			{cells: []render.ScreenCell{
+				{Char: "h", Width: 1},
+				{Char: "i", Width: 1},
+				{Char: " ", Width: 1},
+				{Char: " ", Width: 1},
+			}},
+			{cells: []render.ScreenCell{
+				{Char: "l", Width: 1},
+				{Char: "i", Width: 1, Link: uv.Link{URL: "https://example.com"}},
+				{Char: "n", Width: 1, Link: uv.Link{URL: "https://example.com"}},
+				{Char: "k", Width: 1},
+			}},
+		},
 	}
 
-	emu.cursorBlockCol = 2
-	third, _, _ := capturePaneRenderSnapshot(emu, state)
-	if got, want := emu.renderCalls, 1; got != want {
-		t.Fatalf("moved cursor-block Render calls = %d, want %d", got, want)
+	plainCaps := proto.ClientCapabilities{}
+	if got := render.MaterializeGrid(snap.ansiString(plainCaps), snap.width, snap.height); got != "hi\nlink" {
+		t.Fatalf("materialized ANSI capture = %q, want %q", got, "hi\nlink")
 	}
-	if got, want := emu.renderNoCursorCalls, 1; got != want {
-		t.Fatalf("moved cursor-block RenderWithoutCursorBlock calls = %d, want %d", got, want)
+	if ansi := snap.ansiString(plainCaps); strings.Contains(ansi, "\033]8;") {
+		t.Fatalf("ANSI capture should filter hyperlinks without capability, got %q", ansi)
 	}
-	if third.rendered == second.rendered {
-		t.Fatalf("moved cursor block should refresh rendered ANSI, got %q", third.rendered)
+
+	ansi := snap.ansiString(proto.ClientCapabilities{Hyperlinks: true})
+	if !strings.Contains(ansi, "\033]8;") {
+		t.Fatalf("ANSI capture should preserve hyperlinks with capability, got %q", ansi)
 	}
-	if third.renderedNoCursor == second.renderedNoCursor {
-		t.Fatalf("moved cursor block should refresh cursorless ANSI, got %q", third.renderedNoCursor)
+}
+
+func TestSnapshotPaneDataRenderScreenStripsInactiveCursorBlock(t *testing.T) {
+	t.Parallel()
+
+	reverse := uv.Style{Attrs: uv.AttrReverse}
+	snap := paneRenderSnapshot{
+		width:          2,
+		height:         1,
+		cursorBlockCol: 0,
+		cursorBlockRow: 0,
+		hasCursorBlock: true,
+		screen: []paneBufferLine{
+			{cells: []render.ScreenCell{
+				{Char: " ", Width: 1, Style: reverse},
+				{Char: "x", Width: 1},
+			}},
+		},
+	}
+	pane := snapshotPaneData{pane: snap}
+
+	active := pane.RenderScreen(true)
+	if !strings.Contains(active, "\033[7m") {
+		t.Fatalf("active pane ANSI should preserve cursor block reverse video, got %q", active)
+	}
+	inactive := pane.RenderScreen(false)
+	if strings.Contains(inactive, "\033[7m") {
+		t.Fatalf("inactive pane ANSI should strip cursor block reverse video, got %q", inactive)
 	}
 }
 


### PR DESCRIPTION
## Motivation

The client renderer still refreshed full rendered ANSI snapshots from ordinary pane output when visible pane content changed. The live profile in LAB-1908 showed that `publishPaneCapture -> capturePaneRenderSnapshot -> vt.Emulator.Render -> ultraviolet.renderLine` had become the remaining client-side hot path after the earlier scrollback, screen-cell, and compositor reductions.

## Summary

- Stop storing rendered ANSI strings in the warm pane capture snapshot state.
- Keep JSON/text/cell capture fields warm on pane-output publish: screen cells, text lines, scrollback text, cursor, cursor-block metadata, and terminal metadata.
- Generate pane ANSI lazily from the frozen cell snapshot through `render.RenderPaneViewportANSI` when `capture --ansi pane-N` or the compositor asks for pane ANSI.
- Preserve cursor-block handling for inactive pane rendering and preserve OSC 8 capability filtering on snapshot-backed ANSI capture.
- LAB-1909 overlap: no separate benchmark was added because main already has the focused local benchmark pair used here, `BenchmarkCapturePaneRenderSnapshotRenderChangedScreen` and `BenchmarkPublishPaneCaptureFullScrollback`.

## Testing

- `go test ./internal/client -run "^(TestCapturePaneRenderSnapshot|TestPaneRenderSnapshotANSIStringUsesCapturedCells|TestSnapshotPaneDataRenderScreenStripsInactiveCursorBlock|TestPaneCaptureMissingWarmSnapshotReturnsBlank|TestHandleCaptureRequestDoesNotWaitForRendererActor|TestCaptureDisplayDoesNotWaitForRendererActor|TestCapturePaneTextActorFallbackUsesCurrentCapabilities)$" -count=100 -timeout 120s`
- `go test -race ./internal/client -run "^(TestCapturePaneRenderSnapshot|TestPaneRenderSnapshotANSIStringUsesCapturedCells|TestSnapshotPaneDataRenderScreenStripsInactiveCursorBlock|TestPaneCaptureMissingWarmSnapshotReturnsBlank|TestHandleCaptureRequestDoesNotWaitForRendererActor|TestCaptureDisplayDoesNotWaitForRendererActor|TestCapturePaneTextActorFallbackUsesCurrentCapabilities)$" -count=10 -timeout 120s`
- `go test ./internal/client ./test -run "Capture|capture|RenderArtifacts" -count=1 -timeout 120s`
- `go test ./internal/client -count=1 -timeout 120s`
- `SHELL=/usr/bin/bash go test ./... -timeout 120s`
- `go test ./internal/client -run "^$" -bench "^(BenchmarkPublishPaneCaptureFullScrollback|BenchmarkCapturePaneRenderSnapshotRenderChangedScreen)$" -benchmem -count=5 -timeout 120s`

## Baseline numbers

Hardware: AMD EPYC-Milan Processor, linux/amd64, Go 1.25.10.

| Benchmark | Before median | After median | B/op before -> after | allocs/op before -> after |
| --- | ---: | ---: | ---: | ---: |
| `BenchmarkPublishPaneCaptureFullScrollback` | 1,221,271 ns/op | 676,227 ns/op | ~620,191 -> ~608,312 | 174 -> 94 |
| `BenchmarkCapturePaneRenderSnapshotRenderChangedScreen` | 650,951 ns/op | 69,933 ns/op | 69,008 -> 30,576 | 169 -> 9 |

Before profile inputs were the LAB-1908 client profiles named in the brief: `/tmp/amux-main-client-20260525-063912.pprof` and `/tmp/amux-main-client-idle-20260525-064145.pprof`. This PR uses the benchmark pair above as the after measurement.

## Review focus

Please check that cell-derived ANSI is an acceptable replacement for cached `emu.Render()` output in snapshot-backed pane capture, especially OSC 8 filtering, inactive cursor-block stripping, and full-screen capture through the compositor fast path.

Closes LAB-1908