### PR TITLE
Docs: codify diff-coverage rule and correct amux capture JSON schema

### DIFF
--- a/.agents/skills/amux/SKILL.md
+++ b/.agents/skills/amux/SKILL.md
@@ -51,7 +51,7 @@ amux capture --ansi pane-1
 amux capture --history pane-1 | grep -v '^$' | tail -30
 ```
 
-The JSON capture is the primary interface for agents. It includes pane content lines, cursor position, active/minimized/zoomed state, host, task, color, cwd, git branch, and agent status.
+The JSON capture is the primary interface for agents. It includes pane content lines, cursor position, active/lead/zoomed state, host, task, color, cwd, git branch, and agent-status fields (`exited`, `idle`, `current_command`) as top-level keys on each pane.
 
 **Note:** JSON capture currently only returns the visible viewport. `--history` only works with plain text output. See LAB-527 for tracking JSON + history support.
 
@@ -358,7 +358,7 @@ The `--format json` output looks like:
 ```json
 {
   "session": "default",
-  "window": {"id": 1, "name": "main", "index": 0},
+  "window": {"id": 1, "name": "main", "index": 1, "zoomed": false},
   "width": 200,
   "height": 50,
   "panes": [
@@ -366,32 +366,34 @@ The `--format json` output looks like:
       "id": 1,
       "name": "pane-1",
       "active": true,
-      "minimized": false,
+      "lead": true,
       "zoomed": false,
       "host": "local",
       "task": "",
       "color": "rosewater",
+      "column_index": 0,
       "cwd": "/path/to/project",
       "git_branch": "main",
       "cursor": {"col": 0, "row": 24},
-      "content": ["line 1", "line 2", "..."],
       "position": {"x": 0, "y": 0, "width": 100, "height": 25},
-      "agent_status": {
-        "exited": false,
-        "idle": false,
-        "current_command": "go test ./...",
-        "child_pids": [12345]
-      }
+      "content": ["line 1", "line 2", "..."],
+      "exited": false,
+      "exited_since": "2026-05-26T19:00:00Z",
+      "current_command": "go test ./...",
+      "idle": false,
+      "last_output": "2026-05-26T19:05:00Z"
     }
   ]
 }
 ```
 
-Key fields for agent orchestration:
-- `agent_status.exited` — true when pane shell has no child processes. This corresponds to `wait exited`, not `wait idle`.
-- `agent_status.idle` — true when pane output is screen-quiet. This corresponds to `wait idle`.
-- `agent_status.current_command` — what's currently running
-- `agent_status.child_pids` — PIDs of child processes in the pane
+The agent-status fields are top-level keys on each pane (not nested under an `agent_status` object). Key fields for agent orchestration:
+- `exited` — true when no foreground command is running in the pane (shell sitting at its prompt). Corresponds to `wait exited`, not `wait idle`.
+- `exited_since` — RFC3339 timestamp of the last busy→exited transition; omitted while busy.
+- `current_command` — the foreground process name when busy, or the shell name (e.g. `bash`) when exited.
+- `idle` — true when pane output has been quiet for the settle window. Corresponds to `wait idle`.
+- `last_output` — RFC3339 timestamp of the most recent pane output edge.
+- `lead` — true for the window's lead pane. (There is no `minimized` field; minimized panes are simply absent from the visible layout.)
 - `content` — array of strings, one per visible line (viewport only, no scrollback)
 - `active` — whether this is the focused pane
 

--- a/.agents/skills/amux/SKILL.md
+++ b/.agents/skills/amux/SKILL.md
@@ -378,7 +378,6 @@ The `--format json` output looks like:
       "position": {"x": 0, "y": 0, "width": 100, "height": 25},
       "content": ["line 1", "line 2", "..."],
       "exited": false,
-      "exited_since": "2026-05-26T19:00:00Z",
       "current_command": "go test ./...",
       "idle": false,
       "last_output": "2026-05-26T19:05:00Z"
@@ -392,6 +391,7 @@ The agent-status fields are top-level keys on each pane (not nested under an `ag
 - `exited_since` — RFC3339 timestamp of the last busy→exited transition; omitted while busy.
 - `current_command` — the foreground process name when busy, or the shell name (e.g. `bash`) when exited.
 - `idle` — true when pane output has been quiet for the settle window. Corresponds to `wait idle`.
+- `idle_since` — RFC3339 timestamp when the pane most recently became screen-quiet; omitted while output is still active. (`exited_since` and `idle_since` are both omitted in the example above because the pane is busy.)
 - `last_output` — RFC3339 timestamp of the most recent pane output edge.
 - `lead` — true for the window's lead pane. (There is no `minimized` field; minimized panes are simply absent from the visible layout.)
 - `content` — array of strings, one per visible line (viewport only, no scrollback)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,6 +120,8 @@ When a change adds a new test or modifies an existing test, run that targeted te
 
 **Changes to `main.go` CLI dispatch need direct unit coverage on the touched lines.** Keep the hermetic subprocess tests for end-to-end CLI behavior, but when a change touches the dispatch branches in `main.go`, add direct unit coverage (for example in `main_test.go`) for those specific lines too. Codecov patch coverage measures the changed `main.go` lines directly and may miss coverage that only arrives through subprocess tests.
 
+**Cover every branch of a new function before pushing.** The `pre-push` hook runs `scripts/check-diff-coverage.sh` and rejects the push when changed lines fall below the patch target (currently 70%). Write unit tests for the early returns too -- nil guards and error paths, not just the happy path -- so the function's branches are covered up front. To exercise a tty-ioctl error path on macOS, pass a regular file as the fd: it reliably yields `ENOTTY`, whereas a pipe fd does not.
+
 **Golden files** live in `test/testdata/`. Two types:
 
 - `.golden` -- structural layout frame (status lines, borders, global bar). Open one and you see the expected screen layout.


### PR DESCRIPTION
## Motivation
Two documentation fixes surfaced by the LAB-1930 postmortem:
1. The pre-push diff-coverage gate has rejected pushes across several sessions because a new function's nil/error branches weren't covered up front. The rule was recommended in past postmortems but never codified.
2. The amux skill's documented JSON capture schema drifted from the actual output — it showed an `agent_status` wrapper and `minimized`/`child_pids` fields that don't exist — which misleads agents parsing `amux capture --format json`.

## Summary
- **CLAUDE.md** (Test Philosophy): add a rule to cover every branch of a new function (nil guards, error paths) before pushing, since `scripts/check-diff-coverage.sh` rejects changes below the patch target. Includes the macOS tty-ioctl note (a regular file yields `ENOTTY` where a pipe fd does not).
- **.agents/skills/amux/SKILL.md** (JSON Capture Structure): the agent-status fields (`exited`, `idle`, `current_command`, `exited_since`, `last_output`) are top-level keys on each pane, not nested under `agent_status`. Remove the nonexistent `minimized` and `child_pids` fields, document the `lead` field, and correct the `window` object (1-based `index`, `zoomed`).

## Testing
Docs-only; no code changes. The corrected schema was verified against live `amux capture --format json` output and the authoritative field docs in `internal/proto/types.go` (`CapturePane`).

## Review focus
- Accuracy of the documented field semantics vs `internal/proto/types.go:113-160` (especially `exited` = "no foreground command running" and its relationship to `idle`).
