### PR TITLE
LAB-1931: Restore window size from snapshot cells, not global layout

### DIFF
--- a/internal/mux/snapshot.go
+++ b/internal/mux/snapshot.go
@@ -176,13 +176,26 @@ func RebuildWindowFromSnapshot(ws proto.WindowSnapshot, width, height int, paneM
 		})
 	}
 
+	// Derive the recorded size from the restored root cell so the window stays
+	// consistent with its panes. The passed width/height is one global layout
+	// size shared by every window; adopting it directly desyncs an inactive
+	// window whose snapshotted cells were sized for a different terminal -- the
+	// resize-on-activation guard (w.Width == cols && w.Height == layoutH) would
+	// then see a size that already "matches" the client and skip, stranding the
+	// pane at its stale grid. Fall back to the passed size only when the
+	// snapshot lacks cell dimensions (legacy/degenerate roots).
+	winW, winH := root.W, root.H
+	if winW <= 0 || winH <= 0 {
+		winW, winH = width, height
+	}
+
 	w := &Window{
 		ID:           ws.ID,
 		Name:         ws.Name,
 		Root:         root,
 		ActivePane:   activePane,
-		Width:        width,
-		Height:       height,
+		Width:        winW,
+		Height:       winH,
 		ZoomedPaneID: ws.ZoomedPaneID,
 		LeadPaneID:   ws.LeadPaneID,
 	}

--- a/internal/mux/snapshot_test.go
+++ b/internal/mux/snapshot_test.go
@@ -339,3 +339,50 @@ func TestSnapshotLayoutIncludesColumnIndex(t *testing.T) {
 		}
 	})
 }
+
+func TestRebuildWindowFromSnapshotPreservesWindowSize(t *testing.T) {
+	t.Parallel()
+
+	// A window last sized for a 176x87 terminal -- e.g. an inactive window at
+	// checkpoint time. Its layout cells are sized 176x87.
+	p := &Pane{ID: 1, Meta: PaneMeta{Name: "pane-1", Host: DefaultHost, Color: "f5e0dc"}, emulator: NewVTEmulatorWithScrollback(176, 87, DefaultScrollbackLines)}
+	w := NewWindow(p, 176, 87)
+	w.ID = 7
+
+	ws := w.SnapshotWindow(0)
+
+	// Restore passing a DIFFERENT global layout size (the active client at
+	// checkpoint was 381x69). The rebuilt window must stay consistent with its
+	// restored cells rather than silently adopt the passed size: a mismatch
+	// makes the resize-on-activation guard (w.Width == cols && w.Height ==
+	// layoutH) skip, stranding the pane at its stale 176x87 grid.
+	rebuilt := RebuildWindowFromSnapshot(ws, 381, 69, map[uint32]*Pane{1: p})
+
+	if rebuilt.Width != rebuilt.Root.W || rebuilt.Height != rebuilt.Root.H {
+		t.Fatalf("rebuilt window size %dx%d desynced from restored root cell %dx%d",
+			rebuilt.Width, rebuilt.Height, rebuilt.Root.W, rebuilt.Root.H)
+	}
+	if rebuilt.Width != 176 || rebuilt.Height != 87 {
+		t.Fatalf("rebuilt window size = %dx%d, want 176x87 (its snapshotted size)", rebuilt.Width, rebuilt.Height)
+	}
+}
+
+func TestRebuildWindowFromSnapshotFallsBackWhenRootSizeMissing(t *testing.T) {
+	t.Parallel()
+
+	// A degenerate snapshot whose root cell carries no dimensions (W=0, H=0)
+	// must fall back to the passed layout size.
+	ws := proto.WindowSnapshot{
+		ID:           9,
+		Name:         "legacy",
+		ActivePaneID: 1,
+		Root:         proto.CellSnapshot{IsLeaf: true, PaneID: 1, Dir: -1},
+	}
+	p := &Pane{ID: 1, Meta: PaneMeta{Name: "pane-1", Host: DefaultHost}}
+
+	rebuilt := RebuildWindowFromSnapshot(ws, 120, 40, map[uint32]*Pane{1: p})
+
+	if rebuilt.Width != 120 || rebuilt.Height != 40 {
+		t.Fatalf("fallback window size = %dx%d, want passed 120x40", rebuilt.Width, rebuilt.Height)
+	}
+}


### PR DESCRIPTION
## Motivation
On server reload or crash-restore, an inactive window could come back with its pane stuck at a stale grid size — e.g. `176x87` on a `381x70` screen (narrower than the screen, and even *taller* than it), and it stayed wrong even after the window was selected. (LAB-1931)

## Summary
- **Root cause:** `RebuildWindowFromSnapshot` set the window's `Width/Height` to the single global layout size passed by the restore path (`cp.Layout.Width/Height`, shared by every window) while rebuilding the layout cells and pane emulators from their *own* snapshotted sizes. An inactive window last sized under a different terminal came back with `w.Width/Height` disagreeing with its cells. The resize-on-activation guard in `syncWindowSizeToEffectiveClient` (`if w.Width == cols && w.Height == layoutH { return }`) then saw a size that already "matched" the client and **skipped**, stranding the pane at its stale grid. ("Defer hidden-window resize until activation", #545, relies on that guard being trustworthy.)
- **Fix:** derive the window's recorded size from the restored root cell (`root.W/H`, which the snapshot serializes per-cell and is consistent with the rebuilt panes), falling back to the passed layout size only for degenerate snapshots without cell dimensions.

## Testing
```
env -u AMUX_SESSION -u TMUX go test ./internal/mux/ \
  -run 'TestRebuildWindowFromSnapshotPreservesWindowSize|TestRebuildWindowFromSnapshotFallsBackWhenRootSizeMissing' -count=100
env -u AMUX_SESSION -u TMUX go test ./internal/mux/ -count=1
env -u AMUX_SESSION -u TMUX go vet ./... && env -u AMUX_SESSION -u TMUX go build ./...
```
TDD: the first new test fails before the fix (`rebuilt window size 381x69 desynced from restored root cell 176x87`) and passes after. Full `internal/mux` suite, `go vet`, and `go build` are clean.

## Review focus
- Sourcing the window dims from `root.W/H`: note `SnapshotWindow` does **not** serialize window `Width/Height` (only `SnapshotLayout` does), but `snapshotCell` serializes each cell's `W/H`, so the restored root cell is the authoritative per-window size.
- The fallback path (`root.W <= 0 || root.H <= 0` → use passed size) for legacy/degenerate snapshots.
- This is a unit-level regression test against `RebuildWindowFromSnapshot` (the exact point of the desync); the end-to-end restore→activate flow is exercised indirectly. Happy to add a server-level integration test if you want belt-and-suspenders.

Closes LAB-1931
