### PR TITLE
Bound pane-history cell run length by per-line cell budget

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -51,7 +51,12 @@ if ! command -v golangci-lint &>/dev/null; then
     exit 1
 fi
 
-if ! golangci-lint run $STAGED; then
+# Lint the packages containing staged Go files, not the files themselves.
+# golangci-lint must analyze whole packages so cross-file symbols typecheck;
+# passing bare file paths reports spurious "undefined" errors. Mirrors CI's
+# `golangci-lint run ./...`.
+STAGED_PKGS=$(printf '%s\n' $STAGED | xargs -n1 dirname | sort -u | sed 's#^#./#')
+if ! golangci-lint run $STAGED_PKGS; then
     echo "golangci-lint: fix the reported issues before committing"
     exit 1
 fi

--- a/internal/proto/wire_pane_history.go
+++ b/internal/proto/wire_pane_history.go
@@ -16,6 +16,14 @@ import (
 
 const wireFormatPaneHistory byte = 0x02
 
+// maxPaneHistoryLineCells bounds the number of cells decoded for a single
+// styled-history line. Run-length encoding lets a run count legitimately
+// exceed the payload byte size (a full-width colored bar compresses to a few
+// bytes), so run lengths cannot be validated against the payload length like
+// other counts. This cap guards the decode-time allocation against corrupted
+// frames while staying far above any real terminal width.
+const maxPaneHistoryLineCells = 1 << 16
+
 const (
 	paneHistoryFlagHistoryFromStyledText byte = 1 << iota
 )
@@ -426,11 +434,13 @@ func decodePaneHistoryPayload(paneID uint32, r *paneHistoryReader, payloadLen in
 				return nil, fmt.Errorf("reading styled line %d run count: %w", i, err)
 			}
 			line.Cells = make([]Cell, 0, runCount)
+			cellsRemaining := maxPaneHistoryLineCells
 			for runIndex := 0; runIndex < runCount; runIndex++ {
-				runLen, err := readPaneHistoryCount(r, payloadLen, "cell run length")
+				runLen, err := readPaneHistoryRunLength(r, cellsRemaining)
 				if err != nil {
 					return nil, fmt.Errorf("reading styled line %d run %d length: %w", i, runIndex, err)
 				}
+				cellsRemaining -= runLen
 				char, err := readPaneHistoryString(r)
 				if err != nil {
 					return nil, fmt.Errorf("reading styled line %d run %d char: %w", i, runIndex, err)
@@ -724,6 +734,21 @@ func readPaneHistoryCount(r *paneHistoryReader, payloadLen int, name string) (in
 	}
 	if n > uint64(payloadLen) {
 		return 0, fmt.Errorf("%s too large: %d", name, n)
+	}
+	return int(n), nil
+}
+
+// readPaneHistoryRunLength reads an RLE run length, bounding it by the cells
+// still allowed for the current line. Because run lengths are compressed, they
+// are validated against the per-line cell budget rather than the payload byte
+// length used by readPaneHistoryCount.
+func readPaneHistoryRunLength(r *paneHistoryReader, cellsRemaining int) (int, error) {
+	n, err := binary.ReadUvarint(r)
+	if err != nil {
+		return 0, fmt.Errorf("reading cell run length: %w", err)
+	}
+	if n > uint64(cellsRemaining) {
+		return 0, fmt.Errorf("cell run length too large: %d", n)
 	}
 	return int(n), nil
 }

--- a/internal/proto/wire_pane_history_test.go
+++ b/internal/proto/wire_pane_history_test.go
@@ -134,6 +134,41 @@ func TestReadMsgPaneHistoryBinaryFrameWithExplicitHistory(t *testing.T) {
 	}
 }
 
+func TestReadMsgPaneHistoryBinaryFrameWideRunSmallPayload(t *testing.T) {
+	t.Parallel()
+
+	// A short history whose only styled line is a full-width run of identical
+	// cells (e.g. a colored status bar). Run-length encoding compresses the run
+	// to a few bytes, so the run count legitimately exceeds the total payload
+	// size. Regression for "cell run length too large" on attach.
+	const width = 128
+	cells := make([]Cell, width)
+	for i := range cells {
+		cells[i] = Cell{Char: " ", Width: 1, Style: uv.Style{Bg: ansi.BasicColor(4)}}
+	}
+	msg := &Message{
+		Type:          MsgTypePaneHistory,
+		PaneID:        1,
+		History:       []string{"a", "b", "c", strings.Repeat(" ", width)},
+		StyledHistory: []StyledLine{{Text: "a"}, {Text: "b"}, {Text: "c"}, {Text: strings.Repeat(" ", width), Cells: cells}},
+	}
+
+	var buf bytes.Buffer
+	writer := NewWriter(&buf)
+	enableWriterPaneHistoryBinary(t, writer)
+	if err := writer.WriteMsg(msg); err != nil {
+		t.Fatalf("WriteMsg: %v", err)
+	}
+
+	got, err := ReadMsg(bytes.NewReader(buf.Bytes()))
+	if err != nil {
+		t.Fatalf("ReadMsg: %v", err)
+	}
+	if !equalMessages(got, msg) {
+		t.Fatalf("round-trip mismatch:\n got: %#v\nwant: %#v", got, msg)
+	}
+}
+
 func TestWriterWriteMsgPaneHistoryUsesBinaryFrameWhenEnabled(t *testing.T) {
 	t.Parallel()
 
@@ -424,6 +459,47 @@ func TestPaneHistoryBinaryErrorPaths(t *testing.T) {
 		}
 	})
 
+	t.Run("decoder bounds cell runs by per-line cell budget", func(t *testing.T) {
+		t.Parallel()
+
+		// A single run longer than the per-line cell cap is rejected.
+		var oversizedRun bytes.Buffer
+		oversizedRun.WriteByte(0)
+		writePaneHistoryUvarint(&oversizedRun, 1)
+		writePaneHistoryUvarint(&oversizedRun, 1)
+		writePaneHistoryString(&oversizedRun, "x")
+		writePaneHistoryUvarint(&oversizedRun, 0)
+		oversizedRun.WriteByte(paneHistoryLineFlagHasCells)
+		writePaneHistoryString(&oversizedRun, "y")
+		writePaneHistoryUvarint(&oversizedRun, 1)
+		writePaneHistoryUvarint(&oversizedRun, uint64(maxPaneHistoryLineCells+1))
+		if _, err := decodePaneHistoryPayload(1, newPaneHistoryReader(bytes.NewReader(oversizedRun.Bytes()), int64(oversizedRun.Len())), oversizedRun.Len()); err == nil || !strings.Contains(err.Error(), "cell run length too large") {
+			t.Fatalf("decodePaneHistoryPayload(oversized run) error = %v, want cell run length too large", err)
+		}
+
+		// Runs that individually fit but together exceed the cap are rejected.
+		var cumulativeRuns bytes.Buffer
+		cumulativeRuns.WriteByte(0)
+		writePaneHistoryUvarint(&cumulativeRuns, 1)
+		writePaneHistoryUvarint(&cumulativeRuns, 1)
+		writePaneHistoryString(&cumulativeRuns, "x")
+		writePaneHistoryUvarint(&cumulativeRuns, 1)
+		if err := writePaneHistoryStyle(&cumulativeRuns, uv.Style{}); err != nil {
+			t.Fatalf("writePaneHistoryStyle: %v", err)
+		}
+		cumulativeRuns.WriteByte(paneHistoryLineFlagHasCells)
+		writePaneHistoryString(&cumulativeRuns, "y")
+		writePaneHistoryUvarint(&cumulativeRuns, 2)
+		writePaneHistoryUvarint(&cumulativeRuns, uint64(maxPaneHistoryLineCells))
+		writePaneHistoryString(&cumulativeRuns, "a")
+		writePaneHistoryUvarint(&cumulativeRuns, 1)
+		writePaneHistoryUvarint(&cumulativeRuns, 0)
+		writePaneHistoryUvarint(&cumulativeRuns, 1)
+		if _, err := decodePaneHistoryPayload(1, newPaneHistoryReader(bytes.NewReader(cumulativeRuns.Bytes()), int64(cumulativeRuns.Len())), cumulativeRuns.Len()); err == nil || !strings.Contains(err.Error(), "cell run length too large") {
+			t.Fatalf("decodePaneHistoryPayload(cumulative runs) error = %v, want cell run length too large", err)
+		}
+	})
+
 	t.Run("low level readers reject invalid encodings", func(t *testing.T) {
 		t.Parallel()
 
@@ -435,6 +511,15 @@ func TestPaneHistoryBinaryErrorPaths(t *testing.T) {
 		writePaneHistoryUvarint(&countBuf, 5)
 		if _, err := readPaneHistoryCount(newPaneHistoryReader(bytes.NewReader(countBuf.Bytes()), int64(countBuf.Len())), 4, "test count"); err == nil || !strings.Contains(err.Error(), "too large") {
 			t.Fatalf("readPaneHistoryCount() error = %v, want too large", err)
+		}
+
+		var runLenBuf bytes.Buffer
+		writePaneHistoryUvarint(&runLenBuf, 5)
+		if got, err := readPaneHistoryRunLength(newPaneHistoryReader(bytes.NewReader(runLenBuf.Bytes()), int64(runLenBuf.Len())), 8); err != nil || got != 5 {
+			t.Fatalf("readPaneHistoryRunLength() = %d, %v, want 5, nil", got, err)
+		}
+		if _, err := readPaneHistoryRunLength(newPaneHistoryReader(bytes.NewReader(runLenBuf.Bytes()), int64(runLenBuf.Len())), 4); err == nil || !strings.Contains(err.Error(), "cell run length too large") {
+			t.Fatalf("readPaneHistoryRunLength() error = %v, want too large", err)
 		}
 
 		var stringBuf bytes.Buffer


### PR DESCRIPTION
## Motivation

Attaching to a session failed with `amux: attach failed: reading styled line N run 0 length: cell run length too large: 128` whenever a pane's styled history was short but contained a wide run of identical cells (e.g. a full-width colored status bar or separator). Run-length encoding compresses such a run to a few bytes, so the run count legitimately exceeds the total payload size — and the decoder rejected it. This is easy to hit on wide terminals (the reporting session was 381 columns).

## Summary

- `readPaneHistoryCount` validates every count against the payload byte length. That is correct for counts whose items each consume >=1 wire byte, but wrong for RLE run lengths, which compress N cells into O(1) bytes.
- Add `readPaneHistoryRunLength`, which bounds the run length by the cells still allowed for the current line (`maxPaneHistoryLineCells = 1<<16`), decrementing that budget per run so a line's cumulative cell count is also capped. This keeps a decode-time allocation guard against corrupted frames while accepting any real terminal width.
- Fix a latent `.githooks/pre-commit` bug (separate commit): it ran `golangci-lint run` on bare file paths, which typecheck in isolation under golangci-lint v1.64.8 and report spurious `undefined` errors for sibling-file symbols. It now lints the packages containing staged Go files, matching CI's `golangci-lint run ./...`.

## Testing

```
go test ./internal/proto/ -count=100
golangci-lint run ./internal/proto/
go build ./... && go vet ./...
```

New regression test `TestReadMsgPaneHistoryBinaryFrameWideRunSmallPayload` was confirmed to fail with the exact production error before the fix. Added guard tests cover an oversized single run and cumulative runs exceeding the per-line cap. (One pre-existing flake in the `test/` package, `TestCaptureJSON_AgentStatus_Transition`, fails on `origin/main` independently of this change.)

## Review focus

- The semantic shift from "bytes remaining in payload" to "cells remaining on this line" as the run-length bound, and whether `1<<16` is a comfortable ceiling.
- Whether bundling the pre-commit hook fix here (vs. a separate PR) is acceptable; it was required to commit at all.