### PR TITLE
LAB-1923: Clean stale test build dirs

### DIFF
--- a/internal/mux/pane_window_process_test.go
+++ b/internal/mux/pane_window_process_test.go
@@ -1070,7 +1070,7 @@ func TestPaneRespawnPreservesMetadataAndSuppressesExitCallback(t *testing.T) {
 	if _, err := p.Write([]byte("pwd -P\n")); err != nil {
 		t.Fatalf("write pwd after respawn: %v", err)
 	}
-	waitUntil(t, 5*time.Second, func() bool {
+	waitUntil(t, 15*time.Second, func() bool {
 		return p.ScreenContains(wantDir)
 	})
 }

--- a/internal/server/session_events_pane.go
+++ b/internal/server/session_events_pane.go
@@ -302,6 +302,8 @@ func (e localPaneBuildResultEvent) handle(_ context.Context, s *Session) {
 		notify(err)
 		return
 	}
+	e.pane.Meta = clonePaneMetaForReplacement(current.Meta)
+	e.pane.SetMetaManualBranch(current.MetaManualBranch())
 	if err := s.replacePaneInstance(current, e.pane, w); err != nil {
 		e.pane.SuppressCallbacks()
 		s.closePaneAsync(e.pane)

--- a/internal/server/session_pane.go
+++ b/internal/server/session_pane.go
@@ -407,6 +407,14 @@ func effectiveRespawnDir(pane *mux.Pane) string {
 	return pane.Meta.Dir
 }
 
+func clonePaneMetaForReplacement(meta mux.PaneMeta) mux.PaneMeta {
+	next := meta
+	next.KV = mux.CloneMetaKV(meta.KV)
+	next.TrackedPRs = proto.CloneTrackedPRs(meta.TrackedPRs)
+	next.TrackedIssues = proto.CloneTrackedIssues(meta.TrackedIssues)
+	return next
+}
+
 func (s *Session) replacePaneInstance(oldPane, newPane *mux.Pane, w *mux.Window) error {
 	if oldPane == nil || newPane == nil {
 		return fmt.Errorf("missing pane")

--- a/internal/server/session_pane_pending_test.go
+++ b/internal/server/session_pane_pending_test.go
@@ -1,0 +1,76 @@
+package server
+
+import (
+	"context"
+	"testing"
+
+	"github.com/weill-labs/amux/internal/mux"
+	"github.com/weill-labs/amux/internal/proto"
+)
+
+func TestLocalPaneBuildResultPreservesPendingPaneMetadataUpdates(t *testing.T) {
+	t.Parallel()
+
+	sess := newSession("test-pending-pane-meta")
+	stopCrashCheckpointLoop(t, sess)
+	t.Cleanup(func() {
+		stopSessionBackgroundLoops(t, sess)
+		for _, pane := range sess.Panes {
+			_ = pane.Close()
+			_ = pane.WaitClosed()
+		}
+	})
+
+	pending := newTestPane(sess, 1, "pane-1")
+	window := newTestWindowWithPanes(t, sess, 1, "window-1", pending)
+	setSessionLayoutForTest(t, sess, window.ID, []*mux.Window{window}, pending)
+
+	mustSessionMutation(t, sess, func(sess *Session) {
+		pane := sess.findPaneByID(pending.ID)
+		pane.Meta.Task = "build"
+		pane.Meta.GitBranch = "feat/pending-meta"
+		pane.Meta.PR = "42"
+		pane.Meta.KV = map[string]string{
+			mux.PaneMetaKeyTask:   "build",
+			mux.PaneMetaKeyBranch: "feat/pending-meta",
+			mux.PaneMetaKeyPR:     "42",
+			"issue":               "LAB-1923",
+		}
+		pane.Meta.TrackedPRs = []proto.TrackedPR{{Number: 42, Status: proto.TrackedStatusActive}}
+		pane.SetMetaManualBranch(true)
+	})
+
+	built, err := mux.NewPaneWithScrollback(1, mux.PaneMeta{
+		Name:  "pane-1",
+		Host:  mux.DefaultHost,
+		Color: "f5e0dc",
+	}, 80, 23, "test", mux.DefaultScrollbackLines, sess.paneOutputCallback(), sess.paneExitCallback())
+	if err != nil {
+		t.Fatalf("NewPaneWithScrollback: %v", err)
+	}
+	mustSessionMutation(t, sess, func(sess *Session) {
+		localPaneBuildResultEvent{
+			placeholder: pending,
+			pane:        built,
+		}.handle(context.Background(), sess)
+	})
+
+	got := mustSessionQuery(t, sess, func(sess *Session) *mux.Pane {
+		return sess.findPaneByID(pending.ID)
+	})
+	if got != built {
+		t.Fatalf("replacement pane = %p, want built pane %p", got, built)
+	}
+	if got.Meta.Task != "build" || got.Meta.GitBranch != "feat/pending-meta" || got.Meta.PR != "42" {
+		t.Fatalf("replacement metadata = %+v", got.Meta)
+	}
+	if got.Meta.KV["issue"] != "LAB-1923" {
+		t.Fatalf("replacement metadata issue = %q, want LAB-1923", got.Meta.KV["issue"])
+	}
+	if len(got.Meta.TrackedPRs) != 1 || got.Meta.TrackedPRs[0].Number != 42 {
+		t.Fatalf("replacement tracked PRs = %+v, want PR 42", got.Meta.TrackedPRs)
+	}
+	if !got.MetaManualBranch() {
+		t.Fatal("replacement pane should preserve manual branch override")
+	}
+}

--- a/test/harness_cleanup_test.go
+++ b/test/harness_cleanup_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -67,6 +68,78 @@ func TestHasOtherActiveTestRunRemovesStaleLocks(t *testing.T) {
 	}
 	if _, err := os.Stat(lockPath); !os.IsNotExist(err) {
 		t.Fatalf("stale lock %s should be removed, stat err=%v", filepath.Base(lockPath), err)
+	}
+}
+
+func TestCleanupStaleTestTempDirsRemovesOnlyAmuxTestDirs(t *testing.T) {
+	t.Parallel()
+
+	tempRoot := t.TempDir()
+	staleTempDir := filepath.Join(tempRoot, "amux-test-stale")
+	otherDir := filepath.Join(tempRoot, "not-amux-test-stale")
+	matchingFile := filepath.Join(tempRoot, "amux-test-file")
+	for _, dir := range []string{staleTempDir, otherDir} {
+		if err := os.Mkdir(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(staleTempDir, "amux"), nil, 0o644); err != nil {
+		t.Fatalf("write stale temp file: %v", err)
+	}
+	if err := os.WriteFile(matchingFile, nil, 0o644); err != nil {
+		t.Fatalf("write matching file: %v", err)
+	}
+
+	cleanupStaleTestTempDirsWithDeps(testTempDirCleanupDeps{
+		tempRoot:  tempRoot,
+		socketDir: t.TempDir(),
+		selfPID:   os.Getpid(),
+		readDir:   os.ReadDir,
+		removeAll: os.RemoveAll,
+		hasOtherActiveTestRun: func(string, int) bool {
+			return false
+		},
+	})
+
+	if _, err := os.Stat(staleTempDir); !os.IsNotExist(err) {
+		t.Fatalf("stale temp dir should be removed, stat err=%v", err)
+	}
+	for _, path := range []string{otherDir, matchingFile} {
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("%s should remain, stat err=%v", filepath.Base(path), err)
+		}
+	}
+}
+
+func TestCleanupStaleTestTempDirsSkipsWhenOtherRunActive(t *testing.T) {
+	t.Parallel()
+
+	tempRoot := t.TempDir()
+	staleTempDir := filepath.Join(tempRoot, "amux-test-stale")
+	if err := os.Mkdir(staleTempDir, 0o755); err != nil {
+		t.Fatalf("mkdir stale temp dir: %v", err)
+	}
+
+	var removeCalls []string
+	cleanupStaleTestTempDirsWithDeps(testTempDirCleanupDeps{
+		tempRoot:  tempRoot,
+		socketDir: t.TempDir(),
+		selfPID:   os.Getpid(),
+		readDir:   os.ReadDir,
+		removeAll: func(path string) error {
+			removeCalls = append(removeCalls, path)
+			return nil
+		},
+		hasOtherActiveTestRun: func(string, int) bool {
+			return true
+		},
+	})
+
+	if len(removeCalls) > 0 {
+		t.Fatalf("removeAll called despite active run: %s", strings.Join(removeCalls, ", "))
+	}
+	if _, err := os.Stat(staleTempDir); err != nil {
+		t.Fatalf("stale temp dir should remain while another run is active, stat err=%v", err)
 	}
 }
 

--- a/test/harness_test.go
+++ b/test/harness_test.go
@@ -30,6 +30,15 @@ var childGoCacheDir string
 
 const testRunLockPrefix = "test-run-"
 
+type testTempDirCleanupDeps struct {
+	tempRoot              string
+	socketDir             string
+	selfPID               int
+	readDir               func(string) ([]os.DirEntry, error)
+	removeAll             func(string) error
+	hasOtherActiveTestRun func(string, int) bool
+}
+
 // buildAmux builds the amux binary at binPath. When GOCOVERDIR is set,
 // the binary is built with -cover so it writes coverage data on exit.
 // Set AMUX_TEST_RACE=1 to build with -race (enables race detection in
@@ -115,6 +124,7 @@ func TestMain(m *testing.M) {
 	// Clean up orphaned test sessions from previous runs that may have
 	// been killed by a timeout panic (t.Cleanup doesn't run on panic).
 	cleanupStaleTestSessions()
+	cleanupStaleTestTempDirs()
 
 	// Use GOCOVERDIR if explicitly set (e.g. by CI). When set, the amux
 	// binary is built with -cover and writes coverage data on exit.
@@ -128,12 +138,12 @@ func TestMain(m *testing.M) {
 		removeTestRunLock()
 		os.Exit(1)
 	}
-	defer os.RemoveAll(tmp)
 
 	amuxBin = tmp + "/amux"
 	childGoCacheDir = filepath.Join(tmp, ".gocache")
 	if err := buildAmux(amuxBin); err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
+		_ = os.RemoveAll(tmp)
 		removeTestRunLock()
 		os.Exit(1)
 	}
@@ -155,6 +165,7 @@ func TestMain(m *testing.M) {
 		}
 	}
 
+	_ = os.RemoveAll(tmp)
 	removeTestRunLock()
 	os.Exit(code)
 }
@@ -182,6 +193,37 @@ func newTestHome(tb testing.TB) string {
 		}
 	}
 	return home
+}
+
+// cleanupStaleTestTempDirs removes amux test build directories left behind
+// when previous test binaries exited before reaching their normal cleanup.
+func cleanupStaleTestTempDirs() {
+	socketDir := fmt.Sprintf("/tmp/amux-%d", os.Getuid())
+	cleanupStaleTestTempDirsWithDeps(testTempDirCleanupDeps{
+		tempRoot:              os.TempDir(),
+		socketDir:             socketDir,
+		selfPID:               os.Getpid(),
+		readDir:               os.ReadDir,
+		removeAll:             os.RemoveAll,
+		hasOtherActiveTestRun: hasOtherActiveTestRun,
+	})
+}
+
+func cleanupStaleTestTempDirsWithDeps(deps testTempDirCleanupDeps) {
+	if deps.hasOtherActiveTestRun(deps.socketDir, deps.selfPID) {
+		return
+	}
+
+	entries, err := deps.readDir(deps.tempRoot)
+	if err != nil {
+		return
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() || !strings.HasPrefix(entry.Name(), "amux-test-") {
+			continue
+		}
+		_ = deps.removeAll(filepath.Join(deps.tempRoot, entry.Name()))
+	}
 }
 
 // cleanupStaleTestSessions removes orphaned amux server processes, sockets,

--- a/test/harness_test.go
+++ b/test/harness_test.go
@@ -113,7 +113,7 @@ func TestMain(m *testing.M) {
 	_ = os.Unsetenv("AMUX_SESSION")
 	_ = os.Unsetenv("TMUX")
 
-	socketDir := fmt.Sprintf("/tmp/amux-%d", os.Getuid())
+	socketDir := testSocketDir()
 	lockPath, err := writeTestRunLock(socketDir, os.Getpid())
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "creating test-run lock: %v\n", err)
@@ -195,10 +195,14 @@ func newTestHome(tb testing.TB) string {
 	return home
 }
 
+func testSocketDir() string {
+	return fmt.Sprintf("/tmp/amux-%d", os.Getuid())
+}
+
 // cleanupStaleTestTempDirs removes amux test build directories left behind
 // when previous test binaries exited before reaching their normal cleanup.
 func cleanupStaleTestTempDirs() {
-	socketDir := fmt.Sprintf("/tmp/amux-%d", os.Getuid())
+	socketDir := testSocketDir()
 	cleanupStaleTestTempDirsWithDeps(testTempDirCleanupDeps{
 		tempRoot:              os.TempDir(),
 		socketDir:             socketDir,
@@ -234,7 +238,7 @@ func cleanupStaleTestTempDirsWithDeps(deps testTempDirCleanupDeps) {
 // run owns a lock, any test server without a live test parent is stale even if
 // its socket still accepts connections.
 func cleanupStaleTestSessions() {
-	socketDir := fmt.Sprintf("/tmp/amux-%d", os.Getuid())
+	socketDir := testSocketDir()
 	if hasOtherActiveTestRun(socketDir, os.Getpid()) {
 		return
 	}


### PR DESCRIPTION
## Motivation

Killed or timed-out integration test runs can leave `/tmp/amux-test-*` build directories behind. Those directories include the test binary and Go build cache, and LAB-1923 reports they accumulated enough data to fill a host root filesystem.

## Summary

- Add guarded cleanup for stale `amux-test-*` build directories from `TestMain`, using the existing active test-run lock to avoid touching concurrent runs.
- Remove the current test build directory explicitly before `os.Exit`, since deferred cleanup does not run through `os.Exit`.
- Add unit coverage for safe temp-dir cleanup behavior without sweeping real `/tmp` in tests.
- Preserve metadata updates made while a local pane is still pending so the realized PTY pane cannot replace them with stale reserved metadata.
- Increase the respawn test wait for shell output to tolerate package-level test load observed during verification.

## Testing

- `go test ./test -run 'TestCleanupStaleTestTempDirs|TestHasOtherActiveTestRun' -count=100`
- `go test ./internal/mux -run TestPaneRespawnPreservesMetadataAndSuppressesExitCallback -count=100 -timeout 300s`
- `go test ./internal/server -run TestLocalPaneBuildResultPreservesPendingPaneMetadataUpdates -count=100`
- `go test ./test -run 'TestMetaSet(SetsTaskAndBranch|ClearsBranch)|TestCaptureJSONIncludesPaneMetaKV' -count=100 -timeout 240s`
- `go test ./test -run TestMouseScrollWheel -count=1 -timeout 120s`
- `go test ./... -timeout 180s`

## Review focus

Check that the temp-dir cleanup remains limited to immediate `amux-test-*` directories under `os.TempDir()` and returns when another live test run holds a lock. Also check the pending-pane metadata copy: it intentionally preserves current placeholder metadata immediately before replacement so commands issued during pane startup are not lost.

Closes LAB-1923
