### PR TITLE
LAB-1916: Add cancellable eventloop queues

### DIFF
--- a/internal/eventloop/eventloop_test.go
+++ b/internal/eventloop/eventloop_test.go
@@ -1,6 +1,7 @@
 package eventloop
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"strings"
@@ -76,6 +77,16 @@ func (c blockingWatchdogCommand) Handle(s *watchdogTestState) {
 	if c.rename != "" {
 		s.name = c.rename
 	}
+	<-c.release
+}
+
+type blockingCounterCommand struct {
+	entered chan struct{}
+	release chan struct{}
+}
+
+func (c blockingCounterCommand) Handle(context.Context, *counterState) {
+	close(c.entered)
 	<-c.release
 }
 
@@ -324,6 +335,75 @@ func TestEnqueueReturnsFalseAfterStop(t *testing.T) {
 
 	if Enqueue(queue, stop, addCommand{delta: 1}) {
 		t.Fatal("Enqueue() = true after stop, want false")
+	}
+}
+
+func TestEnqueueReturnsPromptlyWhenContextCanceledWhileQueueSaturated(t *testing.T) {
+	t.Parallel()
+
+	queue := make(chan QueuedCommand[counterState], 1)
+	stop := make(chan struct{})
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	queue <- QueuedCommand[counterState]{}
+
+	start := time.Now()
+	if Enqueue(ctx, queue, stop, addCommand{delta: 1}) {
+		t.Fatal("Enqueue() = true after context cancellation, want false")
+	}
+	if elapsed := time.Since(start); elapsed > 50*time.Millisecond {
+		t.Fatalf("Enqueue() returned after %v with canceled context, want under 50ms", elapsed)
+	}
+}
+
+func TestEnqueueQueryReturnsPromptlyWhenContextCanceledWaitingForReply(t *testing.T) {
+	t.Parallel()
+
+	state := &counterState{}
+	queue := make(chan QueuedCommand[counterState], 1)
+	stop := make(chan struct{})
+	done := make(chan struct{})
+	release := make(chan struct{})
+	t.Cleanup(func() {
+		close(release)
+		close(stop)
+		<-done
+	})
+
+	go Run(state, queue, stop, done, nil)
+
+	blocker := blockingCounterCommand{
+		entered: make(chan struct{}),
+		release: release,
+	}
+	if !Enqueue(context.Background(), queue, stop, blocker) {
+		t.Fatal("Enqueue(blocking command) = false, want true")
+	}
+	select {
+	case <-blocker.entered:
+	case <-time.After(time.Second):
+		t.Fatal("blocking command did not enter Handle")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	queryErr := make(chan error, 1)
+	go func() {
+		_, err := EnqueueQuery(ctx, queue, stop, done, func(context.Context, *counterState) (int, error) {
+			return 1, nil
+		}, nil, ErrStopped)
+		queryErr <- err
+	}()
+
+	time.Sleep(10 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-queryErr:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("EnqueueQuery() error = %v, want %v", err, context.Canceled)
+		}
+	case <-time.After(50 * time.Millisecond):
+		t.Fatal("EnqueueQuery() did not return within 50ms after context cancellation")
 	}
 }
 

--- a/internal/eventloop/eventloop_test.go
+++ b/internal/eventloop/eventloop_test.go
@@ -17,7 +17,7 @@ type addCommand struct {
 	delta int
 }
 
-func (c addCommand) Handle(s *counterState) {
+func (c addCommand) Handle(_ context.Context, s *counterState) {
 	s.value += c.delta
 }
 
@@ -72,7 +72,7 @@ type blockingWatchdogCommand struct {
 	rename  string
 }
 
-func (c blockingWatchdogCommand) Handle(s *watchdogTestState) {
+func (c blockingWatchdogCommand) Handle(_ context.Context, s *watchdogTestState) {
 	close(c.entered)
 	if c.rename != "" {
 		s.name = c.rename
@@ -211,20 +211,20 @@ func TestRunProcessesCommands(t *testing.T) {
 	t.Parallel()
 
 	state := &counterState{}
-	queue := make(chan Command[counterState], 2)
+	queue := make(chan QueuedCommand[counterState], 2)
 	stop := make(chan struct{})
 	done := make(chan struct{})
 
 	go Run(state, queue, stop, done, nil)
 
-	if !Enqueue(queue, stop, addCommand{delta: 2}) {
+	if !Enqueue(context.Background(), queue, stop, addCommand{delta: 2}) {
 		t.Fatal("Enqueue(first) = false, want true")
 	}
-	if !Enqueue(queue, stop, addCommand{delta: 3}) {
+	if !Enqueue(context.Background(), queue, stop, addCommand{delta: 3}) {
 		t.Fatal("Enqueue(second) = false, want true")
 	}
 
-	result, err := EnqueueQuery(queue, stop, done, func(s *counterState) (int, error) {
+	result, err := EnqueueQuery(context.Background(), queue, stop, done, func(_ context.Context, s *counterState) (int, error) {
 		return s.value, nil
 	}, nil, ErrStopped)
 	if err != nil {
@@ -246,7 +246,7 @@ func TestRunWatchdogReportsStuckHandlerAndStopsLoop(t *testing.T) {
 		name:     "watchdog-state-before-handle",
 		timedOut: make(chan watchdogTimeoutCall, 1),
 	}
-	queue := make(chan Command[watchdogTestState], 1)
+	queue := make(chan QueuedCommand[watchdogTestState], 1)
 	stop := make(chan struct{})
 	done := make(chan struct{})
 	release := make(chan struct{})
@@ -263,7 +263,7 @@ func TestRunWatchdogReportsStuckHandlerAndStopsLoop(t *testing.T) {
 		release: release,
 		rename:  "watchdog-state-during-handle",
 	}
-	if !Enqueue(queue, stop, cmd) {
+	if !Enqueue(context.Background(), queue, stop, cmd) {
 		t.Fatal("Enqueue(blocking command) = false, want true")
 	}
 	select {
@@ -310,7 +310,7 @@ func TestRunWatchdogEntersHandlerBeforeFirstCommand(t *testing.T) {
 		timeout: 100 * time.Millisecond,
 		entered: make(chan struct{}, 1),
 	}
-	queue := make(chan Command[watchdogTestState], 1)
+	queue := make(chan QueuedCommand[watchdogTestState], 1)
 	stop := make(chan struct{})
 	done := make(chan struct{})
 
@@ -329,11 +329,11 @@ func TestRunWatchdogEntersHandlerBeforeFirstCommand(t *testing.T) {
 func TestEnqueueReturnsFalseAfterStop(t *testing.T) {
 	t.Parallel()
 
-	queue := make(chan Command[counterState], 1)
+	queue := make(chan QueuedCommand[counterState], 1)
 	stop := make(chan struct{})
 	close(stop)
 
-	if Enqueue(queue, stop, addCommand{delta: 1}) {
+	if Enqueue(context.Background(), queue, stop, addCommand{delta: 1}) {
 		t.Fatal("Enqueue() = true after stop, want false")
 	}
 }
@@ -411,13 +411,13 @@ func TestEnqueueQueryRecoversPanics(t *testing.T) {
 	t.Parallel()
 
 	state := &counterState{}
-	queue := make(chan Command[counterState], 1)
+	queue := make(chan QueuedCommand[counterState], 1)
 	stop := make(chan struct{})
 	done := make(chan struct{})
 
 	go Run(state, queue, stop, done, nil)
 
-	_, err := EnqueueQuery(queue, stop, done, func(*counterState) (int, error) {
+	_, err := EnqueueQuery(context.Background(), queue, stop, done, func(context.Context, *counterState) (int, error) {
 		panic("boom")
 	}, func(r any, _ []byte) error {
 		return errors.New("internal error: recovered boom")
@@ -433,12 +433,12 @@ func TestEnqueueQueryRecoversPanics(t *testing.T) {
 func TestEnqueueQueryReturnsShutdownErrorWhenLoopDone(t *testing.T) {
 	t.Parallel()
 
-	queue := make(chan Command[counterState], 1)
+	queue := make(chan QueuedCommand[counterState], 1)
 	stop := make(chan struct{})
 	done := make(chan struct{})
 	close(done)
 
-	_, err := EnqueueQuery(queue, stop, done, func(*counterState) (int, error) {
+	_, err := EnqueueQuery(context.Background(), queue, stop, done, func(context.Context, *counterState) (int, error) {
 		return 0, nil
 	}, nil, ErrStopped)
 	if !errors.Is(err, ErrStopped) {

--- a/internal/eventloop/loop.go
+++ b/internal/eventloop/loop.go
@@ -1,6 +1,7 @@
 package eventloop
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"runtime/debug"
@@ -17,7 +18,12 @@ var ErrStopped = errors.New("event loop stopped")
 const DefaultWatchdogTimeout = 30 * time.Second
 
 type Command[S any] interface {
-	Handle(*S)
+	Handle(context.Context, *S)
+}
+
+type QueuedCommand[S any] struct {
+	ctx context.Context
+	cmd Command[S]
 }
 
 type LoopHook[S any] func(*S) bool
@@ -61,6 +67,7 @@ type commandTypeNamer interface {
 }
 
 type handleRequest[S any] struct {
+	ctx     context.Context
 	cmd     Command[S]
 	entered chan handleEntry
 	done    chan struct{}
@@ -75,7 +82,7 @@ type handleEntry struct {
 
 // Run processes commands serially until stop closes, the queue closes, or the
 // hook returns false.
-func Run[S any](state *S, queue <-chan Command[S], stop <-chan struct{}, done chan<- struct{}, hook LoopHook[S]) {
+func Run[S any](state *S, queue <-chan QueuedCommand[S], stop <-chan struct{}, done chan<- struct{}, hook LoopHook[S]) {
 	defer close(done)
 	timeout := watchdogTimeout(state)
 	if timeout <= 0 {
@@ -97,7 +104,10 @@ func Run[S any](state *S, queue <-chan Command[S], stop <-chan struct{}, done ch
 			if !ok {
 				return
 			}
-			if cmd != nil && !handleWithWatchdog(state, handlerRequests, cmd, timeout) {
+			if !cmd.ready() {
+				continue
+			}
+			if !handleWithWatchdog(state, handlerRequests, cmd, timeout) {
 				return
 			}
 			if hook != nil && !hook(state) {
@@ -107,7 +117,7 @@ func Run[S any](state *S, queue <-chan Command[S], stop <-chan struct{}, done ch
 	}
 }
 
-func runInline[S any](state *S, queue <-chan Command[S], stop <-chan struct{}, hook LoopHook[S]) {
+func runInline[S any](state *S, queue <-chan QueuedCommand[S], stop <-chan struct{}, hook LoopHook[S]) {
 	notifyCommandEntry(state)
 	for {
 		select {
@@ -117,8 +127,8 @@ func runInline[S any](state *S, queue <-chan Command[S], stop <-chan struct{}, h
 			if !ok {
 				return
 			}
-			if cmd != nil {
-				cmd.Handle(state)
+			if cmd.ready() {
+				cmd.cmd.Handle(cmd.ctx, state)
 			}
 			if hook != nil && !hook(state) {
 				return
@@ -137,7 +147,9 @@ func handleCommands[S any](state *S, requests <-chan handleRequest[S], ready cha
 			commandType: commandType(req.cmd),
 			snapshot:    watchdogSnapshot(state),
 		}
-		req.cmd.Handle(state)
+		if req.ctx.Err() == nil {
+			req.cmd.Handle(req.ctx, state)
+		}
 		req.done <- struct{}{}
 	}
 }
@@ -148,10 +160,10 @@ func notifyCommandEntry[S any](state *S) {
 	}
 }
 
-func handleWithWatchdog[S any](state *S, requests chan<- handleRequest[S], cmd Command[S], timeout time.Duration) bool {
+func handleWithWatchdog[S any](state *S, requests chan<- handleRequest[S], cmd QueuedCommand[S], timeout time.Duration) bool {
 	entered := make(chan handleEntry, 1)
 	finished := make(chan struct{}, 1)
-	requests <- handleRequest[S]{cmd: cmd, entered: entered, done: finished}
+	requests <- handleRequest[S]{ctx: cmd.ctx, cmd: cmd.cmd, entered: entered, done: finished}
 	entry := <-entered
 
 	timer := time.NewTimer(timeout)
@@ -164,6 +176,13 @@ func handleWithWatchdog[S any](state *S, requests chan<- handleRequest[S], cmd C
 		notifyWatchdogTimeout(state, entry, timeout)
 		return false
 	}
+}
+
+func (cmd QueuedCommand[S]) ready() bool {
+	if cmd.cmd == nil || cmd.ctx == nil {
+		return false
+	}
+	return cmd.ctx.Err() == nil
 }
 
 func watchdogTimeout[S any](state *S) time.Duration {
@@ -217,17 +236,24 @@ func stopTimer(timer *time.Timer) {
 	}
 }
 
-func Enqueue[S any](queue chan<- Command[S], stop <-chan struct{}, cmd Command[S]) bool {
+func Enqueue[S any](ctx context.Context, queue chan<- QueuedCommand[S], stop <-chan struct{}, cmd Command[S]) bool {
+	if ctx == nil {
+		panic("eventloop.Enqueue called with nil context")
+	}
 	select {
+	case <-ctx.Done():
+		return false
 	case <-stop:
 		return false
 	default:
 	}
 
 	select {
+	case <-ctx.Done():
+		return false
 	case <-stop:
 		return false
-	case queue <- cmd:
+	case queue <- QueuedCommand[S]{ctx: ctx, cmd: cmd}:
 		return true
 	}
 }
@@ -240,16 +266,20 @@ type QueryResult[T any] struct {
 }
 
 type QueryCommand[S any, T any] struct {
-	Fn      func(*S) (T, error)
+	Fn      func(context.Context, *S) (T, error)
 	Reply   chan QueryResult[T]
 	Recover PanicHandler
 }
 
-func (q QueryCommand[S, T]) Handle(state *S) {
-	q.Reply <- recoverQuery(q.Fn, state, q.Recover)
+func (q QueryCommand[S, T]) Handle(ctx context.Context, state *S) {
+	res := recoverQuery(ctx, q.Fn, state, q.Recover)
+	select {
+	case q.Reply <- res:
+	case <-ctx.Done():
+	}
 }
 
-func recoverQuery[S any, T any](fn func(*S) (T, error), state *S, recoverFn PanicHandler) (res QueryResult[T]) {
+func recoverQuery[S any, T any](ctx context.Context, fn func(context.Context, *S) (T, error), state *S, recoverFn PanicHandler) (res QueryResult[T]) {
 	defer func() {
 		if r := recover(); r != nil {
 			if recoverFn != nil {
@@ -259,28 +289,34 @@ func recoverQuery[S any, T any](fn func(*S) (T, error), state *S, recoverFn Pani
 			res = QueryResult[T]{Err: errors.New("internal error")}
 		}
 	}()
-	value, err := fn(state)
+	value, err := fn(ctx, state)
 	return QueryResult[T]{Value: value, Err: err}
 }
 
 func EnqueueQuery[S any, T any](
-	queue chan<- Command[S],
+	ctx context.Context,
+	queue chan<- QueuedCommand[S],
 	stop <-chan struct{},
 	done <-chan struct{},
-	fn func(*S) (T, error),
+	fn func(context.Context, *S) (T, error),
 	recoverFn PanicHandler,
 	stoppedErr error,
 ) (T, error) {
 	zero := *new(T)
 
 	reply := make(chan QueryResult[T], 1)
-	if !Enqueue(queue, stop, QueryCommand[S, T]{Fn: fn, Reply: reply, Recover: recoverFn}) {
+	if !Enqueue(ctx, queue, stop, QueryCommand[S, T]{Fn: fn, Reply: reply, Recover: recoverFn}) {
+		if err := ctx.Err(); err != nil {
+			return zero, err
+		}
 		return zero, stoppedErr
 	}
 
 	select {
 	case res := <-reply:
 		return res.Value, res.Err
+	case <-ctx.Done():
+		return zero, ctx.Err()
 	case <-done:
 		select {
 		case res := <-reply:

--- a/internal/server/attach_bootstrap_test.go
+++ b/internal/server/attach_bootstrap_test.go
@@ -414,7 +414,7 @@ func newAttachTestPane(sess *Session, id uint32, name string, cols, rows int) *m
 }
 
 func setAttachTestLayout(sess *Session, windows []*mux.Window, activeWindowID uint32, panes []*mux.Pane) error {
-	_, err := enqueueSessionQueryLegacy(sess.context(), sess, func(sess *Session) (struct{}, error) {
+	_, err := enqueueSessionQueryOnState(sess.context(), sess, func(sess *Session) (struct{}, error) {
 		sess.Windows = windows
 		sess.ActiveWindowID = activeWindowID
 		sess.Panes = panes
@@ -448,7 +448,7 @@ func queueAttachTestSplit(sess *Session, pane *mux.Pane, dir mux.SplitDir, rootL
 }
 
 func snapshotAttachTestLayout(sess *Session) (*proto.LayoutSnapshot, error) {
-	return enqueueSessionQueryLegacy(sess.context(), sess, func(sess *Session) (*proto.LayoutSnapshot, error) {
+	return enqueueSessionQueryOnState(sess.context(), sess, func(sess *Session) (*proto.LayoutSnapshot, error) {
 		idleSnap := sess.snapshotIdleState()
 		return sess.snapshotLayout(idleSnap), nil
 	})

--- a/internal/server/attach_bootstrap_test.go
+++ b/internal/server/attach_bootstrap_test.go
@@ -414,7 +414,7 @@ func newAttachTestPane(sess *Session, id uint32, name string, cols, rows int) *m
 }
 
 func setAttachTestLayout(sess *Session, windows []*mux.Window, activeWindowID uint32, panes []*mux.Pane) error {
-	_, err := enqueueSessionQuery(sess, func(sess *Session) (struct{}, error) {
+	_, err := enqueueSessionQueryLegacy(sess.context(), sess, func(sess *Session) (struct{}, error) {
 		sess.Windows = windows
 		sess.ActiveWindowID = activeWindowID
 		sess.Panes = panes
@@ -424,7 +424,7 @@ func setAttachTestLayout(sess *Session, windows []*mux.Window, activeWindowID ui
 }
 
 func subscribeAttachTestPaneOutput(sess *Session, paneID uint32) (chan struct{}, func()) {
-	ch := sess.enqueuePaneOutputSubscribe(paneID)
+	ch := sess.enqueuePaneOutputSubscribe(sess.context(), paneID)
 	cleanup := func() {}
 	if ch != nil {
 		cleanup = func() {
@@ -448,7 +448,7 @@ func queueAttachTestSplit(sess *Session, pane *mux.Pane, dir mux.SplitDir, rootL
 }
 
 func snapshotAttachTestLayout(sess *Session) (*proto.LayoutSnapshot, error) {
-	return enqueueSessionQuery(sess, func(sess *Session) (*proto.LayoutSnapshot, error) {
+	return enqueueSessionQueryLegacy(sess.context(), sess, func(sess *Session) (*proto.LayoutSnapshot, error) {
 		idleSnap := sess.snapshotIdleState()
 		return sess.snapshotLayout(idleSnap), nil
 	})

--- a/internal/server/audit_logging_test.go
+++ b/internal/server/audit_logging_test.go
@@ -92,7 +92,7 @@ func TestSessionAuditLogsLifecycleEvents(t *testing.T) {
 		sess.refreshInputTarget()
 	})
 
-	pane2, err := enqueueSessionQuery(sess, func(sess *Session) (*mux.Pane, error) {
+	pane2, err := enqueueSessionQueryLegacy(sess.context(), sess, func(sess *Session) (*mux.Pane, error) {
 		pane := newTestPane(sess, 2, "pane-2")
 		return pane, sess.insertPreparedPaneIntoActiveWindow(pane, mux.SplitHorizontal, false, false)
 	})
@@ -112,7 +112,7 @@ func TestSessionAuditLogsLifecycleEvents(t *testing.T) {
 		sess.handleFinalizedPaneRemoval(pane2.ID, false, "exit 0")
 	})
 
-	pane3, err := enqueueSessionQuery(sess, func(sess *Session) (*mux.Pane, error) {
+	pane3, err := enqueueSessionQueryLegacy(sess.context(), sess, func(sess *Session) (*mux.Pane, error) {
 		pane := newTestPane(sess, 3, "pane-3")
 		return pane, sess.insertPreparedPaneIntoActiveWindow(pane, mux.SplitHorizontal, false, false)
 	})
@@ -133,7 +133,7 @@ func TestSessionAuditLogsLifecycleEvents(t *testing.T) {
 
 	cc.markDisconnectReason(disconnectReasonClosed)
 	mustSessionMutation(t, sess, func(sess *Session) {
-		(detachClientEvent{cc: cc, reason: DisconnectReasonSocketError}).handle(sess)
+		(detachClientEvent{cc: cc, reason: DisconnectReasonSocketError}).handle(sess.context(), sess)
 	})
 
 	records := parseAuditRecords(t, buf)

--- a/internal/server/audit_logging_test.go
+++ b/internal/server/audit_logging_test.go
@@ -92,7 +92,7 @@ func TestSessionAuditLogsLifecycleEvents(t *testing.T) {
 		sess.refreshInputTarget()
 	})
 
-	pane2, err := enqueueSessionQueryLegacy(sess.context(), sess, func(sess *Session) (*mux.Pane, error) {
+	pane2, err := enqueueSessionQueryOnState(sess.context(), sess, func(sess *Session) (*mux.Pane, error) {
 		pane := newTestPane(sess, 2, "pane-2")
 		return pane, sess.insertPreparedPaneIntoActiveWindow(pane, mux.SplitHorizontal, false, false)
 	})
@@ -112,7 +112,7 @@ func TestSessionAuditLogsLifecycleEvents(t *testing.T) {
 		sess.handleFinalizedPaneRemoval(pane2.ID, false, "exit 0")
 	})
 
-	pane3, err := enqueueSessionQueryLegacy(sess.context(), sess, func(sess *Session) (*mux.Pane, error) {
+	pane3, err := enqueueSessionQueryOnState(sess.context(), sess, func(sess *Session) (*mux.Pane, error) {
 		pane := newTestPane(sess, 3, "pane-3")
 		return pane, sess.insertPreparedPaneIntoActiveWindow(pane, mux.SplitHorizontal, false, false)
 	})

--- a/internal/server/capture_forward.go
+++ b/internal/server/capture_forward.go
@@ -91,7 +91,7 @@ func (s *Session) captureClientSnapshot(req caputil.Request, target *capturePane
 }
 
 func (s *Session) captureClientSnapshotForActor(req caputil.Request, actorPaneID uint32, target *capturePaneTarget) (captureClientSnapshot, error) {
-	return enqueueSessionQueryLegacy(s.context(), s, func(s *Session) (captureClientSnapshot, error) {
+	return enqueueSessionQueryOnState(s.context(), s, func(s *Session) (captureClientSnapshot, error) {
 		snap := captureClientSnapshot{}
 		for _, cc := range s.ensureClientManager().snapshotClients() {
 			if cc.isBootstrapping() {
@@ -217,7 +217,7 @@ func ensureTrailingNewline(s string) string {
 // routeCaptureResponse delivers a capture response from the interactive client
 // to the waiting forwardCapture caller. Thread-safe.
 func (s *Session) routeCaptureResponse(msg *Message) {
-	_, _ = enqueueSessionQueryLegacy(s.context(), s, func(s *Session) (struct{}, error) {
+	_, _ = enqueueSessionQueryOnState(s.context(), s, func(s *Session) (struct{}, error) {
 		s.ensureCaptureForwarder().routeResponse(msg, s.sendCaptureRequestAsync)
 		return struct{}{}, nil
 	})
@@ -245,7 +245,7 @@ func (s *Session) startNextCaptureRequest() {
 }
 
 func (s *Session) enqueueCaptureRequest(req *captureRequest) error {
-	_, err := enqueueSessionQueryLegacy(s.context(), s, func(s *Session) (struct{}, error) {
+	_, err := enqueueSessionQueryOnState(s.context(), s, func(s *Session) (struct{}, error) {
 		s.ensureCaptureForwarder().enqueue(req, s.sendCaptureRequestAsync)
 		return struct{}{}, nil
 	})
@@ -253,7 +253,7 @@ func (s *Session) enqueueCaptureRequest(req *captureRequest) error {
 }
 
 func (s *Session) cancelCaptureRequest(id uint64) {
-	_, _ = enqueueSessionQueryLegacy(s.context(), s, func(s *Session) (struct{}, error) {
+	_, _ = enqueueSessionQueryOnState(s.context(), s, func(s *Session) (struct{}, error) {
 		s.ensureCaptureForwarder().cancel(id, s.sendCaptureRequestAsync)
 		return struct{}{}, nil
 	})

--- a/internal/server/capture_forward.go
+++ b/internal/server/capture_forward.go
@@ -91,7 +91,7 @@ func (s *Session) captureClientSnapshot(req caputil.Request, target *capturePane
 }
 
 func (s *Session) captureClientSnapshotForActor(req caputil.Request, actorPaneID uint32, target *capturePaneTarget) (captureClientSnapshot, error) {
-	return enqueueSessionQuery(s, func(s *Session) (captureClientSnapshot, error) {
+	return enqueueSessionQueryLegacy(s.context(), s, func(s *Session) (captureClientSnapshot, error) {
 		snap := captureClientSnapshot{}
 		for _, cc := range s.ensureClientManager().snapshotClients() {
 			if cc.isBootstrapping() {
@@ -217,7 +217,7 @@ func ensureTrailingNewline(s string) string {
 // routeCaptureResponse delivers a capture response from the interactive client
 // to the waiting forwardCapture caller. Thread-safe.
 func (s *Session) routeCaptureResponse(msg *Message) {
-	_, _ = enqueueSessionQuery(s, func(s *Session) (struct{}, error) {
+	_, _ = enqueueSessionQueryLegacy(s.context(), s, func(s *Session) (struct{}, error) {
 		s.ensureCaptureForwarder().routeResponse(msg, s.sendCaptureRequestAsync)
 		return struct{}{}, nil
 	})
@@ -245,7 +245,7 @@ func (s *Session) startNextCaptureRequest() {
 }
 
 func (s *Session) enqueueCaptureRequest(req *captureRequest) error {
-	_, err := enqueueSessionQuery(s, func(s *Session) (struct{}, error) {
+	_, err := enqueueSessionQueryLegacy(s.context(), s, func(s *Session) (struct{}, error) {
 		s.ensureCaptureForwarder().enqueue(req, s.sendCaptureRequestAsync)
 		return struct{}{}, nil
 	})
@@ -253,7 +253,7 @@ func (s *Session) enqueueCaptureRequest(req *captureRequest) error {
 }
 
 func (s *Session) cancelCaptureRequest(id uint64) {
-	_, _ = enqueueSessionQuery(s, func(s *Session) (struct{}, error) {
+	_, _ = enqueueSessionQueryLegacy(s.context(), s, func(s *Session) (struct{}, error) {
 		s.ensureCaptureForwarder().cancel(id, s.sendCaptureRequestAsync)
 		return struct{}{}, nil
 	})

--- a/internal/server/capture_forward_test.go
+++ b/internal/server/capture_forward_test.go
@@ -52,7 +52,7 @@ func TestForwardCaptureAgentStatusScope(t *testing.T) {
 			pane1 := newTestPane(sess, 1, "pane-1")
 			pane2 := newTestPane(sess, 2, "pane-2")
 			w := newTestWindowWithPanes(t, sess, 1, "window-1", pane1, pane2)
-			if _, err := enqueueSessionQuery(sess, func(sess *Session) (struct{}, error) {
+			if _, err := enqueueSessionQueryLegacy(sess.context(), sess, func(sess *Session) (struct{}, error) {
 				sess.Windows = []*mux.Window{w}
 				sess.ActiveWindowID = w.ID
 				sess.Panes = []*mux.Pane{pane1, pane2}
@@ -97,7 +97,7 @@ func TestForwardCaptureFullScreenJSONUsesActiveWindowPanesOnly(t *testing.T) {
 	pane3 := newTestPane(sess, 3, "pane-3")
 	window1 := newTestWindowWithPanes(t, sess, 1, "window-1", pane1, pane2)
 	window2 := newTestWindowWithPanes(t, sess, 2, "window-2", pane3)
-	if _, err := enqueueSessionQuery(sess, func(sess *Session) (struct{}, error) {
+	if _, err := enqueueSessionQueryLegacy(sess.context(), sess, func(sess *Session) (struct{}, error) {
 		sess.Windows = []*mux.Window{window1, window2}
 		sess.ActiveWindowID = window1.ID
 		sess.Panes = []*mux.Pane{pane1, pane2, pane3}
@@ -200,7 +200,7 @@ func TestForwardCapturePaneFallsBackWithoutClient(t *testing.T) {
 	pane := newTestPane(sess, 1, "pane-1")
 	pane.FeedOutput([]byte("\x1b[31mHEADLESS-ANSI\x1b[m\r\nHEADLESS-PLAIN\r\n"))
 	window := newTestWindowWithPanes(t, sess, 1, "window-1", pane)
-	if _, err := enqueueSessionQuery(sess, func(sess *Session) (struct{}, error) {
+	if _, err := enqueueSessionQueryLegacy(sess.context(), sess, func(sess *Session) (struct{}, error) {
 		sess.Windows = []*mux.Window{window}
 		sess.ActiveWindowID = window.ID
 		sess.Panes = []*mux.Pane{pane}
@@ -256,7 +256,7 @@ func TestForwardCapturePaneUsesResolvedNumericID(t *testing.T) {
 	pane := newTestPane(sess, 1, "pane-1")
 	pane.FeedOutput([]byte("FALLBACK-CLIENT-NOT-FOUND\r\n"))
 	window := newTestWindowWithPanes(t, sess, 1, "window-1", pane)
-	if _, err := enqueueSessionQuery(sess, func(sess *Session) (struct{}, error) {
+	if _, err := enqueueSessionQueryLegacy(sess.context(), sess, func(sess *Session) (struct{}, error) {
 		sess.Windows = []*mux.Window{window}
 		sess.ActiveWindowID = window.ID
 		sess.Panes = []*mux.Pane{pane}
@@ -297,7 +297,7 @@ func TestForwardCaptureJSONWrapsBadClientResponses(t *testing.T) {
 
 			pane1 := newTestPane(sess, 1, "pane-1")
 			window := newTestWindowWithPanes(t, sess, 1, "window-1", pane1)
-			if _, err := enqueueSessionQuery(sess, func(sess *Session) (struct{}, error) {
+			if _, err := enqueueSessionQueryLegacy(sess.context(), sess, func(sess *Session) (struct{}, error) {
 				sess.Windows = []*mux.Window{window}
 				sess.ActiveWindowID = window.ID
 				sess.Panes = []*mux.Pane{pane1}
@@ -465,7 +465,7 @@ func assertSessionEventLoopResponsive(t *testing.T, sess *Session) {
 
 	done := make(chan error, 1)
 	go func() {
-		_, err := enqueueSessionQuery(sess, func(sess *Session) (struct{}, error) {
+		_, err := enqueueSessionQueryLegacy(sess.context(), sess, func(sess *Session) (struct{}, error) {
 			return struct{}{}, nil
 		})
 		done <- err
@@ -655,7 +655,7 @@ func TestCaptureClientSnapshotSkipsBootstrappingClientWithoutWriterRoundTrip(t *
 	ready := newClientConn(serverConn)
 	t.Cleanup(ready.Close)
 
-	if _, err := enqueueSessionQuery(sess, func(sess *Session) (struct{}, error) {
+	if _, err := enqueueSessionQueryLegacy(sess.context(), sess, func(sess *Session) (struct{}, error) {
 		sess.ensureClientManager().setClientsForTest(blocked, ready)
 		return struct{}{}, nil
 	}); err != nil {
@@ -818,7 +818,7 @@ func TestForwardCaptureJSONReturnsSessionShuttingDownWhileWaiting(t *testing.T) 
 	defer cc.Close()
 	defer clientEnd.Close()
 
-	if _, err := enqueueSessionQuery(sess, func(sess *Session) (struct{}, error) {
+	if _, err := enqueueSessionQueryLegacy(sess.context(), sess, func(sess *Session) (struct{}, error) {
 		sess.ensureClientManager().setClientsForTest(cc)
 		return struct{}{}, nil
 	}); err != nil {
@@ -861,7 +861,7 @@ func TestForwardCaptureJSONStressUnderPaneOutput(t *testing.T) {
 	pane3 := newTestPane(sess, 3, "pane-3")
 	pane4 := newTestPane(sess, 4, "pane-4")
 	window := newTestWindowWithPanes(t, sess, 1, "window-1", pane1, pane2, pane3, pane4)
-	if _, err := enqueueSessionQuery(sess, func(sess *Session) (struct{}, error) {
+	if _, err := enqueueSessionQueryLegacy(sess.context(), sess, func(sess *Session) (struct{}, error) {
 		sess.Windows = []*mux.Window{window}
 		sess.ActiveWindowID = window.ID
 		sess.Panes = []*mux.Pane{pane1, pane2, pane3, pane4}
@@ -949,7 +949,7 @@ func TestForwardCaptureJSONStressUnderPaneOutput(t *testing.T) {
 		}
 	}()
 
-	if _, err := enqueueSessionQuery(sess, func(sess *Session) (struct{}, error) {
+	if _, err := enqueueSessionQueryLegacy(sess.context(), sess, func(sess *Session) (struct{}, error) {
 		sess.ensureClientManager().setClientsForTest(cc)
 		return struct{}{}, nil
 	}); err != nil {
@@ -1076,7 +1076,7 @@ func startCaptureCallForTest(t *testing.T, sess *Session, call func() *Message) 
 		cc.Close()
 	})
 
-	if _, err := enqueueSessionQuery(sess, func(sess *Session) (struct{}, error) {
+	if _, err := enqueueSessionQueryLegacy(sess.context(), sess, func(sess *Session) (struct{}, error) {
 		sess.ensureClientManager().setClientsForTest(cc)
 		return struct{}{}, nil
 	}); err != nil {

--- a/internal/server/capture_forward_test.go
+++ b/internal/server/capture_forward_test.go
@@ -52,7 +52,7 @@ func TestForwardCaptureAgentStatusScope(t *testing.T) {
 			pane1 := newTestPane(sess, 1, "pane-1")
 			pane2 := newTestPane(sess, 2, "pane-2")
 			w := newTestWindowWithPanes(t, sess, 1, "window-1", pane1, pane2)
-			if _, err := enqueueSessionQueryLegacy(sess.context(), sess, func(sess *Session) (struct{}, error) {
+			if _, err := enqueueSessionQueryOnState(sess.context(), sess, func(sess *Session) (struct{}, error) {
 				sess.Windows = []*mux.Window{w}
 				sess.ActiveWindowID = w.ID
 				sess.Panes = []*mux.Pane{pane1, pane2}
@@ -97,7 +97,7 @@ func TestForwardCaptureFullScreenJSONUsesActiveWindowPanesOnly(t *testing.T) {
 	pane3 := newTestPane(sess, 3, "pane-3")
 	window1 := newTestWindowWithPanes(t, sess, 1, "window-1", pane1, pane2)
 	window2 := newTestWindowWithPanes(t, sess, 2, "window-2", pane3)
-	if _, err := enqueueSessionQueryLegacy(sess.context(), sess, func(sess *Session) (struct{}, error) {
+	if _, err := enqueueSessionQueryOnState(sess.context(), sess, func(sess *Session) (struct{}, error) {
 		sess.Windows = []*mux.Window{window1, window2}
 		sess.ActiveWindowID = window1.ID
 		sess.Panes = []*mux.Pane{pane1, pane2, pane3}
@@ -200,7 +200,7 @@ func TestForwardCapturePaneFallsBackWithoutClient(t *testing.T) {
 	pane := newTestPane(sess, 1, "pane-1")
 	pane.FeedOutput([]byte("\x1b[31mHEADLESS-ANSI\x1b[m\r\nHEADLESS-PLAIN\r\n"))
 	window := newTestWindowWithPanes(t, sess, 1, "window-1", pane)
-	if _, err := enqueueSessionQueryLegacy(sess.context(), sess, func(sess *Session) (struct{}, error) {
+	if _, err := enqueueSessionQueryOnState(sess.context(), sess, func(sess *Session) (struct{}, error) {
 		sess.Windows = []*mux.Window{window}
 		sess.ActiveWindowID = window.ID
 		sess.Panes = []*mux.Pane{pane}
@@ -256,7 +256,7 @@ func TestForwardCapturePaneUsesResolvedNumericID(t *testing.T) {
 	pane := newTestPane(sess, 1, "pane-1")
 	pane.FeedOutput([]byte("FALLBACK-CLIENT-NOT-FOUND\r\n"))
 	window := newTestWindowWithPanes(t, sess, 1, "window-1", pane)
-	if _, err := enqueueSessionQueryLegacy(sess.context(), sess, func(sess *Session) (struct{}, error) {
+	if _, err := enqueueSessionQueryOnState(sess.context(), sess, func(sess *Session) (struct{}, error) {
 		sess.Windows = []*mux.Window{window}
 		sess.ActiveWindowID = window.ID
 		sess.Panes = []*mux.Pane{pane}
@@ -297,7 +297,7 @@ func TestForwardCaptureJSONWrapsBadClientResponses(t *testing.T) {
 
 			pane1 := newTestPane(sess, 1, "pane-1")
 			window := newTestWindowWithPanes(t, sess, 1, "window-1", pane1)
-			if _, err := enqueueSessionQueryLegacy(sess.context(), sess, func(sess *Session) (struct{}, error) {
+			if _, err := enqueueSessionQueryOnState(sess.context(), sess, func(sess *Session) (struct{}, error) {
 				sess.Windows = []*mux.Window{window}
 				sess.ActiveWindowID = window.ID
 				sess.Panes = []*mux.Pane{pane1}
@@ -465,7 +465,7 @@ func assertSessionEventLoopResponsive(t *testing.T, sess *Session) {
 
 	done := make(chan error, 1)
 	go func() {
-		_, err := enqueueSessionQueryLegacy(sess.context(), sess, func(sess *Session) (struct{}, error) {
+		_, err := enqueueSessionQueryOnState(sess.context(), sess, func(sess *Session) (struct{}, error) {
 			return struct{}{}, nil
 		})
 		done <- err
@@ -655,7 +655,7 @@ func TestCaptureClientSnapshotSkipsBootstrappingClientWithoutWriterRoundTrip(t *
 	ready := newClientConn(serverConn)
 	t.Cleanup(ready.Close)
 
-	if _, err := enqueueSessionQueryLegacy(sess.context(), sess, func(sess *Session) (struct{}, error) {
+	if _, err := enqueueSessionQueryOnState(sess.context(), sess, func(sess *Session) (struct{}, error) {
 		sess.ensureClientManager().setClientsForTest(blocked, ready)
 		return struct{}{}, nil
 	}); err != nil {
@@ -818,7 +818,7 @@ func TestForwardCaptureJSONReturnsSessionShuttingDownWhileWaiting(t *testing.T) 
 	defer cc.Close()
 	defer clientEnd.Close()
 
-	if _, err := enqueueSessionQueryLegacy(sess.context(), sess, func(sess *Session) (struct{}, error) {
+	if _, err := enqueueSessionQueryOnState(sess.context(), sess, func(sess *Session) (struct{}, error) {
 		sess.ensureClientManager().setClientsForTest(cc)
 		return struct{}{}, nil
 	}); err != nil {
@@ -861,7 +861,7 @@ func TestForwardCaptureJSONStressUnderPaneOutput(t *testing.T) {
 	pane3 := newTestPane(sess, 3, "pane-3")
 	pane4 := newTestPane(sess, 4, "pane-4")
 	window := newTestWindowWithPanes(t, sess, 1, "window-1", pane1, pane2, pane3, pane4)
-	if _, err := enqueueSessionQueryLegacy(sess.context(), sess, func(sess *Session) (struct{}, error) {
+	if _, err := enqueueSessionQueryOnState(sess.context(), sess, func(sess *Session) (struct{}, error) {
 		sess.Windows = []*mux.Window{window}
 		sess.ActiveWindowID = window.ID
 		sess.Panes = []*mux.Pane{pane1, pane2, pane3, pane4}
@@ -949,7 +949,7 @@ func TestForwardCaptureJSONStressUnderPaneOutput(t *testing.T) {
 		}
 	}()
 
-	if _, err := enqueueSessionQueryLegacy(sess.context(), sess, func(sess *Session) (struct{}, error) {
+	if _, err := enqueueSessionQueryOnState(sess.context(), sess, func(sess *Session) (struct{}, error) {
 		sess.ensureClientManager().setClientsForTest(cc)
 		return struct{}{}, nil
 	}); err != nil {
@@ -1076,7 +1076,7 @@ func startCaptureCallForTest(t *testing.T, sess *Session, call func() *Message) 
 		cc.Close()
 	})
 
-	if _, err := enqueueSessionQueryLegacy(sess.context(), sess, func(sess *Session) (struct{}, error) {
+	if _, err := enqueueSessionQueryOnState(sess.context(), sess, func(sess *Session) (struct{}, error) {
 		sess.ensureClientManager().setClientsForTest(cc)
 		return struct{}{}, nil
 	}); err != nil {

--- a/internal/server/capture_history.go
+++ b/internal/server/capture_history.go
@@ -19,7 +19,7 @@ type capturePaneTarget struct {
 }
 
 func (s *Session) resolveCapturePaneTargetForActor(actorPaneID uint32, ref string) (capturePaneTarget, error) {
-	return enqueueSessionQueryLegacy(s.context(), s, func(s *Session) (capturePaneTarget, error) {
+	return enqueueSessionQueryOnState(s.context(), s, func(s *Session) (capturePaneTarget, error) {
 		pane, w, err := s.resolvePaneAcrossWindowsForActor(actorPaneID, ref)
 		if err != nil {
 			return capturePaneTarget{}, err

--- a/internal/server/capture_history.go
+++ b/internal/server/capture_history.go
@@ -19,7 +19,7 @@ type capturePaneTarget struct {
 }
 
 func (s *Session) resolveCapturePaneTargetForActor(actorPaneID uint32, ref string) (capturePaneTarget, error) {
-	return enqueueSessionQuery(s, func(s *Session) (capturePaneTarget, error) {
+	return enqueueSessionQueryLegacy(s.context(), s, func(s *Session) (capturePaneTarget, error) {
 		pane, w, err := s.resolvePaneAcrossWindowsForActor(actorPaneID, ref)
 		if err != nil {
 			return capturePaneTarget{}, err

--- a/internal/server/checkpoint.go
+++ b/internal/server/checkpoint.go
@@ -36,7 +36,7 @@ func (s *Server) Reload(execPath string) error {
 		"exec_path", execPath,
 	)
 
-	clients, err := enqueueSessionQuery(sess, func(sess *Session) ([]*clientConn, error) {
+	clients, err := enqueueSessionQueryLegacy(sess.context(), sess, func(sess *Session) ([]*clientConn, error) {
 		return sess.ensureClientManager().snapshotClients(), nil
 	})
 	if err != nil {
@@ -46,7 +46,7 @@ func (s *Server) Reload(execPath string) error {
 	sess.shutdown.Store(true)
 
 	// Build checkpoint
-	cp, err := enqueueSessionQuery(sess, func(sess *Session) (*checkpoint.ServerCheckpoint, error) {
+	cp, err := enqueueSessionQueryLegacy(sess.context(), sess, func(sess *Session) (*checkpoint.ServerCheckpoint, error) {
 		if len(sess.Windows) == 0 {
 			return nil, fmt.Errorf("no window to checkpoint")
 		}
@@ -152,7 +152,7 @@ func (s *Server) Reload(execPath string) error {
 	for _, c := range clients {
 		c.sendBroadcastSync(&Message{Type: MsgTypeServerReload, Text: BuildVersion})
 	}
-	if _, err := enqueueSessionQuery(sess, func(sess *Session) (struct{}, error) {
+	if _, err := enqueueSessionQueryLegacy(sess.context(), sess, func(sess *Session) (struct{}, error) {
 		sess.disconnectClientsForReload(clients)
 		return struct{}{}, nil
 	}); err != nil {
@@ -331,7 +331,7 @@ func NewServerFromCheckpointWithScrollbackConfigLogger(cp *checkpoint.ServerChec
 		}
 
 		resizeVisible := func(heightAdj int) bool {
-			targets, err := enqueueSessionQuery(sess, func(sess *Session) ([]resizeTarget, error) {
+			targets, err := enqueueSessionQueryLegacy(sess.context(), sess, func(sess *Session) ([]resizeTarget, error) {
 				var targets []resizeTarget
 				for _, w := range sess.Windows {
 					for _, p := range sess.Panes {

--- a/internal/server/checkpoint.go
+++ b/internal/server/checkpoint.go
@@ -36,7 +36,7 @@ func (s *Server) Reload(execPath string) error {
 		"exec_path", execPath,
 	)
 
-	clients, err := enqueueSessionQueryLegacy(sess.context(), sess, func(sess *Session) ([]*clientConn, error) {
+	clients, err := enqueueSessionQueryOnState(sess.context(), sess, func(sess *Session) ([]*clientConn, error) {
 		return sess.ensureClientManager().snapshotClients(), nil
 	})
 	if err != nil {
@@ -46,7 +46,7 @@ func (s *Server) Reload(execPath string) error {
 	sess.shutdown.Store(true)
 
 	// Build checkpoint
-	cp, err := enqueueSessionQueryLegacy(sess.context(), sess, func(sess *Session) (*checkpoint.ServerCheckpoint, error) {
+	cp, err := enqueueSessionQueryOnState(sess.context(), sess, func(sess *Session) (*checkpoint.ServerCheckpoint, error) {
 		if len(sess.Windows) == 0 {
 			return nil, fmt.Errorf("no window to checkpoint")
 		}
@@ -152,7 +152,7 @@ func (s *Server) Reload(execPath string) error {
 	for _, c := range clients {
 		c.sendBroadcastSync(&Message{Type: MsgTypeServerReload, Text: BuildVersion})
 	}
-	if _, err := enqueueSessionQueryLegacy(sess.context(), sess, func(sess *Session) (struct{}, error) {
+	if _, err := enqueueSessionQueryOnState(sess.context(), sess, func(sess *Session) (struct{}, error) {
 		sess.disconnectClientsForReload(clients)
 		return struct{}{}, nil
 	}); err != nil {
@@ -331,7 +331,7 @@ func NewServerFromCheckpointWithScrollbackConfigLogger(cp *checkpoint.ServerChec
 		}
 
 		resizeVisible := func(heightAdj int) bool {
-			targets, err := enqueueSessionQueryLegacy(sess.context(), sess, func(sess *Session) ([]resizeTarget, error) {
+			targets, err := enqueueSessionQueryOnState(sess.context(), sess, func(sess *Session) ([]resizeTarget, error) {
 				var targets []resizeTarget
 				for _, w := range sess.Windows {
 					for _, p := range sess.Panes {

--- a/internal/server/checkpoint_coordinator.go
+++ b/internal/server/checkpoint_coordinator.go
@@ -226,7 +226,7 @@ func newSessionCheckpointCoordinator(sess *Session) crashCheckpointCoordinator {
 		BuildCrashCheckpoint: sess.buildCrashCheckpoint,
 		IsShuttingDown:       func() bool { return sess.shutdown.Load() },
 		OnCheckpointWritten: func(path string) {
-			sess.enqueueEvent(crashCheckpointWrittenEvent{path: path})
+			sess.enqueueEvent(sess.context(), crashCheckpointWrittenEvent{path: path})
 		},
 		LogCheckpointWrite: func(path string, duration time.Duration, err error) {
 			sess.logCheckpointWrite("crash", path, duration, err)

--- a/internal/server/client_conn.go
+++ b/internal/server/client_conn.go
@@ -333,6 +333,9 @@ func (cc *clientConn) readLoop(srv *Server, sess *Session) {
 	commandQueue := make(chan *Message, 64)
 	go func() {
 		for msg := range commandQueue {
+			if cc.context().Err() != nil {
+				return
+			}
 			cc.handleCommand(srv, sess, msg)
 		}
 	}()

--- a/internal/server/client_conn.go
+++ b/internal/server/client_conn.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -26,6 +27,8 @@ const (
 // clientConn manages a single client connection to the server.
 type clientConn struct {
 	conn               net.Conn
+	ctx                context.Context
+	cancel             context.CancelFunc
 	reader             *proto.Reader
 	ID                 string
 	displayPanesShown  bool
@@ -60,8 +63,11 @@ type pendingPredictionEpoch struct {
 
 // newClientConn wraps a net.Conn for protocol communication.
 func newClientConn(conn net.Conn) *clientConn {
+	ctx, cancel := context.WithCancel(serverInternalContext())
 	cc := &clientConn{
 		conn:        conn,
+		ctx:         ctx,
+		cancel:      cancel,
 		reader:      proto.NewReader(conn),
 		inputIdle:   true,
 		predictions: make(map[uint32][]pendingPredictionEpoch),
@@ -69,6 +75,13 @@ func newClientConn(conn net.Conn) *clientConn {
 	}
 	cc.writer = newClientWriter(conn)
 	return cc
+}
+
+func (cc *clientConn) context() context.Context {
+	if cc != nil && cc.ctx != nil {
+		return cc.ctx
+	}
+	return serverInternalContext()
 }
 
 func (cc *clientConn) setNegotiatedCapabilities(caps proto.ClientCapabilities) {
@@ -108,6 +121,9 @@ func (cc *clientConn) Flush() error {
 
 // Close shuts down the connection.
 func (cc *clientConn) Close() {
+	if cc.cancel != nil {
+		cc.cancel()
+	}
 	if cc.typeKeyQueue != nil {
 		cc.typeKeyQueue.close()
 	}
@@ -315,6 +331,9 @@ func (cc *clientConn) consumePredictionEpoch(paneID uint32, data []byte) uint32 
 func (cc *clientConn) readLoop(srv *Server, sess *Session) {
 	detachReason := DisconnectReasonSocketError
 	defer func() {
+		if cc.cancel != nil {
+			cc.cancel()
+		}
 		sess.enqueueDetachClient(cc, detachReason)
 		cc.Close()
 	}()
@@ -342,7 +361,7 @@ func (cc *clientConn) readLoop(srv *Server, sess *Session) {
 			return
 
 		case MsgTypeCommand:
-			cc.handleCommand(srv, sess, msg)
+			go cc.handleCommand(srv, sess, msg)
 
 		case MsgTypeCaptureResponse:
 			sess.routeCaptureResponse(msg)
@@ -356,6 +375,7 @@ func (cc *clientConn) readLoop(srv *Server, sess *Session) {
 func (cc *clientConn) handleCommand(srv *Server, sess *Session, msg *Message) {
 	started := time.Now()
 	ctx := &CommandContext{
+		Context:     cc.context(),
 		CommandName: msg.CmdName,
 		CC:          cc,
 		Srv:         srv,

--- a/internal/server/client_conn.go
+++ b/internal/server/client_conn.go
@@ -330,10 +330,17 @@ func (cc *clientConn) consumePredictionEpoch(paneID uint32, data []byte) uint32 
 // readLoop reads messages from the client and dispatches them to the session.
 func (cc *clientConn) readLoop(srv *Server, sess *Session) {
 	detachReason := DisconnectReasonSocketError
+	commandQueue := make(chan *Message, 64)
+	go func() {
+		for msg := range commandQueue {
+			cc.handleCommand(srv, sess, msg)
+		}
+	}()
 	defer func() {
 		if cc.cancel != nil {
 			cc.cancel()
 		}
+		close(commandQueue)
 		sess.enqueueDetachClient(cc, detachReason)
 		cc.Close()
 	}()
@@ -361,7 +368,11 @@ func (cc *clientConn) readLoop(srv *Server, sess *Session) {
 			return
 
 		case MsgTypeCommand:
-			go cc.handleCommand(srv, sess, msg)
+			select {
+			case commandQueue <- msg:
+			case <-cc.context().Done():
+				return
+			}
 
 		case MsgTypeCaptureResponse:
 			sess.routeCaptureResponse(msg)

--- a/internal/server/client_conn_test.go
+++ b/internal/server/client_conn_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"errors"
 	"net"
 	"testing"
@@ -277,7 +278,7 @@ func TestClientConnQueuesInputBehindBusySessionActor(t *testing.T) {
 				}
 			})
 			blocker := blockingSessionEvent{entered: make(chan struct{}), release: release}
-			if !sess.enqueueEvent(blocker) {
+			if !sess.enqueueEvent(sess.context(), blocker) {
 				t.Fatal("enqueue blocking event")
 			}
 			select {
@@ -785,7 +786,7 @@ type blockingSessionEvent struct {
 	release <-chan struct{}
 }
 
-func (e blockingSessionEvent) handle(*Session) {
+func (e blockingSessionEvent) handle(_ context.Context, _ *Session) {
 	close(e.entered)
 	<-e.release
 }

--- a/internal/server/command_queue_test.go
+++ b/internal/server/command_queue_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net"
@@ -41,6 +42,72 @@ func TestEnqueueCommandMutationReturnsOnSessionShutdown(t *testing.T) {
 		}
 	case <-time.After(time.Second):
 		t.Fatal("enqueueCommandMutation did not return after shutdown")
+	}
+}
+
+func TestClientDisconnectCancelsLongRunningSessionQuery(t *testing.T) {
+	t.Parallel()
+
+	srv, sess, cleanup := newCommandTestSession(t)
+	defer cleanup()
+
+	queryStarted := make(chan struct{})
+	queryCanceled := make(chan struct{})
+	releaseQuery := make(chan struct{})
+	t.Cleanup(func() { close(releaseQuery) })
+
+	srv.commands = map[string]CommandHandler{
+		"long-query": func(ctx *CommandContext) {
+			_, _ = enqueueSessionQuery(ctx.Context, sess, func(queryCtx context.Context, _ *Session) (struct{}, error) {
+				close(queryStarted)
+				select {
+				case <-queryCtx.Done():
+					close(queryCanceled)
+					return struct{}{}, queryCtx.Err()
+				case <-releaseQuery:
+					return struct{}{}, nil
+				}
+			})
+		},
+	}
+
+	serverConn, peerConn := net.Pipe()
+	t.Cleanup(func() { _ = peerConn.Close() })
+	t.Cleanup(func() { _ = serverConn.Close() })
+
+	cc := newClientConn(serverConn)
+	t.Cleanup(cc.Close)
+
+	readLoopDone := make(chan struct{})
+	go func() {
+		defer close(readLoopDone)
+		cc.readLoop(srv, sess)
+	}()
+
+	if err := writeMsgOnConn(peerConn, &Message{Type: MsgTypeCommand, CmdName: "long-query"}); err != nil {
+		t.Fatalf("WriteMsg command: %v", err)
+	}
+
+	select {
+	case <-queryStarted:
+	case <-time.After(time.Second):
+		t.Fatal("long-running query did not start")
+	}
+
+	if err := peerConn.Close(); err != nil {
+		t.Fatalf("Close peer connection: %v", err)
+	}
+
+	select {
+	case <-queryCanceled:
+	case <-time.After(time.Second):
+		t.Fatal("client disconnect did not cancel the in-flight session query")
+	}
+
+	select {
+	case <-readLoopDone:
+	case <-time.After(time.Second):
+		t.Fatal("readLoop did not exit after client disconnect")
 	}
 }
 

--- a/internal/server/commands.go
+++ b/internal/server/commands.go
@@ -1,6 +1,8 @@
 package server
 
 import (
+	"context"
+
 	"github.com/weill-labs/amux/internal/proto"
 	commandpkg "github.com/weill-labs/amux/internal/server/commands"
 )
@@ -10,6 +12,7 @@ type CommandHandler func(ctx *CommandContext)
 
 // CommandContext provides all state a command handler needs.
 type CommandContext struct {
+	Context     context.Context
 	CommandName string
 	CC          *clientConn
 	Srv         *Server
@@ -17,6 +20,19 @@ type CommandContext struct {
 	Args        []string
 	ActorPaneID uint32
 	auditErr    string
+}
+
+func (ctx *CommandContext) context() context.Context {
+	if ctx != nil && ctx.Context != nil {
+		return ctx.Context
+	}
+	if ctx != nil && ctx.CC != nil {
+		return ctx.CC.context()
+	}
+	if ctx != nil && ctx.Sess != nil {
+		return ctx.Sess.context()
+	}
+	return serverInternalContext()
 }
 
 func (ctx *CommandContext) send(msg *Message) {
@@ -87,7 +103,7 @@ func (s commandStreamSender) Flush() error {
 func (ctx *CommandContext) applyCommandResult(res commandpkg.Result) {
 	switch {
 	case res.Mutate != nil:
-		ctx.replyCommandMutation(ctx.Sess.enqueueCommandMutation(func(mctx *MutationContext) commandMutationResult {
+		ctx.replyCommandMutation(ctx.Sess.enqueueCommandMutationContext(ctx.context(), func(mctx *MutationContext) commandMutationResult {
 			result := res.Mutate()
 			mctx.syncFromSession()
 			return toCommandMutationResult(result)

--- a/internal/server/commands_capture.go
+++ b/internal/server/commands_capture.go
@@ -64,7 +64,7 @@ func shouldCaptureLocally(req caputil.Request) bool {
 func cmdCapture(ctx *CommandContext) {
 	req := caputil.ParseArgs(ctx.Args)
 	if req.PaneRef != "" {
-		ref, err := ctx.Sess.queryPaneRef(req.PaneRef)
+		ref, err := ctx.Sess.queryPaneRefContext(ctx.context(), req.PaneRef)
 		if err != nil {
 			ctx.replyErr(err.Error())
 			return

--- a/internal/server/commands_events.go
+++ b/internal/server/commands_events.go
@@ -39,7 +39,7 @@ func (ctx eventsCommandContext) DefaultThrottle() time.Duration {
 }
 
 func (ctx eventsCommandContext) Subscribe(filter eventscmd.Filter) (eventscmd.Subscription, error) {
-	res := ctx.Sess.enqueueEventSubscribe(eventFilter{
+	res := ctx.Sess.enqueueEventSubscribe(ctx.context(), eventFilter{
 		Types:    append([]string(nil), filter.Types...),
 		PaneName: filter.PaneName,
 		Host:     filter.Host,

--- a/internal/server/commands_extra_test.go
+++ b/internal/server/commands_extra_test.go
@@ -684,8 +684,8 @@ func TestKillCommandUsageAndSubscriptionCleanup(t *testing.T) {
 		sess.ActiveWindowID = window.ID
 		sess.Panes = []*mux.Pane{pane1, pane2}
 
-		sub := sess.enqueueEventSubscribe(eventFilter{PaneName: "pane-2"}, false)
-		waitCh := sess.enqueuePaneOutputSubscribe(pane2.ID)
+		sub := sess.enqueueEventSubscribe(sess.context(), eventFilter{PaneName: "pane-2"}, false)
+		waitCh := sess.enqueuePaneOutputSubscribe(sess.context(), pane2.ID)
 		defer sess.enqueueEventUnsubscribe(sub.sub)
 		defer sess.enqueuePaneOutputUnsubscribe(pane2.ID, waitCh)
 

--- a/internal/server/commands_input.go
+++ b/internal/server/commands_input.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"path/filepath"
@@ -177,9 +178,9 @@ func (ctx inputCommandContext) SendKeys(actorPaneID uint32, args []string) (stri
 	applyFinalDelay(chunks, opts.delayFinal)
 	var pane resolvedPaneRef
 	if target.windowRef != "" {
-		pane, err = ctx.Sess.queryActivePaneForWindow(target.windowRef)
+		pane, err = ctx.Sess.queryActivePaneForWindowContext(ctx.context(), target.windowRef)
 	} else {
-		pane, err = ctx.Sess.queryResolvedPaneForActor(actorPaneID, target.paneRef)
+		pane, err = ctx.Sess.queryResolvedPaneForActorContext(ctx.context(), actorPaneID, target.paneRef)
 	}
 	if err != nil {
 		return "", 0, err
@@ -190,19 +191,19 @@ func (ctx inputCommandContext) SendKeys(actorPaneID uint32, args []string) (stri
 		if err := waitForPaneReady(ctx.Sess, pane.paneName, pane, waitReadyOptions{timeout: opts.waitTimeout}); err != nil {
 			return "", 0, err
 		}
-		if err := enqueueSendKeysInput(ctx.Sess, pane, chunks, opts, nil); err != nil {
+		if err := enqueueSendKeysInput(ctx.context(), ctx.Sess, pane, chunks, opts, nil); err != nil {
 			return "", 0, err
 		}
 	case sendKeysWaitInputIdle:
-		uiWait, err := querySendKeysClient(ctx.Sess, opts.requestedClientID, proto.UIEventInputIdle)
+		uiWait, err := querySendKeysClient(ctx.context(), ctx.Sess, opts.requestedClientID, proto.UIEventInputIdle)
 		if err != nil {
 			return "", 0, err
 		}
-		if err := enqueueSendKeysInput(ctx.Sess, pane, chunks, opts, uiWait); err != nil {
+		if err := enqueueSendKeysInput(ctx.context(), ctx.Sess, pane, chunks, opts, uiWait); err != nil {
 			return "", 0, err
 		}
 	default:
-		if err := enqueueSendKeysInput(ctx.Sess, pane, chunks, opts, nil); err != nil {
+		if err := enqueueSendKeysInput(ctx.context(), ctx.Sess, pane, chunks, opts, nil); err != nil {
 			return "", 0, err
 		}
 	}
@@ -211,7 +212,7 @@ func (ctx inputCommandContext) SendKeys(actorPaneID uint32, args []string) (stri
 
 func cmdSendKeys(ctx *CommandContext) {
 	if len(ctx.Args) > 0 && ctx.Args[0] != "--window" {
-		ref, err := ctx.Sess.queryPaneRef(ctx.Args[0])
+		ref, err := ctx.Sess.queryPaneRefContext(ctx.context(), ctx.Args[0])
 		if err != nil {
 			ctx.replyErr(err.Error())
 			return
@@ -224,22 +225,22 @@ func cmdSendKeys(ctx *CommandContext) {
 	ctx.applyCommandResult(inputcmd.SendKeys(inputCommandContext{ctx}, ctx.ActorPaneID, ctx.Args))
 }
 
-func enqueueSendKeysInput(sess *Session, pane resolvedPaneRef, chunks []encodedKeyChunk, opts sendKeysOptions, uiWait *uiClientSnapshot) error {
+func enqueueSendKeysInput(ctx context.Context, sess *Session, pane resolvedPaneRef, chunks []encodedKeyChunk, opts sendKeysOptions, uiWait *uiClientSnapshot) error {
 	if opts.transport == sendKeysViaClient {
 		if uiWait == nil {
 			var err error
-			uiWait, err = querySendKeysClient(sess, opts.requestedClientID, "")
+			uiWait, err = querySendKeysClient(ctx, sess, opts.requestedClientID, "")
 			if err != nil {
 				return err
 			}
 		}
-		return enqueueTargetedClientKeys(sess, uiWait.client, pane.pane, chunks, uiWait, opts.waitTimeout)
+		return enqueueTargetedClientKeys(ctx, sess, uiWait.client, pane.pane, chunks, uiWait, opts.waitTimeout)
 	}
 	return sess.enqueuePacedPaneInput(pane.pane, chunks)
 }
 
-func querySendKeysClient(sess *Session, requestedClientID, eventName string) (*uiClientSnapshot, error) {
-	snap, err := sess.queryUIClient(requestedClientID, eventName)
+func querySendKeysClient(ctx context.Context, sess *Session, requestedClientID, eventName string) (*uiClientSnapshot, error) {
+	snap, err := sess.queryUIClientContext(ctx, requestedClientID, eventName)
 	if err != nil {
 		return nil, err
 	}
@@ -255,14 +256,14 @@ func applyFinalDelay(chunks []encodedKeyChunk, delay time.Duration) {
 	last.paceBefore = false
 }
 
-func enqueueTargetedClientKeys(sess *Session, client *clientConn, pane *mux.Pane, chunks []encodedKeyChunk, uiWait *uiClientSnapshot, waitTimeout time.Duration) error {
+func enqueueTargetedClientKeys(ctx context.Context, sess *Session, client *clientConn, pane *mux.Pane, chunks []encodedKeyChunk, uiWait *uiClientSnapshot, waitTimeout time.Duration) error {
 	if err := client.enqueueTypeKeysToPane(pane.ID, chunks); err != nil {
 		return err
 	}
 	if uiWait == nil {
 		return nil
 	}
-	return waitForNextUIEvent(sess, *uiWait, proto.UIEventInputIdle, waitTimeout)
+	return waitForNextUIEventContext(ctx, sess, *uiWait, proto.UIEventInputIdle, waitTimeout)
 }
 
 type broadcastCommandArgs struct {
@@ -380,7 +381,7 @@ func resolveBroadcastTargets(sess *Session, args broadcastCommandArgs) ([]resolv
 }
 
 func resolveBroadcastTargetsForActor(sess *Session, actorPaneID uint32, args broadcastCommandArgs) ([]resolvedPaneRef, error) {
-	return enqueueSessionQuery(sess, func(sess *Session) ([]resolvedPaneRef, error) {
+	return enqueueSessionQueryLegacy(sess.context(), sess, func(sess *Session) ([]resolvedPaneRef, error) {
 		switch {
 		case len(args.paneRefs) > 0:
 			return resolveBroadcastPaneRefs(sess, actorPaneID, args.paneRefs)
@@ -518,13 +519,13 @@ func (ctx inputCommandContext) TypeKeys(args []string) (int, error) {
 		uiWait uiClientSnapshot
 	)
 	if opts.waitInputIdle {
-		uiWait, err = ctx.Sess.queryUIClient("", proto.UIEventInputIdle)
+		uiWait, err = ctx.Sess.queryUIClientContext(ctx.context(), "", proto.UIEventInputIdle)
 		if err != nil {
 			return 0, err
 		}
 		client = uiWait.client
 	} else {
-		client, err = ctx.Sess.queryFirstClient()
+		client, err = ctx.Sess.queryFirstClientContext(ctx.context())
 		if err != nil {
 			return 0, err
 		}
@@ -534,7 +535,7 @@ func (ctx inputCommandContext) TypeKeys(args []string) (int, error) {
 		return 0, err
 	}
 	if opts.waitInputIdle {
-		if err := waitForNextUIEvent(ctx.Sess, uiWait, proto.UIEventInputIdle, opts.waitTimeout); err != nil {
+		if err := waitForNextUIEventContext(ctx.context(), ctx.Sess, uiWait, proto.UIEventInputIdle, opts.waitTimeout); err != nil {
 			return 0, err
 		}
 	}

--- a/internal/server/commands_input.go
+++ b/internal/server/commands_input.go
@@ -381,7 +381,7 @@ func resolveBroadcastTargets(sess *Session, args broadcastCommandArgs) ([]resolv
 }
 
 func resolveBroadcastTargetsForActor(sess *Session, actorPaneID uint32, args broadcastCommandArgs) ([]resolvedPaneRef, error) {
-	return enqueueSessionQueryLegacy(sess.context(), sess, func(sess *Session) ([]resolvedPaneRef, error) {
+	return enqueueSessionQueryOnState(sess.context(), sess, func(sess *Session) ([]resolvedPaneRef, error) {
 		switch {
 		case len(args.paneRefs) > 0:
 			return resolveBroadcastPaneRefs(sess, actorPaneID, args.paneRefs)

--- a/internal/server/commands_input_test.go
+++ b/internal/server/commands_input_test.go
@@ -107,7 +107,7 @@ func TestCmdSendKeysWaitsForPendingLocalPaneInputTarget(t *testing.T) {
 		return defaultLocalPaneBuilder(req)
 	}
 
-	_, err := enqueueSessionQuery(sess, func(sess *Session) (ensureInitialWindowResult, error) {
+	_, err := enqueueSessionQueryLegacy(sess.context(), sess, func(sess *Session) (ensureInitialWindowResult, error) {
 		return sess.ensureInitialWindowLocked(srv, 80, 24, nil)
 	})
 	if err != nil {

--- a/internal/server/commands_input_test.go
+++ b/internal/server/commands_input_test.go
@@ -107,7 +107,7 @@ func TestCmdSendKeysWaitsForPendingLocalPaneInputTarget(t *testing.T) {
 		return defaultLocalPaneBuilder(req)
 	}
 
-	_, err := enqueueSessionQueryLegacy(sess.context(), sess, func(sess *Session) (ensureInitialWindowResult, error) {
+	_, err := enqueueSessionQueryOnState(sess.context(), sess, func(sess *Session) (ensureInitialWindowResult, error) {
 		return sess.ensureInitialWindowLocked(srv, 80, 24, nil)
 	})
 	if err != nil {

--- a/internal/server/commands_layout.go
+++ b/internal/server/commands_layout.go
@@ -122,7 +122,7 @@ func runCreatePane(ctx *CommandContext, actorPaneID uint32, command string, plac
 			return commandpkg.Result{Err: err}
 		}
 		applyCreatePaneMeta(&pane.Meta, req)
-		return toCommandResult(ctx.Sess.enqueueCommandMutation(func(mctx *MutationContext) commandMutationResult {
+		return toCommandResult(ctx.Sess.enqueueCommandMutationContext(ctx.context(), func(mctx *MutationContext) commandMutationResult {
 			w, err := resolveCreatePaneWindow(mctx, actorPaneID, placement, snapshot)
 			if err != nil {
 				return cleanupFailedPreparedPaneMutationContext(mctx, pane, err)
@@ -144,7 +144,7 @@ func runCreatePane(ctx *CommandContext, actorPaneID uint32, command string, plac
 		Color: req.color,
 		Dir:   resolveInheritedPaneDir(ctx.Sess, snapshot.inheritPane),
 	}
-	return toCommandResult(ctx.Sess.enqueueCommandMutation(func(mctx *MutationContext) commandMutationResult {
+	return toCommandResult(ctx.Sess.enqueueCommandMutationContext(ctx.context(), func(mctx *MutationContext) commandMutationResult {
 		w, err := resolveCreatePaneWindow(mctx, actorPaneID, placement, snapshot)
 		if err != nil {
 			return commandMutationResult{err: err}
@@ -166,7 +166,7 @@ func runCreatePane(ctx *CommandContext, actorPaneID uint32, command string, plac
 }
 
 func queryCreatePaneSnapshot(sess *Session, actorPaneID uint32, command string, placement createPanePlacement, paneRef, windowRef string) (createPaneSnapshot, error) {
-	return enqueueSessionQuery(sess, func(sess *Session) (createPaneSnapshot, error) {
+	return enqueueSessionQueryLegacy(sess.context(), sess, func(sess *Session) (createPaneSnapshot, error) {
 		if placement == createPanePlacementColumnFill {
 			resolvedWindowRef, err := resolveCreatePaneWindowHint(sess, actorPaneID, paneRef, windowRef)
 			if err != nil {
@@ -492,7 +492,7 @@ func cmdSplit(ctx *CommandContext) {
 }
 
 func runFocus(ctx *CommandContext, actorPaneID uint32, direction string) commandpkg.Result {
-	return toCommandResult(ctx.Sess.enqueueCommandMutation(func(mctx *MutationContext) commandMutationResult {
+	return toCommandResult(ctx.Sess.enqueueCommandMutationContext(ctx.context(), func(mctx *MutationContext) commandMutationResult {
 		w := mctx.activeWindow()
 		if w == nil {
 			return commandMutationResult{err: fmt.Errorf("no session")}
@@ -529,7 +529,7 @@ func cmdFocus(ctx *CommandContext) {
 }
 
 func runRename(ctx *CommandContext, actorPaneID uint32, paneRef, name string) commandpkg.Result {
-	return toCommandResult(ctx.Sess.enqueueCommandMutation(func(mctx *MutationContext) commandMutationResult {
+	return toCommandResult(ctx.Sess.enqueueCommandMutationContext(ctx.context(), func(mctx *MutationContext) commandMutationResult {
 		pane, _, err := mctx.resolvePaneAcrossWindowsForActor(actorPaneID, paneRef)
 		if err != nil {
 			return commandMutationResult{err: err}
@@ -572,7 +572,7 @@ func cmdSpawn(ctx *CommandContext) {
 }
 
 func runZoom(ctx *CommandContext, actorPaneID uint32, paneRef string) commandpkg.Result {
-	return toCommandResult(ctx.Sess.enqueueCommandMutation(func(mctx *MutationContext) commandMutationResult {
+	return toCommandResult(ctx.Sess.enqueueCommandMutationContext(ctx.context(), func(mctx *MutationContext) commandMutationResult {
 		w := mctx.activeWindow()
 		if paneRef != "" {
 			// When zooming a named pane, resolve from the actor's window.
@@ -615,7 +615,7 @@ func cmdZoom(ctx *CommandContext) {
 }
 
 func runReset(ctx *CommandContext, actorPaneID uint32, paneRef string) commandpkg.Result {
-	return toCommandResult(ctx.Sess.enqueueCommandMutation(func(mctx *MutationContext) commandMutationResult {
+	return toCommandResult(ctx.Sess.enqueueCommandMutationContext(ctx.context(), func(mctx *MutationContext) commandMutationResult {
 		pane, w, err := mctx.resolvePaneAcrossWindowsForActor(actorPaneID, paneRef)
 		if err != nil {
 			return commandMutationResult{err: err}
@@ -650,7 +650,7 @@ func cmdRespawn(ctx *CommandContext) {
 		return
 	}
 
-	ctx.replyCommandMutation(ctx.Sess.enqueueCommandMutation(func(mctx *MutationContext) commandMutationResult {
+	ctx.replyCommandMutation(ctx.Sess.enqueueCommandMutationContext(ctx.context(), func(mctx *MutationContext) commandMutationResult {
 		pane := mctx.findPaneByID(target.pane.ID)
 		if pane == nil {
 			newPane.SuppressCallbacks()
@@ -688,7 +688,7 @@ func cmdRespawn(ctx *CommandContext) {
 }
 
 func queryRespawnTarget(sess *Session, actorPaneID uint32, args []string) (respawnTarget, error) {
-	return enqueueSessionQuery(sess, func(sess *Session) (respawnTarget, error) {
+	return enqueueSessionQueryLegacy(sess.context(), sess, func(sess *Session) (respawnTarget, error) {
 		pane, _, err := sess.resolvePaneWindowForActor(actorPaneID, "respawn", args)
 		if err != nil {
 			return respawnTarget{}, err
@@ -725,7 +725,7 @@ func cmdReset(ctx *CommandContext) {
 
 func runKill(ctx *CommandContext, actorPaneID uint32, opts killCommandArgs) commandpkg.Result {
 	if opts.paneRef != "" {
-		ref, err := ctx.Sess.queryPaneRef(opts.paneRef)
+		ref, err := ctx.Sess.queryPaneRefContext(ctx.context(), opts.paneRef)
 		if err != nil {
 			return commandpkg.Result{Err: err}
 		}
@@ -741,7 +741,7 @@ func runKill(ctx *CommandContext, actorPaneID uint32, opts killCommandArgs) comm
 		}
 	}
 
-	target, err := ctx.Sess.queryKillTarget(actorPaneID, opts.paneRef)
+	target, err := ctx.Sess.queryKillTargetContext(ctx.context(), actorPaneID, opts.paneRef)
 	if err != nil {
 		return commandpkg.Result{Err: err}
 	}
@@ -760,7 +760,7 @@ func runKill(ctx *CommandContext, actorPaneID uint32, opts killCommandArgs) comm
 		return commandpkg.Result{Output: fmt.Sprintf("%s %s\n", verb, target.paneName)}
 	}
 
-	return toCommandResult(ctx.Sess.enqueueCommandMutation(func(mctx *MutationContext) commandMutationResult {
+	return toCommandResult(ctx.Sess.enqueueCommandMutationContext(ctx.context(), func(mctx *MutationContext) commandMutationResult {
 		pane := mctx.findPaneByID(target.paneID)
 		if pane == nil {
 			return commandMutationResult{err: fmt.Errorf("pane %q not found", target.paneName)}
@@ -814,7 +814,7 @@ func cmdKill(ctx *CommandContext) {
 }
 
 func runUndo(ctx *CommandContext) commandpkg.Result {
-	return toCommandResult(ctx.Sess.enqueueCommandMutation(func(mctx *MutationContext) commandMutationResult {
+	return toCommandResult(ctx.Sess.enqueueCommandMutationContext(ctx.context(), func(mctx *MutationContext) commandMutationResult {
 		pane, err := mctx.undoClosePane()
 		if err != nil {
 			return commandMutationResult{err: err}
@@ -852,7 +852,7 @@ func runCopyMode(ctx *CommandContext, actorPaneID uint32, opts copyModeOptions) 
 	var err error
 	var pane resolvedPaneRef
 	if opts.paneRef == "" {
-		pane, err = enqueueSessionQuery(ctx.Sess, func(sess *Session) (resolvedPaneRef, error) {
+		pane, err = enqueueSessionQueryLegacy(ctx.context(), ctx.Sess, func(sess *Session) (resolvedPaneRef, error) {
 			w := sess.activeWindow()
 			if w == nil || w.ActivePane == nil {
 				return resolvedPaneRef{}, fmt.Errorf("no active pane")
@@ -866,7 +866,7 @@ func runCopyMode(ctx *CommandContext, actorPaneID uint32, opts copyModeOptions) 
 			}, nil
 		})
 	} else {
-		pane, err = ctx.Sess.queryResolvedPaneForActor(actorPaneID, opts.paneRef)
+		pane, err = ctx.Sess.queryResolvedPaneForActorContext(ctx.context(), actorPaneID, opts.paneRef)
 	}
 	if err != nil {
 		return commandpkg.Result{Err: err}
@@ -874,7 +874,7 @@ func runCopyMode(ctx *CommandContext, actorPaneID uint32, opts copyModeOptions) 
 
 	var uiWait uiClientSnapshot
 	if opts.waitCopyModeShown {
-		uiWait, err = ctx.Sess.queryUIClient("", proto.UIEventCopyModeShown)
+		uiWait, err = ctx.Sess.queryUIClientContext(ctx.context(), "", proto.UIEventCopyModeShown)
 		if err != nil {
 			return commandpkg.Result{Err: err}
 		}
@@ -882,7 +882,7 @@ func runCopyMode(ctx *CommandContext, actorPaneID uint32, opts copyModeOptions) 
 
 	ctx.Sess.broadcast(&Message{Type: MsgTypeCopyMode, PaneID: pane.paneID})
 	if opts.waitCopyModeShown {
-		if err := waitForNextUIEvent(ctx.Sess, uiWait, proto.UIEventCopyModeShown, opts.waitTimeout); err != nil {
+		if err := waitForNextUIEventContext(ctx.context(), ctx.Sess, uiWait, proto.UIEventCopyModeShown, opts.waitTimeout); err != nil {
 			return commandpkg.Result{Err: err}
 		}
 	}
@@ -894,12 +894,12 @@ func cmdCopyMode(ctx *CommandContext) {
 }
 
 func runNewWindow(ctx *CommandContext, name string) commandpkg.Result {
-	snap, err := ctx.Sess.queryActiveWindowSnapshot()
+	snap, err := ctx.Sess.queryActiveWindowSnapshotContext(ctx.context())
 	if err != nil {
 		return commandpkg.Result{Err: err}
 	}
 	meta := mux.PaneMeta{Dir: resolveInheritedPaneDir(ctx.Sess, snap.activePane)}
-	return toCommandResult(ctx.Sess.enqueueCommandMutation(func(mctx *MutationContext) commandMutationResult {
+	return toCommandResult(ctx.Sess.enqueueCommandMutationContext(ctx.context(), func(mctx *MutationContext) commandMutationResult {
 		w := mctx.activeWindow()
 		if w == nil {
 			return commandMutationResult{err: fmt.Errorf("no session")}
@@ -931,7 +931,7 @@ func runNewWindow(ctx *CommandContext, name string) commandpkg.Result {
 }
 
 func runSelectWindow(ctx *CommandContext, ref string) commandpkg.Result {
-	return toCommandResult(ctx.Sess.enqueueCommandMutation(func(mctx *MutationContext) commandMutationResult {
+	return toCommandResult(ctx.Sess.enqueueCommandMutationContext(ctx.context(), func(mctx *MutationContext) commandMutationResult {
 		w := mctx.resolveWindow(ref)
 		if w == nil {
 			return commandMutationResult{err: fmt.Errorf("window %q not found", ref)}
@@ -946,7 +946,7 @@ func runSelectWindow(ctx *CommandContext, ref string) commandpkg.Result {
 }
 
 func runNextWindow(ctx *CommandContext) commandpkg.Result {
-	return toCommandResult(ctx.Sess.enqueueCommandMutation(func(mctx *MutationContext) commandMutationResult {
+	return toCommandResult(ctx.Sess.enqueueCommandMutationContext(ctx.context(), func(mctx *MutationContext) commandMutationResult {
 		mctx.nextWindow()
 		return commandMutationResult{
 			output:          "Next window\n",
@@ -957,7 +957,7 @@ func runNextWindow(ctx *CommandContext) commandpkg.Result {
 }
 
 func runPrevWindow(ctx *CommandContext) commandpkg.Result {
-	return toCommandResult(ctx.Sess.enqueueCommandMutation(func(mctx *MutationContext) commandMutationResult {
+	return toCommandResult(ctx.Sess.enqueueCommandMutationContext(ctx.context(), func(mctx *MutationContext) commandMutationResult {
 		mctx.prevWindow()
 		return commandMutationResult{
 			output:          "Previous window\n",
@@ -968,7 +968,7 @@ func runPrevWindow(ctx *CommandContext) commandpkg.Result {
 }
 
 func runRenameWindow(ctx *CommandContext, name string) commandpkg.Result {
-	return toCommandResult(ctx.Sess.enqueueCommandMutation(func(mctx *MutationContext) commandMutationResult {
+	return toCommandResult(ctx.Sess.enqueueCommandMutationContext(ctx.context(), func(mctx *MutationContext) commandMutationResult {
 		w := mctx.activeWindow()
 		if w == nil {
 			return commandMutationResult{err: fmt.Errorf("no window")}
@@ -982,7 +982,7 @@ func runRenameWindow(ctx *CommandContext, name string) commandpkg.Result {
 }
 
 func runReorderWindow(ctx *CommandContext, from, to int) commandpkg.Result {
-	return toCommandResult(ctx.Sess.enqueueCommandMutation(func(mctx *MutationContext) commandMutationResult {
+	return toCommandResult(ctx.Sess.enqueueCommandMutationContext(ctx.context(), func(mctx *MutationContext) commandMutationResult {
 		if len(mctx.Windows) == 0 {
 			return commandMutationResult{err: fmt.Errorf("no window")}
 		}
@@ -1001,7 +1001,7 @@ func runReorderWindow(ctx *CommandContext, from, to int) commandpkg.Result {
 }
 
 func runResizeBorder(ctx *CommandContext, x, y, delta int) commandpkg.Result {
-	return toCommandResult(ctx.Sess.enqueueCommandMutation(func(mctx *MutationContext) commandMutationResult {
+	return toCommandResult(ctx.Sess.enqueueCommandMutationContext(ctx.context(), func(mctx *MutationContext) commandMutationResult {
 		if w := mctx.activeWindow(); w != nil {
 			w.ResizeBorder(x, y, delta)
 		}
@@ -1010,7 +1010,7 @@ func runResizeBorder(ctx *CommandContext, x, y, delta int) commandpkg.Result {
 }
 
 func runResizeActive(ctx *CommandContext, direction string, delta int) commandpkg.Result {
-	return toCommandResult(ctx.Sess.enqueueCommandMutation(func(mctx *MutationContext) commandMutationResult {
+	return toCommandResult(ctx.Sess.enqueueCommandMutationContext(ctx.context(), func(mctx *MutationContext) commandMutationResult {
 		if w := mctx.activeWindow(); w != nil {
 			if w.ActivePane != nil && w.IsLeadPane(w.ActivePane.ID) {
 				return commandMutationResult{err: fmt.Errorf("cannot operate on lead pane")}
@@ -1022,7 +1022,7 @@ func runResizeActive(ctx *CommandContext, direction string, delta int) commandpk
 }
 
 func runResizePane(ctx *CommandContext, actorPaneID uint32, paneRef, direction string, delta int) commandpkg.Result {
-	return toCommandResult(ctx.Sess.enqueueCommandMutation(func(mctx *MutationContext) commandMutationResult {
+	return toCommandResult(ctx.Sess.enqueueCommandMutationContext(ctx.context(), func(mctx *MutationContext) commandMutationResult {
 		p, w, err := mctx.resolvePaneWindowForActor(actorPaneID, "resize-pane", []string{paneRef})
 		if err != nil {
 			return commandMutationResult{err: err}
@@ -1043,7 +1043,7 @@ func parseEqualizeCommandArgs(args []string) (widths, heights bool, err error) {
 }
 
 func runEqualize(ctx *CommandContext, widths, heights bool) commandpkg.Result {
-	return toCommandResult(ctx.Sess.enqueueCommandMutation(func(mctx *MutationContext) commandMutationResult {
+	return toCommandResult(ctx.Sess.enqueueCommandMutationContext(ctx.context(), func(mctx *MutationContext) commandMutationResult {
 		w := mctx.activeWindow()
 		if w == nil {
 			return commandMutationResult{err: fmt.Errorf("no window")}
@@ -1065,7 +1065,7 @@ func cmdEqualize(ctx *CommandContext) {
 }
 
 func runResizeWindow(ctx *CommandContext, cols, rows int) commandpkg.Result {
-	return toCommandResult(ctx.Sess.enqueueCommandMutation(func(mctx *MutationContext) commandMutationResult {
+	return toCommandResult(ctx.Sess.enqueueCommandMutationContext(ctx.context(), func(mctx *MutationContext) commandMutationResult {
 		layoutH := rows - render.GlobalBarHeight
 		for _, w := range mctx.Windows {
 			w.Resize(cols, layoutH)
@@ -1082,7 +1082,7 @@ func cmdResizeWindow(ctx *CommandContext) {
 }
 
 func runSetLead(ctx *CommandContext, actorPaneID uint32, paneRef string) commandpkg.Result {
-	return toCommandResult(ctx.Sess.enqueueCommandMutation(func(mctx *MutationContext) commandMutationResult {
+	return toCommandResult(ctx.Sess.enqueueCommandMutationContext(ctx.context(), func(mctx *MutationContext) commandMutationResult {
 		w := mctx.windowForActor(actorPaneID)
 		if w == nil {
 			return commandMutationResult{err: fmt.Errorf("no session")}
@@ -1113,7 +1113,7 @@ func cmdSetLead(ctx *CommandContext) {
 }
 
 func runUnsetLead(ctx *CommandContext, actorPaneID uint32) commandpkg.Result {
-	return toCommandResult(ctx.Sess.enqueueCommandMutation(func(mctx *MutationContext) commandMutationResult {
+	return toCommandResult(ctx.Sess.enqueueCommandMutationContext(ctx.context(), func(mctx *MutationContext) commandMutationResult {
 		w := mctx.windowForActor(actorPaneID)
 		if w == nil {
 			return commandMutationResult{err: fmt.Errorf("no session")}
@@ -1133,7 +1133,7 @@ func cmdUnsetLead(ctx *CommandContext) {
 }
 
 func runToggleLead(ctx *CommandContext, actorPaneID uint32) commandpkg.Result {
-	return toCommandResult(ctx.Sess.enqueueCommandMutation(func(mctx *MutationContext) commandMutationResult {
+	return toCommandResult(ctx.Sess.enqueueCommandMutationContext(ctx.context(), func(mctx *MutationContext) commandMutationResult {
 		w := mctx.windowForActor(actorPaneID)
 		if w == nil {
 			return commandMutationResult{err: fmt.Errorf("no session")}

--- a/internal/server/commands_layout.go
+++ b/internal/server/commands_layout.go
@@ -166,7 +166,7 @@ func runCreatePane(ctx *CommandContext, actorPaneID uint32, command string, plac
 }
 
 func queryCreatePaneSnapshot(sess *Session, actorPaneID uint32, command string, placement createPanePlacement, paneRef, windowRef string) (createPaneSnapshot, error) {
-	return enqueueSessionQueryLegacy(sess.context(), sess, func(sess *Session) (createPaneSnapshot, error) {
+	return enqueueSessionQueryOnState(sess.context(), sess, func(sess *Session) (createPaneSnapshot, error) {
 		if placement == createPanePlacementColumnFill {
 			resolvedWindowRef, err := resolveCreatePaneWindowHint(sess, actorPaneID, paneRef, windowRef)
 			if err != nil {
@@ -688,7 +688,7 @@ func cmdRespawn(ctx *CommandContext) {
 }
 
 func queryRespawnTarget(sess *Session, actorPaneID uint32, args []string) (respawnTarget, error) {
-	return enqueueSessionQueryLegacy(sess.context(), sess, func(sess *Session) (respawnTarget, error) {
+	return enqueueSessionQueryOnState(sess.context(), sess, func(sess *Session) (respawnTarget, error) {
 		pane, _, err := sess.resolvePaneWindowForActor(actorPaneID, "respawn", args)
 		if err != nil {
 			return respawnTarget{}, err
@@ -852,7 +852,7 @@ func runCopyMode(ctx *CommandContext, actorPaneID uint32, opts copyModeOptions) 
 	var err error
 	var pane resolvedPaneRef
 	if opts.paneRef == "" {
-		pane, err = enqueueSessionQueryLegacy(ctx.context(), ctx.Sess, func(sess *Session) (resolvedPaneRef, error) {
+		pane, err = enqueueSessionQueryOnState(ctx.context(), ctx.Sess, func(sess *Session) (resolvedPaneRef, error) {
 			w := sess.activeWindow()
 			if w == nil || w.ActivePane == nil {
 				return resolvedPaneRef{}, fmt.Errorf("no active pane")

--- a/internal/server/commands_listing.go
+++ b/internal/server/commands_listing.go
@@ -129,7 +129,7 @@ func (ctx listingCommandContext) BuildVersion() string {
 }
 
 func (ctx listingCommandContext) QueryPaneList() ([]listingcmd.PaneEntry, error) {
-	entries, err := ctx.Sess.queryPaneList()
+	entries, err := ctx.Sess.queryPaneListContext(ctx.context())
 	if err != nil {
 		return nil, err
 	}
@@ -137,7 +137,7 @@ func (ctx listingCommandContext) QueryPaneList() ([]listingcmd.PaneEntry, error)
 }
 
 func (ctx listingCommandContext) QuerySessionStatus() (listingcmd.SessionStatus, error) {
-	snap, err := ctx.Sess.querySessionStatus()
+	snap, err := ctx.Sess.querySessionStatusContext(ctx.context())
 	if err != nil {
 		return listingcmd.SessionStatus{}, err
 	}
@@ -145,7 +145,7 @@ func (ctx listingCommandContext) QuerySessionStatus() (listingcmd.SessionStatus,
 }
 
 func (ctx listingCommandContext) QueryWindowList() ([]listingcmd.WindowEntry, error) {
-	entries, err := ctx.Sess.queryWindowList()
+	entries, err := ctx.Sess.queryWindowListContext(ctx.context())
 	if err != nil {
 		return nil, err
 	}
@@ -153,7 +153,7 @@ func (ctx listingCommandContext) QueryWindowList() ([]listingcmd.WindowEntry, er
 }
 
 func (ctx listingCommandContext) QueryClientList() ([]listingcmd.ClientEntry, error) {
-	clients, err := ctx.Sess.queryClientList()
+	clients, err := ctx.Sess.queryClientListContext(ctx.context())
 	if err != nil {
 		return nil, err
 	}
@@ -161,7 +161,7 @@ func (ctx listingCommandContext) QueryClientList() ([]listingcmd.ClientEntry, er
 }
 
 func (ctx listingCommandContext) QueryConnectionLog() ([]listingcmd.ConnectionLogEntry, error) {
-	entries, err := ctx.Sess.queryConnectionLog()
+	entries, err := ctx.Sess.queryConnectionLogContext(ctx.context())
 	if err != nil {
 		return nil, err
 	}
@@ -169,7 +169,7 @@ func (ctx listingCommandContext) QueryConnectionLog() ([]listingcmd.ConnectionLo
 }
 
 func (ctx listingCommandContext) QueryPaneLog() ([]listingcmd.PaneLogEntry, error) {
-	entries, err := ctx.Sess.queryPaneLog()
+	entries, err := ctx.Sess.queryPaneLogContext(ctx.context())
 	if err != nil {
 		return nil, err
 	}

--- a/internal/server/commands_meta_v2.go
+++ b/internal/server/commands_meta_v2.go
@@ -18,7 +18,7 @@ func (ctx metaCommandContext) ResolvePaneForMutation(paneRef string) (*mux.Pane,
 }
 
 func (ctx metaCommandContext) QueryPaneKV(paneRef string, requested []string) (string, error) {
-	return enqueueSessionQuery(ctx.Sess, func(sess *Session) (string, error) {
+	return enqueueSessionQueryLegacy(ctx.context(), ctx.Sess, func(sess *Session) (string, error) {
 		pane, _, err := sess.resolvePaneAcrossWindowsForActor(ctx.ActorPaneID, paneRef)
 		if err != nil {
 			return "", err

--- a/internal/server/commands_meta_v2.go
+++ b/internal/server/commands_meta_v2.go
@@ -18,7 +18,7 @@ func (ctx metaCommandContext) ResolvePaneForMutation(paneRef string) (*mux.Pane,
 }
 
 func (ctx metaCommandContext) QueryPaneKV(paneRef string, requested []string) (string, error) {
-	return enqueueSessionQueryLegacy(ctx.context(), ctx.Sess, func(sess *Session) (string, error) {
+	return enqueueSessionQueryOnState(ctx.context(), ctx.Sess, func(sess *Session) (string, error) {
 		pane, _, err := sess.resolvePaneAcrossWindowsForActor(ctx.ActorPaneID, paneRef)
 		if err != nil {
 			return "", err

--- a/internal/server/commands_mouse.go
+++ b/internal/server/commands_mouse.go
@@ -195,7 +195,7 @@ func buildMouseVisibleLayout(w *mux.Window, cols, rows int) (*mux.LayoutCell, er
 }
 
 func queryMouseClientTarget(ctx context.Context, sess *Session, actorPaneID uint32, requestedClientID string, paneRef, targetPaneRef string) (mouseClientTarget, error) {
-	return enqueueSessionQueryLegacy(ctx, sess, func(sess *Session) (mouseClientTarget, error) {
+	return enqueueSessionQueryOnState(ctx, sess, func(sess *Session) (mouseClientTarget, error) {
 		uiWait, err := sess.resolveUIClientSnapshot(requestedClientID, "")
 		if err != nil {
 			return mouseClientTarget{}, err

--- a/internal/server/commands_mouse.go
+++ b/internal/server/commands_mouse.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strconv"
@@ -193,8 +194,8 @@ func buildMouseVisibleLayout(w *mux.Window, cols, rows int) (*mux.LayoutCell, er
 	return layout, nil
 }
 
-func queryMouseClientTarget(sess *Session, actorPaneID uint32, requestedClientID string, paneRef, targetPaneRef string) (mouseClientTarget, error) {
-	return enqueueSessionQuery(sess, func(sess *Session) (mouseClientTarget, error) {
+func queryMouseClientTarget(ctx context.Context, sess *Session, actorPaneID uint32, requestedClientID string, paneRef, targetPaneRef string) (mouseClientTarget, error) {
+	return enqueueSessionQueryLegacy(ctx, sess, func(sess *Session) (mouseClientTarget, error) {
 		uiWait, err := sess.resolveUIClientSnapshot(requestedClientID, "")
 		if err != nil {
 			return mouseClientTarget{}, err
@@ -357,11 +358,11 @@ func mouseChunksForAction(layout *mux.LayoutCell, opts mouseCommandOptions, pane
 	}
 }
 
-func enqueueClientTypeKeys(sess *Session, uiWait uiClientSnapshot, chunks []encodedKeyChunk, waitTimeout time.Duration) error {
+func enqueueClientTypeKeys(ctx context.Context, sess *Session, uiWait uiClientSnapshot, chunks []encodedKeyChunk, waitTimeout time.Duration) error {
 	if err := uiWait.client.enqueueTypeKeys(chunks); err != nil {
 		return err
 	}
-	return waitForNextUIEvent(sess, uiWait, "input-idle", waitTimeout)
+	return waitForNextUIEventContext(ctx, sess, uiWait, "input-idle", waitTimeout)
 }
 
 func (ctx inputCommandContext) Mouse(actorPaneID uint32, args []string) (string, int, error) {
@@ -379,7 +380,7 @@ func (ctx inputCommandContext) Mouse(actorPaneID uint32, args []string) (string,
 		targetRef = opts.targetPaneRef
 	}
 
-	target, err := queryMouseClientTarget(ctx.Sess, actorPaneID, opts.requestedClientID, paneRef, targetRef)
+	target, err := queryMouseClientTarget(ctx.context(), ctx.Sess, actorPaneID, opts.requestedClientID, paneRef, targetRef)
 	if err != nil {
 		return "", 0, err
 	}
@@ -388,7 +389,7 @@ func (ctx inputCommandContext) Mouse(actorPaneID uint32, args []string) (string,
 	if err != nil {
 		return "", 0, err
 	}
-	if err := enqueueClientTypeKeys(ctx.Sess, target.uiWait, chunks, opts.waitTimeout); err != nil {
+	if err := enqueueClientTypeKeys(ctx.context(), ctx.Sess, target.uiWait, chunks, opts.waitTimeout); err != nil {
 		return "", 0, err
 	}
 

--- a/internal/server/commands_mouse_test.go
+++ b/internal/server/commands_mouse_test.go
@@ -214,7 +214,7 @@ func TestQueryMouseClientTargetErrors(t *testing.T) {
 		_, sess, cleanup := newCommandTestSession(t)
 		defer cleanup()
 
-		if _, err := queryMouseClientTarget(sess, 0, "", "", ""); err == nil || err.Error() != "no client attached" {
+		if _, err := queryMouseClientTarget(sess.context(), sess, 0, "", "", ""); err == nil || err.Error() != "no client attached" {
 			t.Fatalf("queryMouseClientTarget no client error = %v", err)
 		}
 	})
@@ -239,7 +239,7 @@ func TestQueryMouseClientTargetErrors(t *testing.T) {
 			sess.ensureClientManager().setClientsForTest(client)
 		})
 
-		if _, err := queryMouseClientTarget(sess, 0, client.ID, "", ""); err == nil || err.Error() != "no window" {
+		if _, err := queryMouseClientTarget(sess.context(), sess, 0, client.ID, "", ""); err == nil || err.Error() != "no window" {
 			t.Fatalf("queryMouseClientTarget no window error = %v", err)
 		}
 	})
@@ -279,10 +279,10 @@ func TestQueryMouseClientTargetErrors(t *testing.T) {
 			sess.ensureClientManager().setClientsForTest(client)
 		})
 
-		if _, err := queryMouseClientTarget(sess, 0, client.ID, "pane-2", ""); err == nil || err.Error() != `pane "pane-2" is not in the active window` {
+		if _, err := queryMouseClientTarget(sess.context(), sess, 0, client.ID, "pane-2", ""); err == nil || err.Error() != `pane "pane-2" is not in the active window` {
 			t.Fatalf("queryMouseClientTarget pane error = %v", err)
 		}
-		if _, err := queryMouseClientTarget(sess, 0, client.ID, "pane-1", "pane-2"); err == nil || err.Error() != `pane "pane-2" is not in the active window` {
+		if _, err := queryMouseClientTarget(sess.context(), sess, 0, client.ID, "pane-1", "pane-2"); err == nil || err.Error() != `pane "pane-2" is not in the active window` {
 			t.Fatalf("queryMouseClientTarget target pane error = %v", err)
 		}
 	})

--- a/internal/server/commands_remote.go
+++ b/internal/server/commands_remote.go
@@ -210,7 +210,7 @@ func runConnect(ctx *CommandContext) commandpkg.Result {
 		return commandpkg.Result{Err: err}
 	}
 
-	return toCommandResult(ctx.Sess.enqueueCommandMutation(func(mctx *MutationContext) commandMutationResult {
+	return toCommandResult(ctx.Sess.enqueueCommandMutationContext(ctx.context(), func(mctx *MutationContext) commandMutationResult {
 		if err := mutationContextDo(mctx, func(sess *Session) error {
 			return sess.connectRemoteSession(hostName, layout, RemoteSessionConnect, 0, true)
 		}); err != nil {

--- a/internal/server/commands_resize.go
+++ b/internal/server/commands_resize.go
@@ -12,7 +12,7 @@ func cmdResizeActive(ctx *CommandContext) {
 
 func cmdResizePane(ctx *CommandContext) {
 	if len(ctx.Args) > 0 {
-		ref, err := ctx.Sess.queryPaneRef(ctx.Args[0])
+		ref, err := ctx.Sess.queryPaneRefContext(ctx.context(), ctx.Args[0])
 		if err != nil {
 			ctx.replyErr(err.Error())
 			return

--- a/internal/server/commands_tree.go
+++ b/internal/server/commands_tree.go
@@ -92,7 +92,7 @@ func (ctx treeCommandContext) Rotate(forward bool) commandpkg.Result {
 }
 
 func runSwapForward(ctx *CommandContext, actorPaneID uint32) commandpkg.Result {
-	return toCommandResult(ctx.Sess.enqueueCommandMutation(func(mctx *MutationContext) commandMutationResult {
+	return toCommandResult(ctx.Sess.enqueueCommandMutationContext(ctx.context(), func(mctx *MutationContext) commandMutationResult {
 		w := mctx.windowForActor(actorPaneID)
 		if w == nil {
 			return commandMutationResult{err: fmt.Errorf("no session")}
@@ -105,7 +105,7 @@ func runSwapForward(ctx *CommandContext, actorPaneID uint32) commandpkg.Result {
 }
 
 func runSwapBackward(ctx *CommandContext, actorPaneID uint32) commandpkg.Result {
-	return toCommandResult(ctx.Sess.enqueueCommandMutation(func(mctx *MutationContext) commandMutationResult {
+	return toCommandResult(ctx.Sess.enqueueCommandMutationContext(ctx.context(), func(mctx *MutationContext) commandMutationResult {
 		w := mctx.windowForActor(actorPaneID)
 		if w == nil {
 			return commandMutationResult{err: fmt.Errorf("no session")}
@@ -118,7 +118,7 @@ func runSwapBackward(ctx *CommandContext, actorPaneID uint32) commandpkg.Result 
 }
 
 func runSwap(ctx *CommandContext, actorPaneID uint32, paneRef, targetRef string) commandpkg.Result {
-	return toCommandResult(ctx.Sess.enqueueCommandMutation(func(mctx *MutationContext) commandMutationResult {
+	return toCommandResult(ctx.Sess.enqueueCommandMutationContext(ctx.context(), func(mctx *MutationContext) commandMutationResult {
 		w := mctx.windowForActor(actorPaneID)
 		if w == nil {
 			return commandMutationResult{err: fmt.Errorf("no session")}
@@ -144,7 +144,7 @@ func cmdSwap(ctx *CommandContext) {
 }
 
 func runSwapTree(ctx *CommandContext, actorPaneID uint32, paneRef, targetRef string) commandpkg.Result {
-	return toCommandResult(ctx.Sess.enqueueCommandMutation(func(mctx *MutationContext) commandMutationResult {
+	return toCommandResult(ctx.Sess.enqueueCommandMutationContext(ctx.context(), func(mctx *MutationContext) commandMutationResult {
 		w := mctx.windowForActor(actorPaneID)
 		if w == nil {
 			return commandMutationResult{err: fmt.Errorf("no session")}
@@ -170,7 +170,7 @@ func cmdSwapTree(ctx *CommandContext) {
 }
 
 func runMove(ctx *CommandContext, actorPaneID uint32, paneRef, targetRef string, before bool) commandpkg.Result {
-	return toCommandResult(ctx.Sess.enqueueCommandMutation(func(mctx *MutationContext) commandMutationResult {
+	return toCommandResult(ctx.Sess.enqueueCommandMutationContext(ctx.context(), func(mctx *MutationContext) commandMutationResult {
 		w := mctx.windowForActor(actorPaneID)
 		if w == nil {
 			return commandMutationResult{err: fmt.Errorf("no session")}
@@ -204,7 +204,7 @@ func cmdMove(ctx *CommandContext) {
 }
 
 func runMoveTo(ctx *CommandContext, actorPaneID uint32, paneRef, targetRef string) commandpkg.Result {
-	return toCommandResult(ctx.Sess.enqueueCommandMutation(func(mctx *MutationContext) commandMutationResult {
+	return toCommandResult(ctx.Sess.enqueueCommandMutationContext(ctx.context(), func(mctx *MutationContext) commandMutationResult {
 		w := mctx.windowForActor(actorPaneID)
 		if w == nil {
 			return commandMutationResult{err: fmt.Errorf("no session")}
@@ -234,7 +234,7 @@ func cmdMoveTo(ctx *CommandContext) {
 }
 
 func runDropPane(ctx *CommandContext, actorPaneID uint32, paneRef, targetRef, edge string) commandpkg.Result {
-	return toCommandResult(ctx.Sess.enqueueCommandMutation(func(mctx *MutationContext) commandMutationResult {
+	return toCommandResult(ctx.Sess.enqueueCommandMutationContext(ctx.context(), func(mctx *MutationContext) commandMutationResult {
 		pane, sourceWindow, err := mctx.resolvePaneAcrossWindowsForActor(actorPaneID, paneRef)
 		if err != nil {
 			return commandMutationResult{err: err}
@@ -297,7 +297,7 @@ func cmdDropPane(ctx *CommandContext) {
 }
 
 func runMoveSibling(ctx *CommandContext, actorPaneID uint32, paneRef, direction string) commandpkg.Result {
-	return toCommandResult(ctx.Sess.enqueueCommandMutation(func(mctx *MutationContext) commandMutationResult {
+	return toCommandResult(ctx.Sess.enqueueCommandMutationContext(ctx.context(), func(mctx *MutationContext) commandMutationResult {
 		w := mctx.windowForActor(actorPaneID)
 		if w == nil {
 			return commandMutationResult{err: fmt.Errorf("no session")}
@@ -336,7 +336,7 @@ func cmdMoveDown(ctx *CommandContext) {
 }
 
 func runRotate(ctx *CommandContext, forward bool) commandpkg.Result {
-	return toCommandResult(ctx.Sess.enqueueCommandMutation(func(mctx *MutationContext) commandMutationResult {
+	return toCommandResult(ctx.Sess.enqueueCommandMutationContext(ctx.context(), func(mctx *MutationContext) commandMutationResult {
 		w := mctx.activeWindow()
 		if w == nil {
 			return commandMutationResult{err: fmt.Errorf("no session")}

--- a/internal/server/commands_wait.go
+++ b/internal/server/commands_wait.go
@@ -392,10 +392,6 @@ func waitForUIEvent(ctx context.Context, sess *Session, requestedClientID, event
 	}
 }
 
-func waitForNextUIEvent(sess *Session, client uiClientSnapshot, eventName string, timeout time.Duration) error {
-	return waitForNextUIEventContext(sess.context(), sess, client, eventName, timeout)
-}
-
 func waitForNextUIEventContext(ctx context.Context, sess *Session, client uiClientSnapshot, eventName string, timeout time.Duration) error {
 	_, err := waitForUIEvent(ctx, sess, client.clientID, eventName, client.currentGen, true, timeout)
 	return err

--- a/internal/server/commands_wait.go
+++ b/internal/server/commands_wait.go
@@ -57,7 +57,7 @@ func (ctx waitCommandContext) Generation() uint64 {
 }
 
 func (ctx waitCommandContext) LayoutJSON() (string, error) {
-	snap, err := enqueueSessionQueryLegacy(ctx.context(), ctx.Sess, func(sess *Session) (*proto.LayoutSnapshot, error) {
+	snap, err := enqueueSessionQueryOnState(ctx.context(), ctx.Sess, func(sess *Session) (*proto.LayoutSnapshot, error) {
 		return sess.snapshotLayout(nil), nil
 	})
 	if err != nil {
@@ -155,7 +155,7 @@ func (ctx waitCommandContext) WaitExited(actorPaneID uint32, paneRef string, tim
 	paneID := pane.paneID
 
 	checkIdle := func() (bool, error) {
-		pane, err := enqueueSessionQueryLegacy(ctx.context(), ctx.Sess, func(sess *Session) (*mux.Pane, error) {
+		pane, err := enqueueSessionQueryOnState(ctx.context(), ctx.Sess, func(sess *Session) (*mux.Pane, error) {
 			return sess.findPaneByID(paneID), nil
 		})
 		if err != nil {
@@ -285,7 +285,7 @@ func cmdWaitBusy(ctx *CommandContext) {
 
 func waitForPaneBusy(ctx context.Context, sess *Session, paneID uint32, paneRef string, timeout time.Duration) error {
 	checkBusy := func() (bool, error) {
-		pane, err := enqueueSessionQueryLegacy(ctx, sess, func(sess *Session) (*mux.Pane, error) {
+		pane, err := enqueueSessionQueryOnState(ctx, sess, func(sess *Session) (*mux.Pane, error) {
 			return sess.findPaneByID(paneID), nil
 		})
 		if err != nil {
@@ -297,7 +297,7 @@ func waitForPaneBusy(ctx context.Context, sess *Session, paneID uint32, paneRef 
 		return !pane.ForegroundJobState().Idle, nil
 	}
 	checkBusyStatus := func() (mux.ForegroundJobState, error) {
-		pane, err := enqueueSessionQueryLegacy(ctx, sess, func(sess *Session) (*mux.Pane, error) {
+		pane, err := enqueueSessionQueryOnState(ctx, sess, func(sess *Session) (*mux.Pane, error) {
 			return sess.findPaneByID(paneID), nil
 		})
 		if err != nil {

--- a/internal/server/commands_wait.go
+++ b/internal/server/commands_wait.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"time"
@@ -41,7 +42,7 @@ func waitRemoteForward(ctx *CommandContext, args []string) (commandpkg.Result, b
 		return commandpkg.Result{}, false
 	}
 
-	ref, err := ctx.Sess.queryPaneRef(args[paneArgIndex])
+	ref, err := ctx.Sess.queryPaneRefContext(ctx.context(), args[paneArgIndex])
 	if err != nil {
 		return commandpkg.Result{Err: err}, true
 	}
@@ -56,7 +57,7 @@ func (ctx waitCommandContext) Generation() uint64 {
 }
 
 func (ctx waitCommandContext) LayoutJSON() (string, error) {
-	snap, err := enqueueSessionQuery(ctx.Sess, func(sess *Session) (*proto.LayoutSnapshot, error) {
+	snap, err := enqueueSessionQueryLegacy(ctx.context(), ctx.Sess, func(sess *Session) (*proto.LayoutSnapshot, error) {
 		return sess.snapshotLayout(nil), nil
 	})
 	if err != nil {
@@ -104,7 +105,7 @@ func (ctx waitCommandContext) WaitCheckpoint(afterGen uint64, afterSet bool, tim
 }
 
 func (ctx waitCommandContext) UIGeneration(requestedClientID string) (uint64, error) {
-	client, err := ctx.Sess.queryUIClient(requestedClientID, "")
+	client, err := ctx.Sess.queryUIClientContext(ctx.context(), requestedClientID, "")
 	if err != nil {
 		return 0, err
 	}
@@ -112,7 +113,7 @@ func (ctx waitCommandContext) UIGeneration(requestedClientID string) (uint64, er
 }
 
 func (ctx waitCommandContext) WaitContent(actorPaneID uint32, paneRef, substr string, timeout time.Duration) error {
-	pane, err := ctx.Sess.queryResolvedPaneForActor(actorPaneID, paneRef)
+	pane, err := ctx.Sess.queryResolvedPaneForActorContext(ctx.context(), actorPaneID, paneRef)
 	if err != nil {
 		return err
 	}
@@ -140,19 +141,21 @@ func (ctx waitCommandContext) WaitContent(actorPaneID uint32, paneRef, substr st
 			}
 		case <-timer.C:
 			return fmt.Errorf("timeout waiting for %q in %s", substr, paneRef)
+		case <-ctx.context().Done():
+			return ctx.context().Err()
 		}
 	}
 }
 
 func (ctx waitCommandContext) WaitExited(actorPaneID uint32, paneRef string, timeout time.Duration) error {
-	pane, err := ctx.Sess.queryResolvedPaneForActor(actorPaneID, paneRef)
+	pane, err := ctx.Sess.queryResolvedPaneForActorContext(ctx.context(), actorPaneID, paneRef)
 	if err != nil {
 		return err
 	}
 	paneID := pane.paneID
 
 	checkIdle := func() (bool, error) {
-		pane, err := enqueueSessionQuery(ctx.Sess, func(sess *Session) (*mux.Pane, error) {
+		pane, err := enqueueSessionQueryLegacy(ctx.context(), ctx.Sess, func(sess *Session) (*mux.Pane, error) {
 			return sess.findPaneByID(paneID), nil
 		})
 		if err != nil {
@@ -167,7 +170,7 @@ func (ctx waitCommandContext) WaitExited(actorPaneID uint32, paneRef string, tim
 		return true, nil
 	}
 
-	res := ctx.Sess.enqueueEventSubscribe(eventFilter{Types: []string{EventExited}, PaneID: paneID}, true)
+	res := ctx.Sess.enqueueEventSubscribe(ctx.context(), eventFilter{Types: []string{EventExited}, PaneID: paneID}, true)
 	if res.sub == nil {
 		return fmt.Errorf("session shutting down")
 	}
@@ -198,20 +201,22 @@ func (ctx waitCommandContext) WaitExited(actorPaneID uint32, paneRef string, tim
 			}
 		case <-timer.C:
 			return fmt.Errorf("timeout waiting for %s to become exited", paneRef)
+		case <-ctx.context().Done():
+			return ctx.context().Err()
 		}
 	}
 }
 
 func (ctx waitCommandContext) WaitBusy(actorPaneID uint32, paneRef string, timeout time.Duration) error {
-	pane, err := ctx.Sess.queryResolvedPaneForActor(actorPaneID, paneRef)
+	pane, err := ctx.Sess.queryResolvedPaneForActorContext(ctx.context(), actorPaneID, paneRef)
 	if err != nil {
 		return err
 	}
-	return waitForPaneBusy(ctx.Sess, pane.paneID, paneRef, timeout)
+	return waitForPaneBusy(ctx.context(), ctx.Sess, pane.paneID, paneRef, timeout)
 }
 
 func (ctx waitCommandContext) WaitUI(eventName, requestedClientID string, afterGen uint64, afterSet bool, timeout time.Duration) error {
-	_, err := waitForUIEvent(ctx.Sess, requestedClientID, eventName, afterGen, afterSet, timeout)
+	_, err := waitForUIEvent(ctx.context(), ctx.Sess, requestedClientID, eventName, afterGen, afterSet, timeout)
 	return err
 }
 
@@ -221,7 +226,7 @@ func (ctx waitCommandContext) WaitReady(actorPaneID uint32, args []string) error
 		return err
 	}
 
-	pane, err := ctx.Sess.queryResolvedPaneForActor(actorPaneID, paneRef)
+	pane, err := ctx.Sess.queryResolvedPaneForActorContext(ctx.context(), actorPaneID, paneRef)
 	if err != nil {
 		return err
 	}
@@ -235,7 +240,7 @@ func (ctx waitCommandContext) WaitIdle(actorPaneID uint32, args []string) error 
 		return err
 	}
 
-	pane, err := ctx.Sess.queryResolvedPaneForActor(actorPaneID, paneRef)
+	pane, err := ctx.Sess.queryResolvedPaneForActorContext(ctx.context(), actorPaneID, paneRef)
 	if err != nil {
 		return err
 	}
@@ -278,9 +283,9 @@ func cmdWaitBusy(ctx *CommandContext) {
 	ctx.applyCommandResult(waitcmd.WaitBusy(waitCommandContext{ctx}, ctx.ActorPaneID, ctx.Args))
 }
 
-func waitForPaneBusy(sess *Session, paneID uint32, paneRef string, timeout time.Duration) error {
+func waitForPaneBusy(ctx context.Context, sess *Session, paneID uint32, paneRef string, timeout time.Duration) error {
 	checkBusy := func() (bool, error) {
-		pane, err := enqueueSessionQuery(sess, func(sess *Session) (*mux.Pane, error) {
+		pane, err := enqueueSessionQueryLegacy(ctx, sess, func(sess *Session) (*mux.Pane, error) {
 			return sess.findPaneByID(paneID), nil
 		})
 		if err != nil {
@@ -292,7 +297,7 @@ func waitForPaneBusy(sess *Session, paneID uint32, paneRef string, timeout time.
 		return !pane.ForegroundJobState().Idle, nil
 	}
 	checkBusyStatus := func() (mux.ForegroundJobState, error) {
-		pane, err := enqueueSessionQuery(sess, func(sess *Session) (*mux.Pane, error) {
+		pane, err := enqueueSessionQueryLegacy(ctx, sess, func(sess *Session) (*mux.Pane, error) {
 			return sess.findPaneByID(paneID), nil
 		})
 		if err != nil {
@@ -304,7 +309,7 @@ func waitForPaneBusy(sess *Session, paneID uint32, paneRef string, timeout time.
 		return pane.ForegroundJobState(), nil
 	}
 
-	outputCh := sess.enqueuePaneOutputSubscribe(paneID)
+	outputCh := sess.enqueuePaneOutputSubscribe(ctx, paneID)
 	if outputCh == nil {
 		return fmt.Errorf("session shutting down")
 	}
@@ -344,6 +349,8 @@ func waitForPaneBusy(sess *Session, paneID uint32, paneRef string, timeout time.
 		case <-ticker.C:
 		case <-timeoutTimer.C:
 			return fmt.Errorf("timeout waiting for %s to become busy", paneRef)
+		case <-ctx.Done():
+			return ctx.Err()
 		}
 
 		st, err := checkBusyStatus()
@@ -358,12 +365,12 @@ func waitForPaneBusy(sess *Session, paneID uint32, paneRef string, timeout time.
 	}
 }
 
-func waitForUIEvent(sess *Session, requestedClientID, eventName string, afterGen uint64, afterSet bool, timeout time.Duration) (string, error) {
+func waitForUIEvent(ctx context.Context, sess *Session, requestedClientID, eventName string, afterGen uint64, afterSet bool, timeout time.Duration) (string, error) {
 	if !proto.IsKnownUIEvent(eventName) {
 		return "", errUnknownUIEvent(eventName)
 	}
 
-	subscription, err := sess.enqueueUIWaitSubscribe(requestedClientID, eventName)
+	subscription, err := sess.enqueueUIWaitSubscribe(ctx, requestedClientID, eventName)
 	if err != nil {
 		return "", err
 	}
@@ -380,11 +387,17 @@ func waitForUIEvent(sess *Session, requestedClientID, eventName string, afterGen
 		return subscription.clientID, nil
 	case <-timer.C:
 		return "", fmt.Errorf("timeout waiting for %s on %s", eventName, subscription.clientID)
+	case <-ctx.Done():
+		return "", ctx.Err()
 	}
 }
 
 func waitForNextUIEvent(sess *Session, client uiClientSnapshot, eventName string, timeout time.Duration) error {
-	_, err := waitForUIEvent(sess, client.clientID, eventName, client.currentGen, true, timeout)
+	return waitForNextUIEventContext(sess.context(), sess, client, eventName, timeout)
+}
+
+func waitForNextUIEventContext(ctx context.Context, sess *Session, client uiClientSnapshot, eventName string, timeout time.Duration) error {
+	_, err := waitForUIEvent(ctx, sess, client.clientID, eventName, client.currentGen, true, timeout)
 	return err
 }
 

--- a/internal/server/commands_wait_test.go
+++ b/internal/server/commands_wait_test.go
@@ -144,7 +144,7 @@ func TestWaitForUIEventCurrentMatchWithoutAfterReturnsImmediately(t *testing.T) 
 		return struct{}{}
 	})
 
-	clientID, err := waitForUIEvent(sess, "", proto.UIEventCopyModeShown, 0, false, 50*time.Millisecond)
+	clientID, err := waitForUIEvent(sess.context(), sess, "", proto.UIEventCopyModeShown, 0, false, 50*time.Millisecond)
 	if err != nil {
 		t.Fatalf("waitForUIEvent current match: %v", err)
 	}
@@ -178,7 +178,7 @@ func TestWaitForNextUIEventWaitsForFreshTransition(t *testing.T) {
 
 	done := make(chan error, 1)
 	go func() {
-		done <- waitForNextUIEvent(sess, snapshot, proto.UIEventInputIdle, 250*time.Millisecond)
+		done <- waitForNextUIEventContext(sess.context(), sess, snapshot, proto.UIEventInputIdle, 250*time.Millisecond)
 	}()
 
 	select {
@@ -301,7 +301,7 @@ func TestCmdWaitTransitionCommandsDefaultToNextChange(t *testing.T) {
 		case <-time.After(20 * time.Millisecond):
 		}
 
-		if !sess.enqueueEvent(crashCheckpointWrittenEvent{path: "/tmp/new-checkpoint.json"}) {
+		if !sess.enqueueEvent(sess.context(), crashCheckpointWrittenEvent{path: "/tmp/new-checkpoint.json"}) {
 			t.Fatal("enqueueEvent(crashCheckpointWrittenEvent) = false")
 		}
 

--- a/internal/server/commands_window.go
+++ b/internal/server/commands_window.go
@@ -24,7 +24,7 @@ func cmdPrevWindow(ctx *CommandContext) {
 }
 
 func cmdLastWindow(ctx *CommandContext) {
-	ctx.replyCommandMutation(ctx.Sess.enqueueCommandMutation(func(ctx *MutationContext) commandMutationResult {
+	ctx.replyCommandMutation(ctx.Sess.enqueueCommandMutationContext(ctx.context(), func(ctx *MutationContext) commandMutationResult {
 		if !ctx.lastWindow() {
 			return commandMutationResult{bell: true}
 		}
@@ -49,7 +49,7 @@ func cmdMovePaneToWindow(ctx *CommandContext) {
 		ctx.applyCommandResult(commandpkg.Result{Err: fmt.Errorf("usage: move-pane-to-window <pane> <window>")})
 		return
 	}
-	ctx.replyCommandMutation(ctx.Sess.enqueueCommandMutation(func(mctx *MutationContext) commandMutationResult {
+	ctx.replyCommandMutation(ctx.Sess.enqueueCommandMutationContext(ctx.context(), func(mctx *MutationContext) commandMutationResult {
 		if err := movePaneToWindow(mctx, ctx.ActorPaneID, ctx.Args[0], ctx.Args[1]); err != nil {
 			return commandMutationResult{err: err}
 		}

--- a/internal/server/event_test.go
+++ b/internal/server/event_test.go
@@ -184,7 +184,7 @@ func TestTerminalEventsInitialSnapshotAndUpdates(t *testing.T) {
 			"\x1b[?1049h",
 	))
 
-	res := sess.enqueueEventSubscribe(eventFilter{Types: []string{EventTerminal}}, true)
+	res := sess.enqueueEventSubscribe(sess.context(), eventFilter{Types: []string{EventTerminal}}, true)
 	if res.sub == nil {
 		t.Fatal("terminal subscribe returned nil subscription")
 	}
@@ -272,7 +272,7 @@ func TestPaneOutputWithoutTerminalSubscribersSkipsTerminalSnapshotting(t *testin
 		sess.Panes = []*mux.Pane{pane}
 	})
 
-	res := sess.enqueueEventSubscribe(eventFilter{Types: []string{EventOutput}}, false)
+	res := sess.enqueueEventSubscribe(sess.context(), eventFilter{Types: []string{EventOutput}}, false)
 	if res.sub == nil {
 		t.Fatal("output subscribe returned nil subscription")
 	}
@@ -396,7 +396,7 @@ func TestEmitEventDelivery(t *testing.T) {
 	sess := newSession("test-emit")
 	stopCrashCheckpointLoop(t, sess)
 
-	res := sess.enqueueEventSubscribe(eventFilter{}, false)
+	res := sess.enqueueEventSubscribe(sess.context(), eventFilter{}, false)
 	defer sess.enqueueEventUnsubscribe(res.sub)
 
 	// Emit from within the event loop (emitEvent is event-loop-only).
@@ -427,7 +427,7 @@ func TestEmitEventFiltered(t *testing.T) {
 	sess := newSession("test-filter")
 	stopCrashCheckpointLoop(t, sess)
 
-	res := sess.enqueueEventSubscribe(eventFilter{Types: []string{EventIdle}}, false)
+	res := sess.enqueueEventSubscribe(sess.context(), eventFilter{Types: []string{EventIdle}}, false)
 	defer sess.enqueueEventUnsubscribe(res.sub)
 
 	sess.enqueueCommandMutation(func(s *MutationContext) commandMutationResult {
@@ -461,7 +461,7 @@ func TestEmitEventDropsWhenFull(t *testing.T) {
 	sess := newSession("test-drop")
 	stopCrashCheckpointLoop(t, sess)
 
-	res := sess.enqueueEventSubscribe(eventFilter{}, false)
+	res := sess.enqueueEventSubscribe(sess.context(), eventFilter{}, false)
 
 	// Fill the channel from within the event loop.
 	sess.enqueueCommandMutation(func(s *MutationContext) commandMutationResult {
@@ -496,7 +496,7 @@ func TestEmitEventAfterRemove(t *testing.T) {
 	sess := newSession("test-remove-race")
 	stopCrashCheckpointLoop(t, sess)
 
-	res := sess.enqueueEventSubscribe(eventFilter{}, false)
+	res := sess.enqueueEventSubscribe(sess.context(), eventFilter{}, false)
 	sess.enqueueEventUnsubscribe(res.sub)
 
 	// Emit after unsubscribe: the event loop processes both sequentially,

--- a/internal/server/idle.go
+++ b/internal/server/idle.go
@@ -43,7 +43,7 @@ type idleWaitState struct {
 }
 
 func (s *Session) queryIdleWaitState(paneID uint32) (idleWaitState, error) {
-	return enqueueSessionQuery(s, func(sess *Session) (idleWaitState, error) {
+	return enqueueSessionQueryLegacy(s.context(), s, func(sess *Session) (idleWaitState, error) {
 		pane := sess.findPaneByID(paneID)
 		if pane == nil {
 			return idleWaitState{}, nil
@@ -118,7 +118,7 @@ func stopTimer(timer Timer) {
 }
 
 func waitForPaneIdle(sess *Session, paneRef string, paneID uint32, opts waitIdleOptions) error {
-	outputCh := sess.enqueuePaneOutputSubscribe(paneID)
+	outputCh := sess.enqueuePaneOutputSubscribe(sess.context(), paneID)
 	if outputCh == nil {
 		return fmt.Errorf("session shutting down")
 	}

--- a/internal/server/idle.go
+++ b/internal/server/idle.go
@@ -43,7 +43,7 @@ type idleWaitState struct {
 }
 
 func (s *Session) queryIdleWaitState(paneID uint32) (idleWaitState, error) {
-	return enqueueSessionQueryLegacy(s.context(), s, func(sess *Session) (idleWaitState, error) {
+	return enqueueSessionQueryOnState(s.context(), s, func(sess *Session) (idleWaitState, error) {
 		pane := sess.findPaneByID(paneID)
 		if pane == nil {
 			return idleWaitState{}, nil

--- a/internal/server/idle_test.go
+++ b/internal/server/idle_test.go
@@ -247,7 +247,7 @@ func TestPaneOutputCallbackEmitsIdleEventAfterQuiescence(t *testing.T) {
 	})
 	sess.Panes = []*mux.Pane{pane}
 
-	res := sess.enqueueEventSubscribe(eventFilter{Types: []string{EventIdle}}, false)
+	res := sess.enqueueEventSubscribe(sess.context(), eventFilter{Types: []string{EventIdle}}, false)
 	defer sess.enqueueEventUnsubscribe(res.sub)
 
 	pane.FeedOutput([]byte("hello"))

--- a/internal/server/input_router.go
+++ b/internal/server/input_router.go
@@ -145,7 +145,7 @@ func (r *inputRouter) activeInputPaneForWrite(sess *Session, cc *clientConn) *mu
 		return pane
 	}
 
-	pane, err := enqueueSessionQueryLegacy(sess.context(), sess, func(sess *Session) (*mux.Pane, error) {
+	pane, err := enqueueSessionQueryOnState(sess.context(), sess, func(sess *Session) (*mux.Pane, error) {
 		return sess.ensureInputRouter().activeInputPaneForWriteOnActor(sess, cc), nil
 	})
 	if err != nil {
@@ -173,7 +173,7 @@ func (s *Session) activeInputPaneForWrite(cc *clientConn) *mux.Pane {
 }
 
 func (s *Session) enqueuePacedPaneInput(pane *mux.Pane, chunks []encodedKeyChunk) error {
-	queue, err := enqueueSessionQueryLegacy(s.context(), s, func(sess *Session) (*paneInputQueue, error) {
+	queue, err := enqueueSessionQueryOnState(s.context(), s, func(sess *Session) (*paneInputQueue, error) {
 		if !sess.hasPane(pane.ID) {
 			return nil, fmt.Errorf("%s not found", pane.Meta.Name)
 		}
@@ -233,7 +233,7 @@ func waitForPaneInputTarget(sess *Session, paneID uint32, paneName string) (*mux
 	defer ticker.Stop()
 
 	for {
-		target, err := enqueueSessionQueryLegacy(sess.context(), sess, func(sess *Session) (paneInputTarget, error) {
+		target, err := enqueueSessionQueryOnState(sess.context(), sess, func(sess *Session) (paneInputTarget, error) {
 			pane := sess.findPaneByID(paneID)
 			if pane == nil {
 				return paneInputTarget{}, nil

--- a/internal/server/input_router.go
+++ b/internal/server/input_router.go
@@ -145,7 +145,7 @@ func (r *inputRouter) activeInputPaneForWrite(sess *Session, cc *clientConn) *mu
 		return pane
 	}
 
-	pane, err := enqueueSessionQuery(sess, func(sess *Session) (*mux.Pane, error) {
+	pane, err := enqueueSessionQueryLegacy(sess.context(), sess, func(sess *Session) (*mux.Pane, error) {
 		return sess.ensureInputRouter().activeInputPaneForWriteOnActor(sess, cc), nil
 	})
 	if err != nil {
@@ -173,7 +173,7 @@ func (s *Session) activeInputPaneForWrite(cc *clientConn) *mux.Pane {
 }
 
 func (s *Session) enqueuePacedPaneInput(pane *mux.Pane, chunks []encodedKeyChunk) error {
-	queue, err := enqueueSessionQuery(s, func(sess *Session) (*paneInputQueue, error) {
+	queue, err := enqueueSessionQueryLegacy(s.context(), s, func(sess *Session) (*paneInputQueue, error) {
 		if !sess.hasPane(pane.ID) {
 			return nil, fmt.Errorf("%s not found", pane.Meta.Name)
 		}
@@ -233,7 +233,7 @@ func waitForPaneInputTarget(sess *Session, paneID uint32, paneName string) (*mux
 	defer ticker.Stop()
 
 	for {
-		target, err := enqueueSessionQuery(sess, func(sess *Session) (paneInputTarget, error) {
+		target, err := enqueueSessionQueryLegacy(sess.context(), sess, func(sess *Session) (paneInputTarget, error) {
 			pane := sess.findPaneByID(paneID)
 			if pane == nil {
 				return paneInputTarget{}, nil

--- a/internal/server/pane_close_async_test.go
+++ b/internal/server/pane_close_async_test.go
@@ -106,7 +106,7 @@ func TestSessionEventLoopStaysResponsiveWhilePaneCloseBlocks(t *testing.T) {
 
 			queryDone := make(chan error, 1)
 			go func() {
-				_, err := enqueueSessionQuery(sess, func(sess *Session) (struct{}, error) {
+				_, err := enqueueSessionQueryLegacy(sess.context(), sess, func(sess *Session) (struct{}, error) {
 					return struct{}{}, tt.assert(sess)
 				})
 				queryDone <- err
@@ -378,7 +378,7 @@ func TestEnqueueCommandMutationSchedulesPaneCloseOffLoop(t *testing.T) {
 
 	queryDone := make(chan error, 1)
 	go func() {
-		_, err := enqueueSessionQuery(sess, func(sess *Session) (struct{}, error) {
+		_, err := enqueueSessionQueryLegacy(sess.context(), sess, func(sess *Session) (struct{}, error) {
 			return struct{}{}, nil
 		})
 		queryDone <- err

--- a/internal/server/pane_close_async_test.go
+++ b/internal/server/pane_close_async_test.go
@@ -106,7 +106,7 @@ func TestSessionEventLoopStaysResponsiveWhilePaneCloseBlocks(t *testing.T) {
 
 			queryDone := make(chan error, 1)
 			go func() {
-				_, err := enqueueSessionQueryLegacy(sess.context(), sess, func(sess *Session) (struct{}, error) {
+				_, err := enqueueSessionQueryOnState(sess.context(), sess, func(sess *Session) (struct{}, error) {
 					return struct{}{}, tt.assert(sess)
 				})
 				queryDone <- err
@@ -378,7 +378,7 @@ func TestEnqueueCommandMutationSchedulesPaneCloseOffLoop(t *testing.T) {
 
 	queryDone := make(chan error, 1)
 	go func() {
-		_, err := enqueueSessionQueryLegacy(sess.context(), sess, func(sess *Session) (struct{}, error) {
+		_, err := enqueueSessionQueryOnState(sess.context(), sess, func(sess *Session) (struct{}, error) {
 			return struct{}{}, nil
 		})
 		queryDone <- err

--- a/internal/server/pane_ref.go
+++ b/internal/server/pane_ref.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/weill-labs/amux/internal/proto"
@@ -11,7 +12,11 @@ type remoteHostNamesProvider interface {
 }
 
 func (s *Session) queryPaneRef(ref string) (proto.PaneRef, error) {
-	return enqueueSessionQuery(s, func(s *Session) (proto.PaneRef, error) {
+	return s.queryPaneRefContext(s.context(), ref)
+}
+
+func (s *Session) queryPaneRefContext(ctx context.Context, ref string) (proto.PaneRef, error) {
+	return enqueueSessionQueryLegacy(ctx, s, func(s *Session) (proto.PaneRef, error) {
 		return s.parsePaneRef(ref)
 	})
 }

--- a/internal/server/pane_ref.go
+++ b/internal/server/pane_ref.go
@@ -16,7 +16,7 @@ func (s *Session) queryPaneRef(ref string) (proto.PaneRef, error) {
 }
 
 func (s *Session) queryPaneRefContext(ctx context.Context, ref string) (proto.PaneRef, error) {
-	return enqueueSessionQueryLegacy(ctx, s, func(s *Session) (proto.PaneRef, error) {
+	return enqueueSessionQueryOnState(ctx, s, func(s *Session) (proto.PaneRef, error) {
 		return s.parsePaneRef(ref)
 	})
 }

--- a/internal/server/pane_transport.go
+++ b/internal/server/pane_transport.go
@@ -35,7 +35,7 @@ type PaneTakeoverFactory func(PaneTransportHooks) PaneTakeoverTransport
 func (s *Session) paneTransportHooks() PaneTransportHooks {
 	return PaneTransportHooks{
 		OnPaneOutput: func(localPaneID uint32, data []byte) {
-			pane, err := enqueueSessionQuery(s, func(s *Session) (*mux.Pane, error) {
+			pane, err := enqueueSessionQueryLegacy(s.context(), s, func(s *Session) (*mux.Pane, error) {
 				return s.findPaneByID(localPaneID), nil
 			})
 			if err != nil || pane == nil {

--- a/internal/server/pane_transport.go
+++ b/internal/server/pane_transport.go
@@ -35,7 +35,7 @@ type PaneTakeoverFactory func(PaneTransportHooks) PaneTakeoverTransport
 func (s *Session) paneTransportHooks() PaneTransportHooks {
 	return PaneTransportHooks{
 		OnPaneOutput: func(localPaneID uint32, data []byte) {
-			pane, err := enqueueSessionQueryLegacy(s.context(), s, func(s *Session) (*mux.Pane, error) {
+			pane, err := enqueueSessionQueryOnState(s.context(), s, func(s *Session) (*mux.Pane, error) {
 				return s.findPaneByID(localPaneID), nil
 			})
 			if err != nil || pane == nil {

--- a/internal/server/panic_recovery_test.go
+++ b/internal/server/panic_recovery_test.go
@@ -74,7 +74,7 @@ func TestSessionQueryPanicReturnsError(t *testing.T) {
 	defer stopSessionBackgroundLoops(t, sess)
 
 	// A panicking query closure should return an error.
-	_, err := enqueueSessionQuery(sess, func(sess *Session) (int, error) {
+	_, err := enqueueSessionQueryLegacy(sess.context(), sess, func(sess *Session) (int, error) {
 		panic("query boom")
 	})
 	if err == nil {
@@ -85,7 +85,7 @@ func TestSessionQueryPanicReturnsError(t *testing.T) {
 	}
 
 	// Event loop should still be alive.
-	val, err := enqueueSessionQuery(sess, func(sess *Session) (string, error) {
+	val, err := enqueueSessionQueryLegacy(sess.context(), sess, func(sess *Session) (string, error) {
 		return "alive", nil
 	})
 	if err != nil {

--- a/internal/server/panic_recovery_test.go
+++ b/internal/server/panic_recovery_test.go
@@ -74,7 +74,7 @@ func TestSessionQueryPanicReturnsError(t *testing.T) {
 	defer stopSessionBackgroundLoops(t, sess)
 
 	// A panicking query closure should return an error.
-	_, err := enqueueSessionQueryLegacy(sess.context(), sess, func(sess *Session) (int, error) {
+	_, err := enqueueSessionQueryOnState(sess.context(), sess, func(sess *Session) (int, error) {
 		panic("query boom")
 	})
 	if err == nil {
@@ -85,7 +85,7 @@ func TestSessionQueryPanicReturnsError(t *testing.T) {
 	}
 
 	// Event loop should still be alive.
-	val, err := enqueueSessionQueryLegacy(sess.context(), sess, func(sess *Session) (string, error) {
+	val, err := enqueueSessionQueryOnState(sess.context(), sess, func(sess *Session) (string, error) {
 		return "alive", nil
 	})
 	if err != nil {

--- a/internal/server/remote_session_test.go
+++ b/internal/server/remote_session_test.go
@@ -39,7 +39,7 @@ func TestRemoteStateChangeEventUpdatesRemoteSessionAndProxyPanes(t *testing.T) {
 			})
 
 			mustSessionMutation(t, sess, func(sess *Session) {
-				remoteStateChangeEvent{hostName: "gpu", state: state}.handle(sess)
+				remoteStateChangeEvent{hostName: "gpu", state: state}.handle(sess.context(), sess)
 			})
 
 			snap := mustSessionQuery(t, sess, func(sess *Session) struct {
@@ -271,7 +271,7 @@ func TestRemoteLayoutEventLogsApplyErrors(t *testing.T) {
 					}},
 				}},
 			},
-		}.handle(sess)
+		}.handle(sess.context(), sess)
 	})
 
 	logOutput := buf.String()

--- a/internal/server/respawn_command_test.go
+++ b/internal/server/respawn_command_test.go
@@ -256,7 +256,7 @@ func TestQueryRespawnTargetCapturesColorProfile(t *testing.T) {
 func mustCreatePaneWithMeta(t *testing.T, sess *Session, srv *Server, meta mux.PaneMeta, cols, rows int) *mux.Pane {
 	t.Helper()
 
-	pane, err := enqueueSessionQueryLegacy(sess.context(), sess, func(sess *Session) (*mux.Pane, error) {
+	pane, err := enqueueSessionQueryOnState(sess.context(), sess, func(sess *Session) (*mux.Pane, error) {
 		return sess.createPaneWithMeta(srv, meta, cols, rows)
 	})
 	if err != nil {

--- a/internal/server/respawn_command_test.go
+++ b/internal/server/respawn_command_test.go
@@ -256,7 +256,7 @@ func TestQueryRespawnTargetCapturesColorProfile(t *testing.T) {
 func mustCreatePaneWithMeta(t *testing.T, sess *Session, srv *Server, meta mux.PaneMeta, cols, rows int) *mux.Pane {
 	t.Helper()
 
-	pane, err := enqueueSessionQuery(sess, func(sess *Session) (*mux.Pane, error) {
+	pane, err := enqueueSessionQueryLegacy(sess.context(), sess, func(sess *Session) (*mux.Pane, error) {
 		return sess.createPaneWithMeta(srv, meta, cols, rows)
 	})
 	if err != nil {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -274,7 +274,7 @@ func (s *Session) buildCrashCheckpoint() *checkpoint.CrashCheckpoint {
 		cwdWork []pidEntry
 	}
 
-	snap, err := enqueueSessionQueryLegacy(s.context(), s, func(s *Session) (crashSnapshot, error) {
+	snap, err := enqueueSessionQueryOnState(s.context(), s, func(s *Session) (crashSnapshot, error) {
 		if len(s.Windows) == 0 {
 			return crashSnapshot{}, nil
 		}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -113,6 +113,8 @@ type Session struct {
 	checkpointCoordinator crashCheckpointCoordinator
 
 	// Async session event loop — phase 1 serializes callback-driven writes.
+	sessionCtx       context.Context
+	cancelSessionCtx context.CancelFunc
 	sessionEvents    chan sessionEvent
 	sessionEventStop chan struct{}
 	sessionEventDone chan struct{}
@@ -193,6 +195,20 @@ func defaultSessionLaunchColorProfile() string {
 	return sessionLaunchColorProfile(processEnviron{})
 }
 
+// serverInternalContext is the documented root for server-owned work that is
+// not tied to a client request. Production sessions replace it with a
+// session-scoped child that is canceled when the event loop stops.
+func serverInternalContext() context.Context {
+	return context.Background()
+}
+
+func (s *Session) context() context.Context {
+	if s != nil && s.sessionCtx != nil {
+		return s.sessionCtx
+	}
+	return serverInternalContext()
+}
+
 func (s *Session) clock() Clock {
 	if s.Clock != nil {
 		return s.Clock
@@ -258,7 +274,7 @@ func (s *Session) buildCrashCheckpoint() *checkpoint.CrashCheckpoint {
 		cwdWork []pidEntry
 	}
 
-	snap, err := enqueueSessionQuery(s, func(s *Session) (crashSnapshot, error) {
+	snap, err := enqueueSessionQueryLegacy(s.context(), s, func(s *Session) (crashSnapshot, error) {
 		if len(s.Windows) == 0 {
 			return crashSnapshot{}, nil
 		}

--- a/internal/server/server_capture_full.go
+++ b/internal/server/server_capture_full.go
@@ -175,7 +175,7 @@ func (p *serverPaneData) InCopyMode() bool       { return false }
 func (p *serverPaneData) CopyModeSearch() string { return "" }
 
 func (s *Session) captureFullSessionSnapshot() (serverFullSessionCapture, error) {
-	return enqueueSessionQueryLegacy(s.context(), s, func(s *Session) (serverFullSessionCapture, error) {
+	return enqueueSessionQueryOnState(s.context(), s, func(s *Session) (serverFullSessionCapture, error) {
 		w := s.activeWindow()
 		if w == nil || w.Root == nil {
 			return serverFullSessionCapture{}, fmt.Errorf("no window")

--- a/internal/server/server_capture_full.go
+++ b/internal/server/server_capture_full.go
@@ -175,7 +175,7 @@ func (p *serverPaneData) InCopyMode() bool       { return false }
 func (p *serverPaneData) CopyModeSearch() string { return "" }
 
 func (s *Session) captureFullSessionSnapshot() (serverFullSessionCapture, error) {
-	return enqueueSessionQuery(s, func(s *Session) (serverFullSessionCapture, error) {
+	return enqueueSessionQueryLegacy(s.context(), s, func(s *Session) (serverFullSessionCapture, error) {
 		w := s.activeWindow()
 		if w == nil || w.Root == nil {
 			return serverFullSessionCapture{}, fmt.Errorf("no window")

--- a/internal/server/session_actor.go
+++ b/internal/server/session_actor.go
@@ -17,7 +17,7 @@ func enqueueSessionQuery[T any](ctx context.Context, s *Session, fn func(context
 	}, errSessionShuttingDown)
 }
 
-func enqueueSessionQueryLegacy[T any](ctx context.Context, s *Session, fn func(*Session) (T, error)) (T, error) {
+func enqueueSessionQueryOnState[T any](ctx context.Context, s *Session, fn func(*Session) (T, error)) (T, error) {
 	return enqueueSessionQuery(ctx, s, func(_ context.Context, sess *Session) (T, error) {
 		return fn(sess)
 	})

--- a/internal/server/session_actor.go
+++ b/internal/server/session_actor.go
@@ -1,6 +1,8 @@
 package server
 
 import (
+	"context"
+
 	"github.com/weill-labs/amux/internal/eventloop"
 	"github.com/weill-labs/amux/internal/proto"
 )
@@ -9,10 +11,16 @@ func recoverSessionQuery(s *Session, r any, stack []byte) error {
 	return s.logPanic("session_query_panic", r, stack)
 }
 
-func enqueueSessionQuery[T any](s *Session, fn func(*Session) (T, error)) (T, error) {
-	return eventloop.EnqueueQuery(s.sessionEvents, s.sessionEventStop, s.sessionEventDone, fn, func(r any, stack []byte) error {
+func enqueueSessionQuery[T any](ctx context.Context, s *Session, fn func(context.Context, *Session) (T, error)) (T, error) {
+	return eventloop.EnqueueQuery(ctx, s.sessionEvents, s.sessionEventStop, s.sessionEventDone, fn, func(r any, stack []byte) error {
 		return recoverSessionQuery(s, r, stack)
 	}, errSessionShuttingDown)
+}
+
+func enqueueSessionQueryLegacy[T any](ctx context.Context, s *Session, fn func(*Session) (T, error)) (T, error) {
+	return enqueueSessionQuery(ctx, s, func(_ context.Context, sess *Session) (T, error) {
+		return fn(sess)
+	})
 }
 
 type captureRequest struct {

--- a/internal/server/session_broadcast.go
+++ b/internal/server/session_broadcast.go
@@ -48,7 +48,7 @@ func (s *Session) broadcastNow(msg *Message) {
 
 // broadcast sends a message to all connected clients.
 func (s *Session) broadcast(msg *Message) {
-	_, _ = enqueueSessionQuery(s, func(s *Session) (struct{}, error) {
+	_, _ = enqueueSessionQueryLegacy(s.context(), s, func(s *Session) (struct{}, error) {
 		s.broadcastNow(msg)
 		return struct{}{}, nil
 	})
@@ -72,7 +72,7 @@ func (s *Session) metaCallback() func(paneID uint32, update mux.MetaUpdate) {
 		if s.shutdown.Load() {
 			return
 		}
-		s.enqueueEvent(metaUpdateEvent{paneID: paneID, update: update})
+		s.enqueueEvent(s.context(), metaUpdateEvent{paneID: paneID, update: update})
 	}
 }
 
@@ -147,7 +147,7 @@ func (s *Session) broadcastLayoutNow() {
 // broadcastLayout sends the current layout snapshot to all clients
 // and increments the layout generation counter.
 func (s *Session) broadcastLayout() {
-	_, _ = enqueueSessionQuery(s, func(s *Session) (struct{}, error) {
+	_, _ = enqueueSessionQueryLegacy(s.context(), s, func(s *Session) (struct{}, error) {
 		s.broadcastLayoutNow()
 		return struct{}{}, nil
 	})
@@ -257,7 +257,7 @@ func (s *Session) trackPaneActivity(paneID uint32) {
 // the substring. It resolves the pane through the session event loop, then
 // inspects the emulator outside the event loop.
 func (s *Session) paneScreenContains(paneID uint32, substr string) bool {
-	pane, err := enqueueSessionQuery(s, func(s *Session) (*mux.Pane, error) {
+	pane, err := enqueueSessionQueryLegacy(s.context(), s, func(s *Session) (*mux.Pane, error) {
 		return s.findPaneByID(paneID), nil
 	})
 	if err != nil || pane == nil {

--- a/internal/server/session_broadcast.go
+++ b/internal/server/session_broadcast.go
@@ -48,7 +48,7 @@ func (s *Session) broadcastNow(msg *Message) {
 
 // broadcast sends a message to all connected clients.
 func (s *Session) broadcast(msg *Message) {
-	_, _ = enqueueSessionQueryLegacy(s.context(), s, func(s *Session) (struct{}, error) {
+	_, _ = enqueueSessionQueryOnState(s.context(), s, func(s *Session) (struct{}, error) {
 		s.broadcastNow(msg)
 		return struct{}{}, nil
 	})
@@ -147,7 +147,7 @@ func (s *Session) broadcastLayoutNow() {
 // broadcastLayout sends the current layout snapshot to all clients
 // and increments the layout generation counter.
 func (s *Session) broadcastLayout() {
-	_, _ = enqueueSessionQueryLegacy(s.context(), s, func(s *Session) (struct{}, error) {
+	_, _ = enqueueSessionQueryOnState(s.context(), s, func(s *Session) (struct{}, error) {
 		s.broadcastLayoutNow()
 		return struct{}{}, nil
 	})
@@ -257,7 +257,7 @@ func (s *Session) trackPaneActivity(paneID uint32) {
 // the substring. It resolves the pane through the session event loop, then
 // inspects the emulator outside the event loop.
 func (s *Session) paneScreenContains(paneID uint32, substr string) bool {
-	pane, err := enqueueSessionQueryLegacy(s.context(), s, func(s *Session) (*mux.Pane, error) {
+	pane, err := enqueueSessionQueryOnState(s.context(), s, func(s *Session) (*mux.Pane, error) {
 		return s.findPaneByID(paneID), nil
 	})
 	if err != nil || pane == nil {

--- a/internal/server/session_events_client.go
+++ b/internal/server/session_events_client.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"errors"
 
 	"github.com/weill-labs/amux/internal/eventloop"
@@ -31,7 +32,7 @@ type attachClientEvent struct {
 	reply chan attachResult
 }
 
-func (e attachClientEvent) handle(s *Session) {
+func (e attachClientEvent) handle(_ context.Context, s *Session) {
 	e.reply <- s.handleAttachEvent(e.srv, e.cc, e.cols, e.rows)
 }
 
@@ -40,7 +41,7 @@ type detachClientEvent struct {
 	reason string
 }
 
-func (e detachClientEvent) handle(s *Session) {
+func (e detachClientEvent) handle(_ context.Context, s *Session) {
 	if !s.hasClient(e.cc) {
 		return
 	}
@@ -56,7 +57,7 @@ type resizeClientEvent struct {
 	rows int
 }
 
-func (e resizeClientEvent) handle(s *Session) {
+func (e resizeClientEvent) handle(_ context.Context, s *Session) {
 	e.cc.cols = e.cols
 	e.cc.rows = e.rows
 	s.noteClientActivity(e.cc)
@@ -70,7 +71,7 @@ type liveInputEvent struct {
 	epoch uint32
 }
 
-func (e liveInputEvent) handle(s *Session) {
+func (e liveInputEvent) handle(_ context.Context, s *Session) {
 	pane := s.ensureInputRouter().activeInputPaneForWriteOnActor(s, e.cc)
 	if pane == nil {
 		return
@@ -88,7 +89,7 @@ type liveInputPaneEvent struct {
 	epoch  uint32
 }
 
-func (e liveInputPaneEvent) handle(s *Session) {
+func (e liveInputPaneEvent) handle(_ context.Context, s *Session) {
 	pane := s.ensureInputRouter().paneByIDOnActor(s, e.paneID)
 	if pane == nil {
 		return
@@ -117,37 +118,54 @@ func (s *Session) logLiveInputError(paneID uint32, paneName string, err error) {
 }
 
 func (s *Session) enqueueAttachClient(srv *Server, cc *clientConn, cols, rows int) attachResult {
+	ctx := s.context()
+	if cc != nil {
+		ctx = cc.context()
+	}
 	reply := make(chan attachResult, 1)
-	if !s.enqueueEvent(attachClientEvent{
+	if !s.enqueueEvent(ctx, attachClientEvent{
 		srv:   srv,
 		cc:    cc,
 		cols:  cols,
 		rows:  rows,
 		reply: reply,
 	}) {
+		if err := ctx.Err(); err != nil {
+			return attachResult{err: err}
+		}
 		return attachResult{err: errSessionShuttingDown}
 	}
 	select {
 	case res := <-reply:
 		return res
+	case <-ctx.Done():
+		return attachResult{err: ctx.Err()}
 	case <-s.sessionEventDone:
 		return attachResult{err: errSessionShuttingDown}
 	}
 }
 
 func (s *Session) enqueueDetachClient(cc *clientConn, reason string) {
-	s.enqueueEvent(detachClientEvent{cc: cc, reason: reason})
+	s.enqueueEvent(s.context(), detachClientEvent{cc: cc, reason: reason})
 }
 
 func (s *Session) enqueueResizeClient(cc *clientConn, cols, rows int) {
-	s.enqueueEvent(resizeClientEvent{cc: cc, cols: cols, rows: rows})
+	ctx := s.context()
+	if cc != nil {
+		ctx = cc.context()
+	}
+	s.enqueueEvent(ctx, resizeClientEvent{cc: cc, cols: cols, rows: rows})
 }
 
 func (s *Session) enqueueLiveInputWithEpoch(cc *clientConn, data []byte, epoch uint32) bool {
 	if len(data) == 0 {
 		return true
 	}
-	return s.enqueueEvent(liveInputEvent{cc: cc, data: append([]byte(nil), data...), epoch: epoch})
+	ctx := s.context()
+	if cc != nil {
+		ctx = cc.context()
+	}
+	return s.enqueueEvent(ctx, liveInputEvent{cc: cc, data: append([]byte(nil), data...), epoch: epoch})
 }
 
 func (s *Session) enqueueLiveInputPane(paneID uint32, data []byte) bool {
@@ -158,7 +176,11 @@ func (s *Session) enqueueLiveInputPaneFromClient(cc *clientConn, paneID uint32, 
 	if len(data) == 0 {
 		return true
 	}
-	return s.enqueueEvent(liveInputPaneEvent{cc: cc, paneID: paneID, data: append([]byte(nil), data...), epoch: epoch})
+	ctx := s.context()
+	if cc != nil {
+		ctx = cc.context()
+	}
+	return s.enqueueEvent(ctx, liveInputPaneEvent{cc: cc, paneID: paneID, data: append([]byte(nil), data...), epoch: epoch})
 }
 
 // --- Event subscribe/unsubscribe through the event loop ---
@@ -187,7 +209,7 @@ type eventSubscribeCmd struct {
 	reply       chan eventSubscribeResult
 }
 
-func (e eventSubscribeCmd) handle(s *Session) {
+func (e eventSubscribeCmd) handle(_ context.Context, s *Session) {
 	sub := eventloop.Subscribe(&s.eventSubs, e.filter)
 
 	result := eventSubscribeResult{sub: sub}
@@ -203,7 +225,7 @@ type uiWaitSubscribeCmd struct {
 	reply             chan uiWaitSubscribeResult
 }
 
-func (e uiWaitSubscribeCmd) handle(s *Session) {
+func (e uiWaitSubscribeCmd) handle(_ context.Context, s *Session) {
 	client, err := s.resolveUIClientSnapshot(e.requestedClientID, e.eventName)
 	if err != nil {
 		e.reply <- uiWaitSubscribeResult{err: err}
@@ -227,7 +249,7 @@ type eventUnsubscribeCmd struct {
 	sub *eventSub
 }
 
-func (e eventUnsubscribeCmd) handle(s *Session) {
+func (e eventUnsubscribeCmd) handle(_ context.Context, s *Session) {
 	eventloop.Unsubscribe(&s.eventSubs, e.sub)
 }
 
@@ -238,7 +260,7 @@ type uiEventCmd struct {
 	uiEvent string
 }
 
-func (e uiEventCmd) handle(s *Session) {
+func (e uiEventCmd) handle(_ context.Context, s *Session) {
 	activityChanged := s.noteClientActivity(e.cc)
 	if e.uiEvent == proto.UIEventClientFocusGained {
 		if activityChanged {
@@ -269,14 +291,16 @@ func (e uiEventCmd) handle(s *Session) {
 
 // --- Enqueue helpers ---
 
-func (s *Session) enqueueEventSubscribe(f eventFilter, sendInitial bool) eventSubscribeResult {
+func (s *Session) enqueueEventSubscribe(ctx context.Context, f eventFilter, sendInitial bool) eventSubscribeResult {
 	reply := make(chan eventSubscribeResult, 1)
-	if !s.enqueueEvent(eventSubscribeCmd{filter: f, sendInitial: sendInitial, reply: reply}) {
+	if !s.enqueueEvent(ctx, eventSubscribeCmd{filter: f, sendInitial: sendInitial, reply: reply}) {
 		return eventSubscribeResult{}
 	}
 	select {
 	case res := <-reply:
 		return res
+	case <-ctx.Done():
+		return eventSubscribeResult{}
 	case <-s.sessionEventDone:
 		return eventSubscribeResult{}
 	}
@@ -286,15 +310,18 @@ func (s *Session) enqueueEventSubscribe(f eventFilter, sendInitial bool) eventSu
 // subscription, and snapshots whether the client already matches the requested
 // UI state in one event-loop turn. That closes the race where a UI transition
 // could land between a separate query and subscribe call.
-func (s *Session) enqueueUIWaitSubscribe(requestedClientID, eventName string) (uiWaitSubscription, error) {
+func (s *Session) enqueueUIWaitSubscribe(ctx context.Context, requestedClientID, eventName string) (uiWaitSubscription, error) {
 	var zero uiWaitSubscription
 
 	reply := make(chan uiWaitSubscribeResult, 1)
-	if !s.enqueueEvent(uiWaitSubscribeCmd{
+	if !s.enqueueEvent(ctx, uiWaitSubscribeCmd{
 		requestedClientID: requestedClientID,
 		eventName:         eventName,
 		reply:             reply,
 	}) {
+		if err := ctx.Err(); err != nil {
+			return zero, err
+		}
 		return zero, errSessionShuttingDown
 	}
 
@@ -304,6 +331,8 @@ func (s *Session) enqueueUIWaitSubscribe(requestedClientID, eventName string) (u
 			return zero, res.err
 		}
 		return res.subscription, nil
+	case <-ctx.Done():
+		return zero, ctx.Err()
 	case <-s.sessionEventDone:
 		select {
 		case res := <-reply:
@@ -318,11 +347,15 @@ func (s *Session) enqueueUIWaitSubscribe(requestedClientID, eventName string) (u
 }
 
 func (s *Session) enqueueEventUnsubscribe(sub *eventSub) {
-	s.enqueueEvent(eventUnsubscribeCmd{sub: sub})
+	s.enqueueEvent(s.context(), eventUnsubscribeCmd{sub: sub})
 }
 
 func (s *Session) enqueueUIEvent(cc *clientConn, uiEvent string) {
-	s.enqueueEvent(uiEventCmd{cc: cc, uiEvent: uiEvent})
+	ctx := s.context()
+	if cc != nil {
+		ctx = cc.context()
+	}
+	s.enqueueEvent(ctx, uiEventCmd{cc: cc, uiEvent: uiEvent})
 }
 
 func (s *Session) emitClientConnectEvent(cc *clientConn) {

--- a/internal/server/session_events_layout.go
+++ b/internal/server/session_events_layout.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"runtime/debug"
@@ -15,18 +16,18 @@ import (
 
 var errSessionShuttingDown = errors.New("session shutting down")
 
-type sessionEvent = eventloop.Command[Session]
+type sessionEvent = eventloop.QueuedCommand[Session]
 
 type sessionAction interface {
-	handle(*Session)
+	handle(context.Context, *Session)
 }
 
 type sessionEventCommand struct {
 	sessionAction
 }
 
-func (c sessionEventCommand) Handle(s *Session) {
-	c.sessionAction.handle(s)
+func (c sessionEventCommand) Handle(ctx context.Context, s *Session) {
+	c.sessionAction.handle(ctx, s)
 }
 
 func (c sessionEventCommand) EventLoopCommandType() string {
@@ -469,7 +470,7 @@ type commandMutationEvent struct {
 	reply chan commandMutationResult
 }
 
-func (e commandMutationEvent) handle(s *Session) {
+func (e commandMutationEvent) handle(eventCtx context.Context, s *Session) {
 	beforeActiveWindowID := s.ActiveWindowID
 	ctx := newMutationContext(s)
 	res := recoverCommandMutation(e.fn, ctx)
@@ -501,7 +502,10 @@ func (e commandMutationEvent) handle(s *Session) {
 		}
 		res.paneRenders = nil
 	}
-	e.reply <- res
+	select {
+	case e.reply <- res:
+	case <-eventCtx.Done():
+	}
 }
 
 func (s *Session) drainScheduledMutationPanes(ctx *MutationContext) {
@@ -525,10 +529,12 @@ func recoverCommandMutation(fn func(*MutationContext) commandMutationResult, ctx
 }
 
 func (s *Session) startEventLoop() {
+	s.sessionCtx, s.cancelSessionCtx = context.WithCancel(serverInternalContext())
 	s.sessionEvents = make(chan sessionEvent, 128)
 	s.sessionEventStop = make(chan struct{})
 	s.sessionEventDone = make(chan struct{})
 	go func() {
+		defer s.cancelSessionCtx()
 		eventloop.Run(s, s.sessionEvents, s.sessionEventStop, s.sessionEventDone, func(s *Session) bool {
 			// With the watchdog enabled, Command.Handle runs on eventloop's
 			// handler goroutine while this hook runs on the Run goroutine after
@@ -573,7 +579,7 @@ func (s *Session) HandleEventLoopWatchdogTimeout(info eventloop.WatchdogTimeoutI
 			"goroutine_id", info.GoroutineID,
 		)
 	}
-	closeStopSignal(s.sessionEventStop)
+	s.stopEventLoopSignal()
 	if s.exitServer != nil {
 		go s.exitServer.Shutdown()
 	}
@@ -588,8 +594,15 @@ func (s *Session) stopEventLoop() {
 		return
 	default:
 	}
-	closeStopSignal(s.sessionEventStop)
+	s.stopEventLoopSignal()
 	<-s.sessionEventDone
+}
+
+func (s *Session) stopEventLoopSignal() {
+	if s.cancelSessionCtx != nil {
+		s.cancelSessionCtx()
+	}
+	closeStopSignal(s.sessionEventStop)
 }
 
 func closeStopSignal(ch chan struct{}) {
@@ -601,21 +614,30 @@ func closeStopSignal(ch chan struct{}) {
 	close(ch)
 }
 
-func (s *Session) enqueueEvent(ev sessionAction) bool {
-	return eventloop.Enqueue(s.sessionEvents, s.sessionEventStop, sessionEventCommand{sessionAction: ev})
+func (s *Session) enqueueEvent(ctx context.Context, ev sessionAction) bool {
+	return eventloop.Enqueue(ctx, s.sessionEvents, s.sessionEventStop, sessionEventCommand{sessionAction: ev})
 }
 
 func (s *Session) enqueueCommandMutation(fn func(*MutationContext) commandMutationResult) commandMutationResult {
+	return s.enqueueCommandMutationContext(s.context(), fn)
+}
+
+func (s *Session) enqueueCommandMutationContext(ctx context.Context, fn func(*MutationContext) commandMutationResult) commandMutationResult {
 	reply := make(chan commandMutationResult, 1)
-	if !s.enqueueEvent(commandMutationEvent{
+	if !s.enqueueEvent(ctx, commandMutationEvent{
 		fn:    fn,
 		reply: reply,
 	}) {
+		if err := ctx.Err(); err != nil {
+			return commandMutationResult{err: err}
+		}
 		return commandMutationResult{err: errSessionShuttingDown}
 	}
 	select {
 	case res := <-reply:
 		return res
+	case <-ctx.Done():
+		return commandMutationResult{err: ctx.Err()}
 	case <-s.sessionEventDone:
 		// The event loop exited (e.g., wantShutdown after our handler).
 		// The reply may already be buffered — prefer it over the error.

--- a/internal/server/session_events_pane.go
+++ b/internal/server/session_events_pane.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -14,7 +15,7 @@ type paneOutputEvent struct {
 	seq    uint64
 }
 
-func (e paneOutputEvent) handle(s *Session) {
+func (e paneOutputEvent) handle(_ context.Context, s *Session) {
 	s.broadcastPaneOutputNow(e.paneID, e.data, e.seq)
 }
 
@@ -23,7 +24,7 @@ type paneExitEvent struct {
 	reason string
 }
 
-func (e paneExitEvent) handle(s *Session) {
+func (e paneExitEvent) handle(_ context.Context, s *Session) {
 	if s.shutdown.Load() {
 		return
 	}
@@ -65,7 +66,7 @@ type clipboardEvent struct {
 	data   []byte
 }
 
-func (e clipboardEvent) handle(s *Session) {
+func (e clipboardEvent) handle(_ context.Context, s *Session) {
 	if s.shutdown.Load() {
 		return
 	}
@@ -77,7 +78,7 @@ type crashCheckpointWrittenEvent struct {
 	path string
 }
 
-func (e crashCheckpointWrittenEvent) handle(s *Session) {
+func (e crashCheckpointWrittenEvent) handle(_ context.Context, s *Session) {
 	if e.path == "" {
 		return
 	}
@@ -88,7 +89,7 @@ type idleTimeoutEvent struct {
 	paneID uint32
 }
 
-func (e idleTimeoutEvent) handle(s *Session) {
+func (e idleTimeoutEvent) handle(_ context.Context, s *Session) {
 	s.ensureIdleTracker().HandleIdleTimeout(e.paneID)
 
 	// Refresh CWD/branch off the event loop to avoid blocking on lsof/git.
@@ -98,7 +99,7 @@ func (e idleTimeoutEvent) handle(s *Session) {
 		pane := p
 		go func() {
 			cwd, branch := s.detectPaneCwdBranch(pane)
-			s.enqueueEvent(cwdBranchResultEvent{paneID: e.paneID, cwd: cwd, branch: branch})
+			s.enqueueEvent(s.context(), cwdBranchResultEvent{paneID: e.paneID, cwd: cwd, branch: branch})
 		}()
 	}
 
@@ -130,7 +131,7 @@ type vtIdleTimeoutEvent struct {
 	lastOutput time.Time
 }
 
-func (e vtIdleTimeoutEvent) handle(s *Session) {
+func (e vtIdleTimeoutEvent) handle(_ context.Context, s *Session) {
 	if !s.ensureIdleTracker().HandleVTIdleTimeout(e.paneID, e.lastOutput) {
 		return
 	}
@@ -143,7 +144,7 @@ type agentIdleCheckResultEvent struct {
 	idle     bool
 }
 
-func (e agentIdleCheckResultEvent) handle(s *Session) {
+func (e agentIdleCheckResultEvent) handle(_ context.Context, s *Session) {
 	if !e.idle {
 		return
 	}
@@ -161,7 +162,7 @@ type cwdBranchResultEvent struct {
 	branch string
 }
 
-func (e cwdBranchResultEvent) handle(s *Session) {
+func (e cwdBranchResultEvent) handle(_ context.Context, s *Session) {
 	if p := s.findPaneByID(e.paneID); p != nil {
 		p.ApplyCwdBranch(e.cwd, e.branch)
 		s.broadcastLayoutNow()
@@ -173,7 +174,7 @@ type metaUpdateEvent struct {
 	update mux.MetaUpdate
 }
 
-func (e metaUpdateEvent) handle(s *Session) {
+func (e metaUpdateEvent) handle(_ context.Context, s *Session) {
 	p := s.findPaneByID(e.paneID)
 	if p == nil {
 		return
@@ -196,7 +197,7 @@ type takeoverEvent struct {
 	req    mux.TakeoverRequest
 }
 
-func (e takeoverEvent) handle(s *Session) {
+func (e takeoverEvent) handle(_ context.Context, s *Session) {
 	go s.handleTakeover(e.paneID, e.req)
 }
 
@@ -205,7 +206,7 @@ type remotePaneExitEvent struct {
 	reason string
 }
 
-func (e remotePaneExitEvent) handle(s *Session) {
+func (e remotePaneExitEvent) handle(_ context.Context, s *Session) {
 	if s.shutdown.Load() {
 		return
 	}
@@ -217,7 +218,7 @@ type remoteStateChangeEvent struct {
 	state    proto.ConnState
 }
 
-func (e remoteStateChangeEvent) handle(s *Session) {
+func (e remoteStateChangeEvent) handle(_ context.Context, s *Session) {
 	if rs := s.remoteSessions[e.hostName]; rs != nil {
 		rs.State = e.state
 	}
@@ -234,7 +235,7 @@ type remoteLayoutEvent struct {
 	layout   *proto.LayoutSnapshot
 }
 
-func (e remoteLayoutEvent) handle(s *Session) {
+func (e remoteLayoutEvent) handle(_ context.Context, s *Session) {
 	rs := s.remoteSessions[e.hostName]
 	if rs == nil || e.layout == nil {
 		return
@@ -253,7 +254,7 @@ type localPaneBuildResultEvent struct {
 	done        chan error
 }
 
-func (e localPaneBuildResultEvent) handle(s *Session) {
+func (e localPaneBuildResultEvent) handle(_ context.Context, s *Session) {
 	notify := func(err error) {
 		if e.done == nil {
 			return
@@ -317,39 +318,39 @@ func (e localPaneBuildResultEvent) handle(s *Session) {
 }
 
 func (s *Session) enqueuePaneOutput(paneID uint32, data []byte, seq uint64) {
-	s.enqueueEvent(paneOutputEvent{paneID: paneID, data: data, seq: seq})
+	s.enqueueEvent(s.context(), paneOutputEvent{paneID: paneID, data: data, seq: seq})
 }
 
 func (s *Session) enqueuePaneExit(paneID uint32, reason string) {
-	s.enqueueEvent(paneExitEvent{paneID: paneID, reason: reason})
+	s.enqueueEvent(s.context(), paneExitEvent{paneID: paneID, reason: reason})
 }
 
 func (s *Session) enqueueClipboard(paneID uint32, data []byte) {
-	s.enqueueEvent(clipboardEvent{paneID: paneID, data: data})
+	s.enqueueEvent(s.context(), clipboardEvent{paneID: paneID, data: data})
 }
 
 func (s *Session) enqueueIdleTimeout(paneID uint32) {
-	s.enqueueEvent(idleTimeoutEvent{paneID: paneID})
+	s.enqueueEvent(s.context(), idleTimeoutEvent{paneID: paneID})
 }
 
 func (s *Session) enqueueVTIdleTimeout(paneID uint32, lastOutput time.Time) {
-	s.enqueueEvent(vtIdleTimeoutEvent{paneID: paneID, lastOutput: lastOutput})
+	s.enqueueEvent(s.context(), vtIdleTimeoutEvent{paneID: paneID, lastOutput: lastOutput})
 }
 
 func (s *Session) enqueueTakeover(srv *Server, paneID uint32, req mux.TakeoverRequest) {
-	s.enqueueEvent(takeoverEvent{srv: srv, paneID: paneID, req: req})
+	s.enqueueEvent(s.context(), takeoverEvent{srv: srv, paneID: paneID, req: req})
 }
 
 func (s *Session) enqueueRemotePaneExit(paneID uint32, reason string) {
-	s.enqueueEvent(remotePaneExitEvent{paneID: paneID, reason: reason})
+	s.enqueueEvent(s.context(), remotePaneExitEvent{paneID: paneID, reason: reason})
 }
 
 func (s *Session) enqueueRemoteStateChange(hostName string, state proto.ConnState) {
-	s.enqueueEvent(remoteStateChangeEvent{hostName: hostName, state: state})
+	s.enqueueEvent(s.context(), remoteStateChangeEvent{hostName: hostName, state: state})
 }
 
 func (s *Session) enqueueRemoteLayout(hostName string, layout *proto.LayoutSnapshot) {
-	s.enqueueEvent(remoteLayoutEvent{hostName: hostName, layout: layout})
+	s.enqueueEvent(s.context(), remoteLayoutEvent{hostName: hostName, layout: layout})
 }
 
 // --- Pane output subscribe/unsubscribe through the event loop ---
@@ -359,7 +360,7 @@ type paneOutputSubscribeCmd struct {
 	reply  chan chan struct{}
 }
 
-func (e paneOutputSubscribeCmd) handle(s *Session) {
+func (e paneOutputSubscribeCmd) handle(_ context.Context, s *Session) {
 	ch := s.addPaneOutputSubscriber(e.paneID)
 	e.reply <- ch
 }
@@ -369,23 +370,25 @@ type paneOutputUnsubscribeCmd struct {
 	ch     chan struct{}
 }
 
-func (e paneOutputUnsubscribeCmd) handle(s *Session) {
+func (e paneOutputUnsubscribeCmd) handle(_ context.Context, s *Session) {
 	s.ensureWaiters().removePaneOutputSubscriber(e.paneID, e.ch)
 }
 
-func (s *Session) enqueuePaneOutputSubscribe(paneID uint32) chan struct{} {
+func (s *Session) enqueuePaneOutputSubscribe(ctx context.Context, paneID uint32) chan struct{} {
 	reply := make(chan (chan struct{}), 1)
-	if !s.enqueueEvent(paneOutputSubscribeCmd{paneID: paneID, reply: reply}) {
+	if !s.enqueueEvent(ctx, paneOutputSubscribeCmd{paneID: paneID, reply: reply}) {
 		return nil
 	}
 	select {
 	case ch := <-reply:
 		return ch
+	case <-ctx.Done():
+		return nil
 	case <-s.sessionEventDone:
 		return nil
 	}
 }
 
 func (s *Session) enqueuePaneOutputUnsubscribe(paneID uint32, ch chan struct{}) {
-	s.enqueueEvent(paneOutputUnsubscribeCmd{paneID: paneID, ch: ch})
+	s.enqueueEvent(s.context(), paneOutputUnsubscribeCmd{paneID: paneID, ch: ch})
 }

--- a/internal/server/session_events_test.go
+++ b/internal/server/session_events_test.go
@@ -117,7 +117,7 @@ func TestHandleAttachEventEmitsClientConnect(t *testing.T) {
 	sess.ActiveWindowID = w.ID
 	sess.Panes = []*mux.Pane{pane}
 
-	res := sess.enqueueEventSubscribe(eventFilter{Types: []string{EventClientConnect}}, false)
+	res := sess.enqueueEventSubscribe(sess.context(), eventFilter{Types: []string{EventClientConnect}}, false)
 	defer sess.enqueueEventUnsubscribe(res.sub)
 
 	cc := &clientConn{ID: "client-1", inputIdle: true}
@@ -423,7 +423,7 @@ func TestLiveInputEventDoesNotBlockWhenPacedInputQueueIsFull(t *testing.T) {
 		return len(data), nil
 	})
 
-	_, err := enqueueSessionQuery(sess, func(sess *Session) (struct{}, error) {
+	_, err := enqueueSessionQueryLegacy(sess.context(), sess, func(sess *Session) (struct{}, error) {
 		return struct{}{}, sess.enqueueLivePaneInput(pane, []byte("blocked"))
 	})
 	if err != nil {
@@ -444,13 +444,13 @@ func TestLiveInputEventDoesNotBlockWhenPacedInputQueueIsFull(t *testing.T) {
 		}
 	}
 
-	if !sess.enqueueEvent(liveInputEvent{data: []byte("overflow")}) {
+	if !sess.enqueueEvent(sess.context(), liveInputEvent{data: []byte("overflow")}) {
 		t.Fatal("enqueueEvent(liveInputEvent) = false, want true")
 	}
 
 	actorReady := make(chan error, 1)
 	go func() {
-		_, err := enqueueSessionQuery(sess, func(*Session) (struct{}, error) {
+		_, err := enqueueSessionQueryLegacy(sess.context(), sess, func(*Session) (struct{}, error) {
 			return struct{}{}, nil
 		})
 		actorReady <- err
@@ -581,10 +581,10 @@ func TestPaneOutputCallbackEnqueuesOutputNotifications(t *testing.T) {
 	}, 80, 23, nil, nil, func(data []byte) (int, error) { return len(data), nil })
 	sess.Panes = []*mux.Pane{pane}
 
-	res := sess.enqueueEventSubscribe(eventFilter{Types: []string{EventOutput}}, false)
+	res := sess.enqueueEventSubscribe(sess.context(), eventFilter{Types: []string{EventOutput}}, false)
 	defer sess.enqueueEventUnsubscribe(res.sub)
 
-	waitCh := sess.enqueuePaneOutputSubscribe(pane.ID)
+	waitCh := sess.enqueuePaneOutputSubscribe(sess.context(), pane.ID)
 	defer sess.enqueuePaneOutputUnsubscribe(pane.ID, waitCh)
 
 	sess.paneOutputCallback()(pane.ID, []byte("hello"), 1)
@@ -1286,7 +1286,7 @@ func TestDetachClientEventEmitsDisconnectReason(t *testing.T) {
 		return struct{}{}
 	})
 
-	res := sess.enqueueEventSubscribe(eventFilter{Types: []string{EventClientDisconnect}}, false)
+	res := sess.enqueueEventSubscribe(sess.context(), eventFilter{Types: []string{EventClientDisconnect}}, false)
 	defer sess.enqueueEventUnsubscribe(res.sub)
 
 	sess.enqueueDetachClient(cc, DisconnectReasonExplicitDetach)
@@ -1332,10 +1332,10 @@ func TestDisconnectClientsForReloadEmitsDisconnectWithoutLayoutMutation(t *testi
 		return struct{}{}
 	})
 
-	res := sess.enqueueEventSubscribe(eventFilter{Types: []string{EventClientDisconnect}}, false)
+	res := sess.enqueueEventSubscribe(sess.context(), eventFilter{Types: []string{EventClientDisconnect}}, false)
 	defer sess.enqueueEventUnsubscribe(res.sub)
 
-	if _, err := enqueueSessionQuery(sess, func(sess *Session) (struct{}, error) {
+	if _, err := enqueueSessionQueryLegacy(sess.context(), sess, func(sess *Session) (struct{}, error) {
 		sess.disconnectClientsForReload([]*clientConn{cc1, cc2})
 		return struct{}{}, nil
 	}); err != nil {
@@ -1424,7 +1424,7 @@ func TestEnqueueUIWaitSubscribeAvoidsStaleSnapshotGap(t *testing.T) {
 		})
 	})
 
-	naiveSub := sess.enqueueEventSubscribe(eventFilter{
+	naiveSub := sess.enqueueEventSubscribe(sess.context(), eventFilter{
 		Types:    []string{proto.UIEventCopyModeHidden},
 		ClientID: cc.ID,
 	}, false)
@@ -1435,7 +1435,7 @@ func TestEnqueueUIWaitSubscribeAvoidsStaleSnapshotGap(t *testing.T) {
 	default:
 	}
 
-	atomicSub, err := sess.enqueueUIWaitSubscribe("", proto.UIEventCopyModeHidden)
+	atomicSub, err := sess.enqueueUIWaitSubscribe(sess.context(), "", proto.UIEventCopyModeHidden)
 	if err != nil {
 		t.Fatalf("enqueueUIWaitSubscribe: %v", err)
 	}
@@ -1458,7 +1458,7 @@ func TestEnqueueUIWaitSubscribeAvoidsStaleSnapshotGap(t *testing.T) {
 		})
 	})
 
-	futureSub, err := sess.enqueueUIWaitSubscribe("", proto.UIEventCopyModeHidden)
+	futureSub, err := sess.enqueueUIWaitSubscribe(sess.context(), "", proto.UIEventCopyModeHidden)
 	if err != nil {
 		t.Fatalf("enqueueUIWaitSubscribe future: %v", err)
 	}
@@ -1506,7 +1506,7 @@ func TestMetaUpdateEventSetsTaskAndPR(t *testing.T) {
 
 	task := "deploy"
 	pr := "99"
-	metaUpdateEvent{paneID: 1, update: mux.MetaUpdate{Task: &task, PR: &pr}}.handle(sess)
+	metaUpdateEvent{paneID: 1, update: mux.MetaUpdate{Task: &task, PR: &pr}}.handle(sess.context(), sess)
 
 	if pane.Meta.Task != "deploy" {
 		t.Fatalf("task = %q, want %q", pane.Meta.Task, "deploy")
@@ -1536,7 +1536,7 @@ func TestMetaUpdateEventSetsBranchManual(t *testing.T) {
 	sess.Panes = []*mux.Pane{pane}
 
 	branch := "feat/manual"
-	metaUpdateEvent{paneID: 1, update: mux.MetaUpdate{Branch: &branch}}.handle(sess)
+	metaUpdateEvent{paneID: 1, update: mux.MetaUpdate{Branch: &branch}}.handle(sess.context(), sess)
 
 	if pane.Meta.GitBranch != "feat/manual" {
 		t.Fatalf("git_branch = %q, want %q", pane.Meta.GitBranch, "feat/manual")
@@ -1571,7 +1571,7 @@ func TestMetaUpdateEventClearsBranch(t *testing.T) {
 	sess.Panes = []*mux.Pane{pane}
 
 	empty := ""
-	metaUpdateEvent{paneID: 1, update: mux.MetaUpdate{Branch: &empty}}.handle(sess)
+	metaUpdateEvent{paneID: 1, update: mux.MetaUpdate{Branch: &empty}}.handle(sess.context(), sess)
 
 	if pane.Meta.GitBranch != "" {
 		t.Fatalf("git_branch = %q, want empty after clear", pane.Meta.GitBranch)
@@ -1629,7 +1629,7 @@ func TestMetaUpdateEventIgnoresMissingPane(t *testing.T) {
 
 	// No panes in session; should not panic
 	task := "x"
-	metaUpdateEvent{paneID: 999, update: mux.MetaUpdate{Task: &task}}.handle(sess)
+	metaUpdateEvent{paneID: 999, update: mux.MetaUpdate{Task: &task}}.handle(sess.context(), sess)
 }
 
 func TestCwdBranchResultEventUpdatesPane(t *testing.T) {
@@ -1651,7 +1651,7 @@ func TestCwdBranchResultEventUpdatesPane(t *testing.T) {
 	sess.ActiveWindowID = w.ID
 	sess.Panes = []*mux.Pane{pane}
 
-	cwdBranchResultEvent{paneID: 1, cwd: "/home/user/repo", branch: "main"}.handle(sess)
+	cwdBranchResultEvent{paneID: 1, cwd: "/home/user/repo", branch: "main"}.handle(sess.context(), sess)
 
 	if pane.LiveCwd() != "/home/user/repo" {
 		t.Fatalf("liveCwd = %q, want %q", pane.LiveCwd(), "/home/user/repo")
@@ -1669,7 +1669,7 @@ func TestCwdBranchResultEventIgnoresMissingPane(t *testing.T) {
 	defer stopSessionBackgroundLoops(t, sess)
 
 	// No panes; should not panic
-	cwdBranchResultEvent{paneID: 999, cwd: "/tmp", branch: "main"}.handle(sess)
+	cwdBranchResultEvent{paneID: 999, cwd: "/tmp", branch: "main"}.handle(sess.context(), sess)
 }
 
 func TestIdleTimeoutEventRefreshesPaneMetaWhenAutoRefreshEnabled(t *testing.T) {
@@ -1807,7 +1807,7 @@ func TestIdleTimeoutEventEmitsExitedWhenPaneHasNoChildren(t *testing.T) {
 	sess.ActiveWindowID = w.ID
 	sess.Panes = []*mux.Pane{pane}
 
-	res := sess.enqueueEventSubscribe(eventFilter{Types: []string{EventExited}}, false)
+	res := sess.enqueueEventSubscribe(sess.context(), eventFilter{Types: []string{EventExited}}, false)
 	if res.sub == nil {
 		t.Fatal("exited subscribe returned nil subscription")
 	}
@@ -1849,7 +1849,7 @@ func TestIdleTimeoutEventEmitsExitedAsyncWithoutBlockingLoop(t *testing.T) {
 	sess.Panes = []*mux.Pane{pane}
 
 	// Subscribe to both idle and exited events to verify ordering.
-	res := sess.enqueueEventSubscribe(eventFilter{Types: []string{EventIdle, EventExited}}, false)
+	res := sess.enqueueEventSubscribe(sess.context(), eventFilter{Types: []string{EventIdle, EventExited}}, false)
 	if res.sub == nil {
 		t.Fatal("subscribe returned nil")
 	}
@@ -1904,7 +1904,7 @@ func TestIdleTimeoutEventSkipsExitedWhenPaneIsBusy(t *testing.T) {
 	sess.ActiveWindowID = w.ID
 	sess.Panes = []*mux.Pane{pane}
 
-	res := sess.enqueueEventSubscribe(eventFilter{Types: []string{EventExited}}, false)
+	res := sess.enqueueEventSubscribe(sess.context(), eventFilter{Types: []string{EventExited}}, false)
 	if res.sub == nil {
 		t.Fatal("subscribe returned nil")
 	}
@@ -1912,7 +1912,7 @@ func TestIdleTimeoutEventSkipsExitedWhenPaneIsBusy(t *testing.T) {
 
 	// Directly enqueue a non-idle result — this simulates AgentStatus
 	// reporting the pane as busy.
-	sess.enqueueEvent(agentIdleCheckResultEvent{
+	sess.enqueueEvent(sess.context(), agentIdleCheckResultEvent{
 		paneID:   pane.ID,
 		paneName: "pane-1",
 		host:     mux.DefaultHost,
@@ -1920,7 +1920,7 @@ func TestIdleTimeoutEventSkipsExitedWhenPaneIsBusy(t *testing.T) {
 	})
 
 	// Enqueue a no-op event after to ensure the result was processed.
-	sess.enqueueEvent(crashCheckpointWrittenEvent{path: ""})
+	sess.enqueueEvent(sess.context(), crashCheckpointWrittenEvent{path: ""})
 
 	// No EventExited should arrive.
 	select {
@@ -1941,7 +1941,7 @@ func TestStopSessionBackgroundLoopsKeepsLateEnqueueClosed(t *testing.T) {
 	if sess.sessionEventStop == nil {
 		t.Fatal("sessionEventStop = nil, want closed channel retained")
 	}
-	if sess.enqueueEvent(crashCheckpointWrittenEvent{path: "/tmp/checkpoint.json"}) {
+	if sess.enqueueEvent(sess.context(), crashCheckpointWrittenEvent{path: "/tmp/checkpoint.json"}) {
 		t.Fatal("enqueueEvent() = true after stop, want false")
 	}
 }
@@ -1985,17 +1985,17 @@ func TestUIEventCmdIncrementsClientGenerationOnlyOnRealChanges(t *testing.T) {
 
 	cc := &clientConn{ID: "client-1", inputIdle: true}
 
-	uiEventCmd{cc: cc, uiEvent: proto.UIEventInputBusy}.handle(sess)
+	uiEventCmd{cc: cc, uiEvent: proto.UIEventInputBusy}.handle(sess.context(), sess)
 	if cc.uiGeneration != 1 {
 		t.Fatalf("uiGeneration after first busy = %d, want 1", cc.uiGeneration)
 	}
 
-	uiEventCmd{cc: cc, uiEvent: proto.UIEventInputBusy}.handle(sess)
+	uiEventCmd{cc: cc, uiEvent: proto.UIEventInputBusy}.handle(sess.context(), sess)
 	if cc.uiGeneration != 1 {
 		t.Fatalf("uiGeneration after duplicate busy = %d, want 1", cc.uiGeneration)
 	}
 
-	uiEventCmd{cc: cc, uiEvent: proto.UIEventInputIdle}.handle(sess)
+	uiEventCmd{cc: cc, uiEvent: proto.UIEventInputIdle}.handle(sess.context(), sess)
 	if cc.uiGeneration != 2 {
 		t.Fatalf("uiGeneration after idle = %d, want 2", cc.uiGeneration)
 	}
@@ -2010,12 +2010,12 @@ func TestUIEventCmdClientFocusAlwaysIncrementsGeneration(t *testing.T) {
 
 	cc := &clientConn{ID: "client-1", inputIdle: true}
 
-	uiEventCmd{cc: cc, uiEvent: proto.UIEventClientFocusGained}.handle(sess)
+	uiEventCmd{cc: cc, uiEvent: proto.UIEventClientFocusGained}.handle(sess.context(), sess)
 	if cc.uiGeneration != 1 {
 		t.Fatalf("uiGeneration after first client focus = %d, want 1", cc.uiGeneration)
 	}
 
-	uiEventCmd{cc: cc, uiEvent: proto.UIEventClientFocusGained}.handle(sess)
+	uiEventCmd{cc: cc, uiEvent: proto.UIEventClientFocusGained}.handle(sess.context(), sess)
 	if cc.uiGeneration != 2 {
 		t.Fatalf("uiGeneration after second client focus = %d, want 2", cc.uiGeneration)
 	}

--- a/internal/server/session_events_test.go
+++ b/internal/server/session_events_test.go
@@ -423,7 +423,7 @@ func TestLiveInputEventDoesNotBlockWhenPacedInputQueueIsFull(t *testing.T) {
 		return len(data), nil
 	})
 
-	_, err := enqueueSessionQueryLegacy(sess.context(), sess, func(sess *Session) (struct{}, error) {
+	_, err := enqueueSessionQueryOnState(sess.context(), sess, func(sess *Session) (struct{}, error) {
 		return struct{}{}, sess.enqueueLivePaneInput(pane, []byte("blocked"))
 	})
 	if err != nil {
@@ -450,7 +450,7 @@ func TestLiveInputEventDoesNotBlockWhenPacedInputQueueIsFull(t *testing.T) {
 
 	actorReady := make(chan error, 1)
 	go func() {
-		_, err := enqueueSessionQueryLegacy(sess.context(), sess, func(*Session) (struct{}, error) {
+		_, err := enqueueSessionQueryOnState(sess.context(), sess, func(*Session) (struct{}, error) {
 			return struct{}{}, nil
 		})
 		actorReady <- err
@@ -1335,7 +1335,7 @@ func TestDisconnectClientsForReloadEmitsDisconnectWithoutLayoutMutation(t *testi
 	res := sess.enqueueEventSubscribe(sess.context(), eventFilter{Types: []string{EventClientDisconnect}}, false)
 	defer sess.enqueueEventUnsubscribe(res.sub)
 
-	if _, err := enqueueSessionQueryLegacy(sess.context(), sess, func(sess *Session) (struct{}, error) {
+	if _, err := enqueueSessionQueryOnState(sess.context(), sess, func(sess *Session) (struct{}, error) {
 		sess.disconnectClientsForReload([]*clientConn{cc1, cc2})
 		return struct{}{}, nil
 	}); err != nil {

--- a/internal/server/session_notice.go
+++ b/internal/server/session_notice.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"os"
 	"time"
 )
@@ -16,7 +17,7 @@ type sessionNoticeSetCmd struct {
 	reply   chan sessionNoticeSetResult
 }
 
-func (e sessionNoticeSetCmd) handle(s *Session) {
+func (e sessionNoticeSetCmd) handle(_ context.Context, s *Session) {
 	s.notice = e.message
 	s.noticeToken++
 	token := s.noticeToken
@@ -28,7 +29,7 @@ type sessionNoticeClearCmd struct {
 	token uint64
 }
 
-func (e sessionNoticeClearCmd) handle(s *Session) {
+func (e sessionNoticeClearCmd) handle(_ context.Context, s *Session) {
 	if e.token != s.noticeToken || s.notice == "" {
 		return
 	}
@@ -59,7 +60,7 @@ func (s *Session) showSessionNotice(message string) {
 
 func (s *Session) enqueueSessionNoticeSet(message string) sessionNoticeSetResult {
 	reply := make(chan sessionNoticeSetResult, 1)
-	if !s.enqueueEvent(sessionNoticeSetCmd{message: message, reply: reply}) {
+	if !s.enqueueEvent(s.context(), sessionNoticeSetCmd{message: message, reply: reply}) {
 		return sessionNoticeSetResult{}
 	}
 
@@ -77,7 +78,7 @@ func (s *Session) enqueueSessionNoticeSet(message string) sessionNoticeSetResult
 }
 
 func (s *Session) enqueueSessionNoticeClear(token uint64) {
-	s.enqueueEvent(sessionNoticeClearCmd{token: token})
+	s.enqueueEvent(s.context(), sessionNoticeClearCmd{token: token})
 }
 
 func sessionNoticeDuration() time.Duration {

--- a/internal/server/session_notice_test.go
+++ b/internal/server/session_notice_test.go
@@ -32,19 +32,19 @@ func TestShowSessionNoticeReplacementIgnoresStaleTimer(t *testing.T) {
 	sess := &Session{idle: NewIdleTracker(nil), takenOverPanes: make(map[uint32]bool)}
 
 	firstReply := make(chan sessionNoticeSetResult, 1)
-	sessionNoticeSetCmd{message: "first", reply: firstReply}.handle(sess)
+	sessionNoticeSetCmd{message: "first", reply: firstReply}.handle(sess.context(), sess)
 	firstToken := (<-firstReply).token
 
 	secondReply := make(chan sessionNoticeSetResult, 1)
-	sessionNoticeSetCmd{message: "second", reply: secondReply}.handle(sess)
+	sessionNoticeSetCmd{message: "second", reply: secondReply}.handle(sess.context(), sess)
 	secondToken := (<-secondReply).token
 
-	sessionNoticeClearCmd{token: firstToken}.handle(sess)
+	sessionNoticeClearCmd{token: firstToken}.handle(sess.context(), sess)
 	if got := sess.notice; got != "second" {
 		t.Fatalf("notice after stale clear = %q, want %q", got, "second")
 	}
 
-	sessionNoticeClearCmd{token: secondToken}.handle(sess)
+	sessionNoticeClearCmd{token: secondToken}.handle(sess.context(), sess)
 	if got := sess.notice; got != "" {
 		t.Fatalf("notice after matching clear = %q, want empty", got)
 	}

--- a/internal/server/session_pane.go
+++ b/internal/server/session_pane.go
@@ -173,7 +173,7 @@ func (s *Session) startPendingLocalPaneBuild(srv *Server, placeholder *mux.Pane,
 	go func() {
 		defer s.localPaneBuilds.Done()
 		pane, err := s.buildConfiguredLocalPane(srv, req)
-		if s.enqueueEvent(localPaneBuildResultEvent{
+		if s.enqueueEvent(s.context(), localPaneBuildResultEvent{
 			placeholder: placeholder,
 			pane:        pane,
 			err:         err,

--- a/internal/server/session_queries.go
+++ b/internal/server/session_queries.go
@@ -236,7 +236,7 @@ func (s *Session) queryActiveWindowSnapshot() (activeWindowSnapshot, error) {
 }
 
 func (s *Session) queryActiveWindowSnapshotContext(ctx context.Context) (activeWindowSnapshot, error) {
-	return enqueueSessionQueryLegacy(ctx, s, func(s *Session) (activeWindowSnapshot, error) {
+	return enqueueSessionQueryOnState(ctx, s, func(s *Session) (activeWindowSnapshot, error) {
 		w := s.activeWindow()
 		if w == nil {
 			return activeWindowSnapshot{}, fmt.Errorf("no window")
@@ -261,7 +261,7 @@ func (s *Session) queryResolvedPaneForActor(actorPaneID uint32, ref string) (res
 }
 
 func (s *Session) queryResolvedPaneForActorContext(ctx context.Context, actorPaneID uint32, ref string) (resolvedPaneRef, error) {
-	return enqueueSessionQueryLegacy(ctx, s, func(s *Session) (resolvedPaneRef, error) {
+	return enqueueSessionQueryOnState(ctx, s, func(s *Session) (resolvedPaneRef, error) {
 		pane, w, err := s.resolvePaneAcrossWindowsForActor(actorPaneID, ref)
 		if err != nil {
 			return resolvedPaneRef{}, err
@@ -284,7 +284,7 @@ func (s *Session) queryActivePaneForWindow(ref string) (resolvedPaneRef, error) 
 }
 
 func (s *Session) queryActivePaneForWindowContext(ctx context.Context, ref string) (resolvedPaneRef, error) {
-	return enqueueSessionQueryLegacy(ctx, s, func(s *Session) (resolvedPaneRef, error) {
+	return enqueueSessionQueryOnState(ctx, s, func(s *Session) (resolvedPaneRef, error) {
 		w := s.resolveWindow(ref)
 		if w == nil {
 			return resolvedPaneRef{}, fmt.Errorf("window %q not found", ref)
@@ -307,7 +307,7 @@ func (s *Session) queryKillTarget(actorPaneID uint32, ref string) (killTargetSna
 }
 
 func (s *Session) queryKillTargetContext(ctx context.Context, actorPaneID uint32, ref string) (killTargetSnapshot, error) {
-	return enqueueSessionQueryLegacy(ctx, s, func(s *Session) (killTargetSnapshot, error) {
+	return enqueueSessionQueryOnState(ctx, s, func(s *Session) (killTargetSnapshot, error) {
 		var pane *mux.Pane
 		if ref == "" {
 			w := s.windowForActor(actorPaneID)
@@ -335,7 +335,7 @@ func (s *Session) queryPaneList() ([]paneListEntry, error) {
 }
 
 func (s *Session) queryPaneListContext(ctx context.Context) ([]paneListEntry, error) {
-	return enqueueSessionQueryLegacy(ctx, s, func(s *Session) ([]paneListEntry, error) {
+	return enqueueSessionQueryOnState(ctx, s, func(s *Session) ([]paneListEntry, error) {
 		entries := make([]paneListEntry, 0, len(s.Panes))
 		w := s.activeWindow()
 		now := s.clock().Now()
@@ -405,7 +405,7 @@ func (s *Session) querySessionStatus() (sessionStatusSnapshot, error) {
 }
 
 func (s *Session) querySessionStatusContext(ctx context.Context) (sessionStatusSnapshot, error) {
-	return enqueueSessionQueryLegacy(ctx, s, func(s *Session) (sessionStatusSnapshot, error) {
+	return enqueueSessionQueryOnState(ctx, s, func(s *Session) (sessionStatusSnapshot, error) {
 		snap := sessionStatusSnapshot{
 			total:       len(s.Panes),
 			windowCount: len(s.Windows),
@@ -424,7 +424,7 @@ func (s *Session) queryWindowList() ([]windowListEntry, error) {
 }
 
 func (s *Session) queryWindowListContext(ctx context.Context) ([]windowListEntry, error) {
-	return enqueueSessionQueryLegacy(ctx, s, func(s *Session) ([]windowListEntry, error) {
+	return enqueueSessionQueryOnState(ctx, s, func(s *Session) ([]windowListEntry, error) {
 		entries := make([]windowListEntry, 0, len(s.Windows))
 		for i, w := range s.Windows {
 			entries = append(entries, windowListEntry{
@@ -444,7 +444,7 @@ func (s *Session) queryClientList() ([]clientListEntry, error) {
 }
 
 func (s *Session) queryClientListContext(ctx context.Context) ([]clientListEntry, error) {
-	return enqueueSessionQueryLegacy(ctx, s, func(s *Session) ([]clientListEntry, error) {
+	return enqueueSessionQueryOnState(ctx, s, func(s *Session) ([]clientListEntry, error) {
 		clients := s.ensureClientManager().clients
 		entries := make([]clientListEntry, 0, len(clients))
 		sizeOwner := s.effectiveSizeClient()
@@ -467,7 +467,7 @@ func (s *Session) queryConnectionLog() ([]ConnectionLogEntry, error) {
 }
 
 func (s *Session) queryConnectionLogContext(ctx context.Context) ([]ConnectionLogEntry, error) {
-	return enqueueSessionQueryLegacy(ctx, s, func(s *Session) ([]ConnectionLogEntry, error) {
+	return enqueueSessionQueryOnState(ctx, s, func(s *Session) ([]ConnectionLogEntry, error) {
 		return s.ensureConnectionLog().Snapshot(), nil
 	})
 }
@@ -477,7 +477,7 @@ func (s *Session) queryPaneLog() ([]PaneLogEntry, error) {
 }
 
 func (s *Session) queryPaneLogContext(ctx context.Context) ([]PaneLogEntry, error) {
-	return enqueueSessionQueryLegacy(ctx, s, func(s *Session) ([]PaneLogEntry, error) {
+	return enqueueSessionQueryOnState(ctx, s, func(s *Session) ([]PaneLogEntry, error) {
 		return s.ensurePaneLog().Snapshot(), nil
 	})
 }
@@ -487,7 +487,7 @@ func (s *Session) queryUIClient(requestedClientID, eventName string) (uiClientSn
 }
 
 func (s *Session) queryUIClientContext(ctx context.Context, requestedClientID, eventName string) (uiClientSnapshot, error) {
-	return enqueueSessionQueryLegacy(ctx, s, func(s *Session) (uiClientSnapshot, error) {
+	return enqueueSessionQueryOnState(ctx, s, func(s *Session) (uiClientSnapshot, error) {
 		return s.resolveUIClientSnapshot(requestedClientID, eventName)
 	})
 }
@@ -497,7 +497,7 @@ func (s *Session) queryFirstClient() (*clientConn, error) {
 }
 
 func (s *Session) queryFirstClientContext(ctx context.Context) (*clientConn, error) {
-	return enqueueSessionQueryLegacy(ctx, s, func(s *Session) (*clientConn, error) {
+	return enqueueSessionQueryOnState(ctx, s, func(s *Session) (*clientConn, error) {
 		if s.ensureClientManager().clientCount() == 0 {
 			return nil, fmt.Errorf("no client attached")
 		}

--- a/internal/server/session_queries.go
+++ b/internal/server/session_queries.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"fmt"
 	"slices"
 	"strings"
@@ -231,7 +232,11 @@ func (s *Session) windowForActor(actorPaneID uint32) *mux.Window {
 }
 
 func (s *Session) queryActiveWindowSnapshot() (activeWindowSnapshot, error) {
-	return enqueueSessionQuery(s, func(s *Session) (activeWindowSnapshot, error) {
+	return s.queryActiveWindowSnapshotContext(s.context())
+}
+
+func (s *Session) queryActiveWindowSnapshotContext(ctx context.Context) (activeWindowSnapshot, error) {
+	return enqueueSessionQueryLegacy(ctx, s, func(s *Session) (activeWindowSnapshot, error) {
 		w := s.activeWindow()
 		if w == nil {
 			return activeWindowSnapshot{}, fmt.Errorf("no window")
@@ -252,7 +257,11 @@ func (s *Session) queryActiveWindowSnapshot() (activeWindowSnapshot, error) {
 }
 
 func (s *Session) queryResolvedPaneForActor(actorPaneID uint32, ref string) (resolvedPaneRef, error) {
-	return enqueueSessionQuery(s, func(s *Session) (resolvedPaneRef, error) {
+	return s.queryResolvedPaneForActorContext(s.context(), actorPaneID, ref)
+}
+
+func (s *Session) queryResolvedPaneForActorContext(ctx context.Context, actorPaneID uint32, ref string) (resolvedPaneRef, error) {
+	return enqueueSessionQueryLegacy(ctx, s, func(s *Session) (resolvedPaneRef, error) {
 		pane, w, err := s.resolvePaneAcrossWindowsForActor(actorPaneID, ref)
 		if err != nil {
 			return resolvedPaneRef{}, err
@@ -271,7 +280,11 @@ func (s *Session) queryResolvedPaneForActor(actorPaneID uint32, ref string) (res
 }
 
 func (s *Session) queryActivePaneForWindow(ref string) (resolvedPaneRef, error) {
-	return enqueueSessionQuery(s, func(s *Session) (resolvedPaneRef, error) {
+	return s.queryActivePaneForWindowContext(s.context(), ref)
+}
+
+func (s *Session) queryActivePaneForWindowContext(ctx context.Context, ref string) (resolvedPaneRef, error) {
+	return enqueueSessionQueryLegacy(ctx, s, func(s *Session) (resolvedPaneRef, error) {
 		w := s.resolveWindow(ref)
 		if w == nil {
 			return resolvedPaneRef{}, fmt.Errorf("window %q not found", ref)
@@ -290,7 +303,11 @@ func (s *Session) queryActivePaneForWindow(ref string) (resolvedPaneRef, error) 
 }
 
 func (s *Session) queryKillTarget(actorPaneID uint32, ref string) (killTargetSnapshot, error) {
-	return enqueueSessionQuery(s, func(s *Session) (killTargetSnapshot, error) {
+	return s.queryKillTargetContext(s.context(), actorPaneID, ref)
+}
+
+func (s *Session) queryKillTargetContext(ctx context.Context, actorPaneID uint32, ref string) (killTargetSnapshot, error) {
+	return enqueueSessionQueryLegacy(ctx, s, func(s *Session) (killTargetSnapshot, error) {
 		var pane *mux.Pane
 		if ref == "" {
 			w := s.windowForActor(actorPaneID)
@@ -314,7 +331,11 @@ func (s *Session) queryKillTarget(actorPaneID uint32, ref string) (killTargetSna
 }
 
 func (s *Session) queryPaneList() ([]paneListEntry, error) {
-	return enqueueSessionQuery(s, func(s *Session) ([]paneListEntry, error) {
+	return s.queryPaneListContext(s.context())
+}
+
+func (s *Session) queryPaneListContext(ctx context.Context) ([]paneListEntry, error) {
+	return enqueueSessionQueryLegacy(ctx, s, func(s *Session) ([]paneListEntry, error) {
 		entries := make([]paneListEntry, 0, len(s.Panes))
 		w := s.activeWindow()
 		now := s.clock().Now()
@@ -380,7 +401,11 @@ func (s *Session) queryPaneList() ([]paneListEntry, error) {
 }
 
 func (s *Session) querySessionStatus() (sessionStatusSnapshot, error) {
-	return enqueueSessionQuery(s, func(s *Session) (sessionStatusSnapshot, error) {
+	return s.querySessionStatusContext(s.context())
+}
+
+func (s *Session) querySessionStatusContext(ctx context.Context) (sessionStatusSnapshot, error) {
+	return enqueueSessionQueryLegacy(ctx, s, func(s *Session) (sessionStatusSnapshot, error) {
 		snap := sessionStatusSnapshot{
 			total:       len(s.Panes),
 			windowCount: len(s.Windows),
@@ -395,7 +420,11 @@ func (s *Session) querySessionStatus() (sessionStatusSnapshot, error) {
 }
 
 func (s *Session) queryWindowList() ([]windowListEntry, error) {
-	return enqueueSessionQuery(s, func(s *Session) ([]windowListEntry, error) {
+	return s.queryWindowListContext(s.context())
+}
+
+func (s *Session) queryWindowListContext(ctx context.Context) ([]windowListEntry, error) {
+	return enqueueSessionQueryLegacy(ctx, s, func(s *Session) ([]windowListEntry, error) {
 		entries := make([]windowListEntry, 0, len(s.Windows))
 		for i, w := range s.Windows {
 			entries = append(entries, windowListEntry{
@@ -411,7 +440,11 @@ func (s *Session) queryWindowList() ([]windowListEntry, error) {
 }
 
 func (s *Session) queryClientList() ([]clientListEntry, error) {
-	return enqueueSessionQuery(s, func(s *Session) ([]clientListEntry, error) {
+	return s.queryClientListContext(s.context())
+}
+
+func (s *Session) queryClientListContext(ctx context.Context) ([]clientListEntry, error) {
+	return enqueueSessionQueryLegacy(ctx, s, func(s *Session) ([]clientListEntry, error) {
 		clients := s.ensureClientManager().clients
 		entries := make([]clientListEntry, 0, len(clients))
 		sizeOwner := s.effectiveSizeClient()
@@ -430,25 +463,41 @@ func (s *Session) queryClientList() ([]clientListEntry, error) {
 }
 
 func (s *Session) queryConnectionLog() ([]ConnectionLogEntry, error) {
-	return enqueueSessionQuery(s, func(s *Session) ([]ConnectionLogEntry, error) {
+	return s.queryConnectionLogContext(s.context())
+}
+
+func (s *Session) queryConnectionLogContext(ctx context.Context) ([]ConnectionLogEntry, error) {
+	return enqueueSessionQueryLegacy(ctx, s, func(s *Session) ([]ConnectionLogEntry, error) {
 		return s.ensureConnectionLog().Snapshot(), nil
 	})
 }
 
 func (s *Session) queryPaneLog() ([]PaneLogEntry, error) {
-	return enqueueSessionQuery(s, func(s *Session) ([]PaneLogEntry, error) {
+	return s.queryPaneLogContext(s.context())
+}
+
+func (s *Session) queryPaneLogContext(ctx context.Context) ([]PaneLogEntry, error) {
+	return enqueueSessionQueryLegacy(ctx, s, func(s *Session) ([]PaneLogEntry, error) {
 		return s.ensurePaneLog().Snapshot(), nil
 	})
 }
 
 func (s *Session) queryUIClient(requestedClientID, eventName string) (uiClientSnapshot, error) {
-	return enqueueSessionQuery(s, func(s *Session) (uiClientSnapshot, error) {
+	return s.queryUIClientContext(s.context(), requestedClientID, eventName)
+}
+
+func (s *Session) queryUIClientContext(ctx context.Context, requestedClientID, eventName string) (uiClientSnapshot, error) {
+	return enqueueSessionQueryLegacy(ctx, s, func(s *Session) (uiClientSnapshot, error) {
 		return s.resolveUIClientSnapshot(requestedClientID, eventName)
 	})
 }
 
 func (s *Session) queryFirstClient() (*clientConn, error) {
-	return enqueueSessionQuery(s, func(s *Session) (*clientConn, error) {
+	return s.queryFirstClientContext(s.context())
+}
+
+func (s *Session) queryFirstClientContext(ctx context.Context) (*clientConn, error) {
+	return enqueueSessionQueryLegacy(ctx, s, func(s *Session) (*clientConn, error) {
 		if s.ensureClientManager().clientCount() == 0 {
 			return nil, fmt.Errorf("no client attached")
 		}

--- a/internal/server/session_queries.go
+++ b/internal/server/session_queries.go
@@ -231,10 +231,6 @@ func (s *Session) windowForActor(actorPaneID uint32) *mux.Window {
 	return s.activeWindow()
 }
 
-func (s *Session) queryActiveWindowSnapshot() (activeWindowSnapshot, error) {
-	return s.queryActiveWindowSnapshotContext(s.context())
-}
-
 func (s *Session) queryActiveWindowSnapshotContext(ctx context.Context) (activeWindowSnapshot, error) {
 	return enqueueSessionQueryOnState(ctx, s, func(s *Session) (activeWindowSnapshot, error) {
 		w := s.activeWindow()
@@ -256,10 +252,6 @@ func (s *Session) queryActiveWindowSnapshotContext(ctx context.Context) (activeW
 	})
 }
 
-func (s *Session) queryResolvedPaneForActor(actorPaneID uint32, ref string) (resolvedPaneRef, error) {
-	return s.queryResolvedPaneForActorContext(s.context(), actorPaneID, ref)
-}
-
 func (s *Session) queryResolvedPaneForActorContext(ctx context.Context, actorPaneID uint32, ref string) (resolvedPaneRef, error) {
 	return enqueueSessionQueryOnState(ctx, s, func(s *Session) (resolvedPaneRef, error) {
 		pane, w, err := s.resolvePaneAcrossWindowsForActor(actorPaneID, ref)
@@ -279,10 +271,6 @@ func (s *Session) queryResolvedPaneForActorContext(ctx context.Context, actorPan
 	})
 }
 
-func (s *Session) queryActivePaneForWindow(ref string) (resolvedPaneRef, error) {
-	return s.queryActivePaneForWindowContext(s.context(), ref)
-}
-
 func (s *Session) queryActivePaneForWindowContext(ctx context.Context, ref string) (resolvedPaneRef, error) {
 	return enqueueSessionQueryOnState(ctx, s, func(s *Session) (resolvedPaneRef, error) {
 		w := s.resolveWindow(ref)
@@ -300,10 +288,6 @@ func (s *Session) queryActivePaneForWindowContext(ctx context.Context, ref strin
 			windowID: w.ID,
 		}, nil
 	})
-}
-
-func (s *Session) queryKillTarget(actorPaneID uint32, ref string) (killTargetSnapshot, error) {
-	return s.queryKillTargetContext(s.context(), actorPaneID, ref)
 }
 
 func (s *Session) queryKillTargetContext(ctx context.Context, actorPaneID uint32, ref string) (killTargetSnapshot, error) {
@@ -400,10 +384,6 @@ func (s *Session) queryPaneListContext(ctx context.Context) ([]paneListEntry, er
 	})
 }
 
-func (s *Session) querySessionStatus() (sessionStatusSnapshot, error) {
-	return s.querySessionStatusContext(s.context())
-}
-
 func (s *Session) querySessionStatusContext(ctx context.Context) (sessionStatusSnapshot, error) {
 	return enqueueSessionQueryOnState(ctx, s, func(s *Session) (sessionStatusSnapshot, error) {
 		snap := sessionStatusSnapshot{
@@ -417,10 +397,6 @@ func (s *Session) querySessionStatusContext(ctx context.Context) (sessionStatusS
 		}
 		return snap, nil
 	})
-}
-
-func (s *Session) queryWindowList() ([]windowListEntry, error) {
-	return s.queryWindowListContext(s.context())
 }
 
 func (s *Session) queryWindowListContext(ctx context.Context) ([]windowListEntry, error) {
@@ -472,10 +448,6 @@ func (s *Session) queryConnectionLogContext(ctx context.Context) ([]ConnectionLo
 	})
 }
 
-func (s *Session) queryPaneLog() ([]PaneLogEntry, error) {
-	return s.queryPaneLogContext(s.context())
-}
-
 func (s *Session) queryPaneLogContext(ctx context.Context) ([]PaneLogEntry, error) {
 	return enqueueSessionQueryOnState(ctx, s, func(s *Session) ([]PaneLogEntry, error) {
 		return s.ensurePaneLog().Snapshot(), nil
@@ -490,10 +462,6 @@ func (s *Session) queryUIClientContext(ctx context.Context, requestedClientID, e
 	return enqueueSessionQueryOnState(ctx, s, func(s *Session) (uiClientSnapshot, error) {
 		return s.resolveUIClientSnapshot(requestedClientID, eventName)
 	})
-}
-
-func (s *Session) queryFirstClient() (*clientConn, error) {
-	return s.queryFirstClientContext(s.context())
 }
 
 func (s *Session) queryFirstClientContext(ctx context.Context) (*clientConn, error) {

--- a/internal/server/session_queries_test.go
+++ b/internal/server/session_queries_test.go
@@ -150,7 +150,7 @@ func TestResolvePaneAcrossWindowsForActorPrefersActorWindowForDuplicateNames(t *
 		return struct{}{}
 	})
 
-	resolved, err := enqueueSessionQuery(sess, func(sess *Session) (resolvedPaneRef, error) {
+	resolved, err := enqueueSessionQueryLegacy(sess.context(), sess, func(sess *Session) (resolvedPaneRef, error) {
 		pane, window, err := sess.resolvePaneAcrossWindowsForActor(p3.ID, "shared")
 		if err != nil {
 			return resolvedPaneRef{}, err
@@ -217,7 +217,7 @@ func TestEnqueueUIWaitSubscribeErrors(t *testing.T) {
 		stopCrashCheckpointLoop(t, sess)
 		defer stopSessionBackgroundLoops(t, sess)
 
-		_, err := sess.enqueueUIWaitSubscribe("", proto.UIEventCopyModeHidden)
+		_, err := sess.enqueueUIWaitSubscribe(sess.context(), "", proto.UIEventCopyModeHidden)
 		if err == nil || err.Error() != "no client attached" {
 			t.Fatalf("enqueueUIWaitSubscribe error = %v, want no client attached", err)
 		}
@@ -235,7 +235,7 @@ func TestEnqueueUIWaitSubscribeErrors(t *testing.T) {
 			return struct{}{}
 		})
 
-		_, err := sess.enqueueUIWaitSubscribe("missing", proto.UIEventCopyModeHidden)
+		_, err := sess.enqueueUIWaitSubscribe(sess.context(), "missing", proto.UIEventCopyModeHidden)
 		if err == nil || err.Error() != "unknown client: missing" {
 			t.Fatalf("enqueueUIWaitSubscribe unknown error = %v", err)
 		}
@@ -252,7 +252,7 @@ func TestEnqueueUIWaitSubscribeErrors(t *testing.T) {
 
 		errCh := make(chan error, 1)
 		go func() {
-			_, err := sess.enqueueUIWaitSubscribe("", proto.UIEventCopyModeHidden)
+			_, err := sess.enqueueUIWaitSubscribe(sess.context(), "", proto.UIEventCopyModeHidden)
 			errCh <- err
 		}()
 

--- a/internal/server/session_queries_test.go
+++ b/internal/server/session_queries_test.go
@@ -150,7 +150,7 @@ func TestResolvePaneAcrossWindowsForActorPrefersActorWindowForDuplicateNames(t *
 		return struct{}{}
 	})
 
-	resolved, err := enqueueSessionQueryLegacy(sess.context(), sess, func(sess *Session) (resolvedPaneRef, error) {
+	resolved, err := enqueueSessionQueryOnState(sess.context(), sess, func(sess *Session) (resolvedPaneRef, error) {
 		pane, window, err := sess.resolvePaneAcrossWindowsForActor(p3.ID, "shared")
 		if err != nil {
 			return resolvedPaneRef{}, err

--- a/internal/server/session_remote.go
+++ b/internal/server/session_remote.go
@@ -31,7 +31,7 @@ func (s *Session) handleTakeover(sshPaneID uint32, req mux.TakeoverRequest) {
 		cellH int
 	}
 
-	start, err := enqueueSessionQuery(s, func(s *Session) (takeoverStart, error) {
+	start, err := enqueueSessionQueryLegacy(s.context(), s, func(s *Session) (takeoverStart, error) {
 		if s.takenOverPanes[sshPaneID] {
 			return takeoverStart{}, nil
 		}
@@ -75,7 +75,7 @@ func (s *Session) handleTakeover(sshPaneID uint32, req mux.TakeoverRequest) {
 		return
 	}
 
-	layout, err := enqueueSessionQuery(s, func(s *Session) (takeoverLayout, error) {
+	layout, err := enqueueSessionQueryLegacy(s.context(), s, func(s *Session) (takeoverLayout, error) {
 		w := s.findWindowByPaneID(sshPaneID)
 		if w == nil {
 			return takeoverLayout{}, fmt.Errorf("pane %d not in any window", sshPaneID)

--- a/internal/server/session_remote.go
+++ b/internal/server/session_remote.go
@@ -31,7 +31,7 @@ func (s *Session) handleTakeover(sshPaneID uint32, req mux.TakeoverRequest) {
 		cellH int
 	}
 
-	start, err := enqueueSessionQueryLegacy(s.context(), s, func(s *Session) (takeoverStart, error) {
+	start, err := enqueueSessionQueryOnState(s.context(), s, func(s *Session) (takeoverStart, error) {
 		if s.takenOverPanes[sshPaneID] {
 			return takeoverStart{}, nil
 		}
@@ -75,7 +75,7 @@ func (s *Session) handleTakeover(sshPaneID uint32, req mux.TakeoverRequest) {
 		return
 	}
 
-	layout, err := enqueueSessionQueryLegacy(s.context(), s, func(s *Session) (takeoverLayout, error) {
+	layout, err := enqueueSessionQueryOnState(s.context(), s, func(s *Session) (takeoverLayout, error) {
 		w := s.findWindowByPaneID(sshPaneID)
 		if w == nil {
 			return takeoverLayout{}, fmt.Errorf("pane %d not in any window", sshPaneID)

--- a/internal/server/session_remote_low_coverage_test.go
+++ b/internal/server/session_remote_low_coverage_test.go
@@ -349,7 +349,7 @@ func TestPrepareRemotePaneAndInsertPreparedPane(t *testing.T) {
 	}
 
 	prepared := newStandaloneProxyPane(9, "pane-9")
-	_, err = enqueueSessionQueryLegacy(sess.context(), sess, func(sess *Session) (struct{}, error) {
+	_, err = enqueueSessionQueryOnState(sess.context(), sess, func(sess *Session) (struct{}, error) {
 		return struct{}{}, sess.insertPreparedPaneIntoActiveWindow(prepared, mux.SplitHorizontal, false, false)
 	})
 	if err == nil || err.Error() != "no window" {
@@ -360,7 +360,7 @@ func TestPrepareRemotePaneAndInsertPreparedPane(t *testing.T) {
 	window := newTestWindowWithPanes(t, sess, 1, "main", base)
 	setSessionLayoutForTest(t, sess, window.ID, []*mux.Window{window}, base)
 
-	if _, err := enqueueSessionQueryLegacy(sess.context(), sess, func(sess *Session) (struct{}, error) {
+	if _, err := enqueueSessionQueryOnState(sess.context(), sess, func(sess *Session) (struct{}, error) {
 		return struct{}{}, sess.insertPreparedPaneIntoActiveWindow(prepared, mux.SplitVertical, true, false)
 	}); err != nil {
 		t.Fatalf("insertPreparedPaneIntoActiveWindow success path: %v", err)
@@ -389,7 +389,7 @@ func TestInsertPreparedPaneIntoActiveWindowKeepFocusPreservesZoomAndFocus(t *tes
 	window.ZoomedPaneID = pane1.ID
 	setSessionLayoutForTest(t, sess, window.ID, []*mux.Window{window}, pane1, pane2)
 
-	if _, err := enqueueSessionQueryLegacy(sess.context(), sess, func(sess *Session) (struct{}, error) {
+	if _, err := enqueueSessionQueryOnState(sess.context(), sess, func(sess *Session) (struct{}, error) {
 		return struct{}{}, sess.insertPreparedPaneIntoActiveWindow(prepared, mux.SplitVertical, false, true)
 	}); err != nil {
 		t.Fatalf("insertPreparedPaneIntoActiveWindow keepFocus: %v", err)

--- a/internal/server/session_remote_low_coverage_test.go
+++ b/internal/server/session_remote_low_coverage_test.go
@@ -349,7 +349,7 @@ func TestPrepareRemotePaneAndInsertPreparedPane(t *testing.T) {
 	}
 
 	prepared := newStandaloneProxyPane(9, "pane-9")
-	_, err = enqueueSessionQuery(sess, func(sess *Session) (struct{}, error) {
+	_, err = enqueueSessionQueryLegacy(sess.context(), sess, func(sess *Session) (struct{}, error) {
 		return struct{}{}, sess.insertPreparedPaneIntoActiveWindow(prepared, mux.SplitHorizontal, false, false)
 	})
 	if err == nil || err.Error() != "no window" {
@@ -360,7 +360,7 @@ func TestPrepareRemotePaneAndInsertPreparedPane(t *testing.T) {
 	window := newTestWindowWithPanes(t, sess, 1, "main", base)
 	setSessionLayoutForTest(t, sess, window.ID, []*mux.Window{window}, base)
 
-	if _, err := enqueueSessionQuery(sess, func(sess *Session) (struct{}, error) {
+	if _, err := enqueueSessionQueryLegacy(sess.context(), sess, func(sess *Session) (struct{}, error) {
 		return struct{}{}, sess.insertPreparedPaneIntoActiveWindow(prepared, mux.SplitVertical, true, false)
 	}); err != nil {
 		t.Fatalf("insertPreparedPaneIntoActiveWindow success path: %v", err)
@@ -389,7 +389,7 @@ func TestInsertPreparedPaneIntoActiveWindowKeepFocusPreservesZoomAndFocus(t *tes
 	window.ZoomedPaneID = pane1.ID
 	setSessionLayoutForTest(t, sess, window.ID, []*mux.Window{window}, pane1, pane2)
 
-	if _, err := enqueueSessionQuery(sess, func(sess *Session) (struct{}, error) {
+	if _, err := enqueueSessionQueryLegacy(sess.context(), sess, func(sess *Session) (struct{}, error) {
 		return struct{}{}, sess.insertPreparedPaneIntoActiveWindow(prepared, mux.SplitVertical, false, true)
 	}); err != nil {
 		t.Fatalf("insertPreparedPaneIntoActiveWindow keepFocus: %v", err)

--- a/internal/server/test_session_helpers_test.go
+++ b/internal/server/test_session_helpers_test.go
@@ -37,7 +37,7 @@ func stopSessionBackgroundLoops(t *testing.T, sess *Session) {
 func mustSessionQuery[T any](t *testing.T, sess *Session, fn func(*Session) T) T {
 	t.Helper()
 
-	value, err := enqueueSessionQuery(sess, func(sess *Session) (T, error) {
+	value, err := enqueueSessionQueryLegacy(sess.context(), sess, func(sess *Session) (T, error) {
 		return fn(sess), nil
 	})
 	if err != nil {
@@ -49,7 +49,7 @@ func mustSessionQuery[T any](t *testing.T, sess *Session, fn func(*Session) T) T
 func mustSessionMutation(t *testing.T, sess *Session, fn func(*Session)) {
 	t.Helper()
 
-	if _, err := enqueueSessionQuery(sess, func(sess *Session) (struct{}, error) {
+	if _, err := enqueueSessionQueryLegacy(sess.context(), sess, func(sess *Session) (struct{}, error) {
 		fn(sess)
 		return struct{}{}, nil
 	}); err != nil {
@@ -86,7 +86,7 @@ func setSessionLayoutForTest(t *testing.T, sess *Session, activeWindowID uint32,
 func mustCreatePane(t *testing.T, sess *Session, srv *Server, cols, rows int) *mux.Pane {
 	t.Helper()
 
-	pane, err := enqueueSessionQuery(sess, func(sess *Session) (*mux.Pane, error) {
+	pane, err := enqueueSessionQueryLegacy(sess.context(), sess, func(sess *Session) (*mux.Pane, error) {
 		return sess.createPane(srv, cols, rows)
 	})
 	if err != nil {

--- a/internal/server/test_session_helpers_test.go
+++ b/internal/server/test_session_helpers_test.go
@@ -37,7 +37,7 @@ func stopSessionBackgroundLoops(t *testing.T, sess *Session) {
 func mustSessionQuery[T any](t *testing.T, sess *Session, fn func(*Session) T) T {
 	t.Helper()
 
-	value, err := enqueueSessionQueryLegacy(sess.context(), sess, func(sess *Session) (T, error) {
+	value, err := enqueueSessionQueryOnState(sess.context(), sess, func(sess *Session) (T, error) {
 		return fn(sess), nil
 	})
 	if err != nil {
@@ -49,7 +49,7 @@ func mustSessionQuery[T any](t *testing.T, sess *Session, fn func(*Session) T) T
 func mustSessionMutation(t *testing.T, sess *Session, fn func(*Session)) {
 	t.Helper()
 
-	if _, err := enqueueSessionQueryLegacy(sess.context(), sess, func(sess *Session) (struct{}, error) {
+	if _, err := enqueueSessionQueryOnState(sess.context(), sess, func(sess *Session) (struct{}, error) {
 		fn(sess)
 		return struct{}{}, nil
 	}); err != nil {
@@ -86,7 +86,7 @@ func setSessionLayoutForTest(t *testing.T, sess *Session, activeWindowID uint32,
 func mustCreatePane(t *testing.T, sess *Session, srv *Server, cols, rows int) *mux.Pane {
 	t.Helper()
 
-	pane, err := enqueueSessionQueryLegacy(sess.context(), sess, func(sess *Session) (*mux.Pane, error) {
+	pane, err := enqueueSessionQueryOnState(sess.context(), sess, func(sess *Session) (*mux.Pane, error) {
 		return sess.createPane(srv, cols, rows)
 	})
 	if err != nil {

--- a/internal/server/tree_commands_test.go
+++ b/internal/server/tree_commands_test.go
@@ -597,7 +597,7 @@ func TestQueuedCommandMoveUpDownErrorPaths(t *testing.T) {
 }
 
 func splitQueuedCommandTestWindow(sess *Session, activePane, newPane *mux.Pane) error {
-	_, err := enqueueSessionQuery(sess, func(sess *Session) (struct{}, error) {
+	_, err := enqueueSessionQueryLegacy(sess.context(), sess, func(sess *Session) (struct{}, error) {
 		w := sess.activeWindow()
 		w.FocusPane(activePane)
 		if _, err := w.Split(mux.SplitHorizontal, newPane); err != nil {

--- a/internal/server/tree_commands_test.go
+++ b/internal/server/tree_commands_test.go
@@ -597,7 +597,7 @@ func TestQueuedCommandMoveUpDownErrorPaths(t *testing.T) {
 }
 
 func splitQueuedCommandTestWindow(sess *Session, activePane, newPane *mux.Pane) error {
-	_, err := enqueueSessionQueryLegacy(sess.context(), sess, func(sess *Session) (struct{}, error) {
+	_, err := enqueueSessionQueryOnState(sess.context(), sess, func(sess *Session) (struct{}, error) {
 		w := sess.activeWindow()
 		w.FocusPane(activePane)
 		if _, err := w.Split(mux.SplitHorizontal, newPane); err != nil {

--- a/internal/server/undo_manager.go
+++ b/internal/server/undo_manager.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"fmt"
 	"syscall"
 	"time"
@@ -160,7 +161,7 @@ type paneCleanupTimeoutEvent struct {
 	paneID uint32
 }
 
-func (e paneCleanupTimeoutEvent) handle(s *Session) {
+func (e paneCleanupTimeoutEvent) handle(_ context.Context, s *Session) {
 	if s.shutdown.Load() {
 		return
 	}
@@ -178,7 +179,7 @@ type undoExpiryEvent struct {
 	paneID uint32
 }
 
-func (e undoExpiryEvent) handle(s *Session) {
+func (e undoExpiryEvent) handle(_ context.Context, s *Session) {
 	if s.shutdown.Load() {
 		return
 	}
@@ -186,9 +187,9 @@ func (e undoExpiryEvent) handle(s *Session) {
 }
 
 func (s *Session) enqueueUndoExpiry(paneID uint32) {
-	s.enqueueEvent(undoExpiryEvent{paneID: paneID})
+	s.enqueueEvent(s.context(), undoExpiryEvent{paneID: paneID})
 }
 
 func (s *Session) enqueuePaneCleanupTimeout(paneID uint32) {
-	s.enqueueEvent(paneCleanupTimeoutEvent{paneID: paneID})
+	s.enqueueEvent(s.context(), paneCleanupTimeoutEvent{paneID: paneID})
 }

--- a/internal/server/wait_ready.go
+++ b/internal/server/wait_ready.go
@@ -168,7 +168,7 @@ func parseSendKeysArgs(args []string) (sendKeysOptions, error) {
 }
 
 func waitForPaneReady(sess *Session, paneRef string, paneRefData resolvedPaneRef, opts waitReadyOptions) error {
-	outputCh := sess.enqueuePaneOutputSubscribe(paneRefData.paneID)
+	outputCh := sess.enqueuePaneOutputSubscribe(sess.context(), paneRefData.paneID)
 	if outputCh == nil {
 		return fmt.Errorf("session shutting down")
 	}
@@ -247,7 +247,7 @@ func waitForPaneReady(sess *Session, paneRef string, paneRefData resolvedPaneRef
 }
 
 func queryPaneReadyState(sess *Session, paneID uint32) (paneReadyState, error) {
-	state, err := enqueueSessionQuery(sess, func(sess *Session) (paneReadyState, error) {
+	state, err := enqueueSessionQueryLegacy(sess.context(), sess, func(sess *Session) (paneReadyState, error) {
 		pane := sess.findPaneByID(paneID)
 		if pane == nil {
 			return paneReadyState{}, nil

--- a/internal/server/wait_ready.go
+++ b/internal/server/wait_ready.go
@@ -247,7 +247,7 @@ func waitForPaneReady(sess *Session, paneRef string, paneRefData resolvedPaneRef
 }
 
 func queryPaneReadyState(sess *Session, paneID uint32) (paneReadyState, error) {
-	state, err := enqueueSessionQueryLegacy(sess.context(), sess, func(sess *Session) (paneReadyState, error) {
+	state, err := enqueueSessionQueryOnState(sess.context(), sess, func(sess *Session) (paneReadyState, error) {
 		pane := sess.findPaneByID(paneID)
 		if pane == nil {
 			return paneReadyState{}, nil

--- a/internal/server/wait_test.go
+++ b/internal/server/wait_test.go
@@ -113,7 +113,7 @@ func TestWaitCrashCheckpoint_WakesOnWrite(t *testing.T) {
 		})
 	})
 
-	if !sess.enqueueEvent(crashCheckpointWrittenEvent{path: "/tmp/checkpoint-2.json"}) {
+	if !sess.enqueueEvent(sess.context(), crashCheckpointWrittenEvent{path: "/tmp/checkpoint-2.json"}) {
 		t.Fatal("enqueueEvent(crashCheckpointWrittenEvent) = false")
 	}
 
@@ -234,7 +234,7 @@ func TestNotifyPaneOutputSubs(t *testing.T) {
 	sess := newSession("test-pane-output-subs")
 	stopCrashCheckpointLoop(t, sess)
 
-	ch := sess.enqueuePaneOutputSubscribe(1)
+	ch := sess.enqueuePaneOutputSubscribe(sess.context(), 1)
 
 	// Notification should be received (routed through event loop).
 	sess.enqueueCommandMutation(func(s *MutationContext) commandMutationResult {

--- a/internal/server/waiter_manager.go
+++ b/internal/server/waiter_manager.go
@@ -112,7 +112,7 @@ func (m *waiterManager) notifyPaneOutputSubs(paneID uint32) {
 }
 
 func (m *waiterManager) beginPaneOutputWait(sess *Session, paneID uint32, substr string) (paneOutputWaitStart, error) {
-	return enqueueSessionQueryLegacy(sess.context(), sess, func(s *Session) (paneOutputWaitStart, error) {
+	return enqueueSessionQueryOnState(sess.context(), sess, func(s *Session) (paneOutputWaitStart, error) {
 		pane := s.findPaneByID(paneID)
 		if pane == nil {
 			return paneOutputWaitStart{}, nil
@@ -147,7 +147,7 @@ func (m *waiterManager) waitGeneration(sess *Session, afterGen uint64, timeout t
 		matched bool
 	}
 
-	reg, err := enqueueSessionQueryLegacy(sess.context(), sess, func(s *Session) (waitRegistration, error) {
+	reg, err := enqueueSessionQueryOnState(sess.context(), sess, func(s *Session) (waitRegistration, error) {
 		gen := s.generation.Load()
 		if gen > afterGen {
 			return waitRegistration{gen: gen}, nil
@@ -171,7 +171,7 @@ func (m *waiterManager) waitGeneration(sess *Session, afterGen uint64, timeout t
 	case gen := <-reg.reply:
 		return gen, true
 	case <-timer.C:
-		state, err := enqueueSessionQueryLegacy(sess.context(), sess, func(s *Session) (waitState, error) {
+		state, err := enqueueSessionQueryOnState(sess.context(), sess, func(s *Session) (waitState, error) {
 			delete(m.layoutWaiters, reg.waiterID)
 			gen := s.generation.Load()
 			return waitState{gen: gen, matched: gen > afterGen}, nil
@@ -184,7 +184,7 @@ func (m *waiterManager) waitGeneration(sess *Session, afterGen uint64, timeout t
 }
 
 func (m *waiterManager) waitGenerationAfterCurrent(sess *Session, timeout time.Duration) (uint64, bool) {
-	afterGen, err := enqueueSessionQueryLegacy(sess.context(), sess, func(s *Session) (uint64, error) {
+	afterGen, err := enqueueSessionQueryOnState(sess.context(), sess, func(s *Session) (uint64, error) {
 		return s.generation.Load(), nil
 	})
 	if err != nil {
@@ -221,7 +221,7 @@ func (m *waiterManager) waitClipboard(sess *Session, afterGen uint64, timeout ti
 		matched bool
 	}
 
-	reg, err := enqueueSessionQueryLegacy(sess.context(), sess, func(s *Session) (waitRegistration, error) {
+	reg, err := enqueueSessionQueryOnState(sess.context(), sess, func(s *Session) (waitRegistration, error) {
 		gen := m.clipboardGen.Load()
 		if gen > afterGen {
 			return waitRegistration{payload: m.lastClipboardB64}, nil
@@ -245,7 +245,7 @@ func (m *waiterManager) waitClipboard(sess *Session, afterGen uint64, timeout ti
 	case payload := <-reg.reply:
 		return payload, true
 	case <-timer.C:
-		state, err := enqueueSessionQueryLegacy(sess.context(), sess, func(s *Session) (waitState, error) {
+		state, err := enqueueSessionQueryOnState(sess.context(), sess, func(s *Session) (waitState, error) {
 			delete(m.clipboardWaiters, reg.waiterID)
 			if m.clipboardGen.Load() > afterGen {
 				return waitState{payload: m.lastClipboardB64, matched: true}, nil
@@ -260,7 +260,7 @@ func (m *waiterManager) waitClipboard(sess *Session, afterGen uint64, timeout ti
 }
 
 func (m *waiterManager) waitClipboardAfterCurrent(sess *Session, timeout time.Duration) (string, bool) {
-	afterGen, err := enqueueSessionQueryLegacy(sess.context(), sess, func(s *Session) (uint64, error) {
+	afterGen, err := enqueueSessionQueryOnState(sess.context(), sess, func(s *Session) (uint64, error) {
 		return m.clipboardGen.Load(), nil
 	})
 	if err != nil {
@@ -301,7 +301,7 @@ func (m *waiterManager) waitCrashCheckpoint(sess *Session, afterGen uint64, time
 		matched bool
 	}
 
-	reg, err := enqueueSessionQueryLegacy(sess.context(), sess, func(s *Session) (waitRegistration, error) {
+	reg, err := enqueueSessionQueryOnState(sess.context(), sess, func(s *Session) (waitRegistration, error) {
 		if m.crashCheckpointGen > afterGen {
 			return waitRegistration{
 				record: crashCheckpointRecord{
@@ -329,7 +329,7 @@ func (m *waiterManager) waitCrashCheckpoint(sess *Session, afterGen uint64, time
 	case record := <-reg.reply:
 		return record, true
 	case <-timer.C:
-		state, err := enqueueSessionQueryLegacy(sess.context(), sess, func(s *Session) (waitState, error) {
+		state, err := enqueueSessionQueryOnState(sess.context(), sess, func(s *Session) (waitState, error) {
 			delete(m.checkpointWaiters, reg.waiterID)
 			if m.crashCheckpointGen > afterGen {
 				return waitState{
@@ -350,7 +350,7 @@ func (m *waiterManager) waitCrashCheckpoint(sess *Session, afterGen uint64, time
 }
 
 func (m *waiterManager) waitCrashCheckpointAfterCurrent(sess *Session, timeout time.Duration) (crashCheckpointRecord, bool) {
-	afterGen, err := enqueueSessionQueryLegacy(sess.context(), sess, func(s *Session) (uint64, error) {
+	afterGen, err := enqueueSessionQueryOnState(sess.context(), sess, func(s *Session) (uint64, error) {
 		return m.crashCheckpointGen, nil
 	})
 	if err != nil {

--- a/internal/server/waiter_manager.go
+++ b/internal/server/waiter_manager.go
@@ -112,7 +112,7 @@ func (m *waiterManager) notifyPaneOutputSubs(paneID uint32) {
 }
 
 func (m *waiterManager) beginPaneOutputWait(sess *Session, paneID uint32, substr string) (paneOutputWaitStart, error) {
-	return enqueueSessionQuery(sess, func(s *Session) (paneOutputWaitStart, error) {
+	return enqueueSessionQueryLegacy(sess.context(), sess, func(s *Session) (paneOutputWaitStart, error) {
 		pane := s.findPaneByID(paneID)
 		if pane == nil {
 			return paneOutputWaitStart{}, nil
@@ -147,7 +147,7 @@ func (m *waiterManager) waitGeneration(sess *Session, afterGen uint64, timeout t
 		matched bool
 	}
 
-	reg, err := enqueueSessionQuery(sess, func(s *Session) (waitRegistration, error) {
+	reg, err := enqueueSessionQueryLegacy(sess.context(), sess, func(s *Session) (waitRegistration, error) {
 		gen := s.generation.Load()
 		if gen > afterGen {
 			return waitRegistration{gen: gen}, nil
@@ -171,7 +171,7 @@ func (m *waiterManager) waitGeneration(sess *Session, afterGen uint64, timeout t
 	case gen := <-reg.reply:
 		return gen, true
 	case <-timer.C:
-		state, err := enqueueSessionQuery(sess, func(s *Session) (waitState, error) {
+		state, err := enqueueSessionQueryLegacy(sess.context(), sess, func(s *Session) (waitState, error) {
 			delete(m.layoutWaiters, reg.waiterID)
 			gen := s.generation.Load()
 			return waitState{gen: gen, matched: gen > afterGen}, nil
@@ -184,7 +184,7 @@ func (m *waiterManager) waitGeneration(sess *Session, afterGen uint64, timeout t
 }
 
 func (m *waiterManager) waitGenerationAfterCurrent(sess *Session, timeout time.Duration) (uint64, bool) {
-	afterGen, err := enqueueSessionQuery(sess, func(s *Session) (uint64, error) {
+	afterGen, err := enqueueSessionQueryLegacy(sess.context(), sess, func(s *Session) (uint64, error) {
 		return s.generation.Load(), nil
 	})
 	if err != nil {
@@ -221,7 +221,7 @@ func (m *waiterManager) waitClipboard(sess *Session, afterGen uint64, timeout ti
 		matched bool
 	}
 
-	reg, err := enqueueSessionQuery(sess, func(s *Session) (waitRegistration, error) {
+	reg, err := enqueueSessionQueryLegacy(sess.context(), sess, func(s *Session) (waitRegistration, error) {
 		gen := m.clipboardGen.Load()
 		if gen > afterGen {
 			return waitRegistration{payload: m.lastClipboardB64}, nil
@@ -245,7 +245,7 @@ func (m *waiterManager) waitClipboard(sess *Session, afterGen uint64, timeout ti
 	case payload := <-reg.reply:
 		return payload, true
 	case <-timer.C:
-		state, err := enqueueSessionQuery(sess, func(s *Session) (waitState, error) {
+		state, err := enqueueSessionQueryLegacy(sess.context(), sess, func(s *Session) (waitState, error) {
 			delete(m.clipboardWaiters, reg.waiterID)
 			if m.clipboardGen.Load() > afterGen {
 				return waitState{payload: m.lastClipboardB64, matched: true}, nil
@@ -260,7 +260,7 @@ func (m *waiterManager) waitClipboard(sess *Session, afterGen uint64, timeout ti
 }
 
 func (m *waiterManager) waitClipboardAfterCurrent(sess *Session, timeout time.Duration) (string, bool) {
-	afterGen, err := enqueueSessionQuery(sess, func(s *Session) (uint64, error) {
+	afterGen, err := enqueueSessionQueryLegacy(sess.context(), sess, func(s *Session) (uint64, error) {
 		return m.clipboardGen.Load(), nil
 	})
 	if err != nil {
@@ -301,7 +301,7 @@ func (m *waiterManager) waitCrashCheckpoint(sess *Session, afterGen uint64, time
 		matched bool
 	}
 
-	reg, err := enqueueSessionQuery(sess, func(s *Session) (waitRegistration, error) {
+	reg, err := enqueueSessionQueryLegacy(sess.context(), sess, func(s *Session) (waitRegistration, error) {
 		if m.crashCheckpointGen > afterGen {
 			return waitRegistration{
 				record: crashCheckpointRecord{
@@ -329,7 +329,7 @@ func (m *waiterManager) waitCrashCheckpoint(sess *Session, afterGen uint64, time
 	case record := <-reg.reply:
 		return record, true
 	case <-timer.C:
-		state, err := enqueueSessionQuery(sess, func(s *Session) (waitState, error) {
+		state, err := enqueueSessionQueryLegacy(sess.context(), sess, func(s *Session) (waitState, error) {
 			delete(m.checkpointWaiters, reg.waiterID)
 			if m.crashCheckpointGen > afterGen {
 				return waitState{
@@ -350,7 +350,7 @@ func (m *waiterManager) waitCrashCheckpoint(sess *Session, afterGen uint64, time
 }
 
 func (m *waiterManager) waitCrashCheckpointAfterCurrent(sess *Session, timeout time.Duration) (crashCheckpointRecord, bool) {
-	afterGen, err := enqueueSessionQuery(sess, func(s *Session) (uint64, error) {
+	afterGen, err := enqueueSessionQueryLegacy(sess.context(), sess, func(s *Session) (uint64, error) {
 		return m.crashCheckpointGen, nil
 	})
 	if err != nil {

--- a/scripts/watch-pr-ci.sh
+++ b/scripts/watch-pr-ci.sh
@@ -82,15 +82,17 @@ wait_for_head_runs() {
     local want_sha="$1"
     local deadline=$(( $(current_epoch) + run_discovery_timeout ))
     local run_json
-    while (( $(current_epoch) < deadline )); do
+    while :; do
         run_json="$(gh run list --commit "$want_sha" --json databaseId,workflowName,displayTitle,url,conclusion,status -L "$failed_run_limit" 2>/dev/null || true)"
         if json_has_items "$run_json"; then
             printf '%s\n' "$run_json"
             return 0
         fi
+        if (( $(current_epoch) >= deadline )); then
+            return 1
+        fi
         sleep_seconds "$run_discovery_interval"
     done
-    return 1
 }
 
 poll_required_checks() {


### PR DESCRIPTION
## Motivation
Client command handlers can block while waiting for the session actor to process a query. If the client disconnects during that wait, the command goroutine should observe cancellation and exit instead of waiting indefinitely.

## Summary
- Add context-aware `eventloop.Enqueue` and `EnqueueQuery` APIs that cancel while queueing or waiting for query replies.
- Thread session-scoped and client-scoped contexts through server command mutations, session queries, subscriptions, and wait paths.
- Preserve per-client command ordering while allowing the read loop to notice disconnects and cancel in-flight command work.
- Add regression coverage for canceled eventloop enqueue/query waits and client disconnect cancellation through a command handler.
- Stabilize PR CI run discovery so the watcher always attempts head-run lookup before applying the timeout.

## Testing
- `go test ./internal/eventloop -run 'Test(EnqueueReturnsPromptlyWhenContextCanceledWhileQueueSaturated|EnqueueQueryReturnsPromptlyWhenContextCanceledWaitingForReply|RunWatchdogReportsStuckHandlerAndStopsLoop)$' -count=100`
- `go test ./internal/server -run TestClientDisconnectCancelsLongRunningSessionQuery -count=100`
- `go test ./internal/server ./internal/eventloop`
- `go test ./test -run TestAltHJKLFocus -count=3 -timeout 120s`
- `go test ./test -run TestWatchPRCIScriptPassesWhenRequiredChecksSucceed -count=100 -timeout 120s`
- `go test ./test -run TestWatchPRCIScript -timeout 120s`
- `golangci-lint run ./...`
- `go test ./... -timeout 120s`
- `scripts/push-and-watch-ci.sh`

## Review focus
- Eventloop cancellation semantics for queued commands and query reply delivery.
- Server call sites that should use client request context versus session-owned internal context.
- The per-client command worker in `client_conn.go`, especially ordering and disconnect behavior.
- The small `watch-pr-ci.sh` timeout behavior change.

Closes LAB-1916
