### PR TITLE
LAB-1927: Preserve explicit render exits

### DIFF
--- a/internal/client/attach.go
+++ b/internal/client/attach.go
@@ -706,11 +706,11 @@ func runSessionWithDeps(sessionName string, getTermSize func(int) (int, int, err
 
 	// Read server messages and dispatch to render loop
 	go func() {
-		defer stopRender()
 		for {
 			msg, err := attachReader.ReadMsg()
 			if err != nil {
 				exitState.set(disconnectNoticeForReadError(err))
+				stopRender()
 				return
 			}
 			switch msg.Type {
@@ -771,6 +771,7 @@ func runSessionWithDeps(sessionName string, getTermSize func(int) (int, int, err
 				case triggerReload <- struct{}{}:
 				default:
 				}
+				stopRender()
 				return
 			}
 		}


### PR DESCRIPTION
## Motivation

PR #809 moved attached-client teardown to a separate `renderStop` signal so `msgCh` is no longer closed by one of multiple senders. During post-PR review, one ordering edge remained: closing `renderStop` immediately after queuing an explicit server exit could let the render loop exit via the stop signal before consuming the queued `RenderMsgExit`.

## Summary

- Keep disconnects and server reloads as immediate `renderStop` paths.
- Let explicit server exits continue through the queued `RenderMsgExit` path.
- Base this follow-up on the merged PR #809 so the fix is isolated.

## Testing

- `go test ./internal/client -run 'TestRunSessionIgnoresLateInputAfterReaderDisconnect|TestRunSessionHandlesServerMessagesAndInteractiveInput' -count=100`
- `go test ./... -timeout 120s`

## Review focus

Please review the reader goroutine exit paths in `runSessionWithDeps` and confirm that only non-explicit-exit teardown closes `renderStop` before the render loop drains its exit message.

Follow-up to #809.
Closes LAB-1927