### PR TITLE
FILL-02: Ignore clone-pool marker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ tmux-src/
 
 # orca clone pool (large, machine-local)
 .orca/pool/
+.orca-pool
 
 # Firebase MCP plugin debug log (written to CWD on session start)
 firebase-debug.log


### PR DESCRIPTION
## Motivation
Clone-pool working copies keep a root `.orca-pool` marker so orca can identify eligible clones. That marker is machine-local state and should not appear as an accidental untracked file in repo status.

## Summary
- Ignore the root `.orca-pool` clone-pool marker alongside `.orca/pool/`.

## Testing
- `echo filler; exit 0`
- `git diff --check`
- `git check-ignore -q .orca-pool`
- `go test ./... -timeout 120s` *(fails on current `origin/main` clipboard integration tests: `TestCopyModeClipboardUsesOSC52WhenInnerClientRunsOverSSH` and `TestCopyModeClipboardUsesTmuxPassthroughWhenInnerClientRunsOverSSHInTmux`; rerunning those tests in isolation fails the same way, unrelated to this `.gitignore`-only diff.)*

## Review focus
Confirm `.orca-pool` is intended to be local clone-pool state and should be ignored rather than committed.
