### PR TITLE
LAB-1927: Stop render loop without closing msgCh

### DIFF
--- a/internal/client/attach.go
+++ b/internal/client/attach.go
@@ -691,10 +691,19 @@ func runSessionWithDeps(sessionName string, getTermSize func(int) (int, int, err
 	// 60fps default while coalescing pane output inside each frame budget.
 	done := make(chan struct{})
 	msgCh := make(chan *RenderMsg, 256)
+	renderStop := make(chan struct{})
+	var stopRenderOnce sync.Once
+	stopRender := func() {
+		stopRenderOnce.Do(func() {
+			close(renderStop)
+		})
+	}
+	defer stopRender()
+	cr.renderStop = renderStop
 
 	// Read server messages and dispatch to render loop
 	go func() {
-		defer close(msgCh)
+		defer stopRender()
 		for {
 			msg, err := attachReader.ReadMsg()
 			if err != nil {
@@ -703,25 +712,37 @@ func runSessionWithDeps(sessionName string, getTermSize func(int) (int, int, err
 			}
 			switch msg.Type {
 			case proto.MsgTypeLayout:
-				msgCh <- &RenderMsg{Typ: RenderMsgLayout, Layout: msg.Layout}
+				if !sendRenderMsg(msgCh, renderStop, &RenderMsg{Typ: RenderMsgLayout, Layout: msg.Layout}) {
+					return
+				}
 			case proto.MsgTypePaneHistory:
 				cr.HandlePaneHistoryMessage(msg.PaneID, msg.History, msg.StyledHistory)
 			case proto.MsgTypePaneOutput:
-				msgCh <- &RenderMsg{Typ: RenderMsgPaneOutput, PaneID: msg.PaneID, Data: msg.PaneData, SourceEpoch: msg.SourceEpoch}
+				if !sendRenderMsg(msgCh, renderStop, &RenderMsg{Typ: RenderMsgPaneOutput, PaneID: msg.PaneID, Data: msg.PaneData, SourceEpoch: msg.SourceEpoch}) {
+					return
+				}
 			case proto.MsgTypeCmdResult:
 				if msg.CmdErr != "" {
-					msgCh <- &RenderMsg{Typ: RenderMsgCmdError, Text: msg.CmdErr}
+					if !sendRenderMsg(msgCh, renderStop, &RenderMsg{Typ: RenderMsgCmdError, Text: msg.CmdErr}) {
+						return
+					}
 				}
 			case proto.MsgTypeCopyMode:
-				msgCh <- &RenderMsg{Typ: RenderMsgCopyMode, PaneID: msg.PaneID}
+				if !sendRenderMsg(msgCh, renderStop, &RenderMsg{Typ: RenderMsgCopyMode, PaneID: msg.PaneID}) {
+					return
+				}
 			case proto.MsgTypeExit:
 				exitState.set(formatDetachNotice(msg.Text, "detached: session exited"))
-				msgCh <- &RenderMsg{Typ: RenderMsgExit}
+				_ = sendRenderMsg(msgCh, renderStop, &RenderMsg{Typ: RenderMsgExit})
 				return
 			case proto.MsgTypeBell:
-				msgCh <- &RenderMsg{Typ: RenderMsgBell}
+				if !sendRenderMsg(msgCh, renderStop, &RenderMsg{Typ: RenderMsgBell}) {
+					return
+				}
 			case proto.MsgTypeClipboard:
-				msgCh <- &RenderMsg{Typ: RenderMsgClipboard, Data: msg.PaneData}
+				if !sendRenderMsg(msgCh, renderStop, &RenderMsg{Typ: RenderMsgClipboard, Data: msg.PaneData}) {
+					return
+				}
 			case proto.MsgTypeCaptureRequest:
 				// Server is forwarding a capture request — render from
 				// client-side emulators and send the result back. Wait for the
@@ -771,8 +792,13 @@ func runSessionWithDeps(sessionName string, getTermSize func(int) (int, int, err
 	initCols, initRows := cols, rows
 	go func() {
 		lastCols, lastRows := initCols, initRows
-		for range sigCh {
-			lastCols, lastRows = syncTerminalSize(fd, lastCols, lastRows, cr, sender, getTermSize, msgCh)
+		for {
+			select {
+			case <-renderStop:
+				return
+			case <-sigCh:
+				lastCols, lastRows = syncTerminalSize(fd, lastCols, lastRows, cr, sender, getTermSize, msgCh)
+			}
 		}
 	}()
 	// Recheck once after the handler is live so startup-time size changes
@@ -1056,12 +1082,20 @@ func runSessionWithDeps(sessionName string, getTermSize func(int) (int, int, err
 					ready, pending := splitTrailingIncompleteUTF8(cp)
 					pendingUTF8 = append(pendingUTF8[:0], pending...)
 					if len(ready) > 0 {
-						stdinCh <- ready
+						select {
+						case stdinCh <- ready:
+						case <-renderStop:
+							return
+						}
 					}
 				}
 				if err != nil {
 					if len(pendingUTF8) > 0 {
-						stdinCh <- append([]byte(nil), pendingUTF8...)
+						select {
+						case stdinCh <- append([]byte(nil), pendingUTF8...):
+						case <-renderStop:
+							return
+						}
 					}
 					return
 				}
@@ -1102,6 +1136,8 @@ func runSessionWithDeps(sessionName string, getTermSize func(int) (int, int, err
 					drag.ClickCount = 0
 				}
 				continue
+			case <-renderStop:
+				return
 			}
 
 			if localInput {

--- a/internal/client/attach.go
+++ b/internal/client/attach.go
@@ -700,6 +700,9 @@ func runSessionWithDeps(sessionName string, getTermSize func(int) (int, int, err
 	}
 	defer stopRender()
 	cr.renderStop = renderStop
+	queueRender := func(msg *RenderMsg) bool {
+		return sendRenderMsg(msgCh, renderStop, msg)
+	}
 
 	// Read server messages and dispatch to render loop
 	go func() {
@@ -712,35 +715,35 @@ func runSessionWithDeps(sessionName string, getTermSize func(int) (int, int, err
 			}
 			switch msg.Type {
 			case proto.MsgTypeLayout:
-				if !sendRenderMsg(msgCh, renderStop, &RenderMsg{Typ: RenderMsgLayout, Layout: msg.Layout}) {
+				if !queueRender(&RenderMsg{Typ: RenderMsgLayout, Layout: msg.Layout}) {
 					return
 				}
 			case proto.MsgTypePaneHistory:
 				cr.HandlePaneHistoryMessage(msg.PaneID, msg.History, msg.StyledHistory)
 			case proto.MsgTypePaneOutput:
-				if !sendRenderMsg(msgCh, renderStop, &RenderMsg{Typ: RenderMsgPaneOutput, PaneID: msg.PaneID, Data: msg.PaneData, SourceEpoch: msg.SourceEpoch}) {
+				if !queueRender(&RenderMsg{Typ: RenderMsgPaneOutput, PaneID: msg.PaneID, Data: msg.PaneData, SourceEpoch: msg.SourceEpoch}) {
 					return
 				}
 			case proto.MsgTypeCmdResult:
 				if msg.CmdErr != "" {
-					if !sendRenderMsg(msgCh, renderStop, &RenderMsg{Typ: RenderMsgCmdError, Text: msg.CmdErr}) {
+					if !queueRender(&RenderMsg{Typ: RenderMsgCmdError, Text: msg.CmdErr}) {
 						return
 					}
 				}
 			case proto.MsgTypeCopyMode:
-				if !sendRenderMsg(msgCh, renderStop, &RenderMsg{Typ: RenderMsgCopyMode, PaneID: msg.PaneID}) {
+				if !queueRender(&RenderMsg{Typ: RenderMsgCopyMode, PaneID: msg.PaneID}) {
 					return
 				}
 			case proto.MsgTypeExit:
 				exitState.set(formatDetachNotice(msg.Text, "detached: session exited"))
-				_ = sendRenderMsg(msgCh, renderStop, &RenderMsg{Typ: RenderMsgExit})
+				_ = queueRender(&RenderMsg{Typ: RenderMsgExit})
 				return
 			case proto.MsgTypeBell:
-				if !sendRenderMsg(msgCh, renderStop, &RenderMsg{Typ: RenderMsgBell}) {
+				if !queueRender(&RenderMsg{Typ: RenderMsgBell}) {
 					return
 				}
 			case proto.MsgTypeClipboard:
-				if !sendRenderMsg(msgCh, renderStop, &RenderMsg{Typ: RenderMsgClipboard, Data: msg.PaneData}) {
+				if !queueRender(&RenderMsg{Typ: RenderMsgClipboard, Data: msg.PaneData}) {
 					return
 				}
 			case proto.MsgTypeCaptureRequest:

--- a/internal/client/attach_session_test.go
+++ b/internal/client/attach_session_test.go
@@ -1582,6 +1582,52 @@ func TestRunSessionPrintsDetachReasonWhenConnectionLost(t *testing.T) {
 	h.stderr.waitContains(t, "detached: connection lost")
 }
 
+func TestRunSessionIgnoresLateInputAfterReaderDisconnect(t *testing.T) {
+	// Not parallel: newRunSessionHarness uses t.Setenv and swaps os.Stdin/os.Stdout/os.Stderr.
+	h := newRunSessionHarness(t, func(int) (int, int, error) {
+		return 80, 24, nil
+	})
+
+	attach := h.waitAttach(t)
+	if attach.Type != proto.MsgTypeAttach {
+		t.Fatalf("attach type = %d, want %d", attach.Type, proto.MsgTypeAttach)
+	}
+
+	h.send(t, &proto.Message{Type: proto.MsgTypeLayout, Layout: sessionLayoutSnapshot(h.session)})
+	h.output.waitContains(t, render.AltScreenEnter)
+
+	stopInput := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for {
+			select {
+			case <-stopInput:
+				return
+			default:
+			}
+			_, _ = h.ptmx.Write([]byte{0x01, '?'})
+			_, _ = h.ptmx.Write([]byte("\x1b[<64;2;2M"))
+			time.Sleep(time.Millisecond)
+		}
+	}()
+	h.output.waitContains(t, "q panes")
+
+	h.closeConn()
+	if err := h.waitRunResult(t); err != nil {
+		t.Fatalf("RunSession() = %v, want nil", err)
+	}
+	h.stderr.waitContains(t, "detached: connection lost")
+	time.Sleep(50 * time.Millisecond)
+	close(stopInput)
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("late input writes did not finish")
+	}
+}
+
 func TestRunSessionEnablesPprofEndpointWhenConfigured(t *testing.T) {
 	configPath := filepath.Join(t.TempDir(), "config.toml")
 	if err := os.WriteFile(configPath, []byte("[debug]\npprof = true\n"), 0644); err != nil {

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -26,8 +26,8 @@ type ClientRenderer struct {
 	recentInputUnix atomic.Int64
 	scrollbackLines int
 	OnUIEvent       func(string)
-	CopyToClipboard func(string) // called when copy mode copies text; nil uses default
-	renderStop      <-chan struct{}
+	CopyToClipboard func(string)    // called when copy mode copies text; nil uses default
+	renderStop      <-chan struct{} // closed when attached-client teardown starts
 
 	// Render timing — configurable for tests. Zero values use defaults.
 	renderFrameInterval  time.Duration

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -27,6 +27,7 @@ type ClientRenderer struct {
 	scrollbackLines int
 	OnUIEvent       func(string)
 	CopyToClipboard func(string) // called when copy mode copies text; nil uses default
+	renderStop      <-chan struct{}
 
 	// Render timing — configurable for tests. Zero values use defaults.
 	renderFrameInterval  time.Duration
@@ -800,6 +801,8 @@ func (cr *ClientRenderer) RenderCoalesced(msgCh <-chan *RenderMsg, write func(st
 					return
 				}
 				msg = next
+			case <-cr.renderStop:
+				return
 			case <-state.renderC:
 				cr.renderNow(state, write)
 				continue

--- a/internal/client/local_render.go
+++ b/internal/client/local_render.go
@@ -21,12 +21,25 @@ func applyLocalRenderResultDirect(cr *ClientRenderer, result localRenderResult) 
 	_ = cr.executeRenderEffects(state, result.effects, func(string) {})
 }
 
+func sendRenderMsg(msgCh chan<- *RenderMsg, stop <-chan struct{}, msg *RenderMsg) bool {
+	if stop == nil {
+		msgCh <- msg
+		return true
+	}
+	select {
+	case msgCh <- msg:
+		return true
+	case <-stop:
+		return false
+	}
+}
+
 func runLocalRenderAction(cr *ClientRenderer, msgCh chan<- *RenderMsg, fn localRenderFunc) {
 	if msgCh == nil {
 		applyLocalRenderResultDirect(cr, fn(cr))
 		return
 	}
-	msgCh <- &RenderMsg{Typ: RenderMsgLocalAction, Local: fn}
+	_ = sendRenderMsg(msgCh, cr.renderStop, &RenderMsg{Typ: RenderMsgLocalAction, Local: fn})
 }
 
 func callLocalRenderAction[T any](cr *ClientRenderer, msgCh chan<- *RenderMsg, fn localRenderFunc) T {
@@ -40,12 +53,18 @@ func callLocalRenderAction[T any](cr *ClientRenderer, msgCh chan<- *RenderMsg, f
 		return result.value.(T)
 	}
 	reply := make(chan any, 1)
-	msgCh <- &RenderMsg{Typ: RenderMsgLocalAction, Local: fn, Reply: reply}
-	value := <-reply
-	if value == nil {
+	if !sendRenderMsg(msgCh, cr.renderStop, &RenderMsg{Typ: RenderMsgLocalAction, Local: fn, Reply: reply}) {
 		return zero
 	}
-	return value.(T)
+	select {
+	case value := <-reply:
+		if value == nil {
+			return zero
+		}
+		return value.(T)
+	case <-cr.renderStop:
+		return zero
+	}
 }
 
 func renderNowResult() localRenderResult {


### PR DESCRIPTION
## Motivation

The attached client could panic with `send on closed channel` when the server reader disconnected while the input or resize goroutine was still sending local render work. The render channel had multiple senders, but the reader was the only closer.

## Summary

- Add a regression test that disconnects the reader while local keyboard and mouse input continue.
- Keep `msgCh` open and signal render-loop teardown with a separate `renderStop` channel.
- Make reader sends, local render actions, stdin forwarding, SIGWINCH handling, and reply waits return when teardown starts.

## Testing

- `go test ./internal/client -run TestRunSessionIgnoresLateInputAfterReaderDisconnect -count=100`
- `go test ./... -timeout 120s`

## Review focus

Please look at teardown ordering in `runSessionWithDeps`, especially the interaction between `renderStop`, reader exit, and local render actions that wait for replies.

Closes LAB-1927