### PR TITLE
LAB-1917: Match diag sockets exactly

### DIFF
--- a/internal/cli/cli_diag.go
+++ b/internal/cli/cli_diag.go
@@ -445,7 +445,7 @@ func pprofSocketFromSS(output []byte, mainSocket string) string {
 	pid := ""
 	for _, lineBytes := range lines {
 		line := string(lineBytes)
-		if !strings.Contains(line, mainSocket) {
+		if ssLineSocketPath(line) != mainSocket {
 			continue
 		}
 		pid = ssLinePID(line)
@@ -461,7 +461,7 @@ func pprofSocketFromSS(output []byte, mainSocket string) string {
 		if !strings.Contains(line, ".pprof") || !strings.Contains(line, "pid="+pid) {
 			continue
 		}
-		if path := ssLineSocketPath(line); path != "" {
+		if path := ssLineSocketPath(line); strings.HasSuffix(path, ".pprof") {
 			return path
 		}
 	}
@@ -483,7 +483,7 @@ func ssLinePID(line string) string {
 
 func ssLineSocketPath(line string) string {
 	for _, field := range strings.Fields(line) {
-		if strings.HasPrefix(field, "/") && strings.Contains(field, ".pprof") {
+		if strings.HasPrefix(field, "/") {
 			return field
 		}
 	}

--- a/internal/cli/cli_diag_test.go
+++ b/internal/cli/cli_diag_test.go
@@ -301,8 +301,12 @@ func TestDiscoverDiagPprofSocketUsesLivePIDFromSS(t *testing.T) {
 	session := "diag-session"
 	mainSocket := "/tmp/amux-1000/diag-session"
 	pprofSocket := "/tmp/amux-1000/diag-session.pprof"
+	prefixSocket := "/tmp/amux-1000/diag-session-2"
+	prefixPprofSocket := "/tmp/amux-1000/diag-session-2.pprof"
 	staleSocket := "/tmp/amux-1000/stale.pprof"
 	ssOutput := strings.Join([]string{
+		`u_str LISTEN 0 4096 ` + prefixSocket + ` 123 * 0 users:(("amux",pid=3131,fd=7))`,
+		`u_str LISTEN 0 4096 ` + prefixPprofSocket + ` 123 * 0 users:(("amux",pid=3131,fd=8))`,
 		`u_str LISTEN 0 4096 ` + mainSocket + ` 123 * 0 users:(("amux",pid=4242,fd=7))`,
 		`u_str LISTEN 0 4096 ` + staleSocket + ` 123 * 0 users:(("amux",pid=9999,fd=7))`,
 		`u_str LISTEN 0 4096 ` + pprofSocket + ` 123 * 0 users:(("amux",pid=4242,fd=8))`,


### PR DESCRIPTION
## Motivation

`amux _diag` discovers the server pprof socket by matching the live server PID from `ss -lxp`. After PR #803 merged, manual review found that session names which are prefixes of other sessions could match the wrong main socket line.

## Summary

- Parse the socket path from each `ss` line and require an exact match for the main session socket before taking the PID.
- Keep accepting only `.pprof` socket paths for the matched PID.
- Add a regression case where `diag-session` and `diag-session-2` both appear in `ss` output.

## Testing

- `go test ./internal/cli -run 'TestDiscoverDiagPprofSocketUsesLivePIDFromSS|TestDiscoverDiagPprofSocketFallsBackToProbedSockets|TestRunDiag' -count=100`
- `go test ./test -run 'TestDiag' -count=1 -timeout 120s`
- `go test ./... -timeout 120s`

## Review focus

- The exact socket-path match in `pprofSocketFromSS`.
- The regression test's prefix-session fixture.

Follow-up to LAB-1917 / PR #803.