### PR TITLE
LAB-1917: Add pprof-backed internal diagnostics

### DIFF
--- a/internal/cli/cli_commands_session.go
+++ b/internal/cli/cli_commands_session.go
@@ -22,6 +22,10 @@ func sessionCLICommands() map[string]commandHandler {
 			inv.runtime.RunDebugCommand(inv.sessionName, args)
 			return 0
 		},
+		"_diag": func(inv invocation, args []string) int {
+			inv.runtime.RunDiagCommand(inv.sessionName, args)
+			return 0
+		},
 		"_server": func(inv invocation, args []string) int {
 			name := inv.sessionName
 			if len(args) > 0 {

--- a/internal/cli/cli_diag.go
+++ b/internal/cli/cli_diag.go
@@ -1,0 +1,558 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/weill-labs/amux/internal/config"
+	"github.com/weill-labs/amux/internal/server"
+)
+
+const diagDefaultTimeout = 5 * time.Second
+
+type diagDeps struct {
+	loadConfig     debugConfigLoader
+	discoverSocket func(context.Context, string, *config.Config) (string, error)
+	fetch          func(debugEndpointRequest) ([]byte, error)
+	writeFile      func(string, []byte, fs.FileMode) error
+	readFile       func(string) ([]byte, error)
+	logPath        func(string) string
+}
+
+type diagCommandKind int
+
+const (
+	diagCommandDump diagCommandKind = iota
+	diagCommandGoroutines
+	diagCommandProfile
+	diagCommandInfo
+)
+
+type diagCommandRequest struct {
+	kind       diagCommandKind
+	path       string
+	timeout    time.Duration
+	outputPath string
+}
+
+type diagInfo struct {
+	PID        int    `json:"pid"`
+	Uptime     string `json:"uptime"`
+	Binary     string `json:"binary"`
+	Build      string `json:"build"`
+	GoVersion  string `json:"go_version"`
+	Goroutines int    `json:"goroutines"`
+}
+
+func runDiagCommand(sessionName string, args []string) {
+	if err := runDiagCommandWithIO(context.Background(), os.Stdout, sessionName, args); err != nil {
+		fmt.Fprintf(os.Stderr, "amux _diag: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func runDiagCommandWithIO(ctx context.Context, w io.Writer, sessionName string, args []string) error {
+	return runDiagCommandWithDeps(ctx, w, sessionName, args, diagDeps{})
+}
+
+func runDiagCommandWithDeps(ctx context.Context, w io.Writer, sessionName string, args []string, deps diagDeps) error {
+	cmd, err := parseDiagCommand(args)
+	if err != nil {
+		return err
+	}
+	deps = fillDiagDeps(deps)
+
+	cfg, err := deps.loadConfig()
+	if err != nil {
+		return fmt.Errorf("loading config: %w", err)
+	}
+	sockPath, err := deps.discoverSocket(ctx, sessionName, cfg)
+	if err != nil {
+		var unavailable *diagUnavailableError
+		if errors.As(err, &unavailable) {
+			return err
+		}
+		return diagPprofUnavailableError(sessionName, err)
+	}
+
+	body, err := deps.fetch(debugEndpointRequest{
+		sockPath:      sockPath,
+		path:          cmd.path,
+		timeout:       cmd.timeout,
+		configEnabled: true,
+		missingHint:   diagMissingSocketHint(sessionName),
+	})
+	if err != nil {
+		return err
+	}
+
+	switch cmd.kind {
+	case diagCommandGoroutines:
+		return writeGoroutineSummary(w, body)
+	case diagCommandInfo:
+		return writeDiagInfo(w, sessionName, body, deps)
+	default:
+		if cmd.outputPath != "" {
+			return deps.writeFile(cmd.outputPath, body, 0600)
+		}
+		_, err = w.Write(body)
+		return err
+	}
+}
+
+func fillDiagDeps(deps diagDeps) diagDeps {
+	if deps.loadConfig == nil {
+		deps.loadConfig = loadDebugConfig
+	}
+	if deps.discoverSocket == nil {
+		deps.discoverSocket = discoverDiagPprofSocket
+	}
+	if deps.fetch == nil {
+		deps.fetch = fetchDebugEndpoint
+	}
+	if deps.writeFile == nil {
+		deps.writeFile = os.WriteFile
+	}
+	if deps.readFile == nil {
+		deps.readFile = os.ReadFile
+	}
+	if deps.logPath == nil {
+		deps.logPath = diagSessionLogPath
+	}
+	return deps
+}
+
+func parseDiagCommand(args []string) (diagCommandRequest, error) {
+	if len(args) == 0 {
+		args = []string{"dump"}
+	}
+
+	switch args[0] {
+	case "dump":
+		if len(args) != 1 {
+			return diagCommandRequest{}, errors.New(diagUsage)
+		}
+		return diagCommandRequest{
+			kind:    diagCommandDump,
+			path:    "/debug/pprof/goroutine?debug=2",
+			timeout: diagDefaultTimeout,
+		}, nil
+	case "goroutines":
+		if len(args) != 1 {
+			return diagCommandRequest{}, errors.New(diagUsage)
+		}
+		return diagCommandRequest{
+			kind:    diagCommandGoroutines,
+			path:    "/debug/pprof/goroutine?debug=2",
+			timeout: diagDefaultTimeout,
+		}, nil
+	case "heap":
+		outputPath, err := parseDiagOutputFlag(args[1:])
+		if err != nil {
+			return diagCommandRequest{}, err
+		}
+		return diagCommandRequest{
+			kind:       diagCommandProfile,
+			path:       "/debug/pprof/heap?gc=1",
+			timeout:    diagDefaultTimeout,
+			outputPath: outputPath,
+		}, nil
+	case "profile":
+		seconds, outputPath, err := parseDiagProfileFlags(args[1:])
+		if err != nil {
+			return diagCommandRequest{}, err
+		}
+		return diagCommandRequest{
+			kind:       diagCommandProfile,
+			path:       "/debug/pprof/profile?seconds=" + strconv.Itoa(seconds),
+			timeout:    time.Duration(seconds)*time.Second + 5*time.Second,
+			outputPath: outputPath,
+		}, nil
+	case "pprof":
+		if len(args) < 2 {
+			return diagCommandRequest{}, errors.New(diagUsage)
+		}
+		name := args[1]
+		if !validDiagPprofName(name) {
+			return diagCommandRequest{}, errors.New(diagUsage)
+		}
+		outputPath, err := parseDiagOutputFlag(args[2:])
+		if err != nil {
+			return diagCommandRequest{}, err
+		}
+		return diagCommandRequest{
+			kind:       diagCommandProfile,
+			path:       "/debug/pprof/" + url.PathEscape(name),
+			timeout:    diagDefaultTimeout,
+			outputPath: outputPath,
+		}, nil
+	case "info":
+		if len(args) != 1 {
+			return diagCommandRequest{}, errors.New(diagUsage)
+		}
+		return diagCommandRequest{
+			kind:    diagCommandInfo,
+			path:    "/debug/amux/info",
+			timeout: diagDefaultTimeout,
+		}, nil
+	default:
+		return diagCommandRequest{}, errors.New(diagUsage)
+	}
+}
+
+func parseDiagOutputFlag(args []string) (string, error) {
+	switch len(args) {
+	case 0:
+		return "", nil
+	case 2:
+		if args[0] != "--output" || args[1] == "" {
+			return "", errors.New(diagUsage)
+		}
+		return args[1], nil
+	default:
+		return "", errors.New(diagUsage)
+	}
+}
+
+func parseDiagProfileFlags(args []string) (int, string, error) {
+	seconds := 10
+	outputPath := ""
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--seconds":
+			if i+1 >= len(args) {
+				return 0, "", errors.New(diagUsage)
+			}
+			n, err := strconv.Atoi(args[i+1])
+			if err != nil || n <= 0 {
+				return 0, "", errors.New(diagUsage)
+			}
+			seconds = n
+			i++
+		case "--output":
+			if i+1 >= len(args) || args[i+1] == "" {
+				return 0, "", errors.New(diagUsage)
+			}
+			outputPath = args[i+1]
+			i++
+		default:
+			return 0, "", errors.New(diagUsage)
+		}
+	}
+	return seconds, outputPath, nil
+}
+
+func validDiagPprofName(name string) bool {
+	if name == "" || strings.HasPrefix(name, "-") {
+		return false
+	}
+	return !strings.ContainsAny(name, `/\`)
+}
+
+func writeGoroutineSummary(w io.Writer, dump []byte) error {
+	count, states := summarizeGoroutineStates(dump)
+	if _, err := fmt.Fprintf(w, "goroutines: %d\nstates:\n", count); err != nil {
+		return err
+	}
+	names := make([]string, 0, len(states))
+	for name := range states {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		if _, err := fmt.Fprintf(w, "  %s: %d\n", name, states[name]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func summarizeGoroutineStates(dump []byte) (int, map[string]int) {
+	states := make(map[string]int)
+	for _, rawLine := range strings.Split(string(dump), "\n") {
+		line := strings.TrimSpace(rawLine)
+		if !strings.HasPrefix(line, "goroutine ") {
+			continue
+		}
+		start := strings.Index(line, "[")
+		end := strings.Index(line, "]")
+		if start < 0 || end <= start {
+			continue
+		}
+		state := strings.TrimSpace(line[start+1 : end])
+		if comma := strings.Index(state, ","); comma >= 0 {
+			state = strings.TrimSpace(state[:comma])
+		}
+		if state == "" {
+			state = "unknown"
+		}
+		states[state]++
+	}
+	count := 0
+	for _, n := range states {
+		count += n
+	}
+	return count, states
+}
+
+func writeDiagInfo(w io.Writer, sessionName string, body []byte, deps diagDeps) error {
+	var info diagInfo
+	if err := json.Unmarshal(body, &info); err != nil {
+		return fmt.Errorf("decoding info: %w", err)
+	}
+	if _, err := fmt.Fprintf(w, "pid: %d\nuptime: %s\nbinary: %s\nbuild: %s\ngo: %s\ngoroutines: %d\n",
+		info.PID, info.Uptime, info.Binary, info.Build, info.GoVersion, info.Goroutines); err != nil {
+		return err
+	}
+	lines, err := recentWatchdogLogLines(deps.readFile, deps.logPath(sessionName), 10)
+	if err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintln(w, "recent event_loop_watchdog log lines:"); err != nil {
+		return err
+	}
+	if len(lines) == 0 {
+		_, err := fmt.Fprintln(w, "(none)")
+		return err
+	}
+	for _, line := range lines {
+		if _, err := fmt.Fprintln(w, line); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func recentWatchdogLogLines(readFile func(string) ([]byte, error), path string, limit int) ([]string, error) {
+	data, err := readFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("reading watchdog log %s: %w", path, err)
+	}
+	lines := make([]string, 0)
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.Contains(line, "event_loop_watchdog") {
+			lines = append(lines, line)
+		}
+	}
+	if limit > 0 && len(lines) > limit {
+		lines = lines[len(lines)-limit:]
+	}
+	return lines, nil
+}
+
+func diagSessionLogPath(sessionName string) string {
+	logDir := os.Getenv("AMUX_LOG_DIR")
+	if logDir == "" {
+		logDir = server.SocketDir()
+	}
+	return filepath.Join(logDir, sessionName+".log")
+}
+
+func diagMissingSocketHint(sessionName string) string {
+	return fmt.Sprintf("pprof diagnostics socket %%s is not available for session %q; enable [debug] pprof = true in ~/.config/amux/config.toml and restart amux", sessionName)
+}
+
+type diagUnavailableError struct {
+	sessionName string
+	cause       error
+}
+
+func (e *diagUnavailableError) Error() string {
+	msg := fmt.Sprintf("pprof diagnostics socket is not available for session %q; enable [debug] pprof = true in ~/.config/amux/config.toml and restart amux", e.sessionName)
+	if e.cause == nil {
+		return msg
+	}
+	return msg + ": " + e.cause.Error()
+}
+
+func (e *diagUnavailableError) Unwrap() error {
+	return e.cause
+}
+
+func diagPprofUnavailableError(sessionName string, cause error) error {
+	return &diagUnavailableError{sessionName: sessionName, cause: cause}
+}
+
+type diagDiscoveryDeps struct {
+	serverSocketPath func(string) string
+	pprofSocketPath  func(string) string
+	runSS            func(context.Context) ([]byte, error)
+	glob             func(string) ([]string, error)
+	probe            func(context.Context, string) error
+}
+
+func discoverDiagPprofSocket(ctx context.Context, sessionName string, cfg *config.Config) (string, error) {
+	return discoverDiagPprofSocketWithDeps(ctx, sessionName, cfg, diagDiscoveryDeps{})
+}
+
+func discoverDiagPprofSocketWithDeps(ctx context.Context, sessionName string, cfg *config.Config, deps diagDiscoveryDeps) (string, error) {
+	deps = fillDiagDiscoveryDeps(deps)
+	mainSocket := deps.serverSocketPath(sessionName)
+	directPprofSocket := deps.pprofSocketPath(sessionName)
+
+	if ssOutput, err := deps.runSS(ctx); err == nil {
+		if sockPath := pprofSocketFromSS(ssOutput, mainSocket); sockPath != "" {
+			if err := deps.probe(ctx, sockPath); err == nil {
+				return sockPath, nil
+			}
+		}
+	}
+
+	for _, candidate := range fallbackDiagPprofCandidates(directPprofSocket, deps.glob) {
+		if err := deps.probe(ctx, candidate); err == nil {
+			return candidate, nil
+		}
+	}
+	return "", diagPprofUnavailableError(sessionName, os.ErrNotExist)
+}
+
+func fillDiagDiscoveryDeps(deps diagDiscoveryDeps) diagDiscoveryDeps {
+	if deps.serverSocketPath == nil {
+		deps.serverSocketPath = server.SocketPath
+	}
+	if deps.pprofSocketPath == nil {
+		deps.pprofSocketPath = server.PprofSocketPath
+	}
+	if deps.runSS == nil {
+		deps.runSS = runSSUnixListeners
+	}
+	if deps.glob == nil {
+		deps.glob = filepath.Glob
+	}
+	if deps.probe == nil {
+		deps.probe = probeDiagPprofSocket
+	}
+	return deps
+}
+
+func runSSUnixListeners(ctx context.Context) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(ctx, time.Second)
+	defer cancel()
+	return exec.CommandContext(ctx, "ss", "-lxp").Output()
+}
+
+func pprofSocketFromSS(output []byte, mainSocket string) string {
+	lines := bytes.Split(output, []byte{'\n'})
+	pid := ""
+	for _, lineBytes := range lines {
+		line := string(lineBytes)
+		if !strings.Contains(line, mainSocket) {
+			continue
+		}
+		pid = ssLinePID(line)
+		if pid != "" {
+			break
+		}
+	}
+	if pid == "" {
+		return ""
+	}
+	for _, lineBytes := range lines {
+		line := string(lineBytes)
+		if !strings.Contains(line, ".pprof") || !strings.Contains(line, "pid="+pid) {
+			continue
+		}
+		if path := ssLineSocketPath(line); path != "" {
+			return path
+		}
+	}
+	return ""
+}
+
+func ssLinePID(line string) string {
+	idx := strings.Index(line, "pid=")
+	if idx < 0 {
+		return ""
+	}
+	start := idx + len("pid=")
+	end := start
+	for end < len(line) && line[end] >= '0' && line[end] <= '9' {
+		end++
+	}
+	return line[start:end]
+}
+
+func ssLineSocketPath(line string) string {
+	for _, field := range strings.Fields(line) {
+		if strings.HasPrefix(field, "/") && strings.Contains(field, ".pprof") {
+			return field
+		}
+	}
+	return ""
+}
+
+func fallbackDiagPprofCandidates(directPprofSocket string, glob func(string) ([]string, error)) []string {
+	candidates := []string{directPprofSocket}
+	matches, err := glob(filepath.Join(filepath.Dir(directPprofSocket), "*.pprof"))
+	if err == nil {
+		directBase := filepath.Base(directPprofSocket)
+		for _, match := range matches {
+			if filepath.Base(match) == directBase {
+				candidates = append(candidates, match)
+			}
+		}
+	}
+	sort.Strings(candidates)
+	return compactStrings(candidates)
+}
+
+func compactStrings(values []string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	out := values[:0]
+	for _, value := range values {
+		if value == "" {
+			continue
+		}
+		if len(out) == 0 || out[len(out)-1] != value {
+			out = append(out, value)
+		}
+	}
+	return out
+}
+
+func probeDiagPprofSocket(ctx context.Context, sockPath string) error {
+	ctx, cancel := context.WithTimeout(ctx, time.Second)
+	defer cancel()
+
+	transport := &http.Transport{
+		DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+			return (&net.Dialer{}).DialContext(ctx, "unix", sockPath)
+		},
+	}
+	defer transport.CloseIdleConnections()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://amux/debug/pprof/", nil)
+	if err != nil {
+		return err
+	}
+	resp, err := (&http.Client{Transport: transport}).Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("pprof probe returned %s", resp.Status)
+	}
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 32*1024))
+	return nil
+}

--- a/internal/cli/cli_diag.go
+++ b/internal/cli/cli_diag.go
@@ -50,15 +50,6 @@ type diagCommandRequest struct {
 	outputPath string
 }
 
-type diagInfo struct {
-	PID        int    `json:"pid"`
-	Uptime     string `json:"uptime"`
-	Binary     string `json:"binary"`
-	Build      string `json:"build"`
-	GoVersion  string `json:"go_version"`
-	Goroutines int    `json:"goroutines"`
-}
-
 func runDiagCommand(sessionName string, args []string) {
 	if err := runDiagCommandWithIO(context.Background(), os.Stdout, sessionName, args); err != nil {
 		fmt.Fprintf(os.Stderr, "amux _diag: %v\n", err)
@@ -311,7 +302,7 @@ func summarizeGoroutineStates(dump []byte) (int, map[string]int) {
 }
 
 func writeDiagInfo(w io.Writer, sessionName string, body []byte, deps diagDeps) error {
-	var info diagInfo
+	var info server.DiagInfo
 	if err := json.Unmarshal(body, &info); err != nil {
 		return fmt.Errorf("decoding info: %w", err)
 	}

--- a/internal/cli/cli_diag_test.go
+++ b/internal/cli/cli_diag_test.go
@@ -18,66 +18,66 @@ func TestRunDiagCommandFetchesExpectedEndpoints(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name       string
-		args       []string
-		wantPath   string
-		wantOutput string
-		wantFile   string
+		name        string
+		args        []string
+		wantPath    string
+		wantOutput  string
+		wantFile    string
 		wantTimeout time.Duration
 	}{
 		{
-			name:       "default dumps goroutines",
-			wantPath:   "/debug/pprof/goroutine?debug=2",
-			wantOutput: "profile-body",
+			name:        "default dumps goroutines",
+			wantPath:    "/debug/pprof/goroutine?debug=2",
+			wantOutput:  "profile-body",
 			wantTimeout: 5 * time.Second,
 		},
 		{
-			name:       "dump dumps goroutines",
-			args:       []string{"dump"},
-			wantPath:   "/debug/pprof/goroutine?debug=2",
-			wantOutput: "profile-body",
+			name:        "dump dumps goroutines",
+			args:        []string{"dump"},
+			wantPath:    "/debug/pprof/goroutine?debug=2",
+			wantOutput:  "profile-body",
 			wantTimeout: 5 * time.Second,
 		},
 		{
-			name:       "heap writes binary profile to stdout",
-			args:       []string{"heap"},
-			wantPath:   "/debug/pprof/heap?gc=1",
-			wantOutput: "profile-body",
+			name:        "heap writes binary profile to stdout",
+			args:        []string{"heap"},
+			wantPath:    "/debug/pprof/heap?gc=1",
+			wantOutput:  "profile-body",
 			wantTimeout: 5 * time.Second,
 		},
 		{
-			name:       "heap writes binary profile to output file",
-			args:       []string{"heap", "--output", "heap.pprof"},
-			wantPath:   "/debug/pprof/heap?gc=1",
-			wantFile:   "heap.pprof",
+			name:        "heap writes binary profile to output file",
+			args:        []string{"heap", "--output", "heap.pprof"},
+			wantPath:    "/debug/pprof/heap?gc=1",
+			wantFile:    "heap.pprof",
 			wantTimeout: 5 * time.Second,
 		},
 		{
-			name:       "profile defaults to ten seconds",
-			args:       []string{"profile"},
-			wantPath:   "/debug/pprof/profile?seconds=10",
-			wantOutput: "profile-body",
+			name:        "profile defaults to ten seconds",
+			args:        []string{"profile"},
+			wantPath:    "/debug/pprof/profile?seconds=10",
+			wantOutput:  "profile-body",
 			wantTimeout: 15 * time.Second,
 		},
 		{
-			name:       "profile accepts seconds and output file",
-			args:       []string{"profile", "--seconds", "2", "--output", "cpu.pprof"},
-			wantPath:   "/debug/pprof/profile?seconds=2",
-			wantFile:   "cpu.pprof",
+			name:        "profile accepts seconds and output file",
+			args:        []string{"profile", "--seconds", "2", "--output", "cpu.pprof"},
+			wantPath:    "/debug/pprof/profile?seconds=2",
+			wantFile:    "cpu.pprof",
 			wantTimeout: 7 * time.Second,
 		},
 		{
-			name:       "generic pprof passes name through",
-			args:       []string{"pprof", "block"},
-			wantPath:   "/debug/pprof/block",
-			wantOutput: "profile-body",
+			name:        "generic pprof passes name through",
+			args:        []string{"pprof", "block"},
+			wantPath:    "/debug/pprof/block",
+			wantOutput:  "profile-body",
 			wantTimeout: 5 * time.Second,
 		},
 		{
-			name:       "generic trace passes name through",
-			args:       []string{"pprof", "trace", "--output", "trace.out"},
-			wantPath:   "/debug/pprof/trace",
-			wantFile:   "trace.out",
+			name:        "generic trace passes name through",
+			args:        []string{"pprof", "trace", "--output", "trace.out"},
+			wantPath:    "/debug/pprof/trace",
+			wantFile:    "trace.out",
 			wantTimeout: 5 * time.Second,
 		},
 	}
@@ -311,7 +311,7 @@ func TestDiscoverDiagPprofSocketUsesLivePIDFromSS(t *testing.T) {
 	var probed []string
 	got, err := discoverDiagPprofSocketWithDeps(context.Background(), session, &config.Config{Debug: config.DebugConfig{Pprof: true}}, diagDiscoveryDeps{
 		serverSocketPath: func(string) string { return mainSocket },
-		pprofSocketPath: func(string) string { return "/tmp/amux-1000/diag-session.pprof" },
+		pprofSocketPath:  func(string) string { return "/tmp/amux-1000/diag-session.pprof" },
 		runSS: func(context.Context) ([]byte, error) {
 			return []byte(ssOutput), nil
 		},
@@ -348,7 +348,7 @@ func TestDiscoverDiagPprofSocketFallsBackToProbedSockets(t *testing.T) {
 	var probes []string
 	got, err := discoverDiagPprofSocketWithDeps(context.Background(), session, &config.Config{Debug: config.DebugConfig{Pprof: true}}, diagDiscoveryDeps{
 		serverSocketPath: func(string) string { return "/tmp/amux-1000/diag-session" },
-		pprofSocketPath: func(string) string { return liveSocket },
+		pprofSocketPath:  func(string) string { return liveSocket },
 		runSS: func(context.Context) ([]byte, error) {
 			return nil, errors.New("ss unavailable")
 		},

--- a/internal/cli/cli_diag_test.go
+++ b/internal/cli/cli_diag_test.go
@@ -1,0 +1,378 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/weill-labs/amux/internal/config"
+)
+
+func TestRunDiagCommandFetchesExpectedEndpoints(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		args       []string
+		wantPath   string
+		wantOutput string
+		wantFile   string
+		wantTimeout time.Duration
+	}{
+		{
+			name:       "default dumps goroutines",
+			wantPath:   "/debug/pprof/goroutine?debug=2",
+			wantOutput: "profile-body",
+			wantTimeout: 5 * time.Second,
+		},
+		{
+			name:       "dump dumps goroutines",
+			args:       []string{"dump"},
+			wantPath:   "/debug/pprof/goroutine?debug=2",
+			wantOutput: "profile-body",
+			wantTimeout: 5 * time.Second,
+		},
+		{
+			name:       "heap writes binary profile to stdout",
+			args:       []string{"heap"},
+			wantPath:   "/debug/pprof/heap?gc=1",
+			wantOutput: "profile-body",
+			wantTimeout: 5 * time.Second,
+		},
+		{
+			name:       "heap writes binary profile to output file",
+			args:       []string{"heap", "--output", "heap.pprof"},
+			wantPath:   "/debug/pprof/heap?gc=1",
+			wantFile:   "heap.pprof",
+			wantTimeout: 5 * time.Second,
+		},
+		{
+			name:       "profile defaults to ten seconds",
+			args:       []string{"profile"},
+			wantPath:   "/debug/pprof/profile?seconds=10",
+			wantOutput: "profile-body",
+			wantTimeout: 15 * time.Second,
+		},
+		{
+			name:       "profile accepts seconds and output file",
+			args:       []string{"profile", "--seconds", "2", "--output", "cpu.pprof"},
+			wantPath:   "/debug/pprof/profile?seconds=2",
+			wantFile:   "cpu.pprof",
+			wantTimeout: 7 * time.Second,
+		},
+		{
+			name:       "generic pprof passes name through",
+			args:       []string{"pprof", "block"},
+			wantPath:   "/debug/pprof/block",
+			wantOutput: "profile-body",
+			wantTimeout: 5 * time.Second,
+		},
+		{
+			name:       "generic trace passes name through",
+			args:       []string{"pprof", "trace", "--output", "trace.out"},
+			wantPath:   "/debug/pprof/trace",
+			wantFile:   "trace.out",
+			wantTimeout: 5 * time.Second,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var out bytes.Buffer
+			var wrotePath string
+			var wroteData []byte
+			err := runDiagCommandWithDeps(context.Background(), &out, "diag-session", tt.args, diagDeps{
+				loadConfig: func() (*config.Config, error) {
+					return &config.Config{Debug: config.DebugConfig{Pprof: true}}, nil
+				},
+				discoverSocket: func(ctx context.Context, session string, cfg *config.Config) (string, error) {
+					if session != "diag-session" {
+						t.Fatalf("session = %q, want diag-session", session)
+					}
+					return "/tmp/live.pprof", nil
+				},
+				fetch: func(req debugEndpointRequest) ([]byte, error) {
+					if req.sockPath != "/tmp/live.pprof" {
+						t.Fatalf("sockPath = %q, want /tmp/live.pprof", req.sockPath)
+					}
+					if req.path != tt.wantPath {
+						t.Fatalf("path = %q, want %q", req.path, tt.wantPath)
+					}
+					if req.timeout != tt.wantTimeout {
+						t.Fatalf("timeout = %v, want %v", req.timeout, tt.wantTimeout)
+					}
+					return []byte("profile-body"), nil
+				},
+				writeFile: func(path string, data []byte, perm fs.FileMode) error {
+					wrotePath = path
+					wroteData = append([]byte(nil), data...)
+					if perm != 0600 {
+						t.Fatalf("perm = %#o, want 0600", perm)
+					}
+					return nil
+				},
+			})
+			if err != nil {
+				t.Fatalf("runDiagCommandWithDeps(%v): %v", tt.args, err)
+			}
+			if got := out.String(); got != tt.wantOutput {
+				t.Fatalf("stdout = %q, want %q", got, tt.wantOutput)
+			}
+			if wrotePath != tt.wantFile {
+				t.Fatalf("wrote path = %q, want %q", wrotePath, tt.wantFile)
+			}
+			if tt.wantFile != "" && string(wroteData) != "profile-body" {
+				t.Fatalf("wrote data = %q, want profile-body", wroteData)
+			}
+		})
+	}
+}
+
+func TestRunDiagGoroutinesSummarizesStateHistogram(t *testing.T) {
+	t.Parallel()
+
+	dump := `goroutine 1 [running]:
+main.main()
+
+goroutine 7 [IO wait, 2 minutes]:
+net.(*pollDesc).wait()
+
+goroutine 8 [chan receive]:
+main.worker()
+`
+
+	var out bytes.Buffer
+	err := runDiagCommandWithDeps(context.Background(), &out, "diag-session", []string{"goroutines"}, diagDeps{
+		loadConfig: func() (*config.Config, error) {
+			return &config.Config{Debug: config.DebugConfig{Pprof: true}}, nil
+		},
+		discoverSocket: func(context.Context, string, *config.Config) (string, error) {
+			return "/tmp/live.pprof", nil
+		},
+		fetch: func(req debugEndpointRequest) ([]byte, error) {
+			if req.path != "/debug/pprof/goroutine?debug=2" {
+				t.Fatalf("path = %q, want goroutine dump path", req.path)
+			}
+			return []byte(dump), nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("runDiagCommandWithDeps(goroutines): %v", err)
+	}
+
+	want := "goroutines: 3\nstates:\n  IO wait: 1\n  chan receive: 1\n  running: 1\n"
+	if got := out.String(); got != want {
+		t.Fatalf("stdout = %q, want %q", got, want)
+	}
+}
+
+func TestRunDiagInfoFormatsEndpointAndWatchdogLines(t *testing.T) {
+	t.Parallel()
+
+	logPath := filepath.Join(t.TempDir(), "diag-session.log")
+	logData := strings.Join([]string{
+		`{"event":"startup"}`,
+		`{"event":"event_loop_watchdog","elapsed":"31s","command_type":"server.sessionEventCommand"}`,
+		`plain event_loop_watchdog fallback line`,
+		`{"event":"shutdown"}`,
+	}, "\n")
+
+	var out bytes.Buffer
+	err := runDiagCommandWithDeps(context.Background(), &out, "diag-session", []string{"info"}, diagDeps{
+		loadConfig: func() (*config.Config, error) {
+			return &config.Config{Debug: config.DebugConfig{Pprof: true}}, nil
+		},
+		discoverSocket: func(context.Context, string, *config.Config) (string, error) {
+			return "/tmp/live.pprof", nil
+		},
+		fetch: func(req debugEndpointRequest) ([]byte, error) {
+			if req.path != "/debug/amux/info" {
+				t.Fatalf("path = %q, want /debug/amux/info", req.path)
+			}
+			return []byte(`{"pid":123,"uptime":"2s","binary":"/bin/amux","build":"abc123","go_version":"go1.25.0","goroutines":17}`), nil
+		},
+		readFile: func(path string) ([]byte, error) {
+			if path != logPath {
+				t.Fatalf("log path = %q, want %q", path, logPath)
+			}
+			return []byte(logData), nil
+		},
+		logPath: func(session string) string {
+			if session != "diag-session" {
+				t.Fatalf("session = %q, want diag-session", session)
+			}
+			return logPath
+		},
+	})
+	if err != nil {
+		t.Fatalf("runDiagCommandWithDeps(info): %v", err)
+	}
+
+	got := out.String()
+	for _, want := range []string{
+		"pid: 123\n",
+		"uptime: 2s\n",
+		"binary: /bin/amux\n",
+		"build: abc123\n",
+		"go: go1.25.0\n",
+		"goroutines: 17\n",
+		"recent event_loop_watchdog log lines:\n",
+		`{"event":"event_loop_watchdog","elapsed":"31s","command_type":"server.sessionEventCommand"}`,
+		"plain event_loop_watchdog fallback line",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("info output missing %q:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, `"event":"startup"`) {
+		t.Fatalf("info output included unrelated log line:\n%s", got)
+	}
+}
+
+func TestRunDiagMissingPprofErrorNamesConfigAndRestart(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+	err := runDiagCommandWithDeps(context.Background(), &out, "diag-session", []string{"dump"}, diagDeps{
+		loadConfig: func() (*config.Config, error) {
+			return &config.Config{}, nil
+		},
+		discoverSocket: func(context.Context, string, *config.Config) (string, error) {
+			return "", os.ErrNotExist
+		},
+	})
+	if err == nil {
+		t.Fatal("runDiagCommandWithDeps(dump) error = nil, want missing pprof error")
+	}
+	for _, want := range []string{"[debug] pprof = true", "~/.config/amux/config.toml", "restart"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error = %q, want substring %q", err.Error(), want)
+		}
+	}
+	if out.Len() != 0 {
+		t.Fatalf("stdout = %q, want empty", out.String())
+	}
+}
+
+func TestRunDiagCommandRejectsInvalidArgs(t *testing.T) {
+	t.Parallel()
+
+	tests := [][]string{
+		{"heap", "--output"},
+		{"profile", "--seconds", "0"},
+		{"profile", "--duration", "1s"},
+		{"pprof"},
+		{"pprof", "../heap"},
+		{"info", "--output", "info.txt"},
+		{"unknown"},
+	}
+
+	for _, args := range tests {
+		args := args
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			t.Parallel()
+
+			var out bytes.Buffer
+			err := runDiagCommandWithDeps(context.Background(), &out, "diag-session", args, diagDeps{
+				loadConfig: func() (*config.Config, error) {
+					t.Fatal("loadConfig should not be called for invalid args")
+					return nil, nil
+				},
+			})
+			if err == nil || !strings.Contains(err.Error(), diagUsage) {
+				t.Fatalf("runDiagCommandWithDeps(%v) error = %v, want usage", args, err)
+			}
+		})
+	}
+}
+
+func TestDiscoverDiagPprofSocketUsesLivePIDFromSS(t *testing.T) {
+	t.Parallel()
+
+	session := "diag-session"
+	mainSocket := "/tmp/amux-1000/diag-session"
+	pprofSocket := "/tmp/amux-1000/diag-session.pprof"
+	staleSocket := "/tmp/amux-1000/stale.pprof"
+	ssOutput := strings.Join([]string{
+		`u_str LISTEN 0 4096 ` + mainSocket + ` 123 * 0 users:(("amux",pid=4242,fd=7))`,
+		`u_str LISTEN 0 4096 ` + staleSocket + ` 123 * 0 users:(("amux",pid=9999,fd=7))`,
+		`u_str LISTEN 0 4096 ` + pprofSocket + ` 123 * 0 users:(("amux",pid=4242,fd=8))`,
+	}, "\n")
+
+	var probed []string
+	got, err := discoverDiagPprofSocketWithDeps(context.Background(), session, &config.Config{Debug: config.DebugConfig{Pprof: true}}, diagDiscoveryDeps{
+		serverSocketPath: func(string) string { return mainSocket },
+		pprofSocketPath: func(string) string { return "/tmp/amux-1000/diag-session.pprof" },
+		runSS: func(context.Context) ([]byte, error) {
+			return []byte(ssOutput), nil
+		},
+		glob: func(string) ([]string, error) {
+			t.Fatal("glob fallback should not be used when ss resolves the pprof socket")
+			return nil, nil
+		},
+		probe: func(ctx context.Context, path string) error {
+			probed = append(probed, path)
+			if path != pprofSocket {
+				t.Fatalf("probed path = %q, want %q", path, pprofSocket)
+			}
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("discoverDiagPprofSocketWithDeps: %v", err)
+	}
+	if got != pprofSocket {
+		t.Fatalf("socket = %q, want %q", got, pprofSocket)
+	}
+	if len(probed) != 1 {
+		t.Fatalf("probed = %v, want one probe", probed)
+	}
+}
+
+func TestDiscoverDiagPprofSocketFallsBackToProbedSockets(t *testing.T) {
+	t.Parallel()
+
+	session := "diag-session"
+	liveSocket := "/tmp/amux-1000/diag-session.pprof"
+	staleSocket := "/tmp/amux-1000/other.pprof"
+
+	var probes []string
+	got, err := discoverDiagPprofSocketWithDeps(context.Background(), session, &config.Config{Debug: config.DebugConfig{Pprof: true}}, diagDiscoveryDeps{
+		serverSocketPath: func(string) string { return "/tmp/amux-1000/diag-session" },
+		pprofSocketPath: func(string) string { return liveSocket },
+		runSS: func(context.Context) ([]byte, error) {
+			return nil, errors.New("ss unavailable")
+		},
+		glob: func(pattern string) ([]string, error) {
+			if !strings.HasSuffix(pattern, "*.pprof") {
+				t.Fatalf("glob pattern = %q, want *.pprof", pattern)
+			}
+			return []string{staleSocket, liveSocket}, nil
+		},
+		probe: func(ctx context.Context, path string) error {
+			probes = append(probes, path)
+			if path == liveSocket {
+				return nil
+			}
+			return errors.New("stale")
+		},
+	})
+	if err != nil {
+		t.Fatalf("discoverDiagPprofSocketWithDeps fallback: %v", err)
+	}
+	if got != liveSocket {
+		t.Fatalf("socket = %q, want %q", got, liveSocket)
+	}
+	if len(probes) != 1 || probes[0] != liveSocket {
+		t.Fatalf("probes = %v, want only exact session socket probe", probes)
+	}
+}

--- a/internal/cli/cli_dispatch.go
+++ b/internal/cli/cli_dispatch.go
@@ -16,6 +16,7 @@ type Runtime struct {
 	WriteVersionOutput func(io.Writer, []string) error
 	InstallTerminfo    func() error
 	RunDebugCommand    func(string, []string)
+	RunDiagCommand     func(string, []string)
 	RunServer          func(string, bool)
 	RunServerCommand   func(string, string, []string)
 	RunEventsCommand   func(string, []string)

--- a/internal/cli/cli_usage.go
+++ b/internal/cli/cli_usage.go
@@ -12,6 +12,7 @@ const (
 	captureUsage      = "usage: amux capture [--client] [pane] [--history <pane>] [--ansi] [--colors]"
 	logUsage          = "usage: amux log <clients|panes>"
 	debugUsage        = "usage: amux debug <goroutines|profile|heap|socket|frames|client-goroutines|client-profile|client-heap> [--duration <duration-or-seconds>]"
+	diagUsage         = "usage: amux _diag [dump|goroutines|heap|profile|pprof|info] [--seconds N] [--output <path>]"
 	leadUsage         = "usage: amux lead [pane] | amux lead --clear"
 	metaUsage         = "usage: amux meta <set|get|rm> ..."
 	moveUsage         = "usage: amux move <pane> up|down | amux move <pane> (--before <target>|--after <target>|--to-column <target>)"
@@ -46,6 +47,7 @@ const (
 
 var commandUsageByName = map[string]string{
 	"_inject-proxy":    "usage: amux _inject-proxy <host>",
+	"_diag":            diagUsage,
 	"_layout-json":     "usage: amux _layout-json",
 	"_server":          "usage: amux _server [session]",
 	"broadcast":        "usage: amux broadcast (--panes <pane,pane,...> | --window <index|name> | --match <glob>) [--hex] <keys>...",

--- a/internal/cli/main_cli_subprocess_test.go
+++ b/internal/cli/main_cli_subprocess_test.go
@@ -201,6 +201,18 @@ func TestMainDebugHelp(t *testing.T) {
 	}
 }
 
+func TestMainDiagHelp(t *testing.T) {
+	t.Parallel()
+
+	output, exitCode := runHermeticMain(t, "_diag", "--help")
+	if exitCode != 0 {
+		t.Fatalf("exit code = %d, want 0\noutput:\n%s", exitCode, output)
+	}
+	if !strings.Contains(output, "usage: amux _diag [dump|goroutines|heap|profile|pprof|info]") {
+		t.Fatalf("output = %q, want diag usage", output)
+	}
+}
+
 func TestMainDebugFramesDispatchesDedicatedServerCommand(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cli/main_test.go
+++ b/internal/cli/main_test.go
@@ -812,6 +812,14 @@ func TestRunMainDispatchesCommands(t *testing.T) {
 			},
 		},
 		{
+			name:     "diag command uses dedicated pprof runner",
+			args:     []string{"_diag", "dump"},
+			wantExit: 0,
+			wantCalls: []cliCall{
+				{kind: "diag", session: resolvedSessionMarker, args: []string{"dump"}},
+			},
+		},
+		{
 			name:     "remote command dispatches through server",
 			args:     []string{"disconnect", "host-a"},
 			wantExit: 0,
@@ -1084,6 +1092,13 @@ func (h *cliRuntimeHarness) runtime() Runtime {
 		RunDebugCommand: func(sessionName string, args []string) {
 			h.calls = append(h.calls, cliCall{
 				kind:    "debug",
+				session: sessionName,
+				args:    append([]string(nil), args...),
+			})
+		},
+		RunDiagCommand: func(sessionName string, args []string) {
+			h.calls = append(h.calls, cliCall{
+				kind:    "diag",
 				session: sessionName,
 				args:    append([]string(nil), args...),
 			})

--- a/internal/cli/runtime_entry.go
+++ b/internal/cli/runtime_entry.go
@@ -77,6 +77,7 @@ func defaultRuntime(buildCommit string) Runtime {
 		},
 		InstallTerminfo: terminfo.Install,
 		RunDebugCommand: runDebugCommand,
+		RunDiagCommand:  runDiagCommand,
 		RunServer: func(sessionName string, managedTakeover bool) {
 			RunServer(sessionName, managedTakeover, buildVersion(buildCommit))
 		},

--- a/internal/server/pprof.go
+++ b/internal/server/pprof.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net"
@@ -9,6 +10,7 @@ import (
 	httppprof "net/http/pprof"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
@@ -23,12 +25,29 @@ type pprofEndpoint struct {
 	done     chan struct{}
 }
 
+type DiagInfo struct {
+	PID        int    `json:"pid"`
+	Uptime     string `json:"uptime"`
+	Binary     string `json:"binary"`
+	Build      string `json:"build"`
+	GoVersion  string `json:"go_version"`
+	Goroutines int    `json:"goroutines"`
+}
+
 func PprofSocketPath(session string) string {
 	return filepath.Join(SocketDir(), session+".pprof")
 }
 
-func newPprofMux() *http.ServeMux {
+func newPprofMux(infoProvider func() DiagInfo) *http.ServeMux {
 	mux := http.NewServeMux()
+	if infoProvider != nil {
+		mux.HandleFunc("/debug/amux/info", func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			if err := json.NewEncoder(w).Encode(infoProvider()); err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+			}
+		})
+	}
 	mux.HandleFunc("/debug/pprof/", httppprof.Index)
 	mux.HandleFunc("/debug/pprof/cmdline", httppprof.Cmdline)
 	mux.HandleFunc("/debug/pprof/profile", httppprof.Profile)
@@ -43,7 +62,7 @@ func newPprofMux() *http.ServeMux {
 	return mux
 }
 
-func newPprofEndpoint(sockPath string, logger *charmlog.Logger) (*pprofEndpoint, error) {
+func newPprofEndpoint(sockPath string, logger *charmlog.Logger, infoProvider func() DiagInfo) (*pprofEndpoint, error) {
 	if _, err := os.Stat(sockPath); err == nil {
 		conn, dialErr := dialutil.DialUnixStaleProbe(sockPath)
 		if dialErr == nil {
@@ -66,7 +85,7 @@ func newPprofEndpoint(sockPath string, logger *charmlog.Logger) (*pprofEndpoint,
 	endpoint := &pprofEndpoint{
 		sockPath: sockPath,
 		listener: listener,
-		server:   &http.Server{Handler: newPprofMux()},
+		server:   &http.Server{Handler: newPprofMux(infoProvider)},
 		done:     make(chan struct{}),
 	}
 	go func() {
@@ -97,6 +116,27 @@ func (p *pprofEndpoint) close() {
 	_ = os.Remove(p.sockPath)
 }
 
+func (s *Server) DiagInfo() DiagInfo {
+	sess := s.firstSession()
+	startedAt := time.Now()
+	if sess != nil && !sess.startedAt.IsZero() {
+		startedAt = sess.startedAt
+	}
+	binary, _ := os.Executable()
+	build := BuildVersion
+	if build == "" {
+		build = "dev"
+	}
+	return DiagInfo{
+		PID:        os.Getpid(),
+		Uptime:     time.Since(startedAt).Round(time.Millisecond).String(),
+		Binary:     binary,
+		Build:      build,
+		GoVersion:  runtime.Version(),
+		Goroutines: runtime.NumGoroutine(),
+	}
+}
+
 func (s *Server) EnablePprof() error {
 	if s == nil || s.pprof != nil {
 		return nil
@@ -106,7 +146,7 @@ func (s *Server) EnablePprof() error {
 		return fmt.Errorf("pprof debug endpoint requires an active session")
 	}
 
-	endpoint, err := newPprofEndpoint(PprofSocketPath(sess.Name), s.logger)
+	endpoint, err := newPprofEndpoint(PprofSocketPath(sess.Name), s.logger, s.DiagInfo)
 	if err != nil {
 		return err
 	}

--- a/internal/server/pprof_test.go
+++ b/internal/server/pprof_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -79,6 +80,13 @@ func TestPprofEndpointRespondsWhileSessionMutationPathWedged(t *testing.T) {
 
 	wedgeStarted := make(chan struct{})
 	releaseWedge := make(chan struct{})
+	var releaseOnce sync.Once
+	release := func() {
+		releaseOnce.Do(func() {
+			close(releaseWedge)
+		})
+	}
+	t.Cleanup(release)
 	wedgedDone := make(chan commandMutationResult, 1)
 	go func() {
 		wedgedDone <- sess.enqueueCommandMutation(func(*MutationContext) commandMutationResult {
@@ -112,7 +120,7 @@ func TestPprofEndpointRespondsWhileSessionMutationPathWedged(t *testing.T) {
 		t.Fatalf("goroutine profile missing header:\n%s", body)
 	}
 
-	close(releaseWedge)
+	release()
 	select {
 	case res := <-wedgedDone:
 		if res.err != nil {

--- a/internal/server/pprof_test.go
+++ b/internal/server/pprof_test.go
@@ -1,0 +1,164 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/weill-labs/amux/internal/mux"
+)
+
+func TestPprofInfoEndpointReportsRuntimeInfo(t *testing.T) {
+	t.Parallel()
+
+	session := fmt.Sprintf("pprof-info-%d", time.Now().UnixNano())
+	srv, err := newServerWithScrollbackLogger(session, mux.DefaultScrollbackLines, nil)
+	if err != nil {
+		t.Fatalf("newServerWithScrollbackLogger: %v", err)
+	}
+	defer srv.Shutdown()
+	if err := srv.EnablePprof(); err != nil {
+		t.Fatalf("EnablePprof: %v", err)
+	}
+
+	body := fetchServerUnixHTTP(t, PprofSocketPath(session), "/debug/amux/info", time.Second)
+	var info struct {
+		PID        int    `json:"pid"`
+		Uptime     string `json:"uptime"`
+		Binary     string `json:"binary"`
+		Build      string `json:"build"`
+		GoVersion  string `json:"go_version"`
+		Goroutines int    `json:"goroutines"`
+	}
+	if err := json.Unmarshal([]byte(body), &info); err != nil {
+		t.Fatalf("Unmarshal info: %v\n%s", err, body)
+	}
+	if info.PID != os.Getpid() {
+		t.Fatalf("pid = %d, want %d", info.PID, os.Getpid())
+	}
+	if info.Uptime == "" {
+		t.Fatal("uptime is empty")
+	}
+	if info.Binary == "" {
+		t.Fatal("binary is empty")
+	}
+	if info.Build == "" {
+		t.Fatal("build is empty")
+	}
+	if !strings.HasPrefix(info.GoVersion, "go") {
+		t.Fatalf("go_version = %q, want go*", info.GoVersion)
+	}
+	if info.Goroutines < 1 {
+		t.Fatalf("goroutines = %d, want > 0", info.Goroutines)
+	}
+}
+
+func TestPprofEndpointRespondsWhileSessionMutationPathWedged(t *testing.T) {
+	t.Parallel()
+
+	session := fmt.Sprintf("pprof-wedge-%d", time.Now().UnixNano())
+	srv, err := newServerWithScrollbackLogger(session, mux.DefaultScrollbackLines, nil)
+	if err != nil {
+		t.Fatalf("newServerWithScrollbackLogger: %v", err)
+	}
+	defer srv.Shutdown()
+	if err := srv.EnablePprof(); err != nil {
+		t.Fatalf("EnablePprof: %v", err)
+	}
+	sess := srv.firstSession()
+	if sess == nil {
+		t.Fatal("server has no session")
+	}
+
+	wedgeStarted := make(chan struct{})
+	releaseWedge := make(chan struct{})
+	wedgedDone := make(chan commandMutationResult, 1)
+	go func() {
+		wedgedDone <- sess.enqueueCommandMutation(func(*MutationContext) commandMutationResult {
+			close(wedgeStarted)
+			<-releaseWedge
+			return commandMutationResult{output: "released\n"}
+		})
+	}()
+
+	select {
+	case <-wedgeStarted:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for wedged mutation to start")
+	}
+
+	normalDone := make(chan commandMutationResult, 1)
+	go func() {
+		normalDone <- sess.enqueueCommandMutation(func(*MutationContext) commandMutationResult {
+			return commandMutationResult{output: "normal\n"}
+		})
+	}()
+
+	select {
+	case res := <-normalDone:
+		t.Fatalf("normal mutation completed while wedge was active: %+v", res)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	body := fetchServerUnixHTTP(t, PprofSocketPath(session), "/debug/pprof/goroutine?debug=1", time.Second)
+	if !strings.Contains(body, "goroutine profile:") {
+		t.Fatalf("goroutine profile missing header:\n%s", body)
+	}
+
+	close(releaseWedge)
+	select {
+	case res := <-wedgedDone:
+		if res.err != nil {
+			t.Fatalf("wedged mutation error after release: %v", res.err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for wedged mutation to release")
+	}
+	select {
+	case res := <-normalDone:
+		if res.err != nil {
+			t.Fatalf("normal mutation error after release: %v", res.err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for normal mutation after release")
+	}
+}
+
+func fetchServerUnixHTTP(t *testing.T, sockPath, path string, timeout time.Duration) string {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	transport := &http.Transport{
+		DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+			return (&net.Dialer{}).DialContext(ctx, "unix", sockPath)
+		},
+	}
+	t.Cleanup(transport.CloseIdleConnections)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://amux"+path, nil)
+	if err != nil {
+		t.Fatalf("NewRequest(%q): %v", path, err)
+	}
+	resp, err := (&http.Client{Transport: transport}).Do(req)
+	if err != nil {
+		t.Fatalf("GET %s over %s: %v", path, sockPath, err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("ReadAll(%s): %v", path, err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET %s status = %s, want 200 OK\nbody:\n%s", path, resp.Status, body)
+	}
+	return string(body)
+}

--- a/test/diag_test.go
+++ b/test/diag_test.go
@@ -1,0 +1,97 @@
+package test
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestDiagDumpCommandPrintsGoroutineDump(t *testing.T) {
+	t.Parallel()
+
+	h := newServerHarnessWithConfig(t, 80, 24, "[debug]\npprof = true\n")
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	cmd := h.commandWithContext(ctx, "_diag", "dump")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("_diag dump: %v\n%s", err, out)
+	}
+	if !strings.Contains(string(out), "goroutine") {
+		t.Fatalf("goroutine dump missing goroutine text:\n%s", out)
+	}
+}
+
+func TestDiagGoroutinesCommandPrintsHistogram(t *testing.T) {
+	t.Parallel()
+
+	h := newServerHarnessWithConfig(t, 80, 24, "[debug]\npprof = true\n")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	cmd := h.commandWithContext(ctx, "_diag", "goroutines")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("_diag goroutines: %v\n%s", err, out)
+	}
+	for _, want := range []string{"goroutines:", "states:"} {
+		if !strings.Contains(string(out), want) {
+			t.Fatalf("_diag goroutines output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestDiagCommandReportsDisabledEndpoint(t *testing.T) {
+	t.Parallel()
+
+	h := newServerHarness(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	cmd := h.commandWithContext(ctx, "_diag", "dump")
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("_diag dump should fail when pprof is disabled.\nOutput:\n%s", out)
+	}
+	for _, want := range []string{"[debug] pprof = true", "~/.config/amux/config.toml", "restart"} {
+		if !strings.Contains(string(out), want) {
+			t.Fatalf("output = %q, want substring %q", out, want)
+		}
+	}
+}
+
+func TestDiagInfoIncludesWatchdogLogLines(t *testing.T) {
+	t.Parallel()
+
+	h := newServerHarnessWithConfig(t, 80, 24, "[debug]\npprof = true\n")
+	watchdogLine := `{"event":"event_loop_watchdog","session":"` + h.session + `","elapsed":"31s"}`
+	if err := appendFile(h.logPath, "\n"+watchdogLine+"\n"); err != nil {
+		t.Fatalf("append watchdog line: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	cmd := h.commandWithContext(ctx, "_diag", "info")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("_diag info: %v\n%s", err, out)
+	}
+	for _, want := range []string{"pid:", "uptime:", "binary:", "build:", "go:", "goroutines:", "recent event_loop_watchdog log lines:", watchdogLine} {
+		if !strings.Contains(string(out), want) {
+			t.Fatalf("_diag info output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func appendFile(path, data string) error {
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0600)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	_, err = f.WriteString(data)
+	return err
+}


### PR DESCRIPTION
## Motivation

When a session actor wedges, normal amux commands can block behind the main session command path. The server pprof listener runs separately, so an internal diagnostics path can still collect useful state during those failures.

## Summary

- Add `amux _diag` subcommands for goroutine dumps, goroutine state histograms, heap/CPU profiles, generic pprof passthrough, and runtime info.
- Discover the local server pprof socket through `ss -lxp` PID matching with a probed socket fallback, and print a restart/config hint when pprof is unavailable.
- Serve `/debug/amux/info` on the pprof socket and include recent `event_loop_watchdog` log lines in `_diag info`.
- Cover CLI dispatch, parsing, socket discovery, live pprof behavior while the session mutation path is wedged, and harness-level `_diag` behavior.

## Testing

- `go test ./internal/cli -run 'TestRunDiag|TestDiscoverDiag|TestMainDiag|TestRunWithRuntimeDispatch' -count=100`
- `go test ./internal/server -run 'TestPprof' -count=100`
- `go test ./test -run 'TestDiag' -count=100 -timeout 300s`
- `go test ./... -timeout 120s`

## Review focus

- `_diag` socket discovery and stale-socket fallback behavior.
- Binary profile output handling for `heap`, `profile`, and generic `pprof`.
- The `/debug/amux/info` pprof-side endpoint and watchdog log inclusion.

Closes LAB-1917