### PR TITLE
LAB-1916: Address cancellable wait review feedback

### DIFF
--- a/internal/server/commands_input.go
+++ b/internal/server/commands_input.go
@@ -188,7 +188,7 @@ func (ctx inputCommandContext) SendKeys(actorPaneID uint32, args []string) (stri
 	disableAutomaticEnterPacingForIdlePane(chunks, pane.pane)
 	switch opts.waitTarget {
 	case sendKeysWaitReady:
-		if err := waitForPaneReady(ctx.Sess, pane.paneName, pane, waitReadyOptions{timeout: opts.waitTimeout}); err != nil {
+		if err := waitForPaneReady(ctx.context(), ctx.Sess, pane.paneName, pane, waitReadyOptions{timeout: opts.waitTimeout}); err != nil {
 			return "", 0, err
 		}
 		if err := enqueueSendKeysInput(ctx.context(), ctx.Sess, pane, chunks, opts, nil); err != nil {

--- a/internal/server/commands_wait.go
+++ b/internal/server/commands_wait.go
@@ -230,7 +230,7 @@ func (ctx waitCommandContext) WaitReady(actorPaneID uint32, args []string) error
 	if err != nil {
 		return err
 	}
-	return waitForPaneReady(ctx.Sess, paneRef, pane, opts)
+	return waitForPaneReady(ctx.context(), ctx.Sess, paneRef, pane, opts)
 }
 
 func (ctx waitCommandContext) WaitIdle(actorPaneID uint32, args []string) error {
@@ -244,7 +244,7 @@ func (ctx waitCommandContext) WaitIdle(actorPaneID uint32, args []string) error 
 	if err != nil {
 		return err
 	}
-	return waitForPaneIdle(ctx.Sess, paneRef, pane.paneID, opts)
+	return waitForPaneIdle(ctx.context(), ctx.Sess, paneRef, pane.paneID, opts)
 }
 
 func cmdCursor(ctx *CommandContext) {

--- a/internal/server/idle.go
+++ b/internal/server/idle.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"time"
@@ -42,8 +43,8 @@ type idleWaitState struct {
 	exists        bool
 }
 
-func (s *Session) queryIdleWaitState(paneID uint32) (idleWaitState, error) {
-	return enqueueSessionQueryOnState(s.context(), s, func(sess *Session) (idleWaitState, error) {
+func (s *Session) queryIdleWaitState(ctx context.Context, paneID uint32) (idleWaitState, error) {
+	return enqueueSessionQueryOnState(ctx, s, func(sess *Session) (idleWaitState, error) {
 		pane := sess.findPaneByID(paneID)
 		if pane == nil {
 			return idleWaitState{}, nil
@@ -117,14 +118,17 @@ func stopTimer(timer Timer) {
 	}
 }
 
-func waitForPaneIdle(sess *Session, paneRef string, paneID uint32, opts waitIdleOptions) error {
-	outputCh := sess.enqueuePaneOutputSubscribe(sess.context(), paneID)
+func waitForPaneIdle(ctx context.Context, sess *Session, paneRef string, paneID uint32, opts waitIdleOptions) error {
+	outputCh := sess.enqueuePaneOutputSubscribe(ctx, paneID)
 	if outputCh == nil {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		return fmt.Errorf("session shutting down")
 	}
 	defer sess.enqueuePaneOutputUnsubscribe(paneID, outputCh)
 
-	state, err := sess.queryIdleWaitState(paneID)
+	state, err := sess.queryIdleWaitState(ctx, paneID)
 	if err != nil {
 		return err
 	}
@@ -144,7 +148,7 @@ func waitForPaneIdle(sess *Session, paneRef string, paneID uint32, opts waitIdle
 		case <-outputCh:
 			resetTimer(settleTimer, opts.settle)
 		case <-settleTimer.C():
-			state, err := sess.queryIdleWaitState(paneID)
+			state, err := sess.queryIdleWaitState(ctx, paneID)
 			if err != nil {
 				return err
 			}
@@ -160,6 +164,8 @@ func waitForPaneIdle(sess *Session, paneRef string, paneID uint32, opts waitIdle
 			settleTimer.Reset(remaining)
 		case <-timeoutTimer.C():
 			return fmt.Errorf("timeout waiting for %s to become idle", paneRef)
+		case <-ctx.Done():
+			return ctx.Err()
 		}
 	}
 }

--- a/internal/server/idle_test.go
+++ b/internal/server/idle_test.go
@@ -188,6 +188,27 @@ func TestCmdWaitIdleTimeout(t *testing.T) {
 	}
 }
 
+func TestCmdWaitIdleReturnsWhenContextCanceled(t *testing.T) {
+	t.Parallel()
+
+	clk := NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	srv, sess, pane, cleanup := setupWaitIdleTestPane(t)
+	defer cleanup()
+	sess.Clock = clk
+	pane.SetCreatedAt(clk.Now())
+
+	_, cc, done := startAsyncCommand(t, srv, sess, "wait", "idle", "pane-1", "--settle", "200ms", "--timeout", "5s")
+	clk.AwaitTimers(2)
+
+	cc.Close()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("wait-idle command did not return after context cancellation")
+	}
+}
+
 func TestCmdWaitIdleResetsSettleTimerOnOutput(t *testing.T) {
 	t.Parallel()
 

--- a/internal/server/session_events_client.go
+++ b/internal/server/session_events_client.go
@@ -209,14 +209,18 @@ type eventSubscribeCmd struct {
 	reply       chan eventSubscribeResult
 }
 
-func (e eventSubscribeCmd) handle(_ context.Context, s *Session) {
+func (e eventSubscribeCmd) handle(ctx context.Context, s *Session) {
 	sub := eventloop.Subscribe(&s.eventSubs, e.filter)
 
 	result := eventSubscribeResult{sub: sub}
 	if e.sendInitial {
 		result.initialState = eventloop.MarshalMatching(s.currentStateEvents(), e.filter)
 	}
-	e.reply <- result
+	select {
+	case e.reply <- result:
+	case <-ctx.Done():
+		eventloop.Unsubscribe(&s.eventSubs, sub)
+	}
 }
 
 type uiWaitSubscribeCmd struct {
@@ -225,10 +229,13 @@ type uiWaitSubscribeCmd struct {
 	reply             chan uiWaitSubscribeResult
 }
 
-func (e uiWaitSubscribeCmd) handle(_ context.Context, s *Session) {
+func (e uiWaitSubscribeCmd) handle(ctx context.Context, s *Session) {
 	client, err := s.resolveUIClientSnapshot(e.requestedClientID, e.eventName)
 	if err != nil {
-		e.reply <- uiWaitSubscribeResult{err: err}
+		select {
+		case e.reply <- uiWaitSubscribeResult{err: err}:
+		case <-ctx.Done():
+		}
 		return
 	}
 
@@ -237,12 +244,17 @@ func (e uiWaitSubscribeCmd) handle(_ context.Context, s *Session) {
 		ClientID: client.clientID,
 	})
 
-	e.reply <- uiWaitSubscribeResult{subscription: uiWaitSubscription{
+	result := uiWaitSubscribeResult{subscription: uiWaitSubscription{
 		sub:          sub,
 		clientID:     client.clientID,
 		currentMatch: client.currentMatch,
 		currentGen:   client.currentGen,
 	}}
+	select {
+	case e.reply <- result:
+	case <-ctx.Done():
+		eventloop.Unsubscribe(&s.eventSubs, sub)
+	}
 }
 
 type eventUnsubscribeCmd struct {
@@ -292,7 +304,7 @@ func (e uiEventCmd) handle(_ context.Context, s *Session) {
 // --- Enqueue helpers ---
 
 func (s *Session) enqueueEventSubscribe(ctx context.Context, f eventFilter, sendInitial bool) eventSubscribeResult {
-	reply := make(chan eventSubscribeResult, 1)
+	reply := make(chan eventSubscribeResult)
 	if !s.enqueueEvent(ctx, eventSubscribeCmd{filter: f, sendInitial: sendInitial, reply: reply}) {
 		return eventSubscribeResult{}
 	}
@@ -313,7 +325,7 @@ func (s *Session) enqueueEventSubscribe(ctx context.Context, f eventFilter, send
 func (s *Session) enqueueUIWaitSubscribe(ctx context.Context, requestedClientID, eventName string) (uiWaitSubscription, error) {
 	var zero uiWaitSubscription
 
-	reply := make(chan uiWaitSubscribeResult, 1)
+	reply := make(chan uiWaitSubscribeResult)
 	if !s.enqueueEvent(ctx, uiWaitSubscribeCmd{
 		requestedClientID: requestedClientID,
 		eventName:         eventName,

--- a/internal/server/session_events_layout.go
+++ b/internal/server/session_events_layout.go
@@ -470,7 +470,7 @@ type commandMutationEvent struct {
 	reply chan commandMutationResult
 }
 
-func (e commandMutationEvent) handle(eventCtx context.Context, s *Session) {
+func (e commandMutationEvent) handle(_ context.Context, s *Session) {
 	beforeActiveWindowID := s.ActiveWindowID
 	ctx := newMutationContext(s)
 	res := recoverCommandMutation(e.fn, ctx)
@@ -502,10 +502,7 @@ func (e commandMutationEvent) handle(eventCtx context.Context, s *Session) {
 		}
 		res.paneRenders = nil
 	}
-	select {
-	case e.reply <- res:
-	case <-eventCtx.Done():
-	}
+	e.reply <- res
 }
 
 func (s *Session) drainScheduledMutationPanes(ctx *MutationContext) {
@@ -637,7 +634,12 @@ func (s *Session) enqueueCommandMutationContext(ctx context.Context, fn func(*Mu
 	case res := <-reply:
 		return res
 	case <-ctx.Done():
-		return commandMutationResult{err: ctx.Err()}
+		select {
+		case res := <-reply:
+			return res
+		default:
+			return commandMutationResult{err: ctx.Err()}
+		}
 	case <-s.sessionEventDone:
 		// The event loop exited (e.g., wantShutdown after our handler).
 		// The reply may already be buffered — prefer it over the error.

--- a/internal/server/session_events_pane.go
+++ b/internal/server/session_events_pane.go
@@ -360,9 +360,13 @@ type paneOutputSubscribeCmd struct {
 	reply  chan chan struct{}
 }
 
-func (e paneOutputSubscribeCmd) handle(_ context.Context, s *Session) {
+func (e paneOutputSubscribeCmd) handle(ctx context.Context, s *Session) {
 	ch := s.addPaneOutputSubscriber(e.paneID)
-	e.reply <- ch
+	select {
+	case e.reply <- ch:
+	case <-ctx.Done():
+		s.ensureWaiters().removePaneOutputSubscriber(e.paneID, ch)
+	}
 }
 
 type paneOutputUnsubscribeCmd struct {
@@ -375,7 +379,7 @@ func (e paneOutputUnsubscribeCmd) handle(_ context.Context, s *Session) {
 }
 
 func (s *Session) enqueuePaneOutputSubscribe(ctx context.Context, paneID uint32) chan struct{} {
-	reply := make(chan (chan struct{}), 1)
+	reply := make(chan (chan struct{}))
 	if !s.enqueueEvent(ctx, paneOutputSubscribeCmd{paneID: paneID, reply: reply}) {
 		return nil
 	}

--- a/internal/server/session_subscribe_cancel_test.go
+++ b/internal/server/session_subscribe_cancel_test.go
@@ -25,9 +25,6 @@ func TestPaneOutputSubscribeRemovesSubscriberWhenContextCanceledBeforeReply(t *t
 		}.handle(ctx, sess)
 	}()
 
-	waitUntil(t, func() bool {
-		return sess.ensureWaiters().outputSubscriberCount(1) == 1
-	})
 	cancel()
 
 	select {
@@ -58,9 +55,6 @@ func TestEventSubscribeRemovesSubscriberWhenContextCanceledBeforeReply(t *testin
 		}.handle(ctx, sess)
 	}()
 
-	waitUntil(t, func() bool {
-		return len(sess.eventSubs) == 1
-	})
 	cancel()
 
 	select {
@@ -98,9 +92,6 @@ func TestUIWaitSubscribeRemovesSubscriberWhenContextCanceledBeforeReply(t *testi
 		}.handle(ctx, sess)
 	}()
 
-	waitUntil(t, func() bool {
-		return len(sess.eventSubs) == 1
-	})
 	cancel()
 
 	select {

--- a/internal/server/session_subscribe_cancel_test.go
+++ b/internal/server/session_subscribe_cancel_test.go
@@ -1,0 +1,115 @@
+package server
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/weill-labs/amux/internal/proto"
+)
+
+func TestPaneOutputSubscribeRemovesSubscriberWhenContextCanceledBeforeReply(t *testing.T) {
+	t.Parallel()
+
+	sess := newSession("test-pane-output-subscribe-cancel")
+	stopCrashCheckpointLoop(t, sess)
+	defer stopSessionBackgroundLoops(t, sess)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		paneOutputSubscribeCmd{
+			paneID: 1,
+			reply:  make(chan chan struct{}),
+		}.handle(ctx, sess)
+	}()
+
+	waitUntil(t, func() bool {
+		return sess.ensureWaiters().outputSubscriberCount(1) == 1
+	})
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("pane output subscribe handler did not return after context cancellation")
+	}
+
+	if got := sess.ensureWaiters().outputSubscriberCount(1); got != 0 {
+		t.Fatalf("pane output subscribers after cancellation = %d, want 0", got)
+	}
+}
+
+func TestEventSubscribeRemovesSubscriberWhenContextCanceledBeforeReply(t *testing.T) {
+	t.Parallel()
+
+	sess := newSession("test-event-subscribe-cancel")
+	stopCrashCheckpointLoop(t, sess)
+	defer stopSessionBackgroundLoops(t, sess)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		eventSubscribeCmd{
+			filter: eventFilter{Types: []string{EventExited}},
+			reply:  make(chan eventSubscribeResult),
+		}.handle(ctx, sess)
+	}()
+
+	waitUntil(t, func() bool {
+		return len(sess.eventSubs) == 1
+	})
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("event subscribe handler did not return after context cancellation")
+	}
+
+	if got := len(sess.eventSubs); got != 0 {
+		t.Fatalf("event subscribers after cancellation = %d, want 0", got)
+	}
+}
+
+func TestUIWaitSubscribeRemovesSubscriberWhenContextCanceledBeforeReply(t *testing.T) {
+	t.Parallel()
+
+	sess := newSession("test-ui-wait-subscribe-cancel")
+	stopCrashCheckpointLoop(t, sess)
+	defer stopSessionBackgroundLoops(t, sess)
+
+	cc := newClientConn(nil)
+	cc.ID = "client-1"
+	cc.inputIdle = true
+	defer cc.Close()
+	sess.ensureClientManager().setClientsForTest(cc)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		uiWaitSubscribeCmd{
+			requestedClientID: "client-1",
+			eventName:         proto.UIEventInputIdle,
+			reply:             make(chan uiWaitSubscribeResult),
+		}.handle(ctx, sess)
+	}()
+
+	waitUntil(t, func() bool {
+		return len(sess.eventSubs) == 1
+	})
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("UI wait subscribe handler did not return after context cancellation")
+	}
+
+	if got := len(sess.eventSubs); got != 0 {
+		t.Fatalf("event subscribers after UI wait cancellation = %d, want 0", got)
+	}
+}

--- a/internal/server/wait_ready.go
+++ b/internal/server/wait_ready.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"time"
@@ -167,9 +168,12 @@ func parseSendKeysArgs(args []string) (sendKeysOptions, error) {
 	return opts, nil
 }
 
-func waitForPaneReady(sess *Session, paneRef string, paneRefData resolvedPaneRef, opts waitReadyOptions) error {
-	outputCh := sess.enqueuePaneOutputSubscribe(sess.context(), paneRefData.paneID)
+func waitForPaneReady(ctx context.Context, sess *Session, paneRef string, paneRefData resolvedPaneRef, opts waitReadyOptions) error {
+	outputCh := sess.enqueuePaneOutputSubscribe(ctx, paneRefData.paneID)
 	if outputCh == nil {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		return fmt.Errorf("session shutting down")
 	}
 	defer sess.enqueuePaneOutputUnsubscribe(paneRefData.paneID, outputCh)
@@ -184,7 +188,7 @@ func waitForPaneReady(sess *Session, paneRef string, paneRefData resolvedPaneRef
 	settleActive := false
 
 	syncReady := func() (bool, error) {
-		state, err := queryPaneReadyState(sess, paneRefData.paneID)
+		state, err := queryPaneReadyState(ctx, sess, paneRefData.paneID)
 		if err != nil {
 			return false, fmt.Errorf("pane %q disappeared while waiting to become ready", paneRef)
 		}
@@ -234,6 +238,8 @@ func waitForPaneReady(sess *Session, paneRef string, paneRefData resolvedPaneRef
 			settleActive = false
 		case <-timeoutTimer.C():
 			return fmt.Errorf("timeout waiting for %s to become ready", paneRef)
+		case <-ctx.Done():
+			return ctx.Err()
 		}
 
 		ready, err := syncReady()
@@ -246,8 +252,8 @@ func waitForPaneReady(sess *Session, paneRef string, paneRefData resolvedPaneRef
 	}
 }
 
-func queryPaneReadyState(sess *Session, paneID uint32) (paneReadyState, error) {
-	state, err := enqueueSessionQueryOnState(sess.context(), sess, func(sess *Session) (paneReadyState, error) {
+func queryPaneReadyState(ctx context.Context, sess *Session, paneID uint32) (paneReadyState, error) {
+	state, err := enqueueSessionQueryOnState(ctx, sess, func(sess *Session) (paneReadyState, error) {
 		pane := sess.findPaneByID(paneID)
 		if pane == nil {
 			return paneReadyState{}, nil

--- a/internal/server/wait_ready_test.go
+++ b/internal/server/wait_ready_test.go
@@ -277,7 +277,7 @@ func TestWaitForPaneReadyReturnsSessionShuttingDown(t *testing.T) {
 	}
 	close(sess.sessionEventStop)
 
-	err := waitForPaneReady(sess, "pane-1", resolvedPaneRef{}, waitReadyOptions{timeout: time.Millisecond})
+	err := waitForPaneReady(sess.context(), sess, "pane-1", resolvedPaneRef{}, waitReadyOptions{timeout: time.Millisecond})
 	if err == nil || err.Error() != "session shutting down" {
 		t.Fatalf("waitForPaneReady session shutdown error = %v, want session shutting down", err)
 	}
@@ -317,6 +317,29 @@ func TestWaitReadyFailsWhenPaneDisappearsMidWait(t *testing.T) {
 	case <-done:
 	case <-time.After(time.Second):
 		t.Fatal("wait-ready pane disappearance command did not return")
+	}
+}
+
+func TestCmdWaitReadyReturnsWhenContextCanceled(t *testing.T) {
+	t.Parallel()
+
+	clk := NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	srv, sess, pane, cleanup := setupWaitReadyTestPane(t, nil)
+	defer cleanup()
+
+	sess.Clock = clk
+	sess.ensureIdleTracker().VTIdleSettle = 100 * time.Millisecond
+	pane.SetCreatedAt(clk.Now())
+
+	_, cc, done := startAsyncCommand(t, srv, sess, "wait", "ready", "pane-1", "--timeout", "5s")
+	clk.AwaitTimers(3)
+
+	cc.Close()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("wait-ready command did not return after context cancellation")
 	}
 }
 


### PR DESCRIPTION
## Motivation
PR #802 was merged before the review feedback in `.orca/prompts/review-802.md` was applied. The review found that `wait idle` and `wait ready` still ignored client cancellation after their initial session query, and noted narrow cancellation races around subscription handoff and mutation replies.

## Summary
- Thread client contexts through `waitForPaneIdle`, `waitForPaneReady`, and send-keys `--wait ready`.
- Add `ctx.Done()` handling inside idle and ready wait loops so disconnects unblock command workers promptly.
- Change subscription reply handoff to remove just-created event and pane-output subscribers if cancellation wins before the caller receives the subscription.
- Always deliver completed command mutation results to the reply channel and prefer a ready reply over context cancellation.
- Add regression tests for canceled idle/ready waits and canceled subscription handoffs.

## Testing
- `go test -race ./internal/server -run 'Test(PaneOutputSubscribeRemovesSubscriberWhenContextCanceledBeforeReply|EventSubscribeRemovesSubscriberWhenContextCanceledBeforeReply|UIWaitSubscribeRemovesSubscriberWhenContextCanceledBeforeReply|CmdWaitIdleReturnsWhenContextCanceled|CmdWaitReadyReturnsWhenContextCanceled)$' -count=100`
- `go test -race ./internal/... -timeout 60s`
- `scripts/push-and-watch-ci.sh --force-with-lease` (passed: `test`, `claude-review`, `codecov/patch`, `semgrep-cloud-platform/scan`)

## Review focus
- Whether unbuffered subscription replies are the right tradeoff for cleaning up canceled handoffs.
- Context propagation through `wait idle`, `wait ready`, and send-keys `--wait ready`.
- The command mutation reply preference when cancellation races with a completed mutation.

Follow-up to #802.
Closes LAB-1916
