### PR TITLE
LAB-1909: Benchmark busy client renderer loop

### DIFF
--- a/.github/workflows/renderer-benchmark.yml
+++ b/.github/workflows/renderer-benchmark.yml
@@ -29,6 +29,9 @@ jobs:
           - package: ./internal/client
             benchmark: BenchmarkCapturePaneRenderSnapshotRenderChangedScreen
             file: internal/client/renderer_bench_test.go
+          - package: ./internal/client
+            benchmark: BenchmarkClientRendererBusyMultiPaneRenderLoop
+            file: internal/client/renderer_busy_bench_test.go
           - package: ./internal/render
             benchmark: BenchmarkCompositorDirtyPaneRepresentative
             file: internal/render/compositor_bench_test.go

--- a/docs/client-renderer-benchmarks.md
+++ b/docs/client-renderer-benchmarks.md
@@ -1,0 +1,33 @@
+# Client renderer benchmarks
+
+`BenchmarkClientRendererBusyMultiPaneRenderLoop` is a reproducible local
+workload for the May 25, 2026 busy client profiles. It uses a 240x82 client
+with ten visible panes arranged as a 2x5 grid, updates four panes per frame
+with styled ANSI output, publishes pane capture snapshots, and runs one dirty
+diff render for each benchmark operation.
+
+Run the CI-safe benchmark with allocation reporting:
+
+```bash
+go test ./internal/client -run '^$' -bench '^BenchmarkClientRendererBusyMultiPaneRenderLoop$' -benchmem -count=10 -timeout 120s
+```
+
+Capture a CPU profile:
+
+```bash
+go test ./internal/client -run '^$' -bench '^BenchmarkClientRendererBusyMultiPaneRenderLoop$' -benchtime=10s -cpuprofile /tmp/lab1909-client-renderer.cpu.pprof -benchmem -timeout 120s
+go tool pprof -top -cum -nodecount=30 /tmp/lab1909-client-renderer.cpu.pprof
+```
+
+Capture an allocation profile:
+
+```bash
+go test ./internal/client -run '^$' -bench '^BenchmarkClientRendererBusyMultiPaneRenderLoop$' -benchtime=10s -memprofile /tmp/lab1909-client-renderer.alloc.pprof -memprofilerate=1 -benchmem -timeout 120s
+go tool pprof -top -alloc_space -nodecount=30 /tmp/lab1909-client-renderer.alloc.pprof
+```
+
+The benchmark is intentionally a combined harness rather than a replacement for
+the narrower capture and compositor microbenchmarks. Use it for follow-up work
+that needs to see interactions among `HandlePaneOutputInfo`,
+`publishPaneCapture`, `capturePaneRenderSnapshot`, and
+`RenderDiffWithOverlayDirtyStats` under a live-shaped busy pane mix.

--- a/docs/client-renderer-benchmarks.md
+++ b/docs/client-renderer-benchmarks.md
@@ -6,7 +6,7 @@ with ten visible panes arranged as a 2x5 grid, sends six short styled ANSI
 bursts to each of four panes, publishes pane capture snapshots, and runs one
 dirty diff render for each benchmark operation.
 
-Run the CI-safe benchmark with allocation reporting:
+Run the renderer benchmark gate workload with allocation reporting:
 
 ```bash
 go test ./internal/client -run '^$' -bench '^BenchmarkClientRendererBusyMultiPaneRenderLoop$' -benchmem -count=10 -timeout 120s

--- a/docs/client-renderer-benchmarks.md
+++ b/docs/client-renderer-benchmarks.md
@@ -2,9 +2,9 @@
 
 `BenchmarkClientRendererBusyMultiPaneRenderLoop` is a reproducible local
 workload for the May 25, 2026 busy client profiles. It uses a 240x82 client
-with ten visible panes arranged as a 2x5 grid, updates four panes per frame
-with styled ANSI output, publishes pane capture snapshots, and runs one dirty
-diff render for each benchmark operation.
+with ten visible panes arranged as a 2x5 grid, sends six short styled ANSI
+bursts to each of four panes, publishes pane capture snapshots, and runs one
+dirty diff render for each benchmark operation.
 
 Run the CI-safe benchmark with allocation reporting:
 

--- a/internal/client/renderer_busy_bench_test.go
+++ b/internal/client/renderer_busy_bench_test.go
@@ -1,0 +1,27 @@
+package client
+
+import "testing"
+
+func TestBusyMultiPaneClientRendererBenchmarkWorkload(t *testing.T) {
+	t.Parallel()
+
+	workload := newBusyMultiPaneClientRenderBench(t)
+	defer workload.Close()
+
+	result := workload.Step()
+	if result.VisiblePanes != 10 {
+		t.Fatalf("visible panes = %d, want 10", result.VisiblePanes)
+	}
+	if result.PaneOutputs != 4 {
+		t.Fatalf("pane outputs = %d, want 4", result.PaneOutputs)
+	}
+	if result.ScreenChangedOutputs != result.PaneOutputs {
+		t.Fatalf("screen changed outputs = %d, want %d", result.ScreenChangedOutputs, result.PaneOutputs)
+	}
+	if result.RenderStats.PanesComposited == 0 {
+		t.Fatal("render composed no panes")
+	}
+	if result.ANSIBytes == 0 {
+		t.Fatal("render emitted no ANSI bytes")
+	}
+}

--- a/internal/client/renderer_busy_bench_test.go
+++ b/internal/client/renderer_busy_bench_test.go
@@ -18,6 +18,7 @@ const (
 	busyMultiPaneBenchRows         = 2
 	busyMultiPaneBenchCols         = 5
 	busyMultiPaneBenchPanes        = busyMultiPaneBenchRows * busyMultiPaneBenchCols
+	busyMultiPaneBenchOutputBursts = 6
 )
 
 type busyMultiPaneClientRenderBench struct {
@@ -31,6 +32,7 @@ type busyMultiPaneClientRenderBench struct {
 
 type busyMultiPaneClientRenderResult struct {
 	VisiblePanes         int
+	OutputPanes          int
 	PaneOutputs          int
 	ScreenChangedOutputs int
 	ANSIBytes            int
@@ -48,8 +50,12 @@ func TestBusyMultiPaneClientRendererBenchmarkWorkload(t *testing.T) {
 	if result.VisiblePanes != 10 {
 		t.Fatalf("visible panes = %d, want 10", result.VisiblePanes)
 	}
-	if result.PaneOutputs != 4 {
-		t.Fatalf("pane outputs = %d, want 4", result.PaneOutputs)
+	if result.OutputPanes != 4 {
+		t.Fatalf("output panes = %d, want 4", result.OutputPanes)
+	}
+	wantPaneOutputs := result.OutputPanes * busyMultiPaneBenchOutputBursts
+	if result.PaneOutputs != wantPaneOutputs {
+		t.Fatalf("pane outputs = %d, want %d", result.PaneOutputs, wantPaneOutputs)
 	}
 	if result.ScreenChangedOutputs != result.PaneOutputs {
 		t.Fatalf("screen changed outputs = %d, want %d", result.ScreenChangedOutputs, result.PaneOutputs)
@@ -98,9 +104,12 @@ func newBusyMultiPaneClientRenderBench(tb testing.TB) *busyMultiPaneClientRender
 
 	outputPaneIDs := []uint32{1, 3, 6, 9}
 	bytesPerStep := 0
-	for i, paneID := range outputPaneIDs {
-		cell := paneCells[paneID]
-		bytesPerStep += len(busyMultiPaneTickPayload(paneID, cell.W, mux.PaneContentHeight(cell.H), i))
+	for burst := 0; burst < busyMultiPaneBenchOutputBursts; burst++ {
+		for i, paneID := range outputPaneIDs {
+			cell := paneCells[paneID]
+			seq := burst*len(outputPaneIDs) + i
+			bytesPerStep += len(busyMultiPaneTickPayload(paneID, cell.W, mux.PaneContentHeight(cell.H), seq))
+		}
 	}
 
 	return &busyMultiPaneClientRenderBench{
@@ -119,20 +128,27 @@ func (w *busyMultiPaneClientRenderBench) Close() {
 func (w *busyMultiPaneClientRenderBench) Step() busyMultiPaneClientRenderResult {
 	screenChanged := 0
 	inputBytes := 0
-	for i, paneID := range w.outputPaneIDs {
-		cell := w.paneCells[paneID]
-		payload := busyMultiPaneTickPayload(paneID, cell.W, mux.PaneContentHeight(cell.H), w.step+i)
-		inputBytes += len(payload)
-		info := w.cr.handlePaneOutputRenderInfo(paneID, payload, 0)
-		if info.screenChanged {
-			screenChanged++
+	paneOutputs := 0
+	seqBase := w.step * busyMultiPaneBenchOutputBursts * len(w.outputPaneIDs)
+	for burst := 0; burst < busyMultiPaneBenchOutputBursts; burst++ {
+		for i, paneID := range w.outputPaneIDs {
+			cell := w.paneCells[paneID]
+			seq := seqBase + burst*len(w.outputPaneIDs) + i
+			payload := busyMultiPaneTickPayload(paneID, cell.W, mux.PaneContentHeight(cell.H), seq)
+			inputBytes += len(payload)
+			paneOutputs++
+			info := w.cr.handlePaneOutputRenderInfo(paneID, payload, 0)
+			if info.screenChanged {
+				screenChanged++
+			}
 		}
 	}
 	data, stats := w.cr.renderDiff()
 	w.step++
 	return busyMultiPaneClientRenderResult{
 		VisiblePanes:         len(w.visiblePaneIDs),
-		PaneOutputs:          len(w.outputPaneIDs),
+		OutputPanes:          len(w.outputPaneIDs),
+		PaneOutputs:          paneOutputs,
 		ScreenChangedOutputs: screenChanged,
 		ANSIBytes:            len(data),
 		InputBytes:           inputBytes,

--- a/internal/client/renderer_busy_bench_test.go
+++ b/internal/client/renderer_busy_bench_test.go
@@ -60,6 +60,9 @@ func TestBusyMultiPaneClientRendererBenchmarkWorkload(t *testing.T) {
 	if result.ScreenChangedOutputs != result.PaneOutputs {
 		t.Fatalf("screen changed outputs = %d, want %d", result.ScreenChangedOutputs, result.PaneOutputs)
 	}
+	if result.InputBytes != workload.bytesPerStep {
+		t.Fatalf("input bytes = %d, want %d", result.InputBytes, workload.bytesPerStep)
+	}
 	if result.RenderStats.PanesComposited == 0 {
 		t.Fatal("render composed no panes")
 	}

--- a/internal/client/renderer_busy_bench_test.go
+++ b/internal/client/renderer_busy_bench_test.go
@@ -1,6 +1,42 @@
 package client
 
-import "testing"
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/weill-labs/amux/internal/config"
+	"github.com/weill-labs/amux/internal/mux"
+	"github.com/weill-labs/amux/internal/proto"
+	"github.com/weill-labs/amux/internal/render"
+)
+
+const (
+	busyMultiPaneBenchWidth        = 240
+	busyMultiPaneBenchHeight       = 82
+	busyMultiPaneBenchLayoutHeight = busyMultiPaneBenchHeight - render.GlobalBarHeight
+	busyMultiPaneBenchRows         = 2
+	busyMultiPaneBenchCols         = 5
+	busyMultiPaneBenchPanes        = busyMultiPaneBenchRows * busyMultiPaneBenchCols
+)
+
+type busyMultiPaneClientRenderBench struct {
+	cr             *ClientRenderer
+	paneCells      map[uint32]proto.CellSnapshot
+	outputPaneIDs  []uint32
+	step           int
+	bytesPerStep   int
+	visiblePaneIDs []uint32
+}
+
+type busyMultiPaneClientRenderResult struct {
+	VisiblePanes         int
+	PaneOutputs          int
+	ScreenChangedOutputs int
+	ANSIBytes            int
+	InputBytes           int
+	RenderStats          render.RenderStats
+}
 
 func TestBusyMultiPaneClientRendererBenchmarkWorkload(t *testing.T) {
 	t.Parallel()
@@ -24,4 +60,196 @@ func TestBusyMultiPaneClientRendererBenchmarkWorkload(t *testing.T) {
 	if result.ANSIBytes == 0 {
 		t.Fatal("render emitted no ANSI bytes")
 	}
+}
+
+func BenchmarkClientRendererBusyMultiPaneRenderLoop(b *testing.B) {
+	workload := newBusyMultiPaneClientRenderBench(b)
+	defer workload.Close()
+
+	b.SetBytes(int64(workload.bytesPerStep))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		result := workload.Step()
+		if result.ANSIBytes == 0 {
+			b.Fatal("render emitted no ANSI bytes")
+		}
+	}
+}
+
+func newBusyMultiPaneClientRenderBench(tb testing.TB) *busyMultiPaneClientRenderBench {
+	tb.Helper()
+
+	layout := busyMultiPaneBenchLayoutSnapshot()
+	paneCells := busyMultiPaneBenchPaneCells(layout.Root)
+	cr := NewClientRendererWithScrollback(busyMultiPaneBenchWidth, busyMultiPaneBenchHeight, mux.DefaultScrollbackLines)
+	cr.HandleLayout(layout)
+
+	for _, paneID := range busyMultiPaneBenchPaneIDs() {
+		cell := paneCells[paneID]
+		payload := busyMultiPaneInitialScreen(paneID, cell.W, mux.PaneContentHeight(cell.H))
+		if !cr.HandlePaneOutput(paneID, payload) {
+			tb.Fatalf("preload pane %d did not affect visible frame", paneID)
+		}
+	}
+	if data, _ := cr.renderDiff(); data == "" {
+		tb.Fatal("initial render emitted no ANSI bytes")
+	}
+
+	outputPaneIDs := []uint32{1, 3, 6, 9}
+	bytesPerStep := 0
+	for i, paneID := range outputPaneIDs {
+		cell := paneCells[paneID]
+		bytesPerStep += len(busyMultiPaneTickPayload(paneID, cell.W, mux.PaneContentHeight(cell.H), i))
+	}
+
+	return &busyMultiPaneClientRenderBench{
+		cr:             cr,
+		paneCells:      paneCells,
+		outputPaneIDs:  outputPaneIDs,
+		bytesPerStep:   bytesPerStep,
+		visiblePaneIDs: busyMultiPaneBenchPaneIDs(),
+	}
+}
+
+func (w *busyMultiPaneClientRenderBench) Close() {
+	w.cr.renderer.Close()
+}
+
+func (w *busyMultiPaneClientRenderBench) Step() busyMultiPaneClientRenderResult {
+	screenChanged := 0
+	inputBytes := 0
+	for i, paneID := range w.outputPaneIDs {
+		cell := w.paneCells[paneID]
+		payload := busyMultiPaneTickPayload(paneID, cell.W, mux.PaneContentHeight(cell.H), w.step+i)
+		inputBytes += len(payload)
+		info := w.cr.handlePaneOutputRenderInfo(paneID, payload, 0)
+		if info.screenChanged {
+			screenChanged++
+		}
+	}
+	data, stats := w.cr.renderDiff()
+	w.step++
+	return busyMultiPaneClientRenderResult{
+		VisiblePanes:         len(w.visiblePaneIDs),
+		PaneOutputs:          len(w.outputPaneIDs),
+		ScreenChangedOutputs: screenChanged,
+		ANSIBytes:            len(data),
+		InputBytes:           inputBytes,
+		RenderStats:          stats,
+	}
+}
+
+func busyMultiPaneBenchLayoutSnapshot() *proto.LayoutSnapshot {
+	root := proto.CellSnapshot{
+		X: 0, Y: 0, W: busyMultiPaneBenchWidth, H: busyMultiPaneBenchLayoutHeight,
+		Dir: int(mux.SplitHorizontal),
+	}
+
+	panes := make([]proto.PaneSnapshot, 0, busyMultiPaneBenchPanes)
+	paneID := uint32(1)
+	y := 0
+	rowH := (busyMultiPaneBenchLayoutHeight - (busyMultiPaneBenchRows - 1)) / busyMultiPaneBenchRows
+	for row := 0; row < busyMultiPaneBenchRows; row++ {
+		h := rowH
+		if row == busyMultiPaneBenchRows-1 {
+			h = busyMultiPaneBenchLayoutHeight - y
+		}
+		rowCell := proto.CellSnapshot{
+			X: 0, Y: y, W: busyMultiPaneBenchWidth, H: h,
+			Dir: int(mux.SplitVertical),
+		}
+		x := 0
+		cellW := (busyMultiPaneBenchWidth - (busyMultiPaneBenchCols - 1)) / busyMultiPaneBenchCols
+		for col := 0; col < busyMultiPaneBenchCols; col++ {
+			w := cellW
+			if col == busyMultiPaneBenchCols-1 {
+				w = busyMultiPaneBenchWidth - x
+			}
+			rowCell.Children = append(rowCell.Children, proto.CellSnapshot{
+				X: x, Y: y, W: w, H: h,
+				IsLeaf: true, Dir: -1, PaneID: paneID,
+			})
+			panes = append(panes, proto.PaneSnapshot{
+				ID:          paneID,
+				Name:        fmt.Sprintf("pane-%d", paneID),
+				Host:        "local",
+				Task:        "busy renderer benchmark",
+				Color:       config.AccentColor(paneID - 1),
+				ColumnIndex: col,
+				Idle:        false,
+			})
+			x += w + 1
+			paneID++
+		}
+		root.Children = append(root.Children, rowCell)
+		y += h + 1
+	}
+
+	window := proto.WindowSnapshot{
+		ID:           1,
+		Name:         "bench",
+		Index:        1,
+		ActivePaneID: 1,
+		Root:         root,
+		Panes:        panes,
+	}
+	return &proto.LayoutSnapshot{
+		SessionName:    "bench",
+		ActivePaneID:   1,
+		Width:          busyMultiPaneBenchWidth,
+		Height:         busyMultiPaneBenchLayoutHeight,
+		Root:           root,
+		Panes:          panes,
+		Windows:        []proto.WindowSnapshot{window},
+		ActiveWindowID: 1,
+	}
+}
+
+func busyMultiPaneBenchPaneIDs() []uint32 {
+	ids := make([]uint32, busyMultiPaneBenchPanes)
+	for i := range ids {
+		ids[i] = uint32(i + 1)
+	}
+	return ids
+}
+
+func busyMultiPaneBenchPaneCells(root proto.CellSnapshot) map[uint32]proto.CellSnapshot {
+	cells := make(map[uint32]proto.CellSnapshot, busyMultiPaneBenchPanes)
+	var walk func(proto.CellSnapshot)
+	walk = func(cell proto.CellSnapshot) {
+		if cell.IsLeaf {
+			cells[cell.PaneID] = cell
+			return
+		}
+		for _, child := range cell.Children {
+			walk(child)
+		}
+	}
+	walk(root)
+	return cells
+}
+
+func busyMultiPaneInitialScreen(paneID uint32, width, height int) []byte {
+	var b strings.Builder
+	lineWidth := max(1, width-1)
+	for row := 0; row < height; row++ {
+		text := busyMultiPaneLine(fmt.Sprintf("pane-%02d warm row %02d ", paneID, row), lineWidth, string(rune('a'+row%26)))
+		fmt.Fprintf(&b, "\x1b[%d;1H\x1b[1;3%d;4%dm%s\x1b[0m", row+1, (int(paneID)+row)%8, (int(paneID)+row+1)%8, text)
+	}
+	return []byte(b.String())
+}
+
+func busyMultiPaneTickPayload(paneID uint32, width, height, seq int) []byte {
+	row := (seq*7 + int(paneID)) % max(1, height)
+	lineWidth := max(1, width-1)
+	text := busyMultiPaneLine(fmt.Sprintf("pane-%02d tick %08d row %02d ", paneID, seq, row), lineWidth, string(rune('A'+seq%26)))
+	return []byte(fmt.Sprintf("\x1b[%d;1H\x1b[%d;3%d;4%dm%s\x1b[0m", row+1, 1+seq%2, (int(paneID)+seq)%8, (int(paneID)+seq+3)%8, text))
+}
+
+func busyMultiPaneLine(prefix string, width int, fill string) string {
+	if len(prefix) > width {
+		return prefix[:width]
+	}
+	return prefix + strings.Repeat(fill, width-len(prefix))
 }


### PR DESCRIPTION
## Motivation

The May 25, 2026 live client profiles showed a busy multi-pane renderer workload split across pane-output capture publication and dirty diff compositing. The existing microbenchmarks cover individual capture/render pieces, but there was no reproducible benchmark for the combined live-shaped client loop that LAB-1908/LAB-1910/LAB-1911/LAB-1912 can compare against.

## Summary

- Add `BenchmarkClientRendererBusyMultiPaneRenderLoop`, a 240x82 ten-pane client renderer workload with four panes emitting six styled ANSI bursts before each dirty diff render.
- Add a guard test that verifies the workload shape, screen-change accounting, byte accounting, and non-empty render output.
- Document benchmem, CPU pprof, and allocation pprof commands for the workload.
- Add the new benchmark to the existing renderer benchmark gate matrix.

## Testing

- `go test ./internal/client -run '^TestBusyMultiPaneClientRendererBenchmarkWorkload$' -count=100 -timeout 120s`
- `go test ./internal/client -timeout 120s`
- `go test ./internal/client -run '^$' -bench '^BenchmarkClientRendererBusyMultiPaneRenderLoop$' -benchmem -count=10 -timeout 120s`
- `go test ./internal/client -run '^$' -bench '^BenchmarkClientRendererBusyMultiPaneRenderLoop$' -benchtime=3s -benchmem -count=5 -timeout 120s`
- `go test ./internal/client -run '^$' -bench '^BenchmarkClientRendererBusyMultiPaneRenderLoop$' -benchtime=5s -cpuprofile /tmp/lab1909-client-renderer.cpu.pprof -benchmem -timeout 120s`
- `go tool pprof -top -cum -nodecount=30 /tmp/lab1909-client-renderer.cpu.pprof`
- `go test ./internal/client -run '^$' -bench '^BenchmarkClientRendererBusyMultiPaneRenderLoop$' -benchtime=5s -memprofile /tmp/lab1909-client-renderer.alloc.pprof -memprofilerate=1 -benchmem -timeout 120s`
- `go tool pprof -top -alloc_space -nodecount=30 /tmp/lab1909-client-renderer.alloc.pprof`
- gopls `go_vulncheck` for `./...` before editing: no vulnerabilities reported.

## Review focus

- Confirm the workload shape is representative enough of the supplied live profiles: ten visible panes, several active output panes, multiple pane-output events per frame, styled cells, capture publication, and dirty diff rendering.
- Confirm the benchmark gate addition is acceptable despite adding one more base/head benchmark comparison to the renderer workflow.
- Confirm the docs give enough detail for LAB-1908/LAB-1910/LAB-1911/LAB-1912 follow-up profiling.

## Baseline numbers

Hardware: AMD EPYC-Milan Processor, linux/amd64, Go 1.25.10.

| Command | ns/op | B/op | allocs/op |
| --- | ---: | ---: | ---: |
| `-benchmem -count=10` | 12,504,188-33,409,099 | 5,964,396-5,964,998 | 7,156-7,160 |
| `-benchtime=3s -benchmem -count=5` | 10,644,052-13,861,060 | 5,964,447-5,964,901 | 7,160-7,161 |
| `-benchtime=5s -cpuprofile` | 14,803,712 | 5,964,954 | 7,161 |

Profile evidence from `/tmp/lab1909-client-renderer.cpu.pprof` reproduced the target path mix: `HandlePaneOutputInfo` at 36.13% cumulative, `publishPaneCapture` at 33.84%, `capturePaneRenderSnapshot` at 31.81%, `captureRenderedSnapshot` / `vt.(*Emulator).Render` at 29.52%, `RenderDiffWithOverlayDirtyStats` at 20.10%, and `Style.Equal` at 19.34%.

Closes LAB-1909
