### PR TITLE
LAB-1924: Clean client pprof sockets on signal termination

### DIFF
--- a/internal/client/attach.go
+++ b/internal/client/attach.go
@@ -85,6 +85,13 @@ func waitForRunSessionEnd(done <-chan struct{}, triggerReload <-chan struct{}) b
 	}
 }
 
+func signalExitCode(sig os.Signal) int {
+	if syscallSig, ok := sig.(syscall.Signal); ok {
+		return 128 + int(syscallSig)
+	}
+	return 1
+}
+
 func isConnectionLostError(err error) bool {
 	if err == nil {
 		return false
@@ -499,17 +506,21 @@ func runSessionWithDeps(sessionName string, getTermSize func(int) (int, int, err
 		return fmt.Errorf("loading config: %w", err)
 	}
 	var clientPprof *pprofEndpoint
+	var closeClientPprofOnce sync.Once
+	closeClientPprof := func() {
+		closeClientPprofOnce.Do(func() {
+			if clientPprof != nil {
+				clientPprof.close()
+			}
+		})
+	}
 	if cfg.PprofEnabled() {
 		clientPprof, err = newPprofEndpoint(sessionName, os.Getpid())
 		if err != nil {
 			return fmt.Errorf("enabling client pprof debug endpoint failed: %w", err)
 		}
 	}
-	defer func() {
-		if clientPprof != nil {
-			clientPprof.close()
-		}
-	}()
+	defer closeClientPprof()
 	kb := config.DefaultKeybindings()
 	scrollbackLines := cfg.EffectiveScrollbackLines()
 	stdin := deps.stdin
@@ -583,16 +594,31 @@ func runSessionWithDeps(sessionName string, getTermSize func(int) (int, int, err
 		return fmt.Errorf("raw mode: %w", err)
 	}
 	stdout.Write([]byte(terminalEnterSequence(negotiatedAttachCaps)))
-	terminalRestored := false
+	var restoreTerminalOnce sync.Once
 	restoreTerminal := func() {
-		if terminalRestored {
-			return
-		}
-		terminalRestored = true
-		stdout.Write([]byte(terminalExitSequence(negotiatedAttachCaps)))
-		_ = term.Restore(fd, oldState)
+		restoreTerminalOnce.Do(func() {
+			stdout.Write([]byte(terminalExitSequence(negotiatedAttachCaps)))
+			_ = term.Restore(fd, oldState)
+		})
 	}
 	defer restoreTerminal()
+
+	termSigCh := make(chan os.Signal, 1)
+	termSigDone := make(chan struct{})
+	signal.Notify(termSigCh, syscall.SIGHUP, syscall.SIGTERM, syscall.SIGINT)
+	defer func() {
+		signal.Stop(termSigCh)
+		close(termSigDone)
+	}()
+	go func() {
+		select {
+		case sig := <-termSigCh:
+			closeClientPprof()
+			restoreTerminal()
+			os.Exit(signalExitCode(sig))
+		case <-termSigDone:
+		}
+	}()
 
 	if initial := cr.Render(true); initial != "" {
 		if _, err := io.WriteString(stdout, wrapSynchronizedFrame(initial)); err != nil {
@@ -1360,10 +1386,7 @@ func runSessionWithDeps(sessionName string, getTermSize func(int) (int, int, err
 		if exitState.get() == "" {
 			exitState.set("detached: server requested hot-reload")
 		}
-		if clientPprof != nil {
-			clientPprof.close()
-			clientPprof = nil
-		}
+		closeClientPprof()
 		if execPath != "" {
 			if err := deps.execSelf(execPath, sender, restoreTerminal); err != nil {
 				restoreTerminal()

--- a/internal/client/attach.go
+++ b/internal/client/attach.go
@@ -126,6 +126,10 @@ func installTerminationSignalHandler(cleanup func(), exit func(int)) func() {
 	}()
 	return func() {
 		signal.Stop(sigCh)
+		select {
+		case <-sigCh:
+		default:
+		}
 		close(done)
 	}
 }

--- a/internal/client/attach.go
+++ b/internal/client/attach.go
@@ -59,6 +59,26 @@ func (s *sessionExitState) get() string {
 	return s.notice
 }
 
+type deferredTerminalRestore struct {
+	mu sync.Mutex
+	fn func()
+}
+
+func (r *deferredTerminalRestore) set(fn func()) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.fn = fn
+}
+
+func (r *deferredTerminalRestore) run() {
+	r.mu.Lock()
+	fn := r.fn
+	r.mu.Unlock()
+	if fn != nil {
+		fn()
+	}
+}
+
 func defaultRunSessionDeps() runSessionDeps {
 	return runSessionDeps{
 		stdin:             os.Stdin,
@@ -539,6 +559,13 @@ func runSessionWithDeps(sessionName string, getTermSize func(int) (int, int, err
 		}
 	}
 	defer closeClientPprof()
+	var terminalRestore deferredTerminalRestore
+	restoreTerminal := terminalRestore.run
+	stopTerminationSignalHandler := installTerminationSignalHandler(func() {
+		closeClientPprof()
+		restoreTerminal()
+	}, os.Exit)
+	defer stopTerminationSignalHandler()
 	kb := config.DefaultKeybindings()
 	scrollbackLines := cfg.EffectiveScrollbackLines()
 	stdin := deps.stdin
@@ -613,19 +640,13 @@ func runSessionWithDeps(sessionName string, getTermSize func(int) (int, int, err
 	}
 	stdout.Write([]byte(terminalEnterSequence(negotiatedAttachCaps)))
 	var restoreTerminalOnce sync.Once
-	restoreTerminal := func() {
+	terminalRestore.set(func() {
 		restoreTerminalOnce.Do(func() {
 			stdout.Write([]byte(terminalExitSequence(negotiatedAttachCaps)))
 			_ = term.Restore(fd, oldState)
 		})
-	}
+	})
 	defer restoreTerminal()
-
-	stopTerminationSignalHandler := installTerminationSignalHandler(func() {
-		closeClientPprof()
-		restoreTerminal()
-	}, os.Exit)
-	defer stopTerminationSignalHandler()
 
 	if initial := cr.Render(true); initial != "" {
 		if _, err := io.WriteString(stdout, wrapSynchronizedFrame(initial)); err != nil {

--- a/internal/client/attach.go
+++ b/internal/client/attach.go
@@ -92,6 +92,24 @@ func signalExitCode(sig os.Signal) int {
 	return 1
 }
 
+func installTerminationSignalHandler(cleanup func(), exit func(int)) func() {
+	sigCh := make(chan os.Signal, 1)
+	done := make(chan struct{})
+	signal.Notify(sigCh, syscall.SIGHUP, syscall.SIGTERM, syscall.SIGINT)
+	go func() {
+		select {
+		case sig := <-sigCh:
+			cleanup()
+			exit(signalExitCode(sig))
+		case <-done:
+		}
+	}()
+	return func() {
+		signal.Stop(sigCh)
+		close(done)
+	}
+}
+
 func isConnectionLostError(err error) bool {
 	if err == nil {
 		return false
@@ -603,22 +621,11 @@ func runSessionWithDeps(sessionName string, getTermSize func(int) (int, int, err
 	}
 	defer restoreTerminal()
 
-	termSigCh := make(chan os.Signal, 1)
-	termSigDone := make(chan struct{})
-	signal.Notify(termSigCh, syscall.SIGHUP, syscall.SIGTERM, syscall.SIGINT)
-	defer func() {
-		signal.Stop(termSigCh)
-		close(termSigDone)
-	}()
-	go func() {
-		select {
-		case sig := <-termSigCh:
-			closeClientPprof()
-			restoreTerminal()
-			os.Exit(signalExitCode(sig))
-		case <-termSigDone:
-		}
-	}()
+	stopTerminationSignalHandler := installTerminationSignalHandler(func() {
+		closeClientPprof()
+		restoreTerminal()
+	}, os.Exit)
+	defer stopTerminationSignalHandler()
 
 	if initial := cr.Render(true); initial != "" {
 		if _, err := io.WriteString(stdout, wrapSynchronizedFrame(initial)); err != nil {

--- a/test/debug_test.go
+++ b/test/debug_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -170,6 +171,39 @@ func TestDebugClientCommandsUseInteractiveClientPprofEndpoint(t *testing.T) {
 	pty.detach()
 	if !pty.waitExited(5 * time.Second) {
 		t.Fatal("interactive client did not exit after detach")
+	}
+}
+
+func TestDebugClientPprofSignalTerminationRemovesSocketAndAlias(t *testing.T) {
+	t.Parallel()
+
+	h := newServerHarness(t)
+	writeDebugPprofConfig(t, h)
+
+	pty := newPTYClientHarness(t, h)
+	clientSocket := client.PprofProcessSocketPath(h.session, pty.cmd.Process.Pid)
+	aliasPath := client.PprofSocketPath(h.session)
+
+	if _, err := os.Stat(clientSocket); err != nil {
+		t.Fatalf("Stat(%q): %v", clientSocket, err)
+	}
+	if got, err := os.Readlink(aliasPath); err != nil {
+		t.Fatalf("Readlink(%q): %v", aliasPath, err)
+	} else if got != clientSocket {
+		t.Fatalf("client pprof alias = %q, want %q", got, clientSocket)
+	}
+
+	if err := pty.cmd.Process.Signal(syscall.SIGTERM); err != nil {
+		t.Fatalf("Signal(SIGTERM): %v", err)
+	}
+	if !pty.waitExited(5 * time.Second) {
+		t.Fatal("interactive client did not exit after SIGTERM")
+	}
+	if _, err := os.Lstat(clientSocket); !os.IsNotExist(err) {
+		t.Fatalf("client pprof socket should be removed after SIGTERM, stat err = %v", err)
+	}
+	if _, err := os.Lstat(aliasPath); !os.IsNotExist(err) {
+		t.Fatalf("client pprof alias should be removed after SIGTERM, stat err = %v", err)
 	}
 }
 


### PR DESCRIPTION
## Motivation
The interactive client pprof endpoint left its per-pid Unix socket and latest-client alias behind when the process was terminated by SIGHUP, SIGTERM, or SIGINT. That made debug client commands point at dead sockets until another attach pruned them.

## Summary
- Add a termination signal handler as soon as the client pprof endpoint is installed, closing the endpoint and restoring the terminal before exiting.
- Keep terminal restoration as a deferred no-op until raw mode is active, then guard restore and pprof close with sync.Once so signal, reload, and normal-return paths share cleanup safely.
- Add a PTY regression test that SIGTERMs a real interactive client and checks both socket paths are removed.

## Testing
- go test ./test -run '^TestDebugClientPprofSignalTerminationRemovesSocketAndAlias$' -count=100 -timeout 300s
- go test ./test -run '^TestMetaSetStoresArbitraryMetadataAndProjectsReservedKeys$' -count=1
- go test ./... -timeout 120s

## Review focus
- Signal cleanup order in internal/client/attach.go, especially pprof close before os.Exit.
- Whether the deferred terminal restore helper keeps the early signal handler safe before raw mode is entered.

Closes LAB-1924