### PR TITLE
LAB-1910: Coalesce capture refreshes under output pressure

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -171,14 +171,22 @@ func (cr *ClientRenderer) HandlePaneOutputWithEpoch(paneID uint32, data []byte, 
 	return info.screenChanged || info.cursorChanged
 }
 
+func paneOutputCursorVisible(state *clientSnapshot, activePaneID, paneID uint32) bool {
+	return paneID != 0 &&
+		paneID == activePaneID &&
+		state.ui.copyModes[paneID] == nil &&
+		!paneDragHidesCursor(state, activePaneID, paneID)
+}
+
+func paneOutputNeedsRender(info paneOutputRenderInfo, copyModeVisible bool) bool {
+	return info.cursorChanged || (info.paneVisible && !copyModeVisible && info.screenChanged)
+}
+
 func (cr *ClientRenderer) handlePaneOutputRenderInfo(paneID uint32, data []byte, sourceEpoch uint32) paneOutputRenderInfo {
 	state := cr.loadState()
 	activePaneID := cr.renderer.ActivePaneID()
 	copyModeVisible := state.ui.copyModes[paneID] != nil
-	cursorVisible := paneID != 0 &&
-		paneID == activePaneID &&
-		!copyModeVisible &&
-		!paneDragHidesCursor(state, activePaneID, paneID)
+	cursorVisible := paneOutputCursorVisible(state, activePaneID, paneID)
 
 	var before panePredictionSnapshot
 	if sourceEpoch != 0 {
@@ -193,8 +201,7 @@ func (cr *ClientRenderer) handlePaneOutputRenderInfo(paneID uint32, data []byte,
 			}
 		}
 	}
-	needsRender := info.cursorChanged || (info.paneVisible && !copyModeVisible && info.screenChanged)
-	if !needsRender {
+	if !paneOutputNeedsRender(info, copyModeVisible) {
 		return info
 	}
 	result := cr.reduceUI(uiActionPaneOutput{paneID: paneID})
@@ -626,14 +633,10 @@ func (cr *ClientRenderer) handlePaneOutputBatch(msgs []*RenderMsg) ([]clientEffe
 			paneOrder = append(paneOrder, paneID)
 			copyModeVisible[paneID] = state.ui.copyModes[paneID] != nil
 		}
-		cursorVisible := paneID != 0 &&
-			paneID == activePaneID &&
-			!copyModeVisible[paneID] &&
-			!paneDragHidesCursor(state, activePaneID, paneID)
 		items = append(items, paneOutputBatchItem{
 			paneID:      paneID,
 			data:        msg.Data,
-			trackCursor: cursorVisible,
+			trackCursor: paneOutputCursorVisible(state, activePaneID, paneID),
 		})
 		if cr.shouldPrioritizePaneOutput(paneID) {
 			prioritize = true
@@ -644,8 +647,7 @@ func (cr *ClientRenderer) handlePaneOutputBatch(msgs []*RenderMsg) ([]clientEffe
 	dirtyPaneIDs := make([]uint32, 0, len(paneOrder))
 	for _, paneID := range paneOrder {
 		info := infos[paneID]
-		needsRender := info.cursorChanged || (info.paneVisible && !copyModeVisible[paneID] && info.screenChanged)
-		if needsRender {
+		if paneOutputNeedsRender(info, copyModeVisible[paneID]) {
 			dirtyPaneIDs = append(dirtyPaneIDs, paneID)
 		}
 	}

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -624,7 +624,6 @@ func (cr *ClientRenderer) handlePaneOutputBatch(msgs []*RenderMsg) ([]clientEffe
 	seenPanes := make(map[uint32]struct{})
 	copyModeVisible := make(map[uint32]bool)
 	totalBytes := 0
-	prioritize := false
 	for _, msg := range msgs {
 		totalBytes += len(msg.Data)
 		paneID := msg.PaneID
@@ -638,9 +637,6 @@ func (cr *ClientRenderer) handlePaneOutputBatch(msgs []*RenderMsg) ([]clientEffe
 			data:        msg.Data,
 			trackCursor: paneOutputCursorVisible(state, activePaneID, paneID),
 		})
-		if cr.shouldPrioritizePaneOutput(paneID) {
-			prioritize = true
-		}
 	}
 
 	infos := cr.renderer.HandlePaneOutputBatchInfo(items)
@@ -653,6 +649,14 @@ func (cr *ClientRenderer) handlePaneOutputBatch(msgs []*RenderMsg) ([]clientEffe
 	}
 	if len(dirtyPaneIDs) == 0 {
 		return nil, totalBytes
+	}
+
+	prioritize := false
+	for _, paneID := range dirtyPaneIDs {
+		if cr.shouldPrioritizePaneOutput(paneID) {
+			prioritize = true
+			break
+		}
 	}
 
 	result := cr.updateState(func(next *clientSnapshot) clientUIResult {

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -524,6 +524,31 @@ func appendStopAndRenderNow(effects []clientEffect) []clientEffect {
 	)
 }
 
+func paneOutputCanBatch(msg *RenderMsg) bool {
+	return msg != nil && msg.Typ == RenderMsgPaneOutput && msg.SourceEpoch == 0
+}
+
+func collectPaneOutputBatch(first *RenderMsg, msgCh <-chan *RenderMsg) (batch []*RenderMsg, next *RenderMsg, closed bool) {
+	batch = append(batch, first)
+	if !paneOutputCanBatch(first) {
+		return batch, nil, false
+	}
+	for {
+		select {
+		case msg, ok := <-msgCh:
+			if !ok {
+				return batch, nil, true
+			}
+			if !paneOutputCanBatch(msg) {
+				return batch, msg, false
+			}
+			batch = append(batch, msg)
+		default:
+			return batch, nil, false
+		}
+	}
+}
+
 func (cr *ClientRenderer) handleRenderMsg(msg *RenderMsg) []clientEffect {
 	switch msg.Typ {
 	case RenderMsgLayout:
@@ -574,6 +599,74 @@ func (cr *ClientRenderer) handleRenderMsg(msg *RenderMsg) []clientEffect {
 	default:
 		return nil
 	}
+}
+
+func (cr *ClientRenderer) handlePaneOutputBatch(msgs []*RenderMsg) ([]clientEffect, int) {
+	if len(msgs) == 0 {
+		return nil, 0
+	}
+	if len(msgs) == 1 {
+		effects := cr.handleRenderMsg(msgs[0])
+		return effects, len(msgs[0].Data)
+	}
+
+	state := cr.loadState()
+	activePaneID := cr.renderer.ActivePaneID()
+	items := make([]paneOutputBatchItem, 0, len(msgs))
+	paneOrder := make([]uint32, 0, len(msgs))
+	seenPanes := make(map[uint32]struct{})
+	copyModeVisible := make(map[uint32]bool)
+	totalBytes := 0
+	prioritize := false
+	for _, msg := range msgs {
+		totalBytes += len(msg.Data)
+		paneID := msg.PaneID
+		if _, ok := seenPanes[paneID]; !ok {
+			seenPanes[paneID] = struct{}{}
+			paneOrder = append(paneOrder, paneID)
+			copyModeVisible[paneID] = state.ui.copyModes[paneID] != nil
+		}
+		cursorVisible := paneID != 0 &&
+			paneID == activePaneID &&
+			!copyModeVisible[paneID] &&
+			!paneDragHidesCursor(state, activePaneID, paneID)
+		items = append(items, paneOutputBatchItem{
+			paneID:      paneID,
+			data:        msg.Data,
+			trackCursor: cursorVisible,
+		})
+		if cr.shouldPrioritizePaneOutput(paneID) {
+			prioritize = true
+		}
+	}
+
+	infos := cr.renderer.HandlePaneOutputBatchInfo(items)
+	dirtyPaneIDs := make([]uint32, 0, len(paneOrder))
+	for _, paneID := range paneOrder {
+		info := infos[paneID]
+		needsRender := info.cursorChanged || (info.paneVisible && !copyModeVisible[paneID] && info.screenChanged)
+		if needsRender {
+			dirtyPaneIDs = append(dirtyPaneIDs, paneID)
+		}
+	}
+	if len(dirtyPaneIDs) == 0 {
+		return nil, totalBytes
+	}
+
+	result := cr.updateState(func(next *clientSnapshot) clientUIResult {
+		var merged clientUIResult
+		for _, paneID := range dirtyPaneIDs {
+			result := next.ui.reduce(uiActionPaneOutput{paneID: paneID})
+			merged.uiEvents = append(merged.uiEvents, result.uiEvents...)
+		}
+		return merged
+	})
+	effects := appendUIEventEffect(nil, result.uiEvents)
+	if prioritize {
+		return appendStopAndRenderNow(effects), totalBytes
+	}
+	effects = append(effects, clientEffect{kind: clientEffectScheduleRender})
+	return effects, totalBytes
 }
 
 func (cr *ClientRenderer) handleLocalRenderMsg(state *clientRenderLoopState, msg *RenderMsg, write func(string)) bool {
@@ -688,33 +781,48 @@ func (cr *ClientRenderer) RenderCoalesced(msgCh <-chan *RenderMsg, write func(st
 		renderFrameInterval: frameInterval,
 	}
 
+	var pendingMsg *RenderMsg
 	for {
-		select {
-		case msg, ok := <-msgCh:
-			if !ok {
-				return
-			}
-			if msg.Typ == RenderMsgLocalAction {
-				if cr.handleLocalRenderMsg(state, msg, write) {
+		var msg *RenderMsg
+		if pendingMsg != nil {
+			msg = pendingMsg
+			pendingMsg = nil
+		} else {
+			select {
+			case next, ok := <-msgCh:
+				if !ok {
 					return
 				}
+				msg = next
+			case <-state.renderC:
+				cr.renderNow(state, write)
 				continue
 			}
-			if msg.Typ == RenderMsgPaneOutput {
-				effects := cr.handleRenderMsg(msg)
-				if len(effects) != 0 && state.recordPaneOutput(len(msg.Data), cr.renderOverflowThreshold()) {
-					cr.RequestFullRedraw()
-				}
-				if cr.executeRenderEffects(state, effects, write) {
-					return
-				}
-				continue
-			}
-			if cr.executeRenderEffects(state, cr.handleRenderMsg(msg), write) {
+		}
+
+		if msg.Typ == RenderMsgLocalAction {
+			if cr.handleLocalRenderMsg(state, msg, write) {
 				return
 			}
-		case <-state.renderC:
-			cr.renderNow(state, write)
+			continue
+		}
+		if msg.Typ == RenderMsgPaneOutput {
+			batch, next, closed := collectPaneOutputBatch(msg, msgCh)
+			pendingMsg = next
+			effects, bytes := cr.handlePaneOutputBatch(batch)
+			if len(effects) != 0 && state.recordPaneOutput(bytes, cr.renderOverflowThreshold()) {
+				cr.RequestFullRedraw()
+			}
+			if cr.executeRenderEffects(state, effects, write) {
+				return
+			}
+			if closed {
+				return
+			}
+			continue
+		}
+		if cr.executeRenderEffects(state, cr.handleRenderMsg(msg), write) {
+			return
 		}
 	}
 }

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -1693,6 +1693,45 @@ func TestRenderCoalescedLocalActionReplySentBeforeExit(t *testing.T) {
 	}
 }
 
+func TestRenderCoalescedCaptureBarrierSeesCoalescedPaneOutput(t *testing.T) {
+	t.Parallel()
+
+	cr := NewClientRenderer(20, 4)
+	cr.HandleLayout(singlePane20x3())
+	cr.renderFrameInterval = time.Hour
+	msgCh := make(chan *RenderMsg, 8)
+	done := make(chan struct{})
+	go func() {
+		cr.RenderCoalesced(msgCh, func(string) {})
+		close(done)
+	}()
+
+	msgCh <- &RenderMsg{Typ: RenderMsgPaneOutput, PaneID: 1, Data: []byte("first ")}
+	msgCh <- &RenderMsg{Typ: RenderMsgPaneOutput, PaneID: 1, Data: []byte("second")}
+
+	barrierDone := make(chan struct{})
+	go func() {
+		callLocalRenderAction[struct{}](cr, msgCh, func(*ClientRenderer) localRenderResult {
+			return localRenderResult{}
+		})
+		close(barrierDone)
+	}()
+
+	select {
+	case <-barrierDone:
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("capture barrier did not drain queued pane output")
+	}
+
+	if got := cr.CapturePaneText(1, false); !strings.Contains(got, "first second") {
+		t.Fatalf("capture after barrier = %q, want queued pane output", got)
+	}
+
+	msgCh <- &RenderMsg{Typ: RenderMsgExit}
+	close(msgCh)
+	<-done
+}
+
 func TestRenderCoalescedPaneOutputRendersImmediatelyAfterIdle(t *testing.T) {
 	t.Parallel()
 

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -1962,6 +1962,20 @@ func TestRenderCoalescedDoesNotPrioritizeBackgroundPaneAfterLocalInput(t *testin
 	<-done
 }
 
+func TestHandlePaneOutputBatchDoesNotPrioritizeBackgroundAfterActiveNoop(t *testing.T) {
+	t.Parallel()
+
+	cr := buildTestRenderer(t)
+	cr.MarkLocalInput()
+
+	effects, _ := cr.handlePaneOutputBatch([]*RenderMsg{
+		{Typ: RenderMsgPaneOutput, PaneID: 1, Data: []byte("\x1b[?1002h\x1b[?1006h")},
+		{Typ: RenderMsgPaneOutput, PaneID: 2, Data: []byte("background")},
+	})
+
+	assertClientEffectKinds(t, effects, []clientEffectKind{clientEffectScheduleRender})
+}
+
 func TestClientRenderLoopStateShouldRenderNowReturnsFalseWithPendingTimer(t *testing.T) {
 	t.Parallel()
 

--- a/internal/client/renderer.go
+++ b/internal/client/renderer.go
@@ -199,6 +199,12 @@ type paneOutputRenderInfo struct {
 	cursorChanged bool
 }
 
+type paneOutputBatchItem struct {
+	paneID      uint32
+	data        []byte
+	trackCursor bool
+}
+
 type terminalCursorState struct {
 	col    int
 	row    int
@@ -215,42 +221,79 @@ func captureTerminalCursorState(emu mux.TerminalEmulator) terminalCursorState {
 }
 
 func (r *Renderer) HandlePaneOutputInfo(paneID uint32, data []byte, trackCursor bool) paneOutputRenderInfo {
-	return withRendererActorValue(r, func(st *rendererActorState) paneOutputRenderInfo {
+	infos := r.HandlePaneOutputBatchInfo([]paneOutputBatchItem{{
+		paneID:      paneID,
+		data:        data,
+		trackCursor: trackCursor,
+	}})
+	return infos[paneID]
+}
+
+func (r *Renderer) HandlePaneOutputBatchInfo(items []paneOutputBatchItem) map[uint32]paneOutputRenderInfo {
+	return withRendererActorValue(r, func(st *rendererActorState) map[uint32]paneOutputRenderInfo {
+		return r.handlePaneOutputBatchInfo(st, items)
+	})
+}
+
+func (r *Renderer) handlePaneOutputBatchInfo(st *rendererActorState, items []paneOutputBatchItem) map[uint32]paneOutputRenderInfo {
+	infos := make(map[uint32]paneOutputRenderInfo)
+	if len(items) == 0 {
+		return infos
+	}
+
+	cursorBefore := make(map[uint32]terminalCursorState)
+	trackedCursorPanes := make(map[uint32]struct{})
+	dirtyCapturePanes := make(map[uint32]struct{})
+	for _, item := range items {
+		paneID := item.paneID
 		if _, ok := st.snapshot.paneInfo[paneID]; !ok {
-			return paneOutputRenderInfo{}
+			continue
 		}
 		if !st.snapshot.paneVisible(paneID) {
 			if emu := st.emulators[paneID]; emu != nil {
 				st.warmPaneOutput(paneID, st.emulators)
-				_, _ = emu.Write(data)
-				r.publishPaneCapture(st, paneID)
-				return paneOutputRenderInfo{}
+				_, _ = emu.Write(item.data)
+				dirtyCapturePanes[paneID] = struct{}{}
+				continue
 			}
-			st.bufferPaneOutput(paneID, data)
-			return paneOutputRenderInfo{}
+			st.bufferPaneOutput(paneID, item.data)
+			continue
 		}
+
 		emu := st.ensurePaneEmulator(paneID)
 		if emu == nil {
-			return paneOutputRenderInfo{}
+			continue
 		}
 		st.warmPaneOutput(paneID, st.emulators)
-
-		var before terminalCursorState
-		if trackCursor {
-			before = captureTerminalCursorState(emu)
+		if item.trackCursor {
+			if _, ok := cursorBefore[paneID]; !ok {
+				cursorBefore[paneID] = captureTerminalCursorState(emu)
+			}
+			trackedCursorPanes[paneID] = struct{}{}
 		}
 
-		_, _ = emu.Write(data)
+		_, _ = emu.Write(item.data)
+		info := infos[paneID]
+		info.paneVisible = true
+		infos[paneID] = info
+		dirtyCapturePanes[paneID] = struct{}{}
+	}
 
-		info := paneOutputRenderInfo{
-			paneVisible: true,
+	for paneID, changed := range r.publishPaneCaptures(st, dirtyCapturePanes) {
+		info := infos[paneID]
+		info.screenChanged = info.screenChanged || changed
+		infos[paneID] = info
+	}
+	for paneID := range trackedCursorPanes {
+		emu := st.emulators[paneID]
+		if emu == nil {
+			continue
 		}
-		if trackCursor {
-			info.cursorChanged = before != captureTerminalCursorState(emu)
-		}
-		info.screenChanged = r.publishPaneCapture(st, paneID)
-		return info
-	})
+		info := infos[paneID]
+		info.cursorChanged = cursorBefore[paneID] != captureTerminalCursorState(emu)
+		infos[paneID] = info
+	}
+	return infos
 }
 
 // Resize updates the client's terminal dimensions.

--- a/internal/client/renderer_bench_test.go
+++ b/internal/client/renderer_bench_test.go
@@ -400,6 +400,61 @@ func BenchmarkPublishPaneCaptureFullScrollback(b *testing.B) {
 	}
 }
 
+func BenchmarkPaneOutputCaptureRefreshBurst(b *testing.B) {
+	const (
+		width           = 160
+		layoutHeight    = 25
+		scrollbackLines = mux.DefaultScrollbackLines
+		paneID          = 1
+		burstMessages   = 32
+	)
+
+	newRenderer := func(b *testing.B) (*Renderer, [][]byte, int) {
+		b.Helper()
+		r := NewWithScrollback(width, layoutHeight+1, scrollbackLines)
+		b.Cleanup(r.Close)
+		r.HandleLayout(benchLayoutSnapshot(1, width, layoutHeight))
+		contentHeight := mux.PaneContentHeight(layoutHeight)
+		r.HandlePaneOutputInfo(paneID, benchRenderSnapshotScreen(width, contentHeight), true)
+		payloads := benchRenderSnapshotScreenChanges(width, contentHeight, burstMessages)
+		totalBytes := 0
+		for _, payload := range payloads {
+			totalBytes += len(payload)
+		}
+		return r, payloads, totalBytes
+	}
+
+	b.Run("per-message", func(b *testing.B) {
+		r, payloads, totalBytes := newRenderer(b)
+		b.SetBytes(int64(totalBytes))
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			for _, payload := range payloads {
+				r.HandlePaneOutputInfo(paneID, payload, true)
+			}
+		}
+	})
+
+	b.Run("batched", func(b *testing.B) {
+		r, payloads, totalBytes := newRenderer(b)
+		items := make([]paneOutputBatchItem, len(payloads))
+		for i, payload := range payloads {
+			items[i] = paneOutputBatchItem{
+				paneID:      paneID,
+				data:        payload,
+				trackCursor: true,
+			}
+		}
+		b.SetBytes(int64(totalBytes))
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			r.HandlePaneOutputBatchInfo(items)
+		}
+	})
+}
+
 func BenchmarkCapturePaneRenderSnapshotRender(b *testing.B) {
 	const (
 		width           = 80

--- a/internal/client/renderer_capture_snapshot_test.go
+++ b/internal/client/renderer_capture_snapshot_test.go
@@ -30,6 +30,7 @@ type captureSnapshotFakeEmulator struct {
 	cursorBlockCol      int
 	cursorBlockRow      int
 	cell                uv.Cell
+	writes              [][]byte
 }
 
 type screenCellRead struct {
@@ -48,7 +49,22 @@ func newCaptureSnapshotFakeEmulator(lines []string, pushed uint64) *captureSnaps
 	}
 }
 
-func (e *captureSnapshotFakeEmulator) Write(data []byte) (int, error) { return len(data), nil }
+func (e *captureSnapshotFakeEmulator) Write(data []byte) (int, error) {
+	e.writes = append(e.writes, append([]byte(nil), data...))
+	if len(data) > 0 {
+		if e.height > 0 && len(e.screen) < e.height {
+			e.screen = append(e.screen, make([]string, e.height-len(e.screen))...)
+		}
+		if len(e.screen) == 0 {
+			e.screen = []string{""}
+		}
+		e.screen[0] += string(data)
+		if !slices.Contains(e.changedRows, 0) {
+			e.changedRows = append(e.changedRows, 0)
+		}
+	}
+	return len(data), nil
+}
 func (e *captureSnapshotFakeEmulator) DrainScreenChangeRows() []int {
 	if e.changedRows != nil {
 		rows := e.changedRows
@@ -359,6 +375,44 @@ func TestPublishPaneCaptureMissingEmulatorReportsNoScreenChange(t *testing.T) {
 			t.Fatal("missing emulator publish should not report screen changes")
 		}
 	})
+}
+
+func TestHandlePaneOutputBatchPublishesOneCapturePerPane(t *testing.T) {
+	t.Parallel()
+
+	r := NewWithScrollback(20, 4, 100)
+	t.Cleanup(r.Close)
+	r.HandleLayout(singlePane20x3())
+
+	emu := newCaptureSnapshotFakeEmulator(nil, 0)
+	emu.screen = []string{"", ""}
+	r.withActor(func(st *rendererActorState) {
+		st.emulators[1] = emu
+		st.paneCaptureStates[1] = paneRenderSnapshotState{}
+	})
+
+	infos := r.HandlePaneOutputBatchInfo([]paneOutputBatchItem{
+		{paneID: 1, data: []byte("first "), trackCursor: true},
+		{paneID: 1, data: []byte("second "), trackCursor: true},
+		{paneID: 1, data: []byte("third"), trackCursor: true},
+	})
+
+	info := infos[1]
+	if !info.paneVisible {
+		t.Fatal("batched visible pane output should report paneVisible")
+	}
+	if !info.screenChanged {
+		t.Fatal("batched visible pane output should report one screen change")
+	}
+	if got, want := len(emu.writes), 3; got != want {
+		t.Fatalf("emulator writes = %d, want %d", got, want)
+	}
+	if got, want := emu.renderCalls, 1; got != want {
+		t.Fatalf("batched pane capture Render calls = %d, want %d", got, want)
+	}
+	if got, want := paneRenderSnapshotLines(r.loadSnapshot().paneCaptures[1].screen)[0], "first second third"; got != want {
+		t.Fatalf("published pane capture row 0 = %q, want %q", got, want)
+	}
 }
 
 func equalStrings(a, b []string) bool {

--- a/internal/client/renderer_state.go
+++ b/internal/client/renderer_state.go
@@ -299,15 +299,33 @@ func (st *rendererActorState) refreshPaneCaptures(snap *rendererSnapshot, emulat
 }
 
 func (r *Renderer) publishPaneCapture(st *rendererActorState, paneID uint32) bool {
-	emu := st.emulators[paneID]
-	if emu == nil {
-		return false
+	changed := r.publishPaneCaptures(st, map[uint32]struct{}{paneID: {}})
+	return changed[paneID]
+}
+
+func (r *Renderer) publishPaneCaptures(st *rendererActorState, paneIDs map[uint32]struct{}) map[uint32]bool {
+	screenChanged := make(map[uint32]bool)
+	if len(paneIDs) == 0 {
+		return screenChanged
 	}
+
 	next := *st.snapshot
 	next.paneCaptures = clonePaneRenderSnapshots(st.snapshot.paneCaptures)
-	capture, state, screenChanged := capturePaneRenderSnapshot(emu, st.paneCaptureStates[paneID])
-	next.paneCaptures[paneID] = capture
-	st.paneCaptureStates[paneID] = state
+	published := false
+	for paneID := range paneIDs {
+		emu := st.emulators[paneID]
+		if emu == nil {
+			continue
+		}
+		capture, state, changed := capturePaneRenderSnapshot(emu, st.paneCaptureStates[paneID])
+		next.paneCaptures[paneID] = capture
+		st.paneCaptureStates[paneID] = state
+		screenChanged[paneID] = changed
+		published = true
+	}
+	if !published {
+		return screenChanged
+	}
 	st.snapshot = &next
 	r.publishSnapshot(&next)
 	return screenChanged


### PR DESCRIPTION
## Motivation

Active pane-output bursts made the client renderer pay for every intermediate capture snapshot even though users can only observe frame-paced states. The hot path from the May 25, 2026 profile was `publishPaneCapture -> capturePaneRenderSnapshot` on the renderer actor.

## Summary

- Batch consecutive pane-output render messages with no source epoch before the render loop processes later messages.
- Feed the batched bytes into emulators in socket order, then publish one capture snapshot generation covering all affected panes.
- Keep source-epoch output on the single-message path so local echo reconciliation remains ordered.
- Add regression coverage for batched capture publication and the forwarded-capture barrier.
- Add a focused burst benchmark comparing per-message capture refreshes with batched refreshes.

## Baseline numbers

Hardware: AMD EPYC-Milan Processor, linux/amd64, Go 1.25.10.

`go test ./internal/client -run '^$' -bench '^BenchmarkPaneOutputCaptureRefreshBurst$' -benchmem -count=5 -timeout 120s`

| Benchmark subcase | ns/op range | B/op | allocs/op |
| --- | ---: | ---: | ---: |
| `per-message` | 6,475,974-8,039,092 | 1,460,495-1,460,606 | 3,424 |
| `batched` | 621,560-804,541 | 45,592 | 106 |

The `per-message` subcase models the previous policy by refreshing capture snapshots once per pane-output message. The `batched` subcase writes the same 32-message burst and refreshes the capture snapshot once.

## Testing

- `go test ./internal/client -run '^(TestHandlePaneOutputBatchPublishesOneCapturePerPane|TestRenderCoalescedCaptureBarrierSeesCoalescedPaneOutput)$' -count=100 -timeout 120s`
- `go test ./internal/client -run 'Test(CapturePaneRenderSnapshot|PublishPaneCapture|HandleCaptureRequest|CaptureDisplay|RenderCoalescedPaneOutput|RenderCoalescedPrioritizes|RenderCoalescedDoesNotPrioritize|HandlePaneOutputBatch)' -count=100 -timeout 120s`
- `go test -race ./internal/client -run 'Test(CapturePaneRenderSnapshot|PublishPaneCapture|HandleCaptureRequest|CaptureDisplay|RenderCoalescedPaneOutput|RenderCoalescedPrioritizes|RenderCoalescedDoesNotPrioritize|HandlePaneOutputBatch)' -count=10 -timeout 120s`
- `go test ./internal/client -count=1 -timeout 120s`
- `SHELL=/usr/bin/bash go test ./internal/client ./internal/render ./test -timeout 120s`
- `go test ./internal/client -run '^$' -bench '^BenchmarkPaneOutputCaptureRefreshBurst$' -benchmem -count=5 -timeout 120s`
- `SHELL=/usr/bin/bash go test ./... -timeout 120s`

## Review focus

- Check that `collectPaneOutputBatch` stops before non-output messages, especially capture-barrier local actions.
- Check that `publishPaneCaptures` publishes one internally consistent snapshot generation for all panes affected by a batch.
- Check that source-epoch output intentionally stays off the batch path to preserve local echo reconciliation behavior.

Closes LAB-1910
