### PR TITLE
LAB-1939: Drop pane-issue-meta check from Claude Stop hook

### DIFF
--- a/.claude/hooks/stop-checks.sh
+++ b/.claude/hooks/stop-checks.sh
@@ -20,6 +20,5 @@ run_check() {
 }
 
 run_check ".claude/hooks/tdd-check.sh"
-run_check "scripts/check-pane-issue-meta.sh"
 
 exit "$status"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,7 +94,7 @@ scripts/sync-pane-pr-meta.sh
 scripts/sync-pane-pr-meta.sh 123
 ```
 
-Claude's stop hook still checks for missing pane issue metadata before the session ends. Other agents can run `scripts/check-pane-issue-meta.sh` manually if needed.
+Any agent can run `scripts/check-pane-issue-meta.sh` manually to check whether the current pane is tagged with a Linear issue.
 
 When a worker pushes fixes for Claude review findings, `scripts/check-claude-review.sh` reports whether the latest Claude verdict is `lgtm` or `findings`. Add `--watch` to wait for the next Claude review comment after the push before deciding whether more fixes are needed.
 


### PR DESCRIPTION
## Motivation

`.claude/hooks/stop-checks.sh` runs `scripts/check-pane-issue-meta.sh` on every Stop event. It prints a non-blocking reminder when the current pane is missing an `issue=LAB-XXX` tag, but in practice:

- Lead panes are already exempted, so the warning only ever fires on worker panes spawned by orca or by a fresh `amux new`.
- `scripts/gh-pr-create.sh` and the post-push hook already sync pane PR/issue metadata when a PR lands, so the reminder fires for panes that don't need it.
- It also fires noisily on the lead pane between sessions when tagging hasn't happened yet (e.g. a postmortem chunk after a merge), which is a false positive.

## Summary

- Remove the `check-pane-issue-meta.sh` invocation from `.claude/hooks/stop-checks.sh`. The TDD check stays.
- Update `CLAUDE.md` to describe the script as an opt-in manual tool.
- Keep `scripts/check-pane-issue-meta.sh` itself — any agent can still run it manually.

## Testing

- `go vet ./...` and `go build ./...` clean (no Go files touched).
- Hook surface: opening this PR did not produce a pane-issue reminder on Stop; pre-push only ran the TDD check.

## Review focus

Whether removing the auto-Stop reminder will cause more workers to forget pane tagging in practice. PR-time sync (`gh-pr-create.sh`, post-push hook) is the load-bearing path; this only drops a redundant reminder at session-stop time.

Closes LAB-1939