### PR TITLE
LAB-1912: Pin ultraviolet style equality optimization

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/charmbracelet/colorprofile v0.4.3
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/charmbracelet/log v0.3.1
-	github.com/charmbracelet/ultraviolet v0.0.0-20260303162955-0b88c25f3fff
+	github.com/charmbracelet/ultraviolet v0.0.0-20260525074446-7bbeb326738b
 	github.com/charmbracelet/x/ansi v0.11.7
 	github.com/charmbracelet/x/vt v0.0.0-20260311145557-c83711a11ffa
 	github.com/creack/pty v1.1.24
@@ -46,6 +46,6 @@ require (
 	golang.org/x/text v0.37.0 // indirect
 )
 
-replace github.com/charmbracelet/ultraviolet => github.com/weill-labs/ultraviolet v0.0.0-20260524224635-226eb7d80580
+replace github.com/charmbracelet/ultraviolet => github.com/weill-labs/ultraviolet v0.0.0-20260525074446-7bbeb326738b
 
 replace github.com/charmbracelet/x/vt => github.com/weill-labs/x/vt v0.0.0-20260514062200-6ca40b8a9268

--- a/go.sum
+++ b/go.sum
@@ -70,6 +70,8 @@ github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcU
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/weill-labs/ultraviolet v0.0.0-20260524224635-226eb7d80580 h1:V2CW0b92I3Lc2zb7efU456kQtnF4yzWw+vboEYomlOA=
 github.com/weill-labs/ultraviolet v0.0.0-20260524224635-226eb7d80580/go.mod h1:Vo8TffMf0q7Uho/n8e6XpBZvOWtd3g39yX+9P5rRutA=
+github.com/weill-labs/ultraviolet v0.0.0-20260525074446-7bbeb326738b h1:gJCZigJvmQjLI+dmVABhjDbCZcAC05U4PIocI+KT7QY=
+github.com/weill-labs/ultraviolet v0.0.0-20260525074446-7bbeb326738b/go.mod h1:Vo8TffMf0q7Uho/n8e6XpBZvOWtd3g39yX+9P5rRutA=
 github.com/weill-labs/x/vt v0.0.0-20260514062200-6ca40b8a9268 h1:eK1uv22omrKrgMBmfZud6F9jknE7yVQvSsWZrTyubZg=
 github.com/weill-labs/x/vt v0.0.0-20260514062200-6ca40b8a9268/go.mod h1:u1LOIABor9JqY54oZdktK3TCRrgzP6tzHrDYx1nd3wY=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=

--- a/internal/client/renderer_capture_snapshot_test.go
+++ b/internal/client/renderer_capture_snapshot_test.go
@@ -25,6 +25,7 @@ type captureSnapshotFakeEmulator struct {
 	screenReads         []int
 	cellReads           []screenCellRead
 	changedRows         []int
+	drainRowsCalls      int
 	renderCalls         int
 	renderNoCursorCalls int
 	hasCursorBlock      bool
@@ -67,6 +68,7 @@ func (e *captureSnapshotFakeEmulator) Write(data []byte) (int, error) {
 	return len(data), nil
 }
 func (e *captureSnapshotFakeEmulator) DrainScreenChangeRows() []int {
+	e.drainRowsCalls++
 	if e.changedRows != nil {
 		rows := e.changedRows
 		e.changedRows = nil
@@ -428,8 +430,11 @@ func TestHandlePaneOutputBatchPublishesOneCapturePerPane(t *testing.T) {
 	if got, want := len(emu.writes), 3; got != want {
 		t.Fatalf("emulator writes = %d, want %d", got, want)
 	}
-	if got, want := emu.renderCalls, 1; got != want {
-		t.Fatalf("batched pane capture Render calls = %d, want %d", got, want)
+	if got, want := emu.drainRowsCalls, 1; got != want {
+		t.Fatalf("batched pane capture screen drains = %d, want %d", got, want)
+	}
+	if got := emu.renderCalls; got != 0 {
+		t.Fatalf("batched pane capture Render calls = %d, want 0", got)
 	}
 	if got, want := paneRenderSnapshotLines(r.loadSnapshot().paneCaptures[1].screen)[0], "first second third"; got != want {
 		t.Fatalf("published pane capture row 0 = %q, want %q", got, want)


### PR DESCRIPTION
## Motivation

amux LAB-1912 profiling showed `github.com/weill-labs/ultraviolet` still spending render time in style and color equality after the LAB-1887 renderLine cell-copy fix. The upstream/fork optimization is in weill-labs/ultraviolet#5; this PR pins amux to that commit so capture/render paths use the new equality fast paths.

After rebasing onto the latest `origin/main`, CI also exposed a deterministic stale assertion in `TestHandlePaneOutputBatchPublishesOneCapturePerPane`: the test still expected the older ANSI `Render()` capture path even though pane captures now use cell snapshots.

## Summary

- Update the `github.com/charmbracelet/ultraviolet` replacement to `github.com/weill-labs/ultraviolet v0.0.0-20260525074446-7bbeb326738b`.
- Add the new replacement checksum to `go.sum`.
- Leave amux code unchanged; behavior should only differ by ultraviolet render performance.
- Update the existing batch capture test to assert one screen-change drain and zero ANSI `Render()` calls on the current cell-snapshot path.

## Baseline numbers

Hardware: AMD EPYC-Milan Processor, linux/amd64.

Amux changed-screen benchmark:

```bash
go test ./internal/client -run '^$' -bench BenchmarkCapturePaneRenderSnapshotRenderChangedScreen -benchmem -benchtime=500ms -count=8
```

| Benchmark | Old pin | New pin | Delta |
| --- | ---: | ---: | ---: |
| CapturePaneRenderSnapshotRenderChangedScreen | 29.11 us/op | 28.89 us/op | no significant change, p=0.524 |
| Allocations | 9 allocs/op | 9 allocs/op | unchanged |

Note: after rebasing onto `origin/main` with LAB-1908 through LAB-1910, the amux changed-screen benchmark is dominated by newer capture/render changes and no longer shows the larger upstream ultraviolet delta directly.

Underlying ultraviolet benchmark from weill-labs/ultraviolet#5:

| Benchmark | Before | After | Delta |
| --- | ---: | ---: | ---: |
| LineRenderStyleEquality | 97.42 us/op | 32.60 us/op | -66.54% |
| BufferRenderChangedScreen | 1245.7 us/op | 362.8 us/op | -70.88% |
| StyleEqual/zero | 32.690 ns/op | 3.169 ns/op | -90.31% |
| StyleEqual/styled-same-pointer | 60.290 ns/op | 1.827 ns/op | -96.97% |
| StyleEqual/styled-equal-value | 75.58 ns/op | 19.53 ns/op | -74.16% |

## Testing

- `go test ./internal/mux -run 'TestEmulator|TestRenderWithCursor'`
- `go test ./test -run 'TestGolden|TestCapture'`
- `go test ./internal/client -run 'TestRenderer|TestCapturePaneRenderSnapshot|TestCapture'`
- `go test ./internal/client -run '^$' -bench 'BenchmarkCapturePaneRenderSnapshotRenderChangedScreen|BenchmarkCapturePaneRenderSnapshotRender|BenchmarkRendererHandlePaneOutput' -benchmem -count=5`
- `go test ./internal/mux -run '^$' -bench BenchmarkEmulatorRender -benchmem -count=5`
- `go test ./internal/render -run '^$' -bench BenchmarkRenderFull -benchmem -count=5`
- `go test ./internal/client -run '^$' -bench BenchmarkCapturePaneRenderSnapshotRenderChangedScreen -benchmem -benchtime=500ms -count=8` before and after the pin, compared with `benchstat`
- `go test ./test -run TestPaneMetaSurvivesCrashRecovery -count=3 -timeout 120s`
- `go test ./test -run TestTakeoverAfterServerReload -count=3 -timeout 120s`
- `go test ./test -run TestTypeKeysCompatBellKeyDoesNotChangeLayout -count=3 -timeout 120s`
- `go test ./internal/server -run TestRespawnCommandFailureUsesSessionCloser -count=10`
- `go test ./test -run TestCaptureJSONIncludesPaneKV -count=10 -timeout 120s`
- `go test ./internal/mux -run TestPaneRespawnPreservesMetadataAndSuppressesExitCallback -count=10`
- `go_vulncheck ./...` via gopls, no vulnerabilities reported

After rebasing onto `origin/main` at `9429a4c`, reran:

- `go test ./internal/mux -run 'TestEmulator|TestRenderWithCursor'`
- `go test ./internal/client -run 'TestRenderer|TestCapturePaneRenderSnapshot|TestCapture'`
- `go test ./test -run 'TestGolden|TestCapture' -timeout 120s`
- `go test ./internal/mux -run TestPaneRespawnPreservesMetadataAndSuppressesExitCallback -count=10`
- `go test ./internal/client -run '^$' -bench BenchmarkCapturePaneRenderSnapshotRenderChangedScreen -benchmem -benchtime=500ms -count=8`
- `go_vulncheck ./...` via gopls, no vulnerabilities reported

After fixing the stale rebased-base test assertion, ran:

- `go test ./internal/client -run TestHandlePaneOutputBatchPublishesOneCapturePerPane -count=100`
- `go test ./internal/client`

Full-suite note: `go test ./... -timeout 120s` was run three times. Each run failed on a different existing flaky path (`TestPaneMetaSurvivesCrashRecovery`, then `TestTakeoverAfterServerReload`/`TestTypeKeysCompatBellKeyDoesNotChangeLayout`, then `TestRespawnCommandFailureUsesSessionCloser`). Each exact failed test passed focused reruns listed above.

## Review focus

- Confirm the replacement pseudo-version matches ultraviolet commit `7bbeb326738bc9d8590580d4491c118ffb10ddb6` from weill-labs/ultraviolet#5.
- Review whether the benchmark evidence is sufficient given the now-neutral amux changed-screen benchmark and stronger upstream microbenchmarks.
- Confirm the batch capture test change reflects existing cell-snapshot behavior and does not mask a production regression.
- Note the full-suite failures are not in render/ultraviolet code paths and passed focused reruns.

Closes LAB-1912.
