### PR TITLE
LAB-1948: Avoid compositor ScreenCell value copies

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -1113,22 +1113,29 @@ func (c *clientPaneData) RenderScreen(active bool) string {
 }
 
 func (c *clientPaneData) CellAt(col, row int, active bool) render.ScreenCell {
+	var sc render.ScreenCell
+	c.WriteCellAt(&sc, col, row, active)
+	return sc
+}
+
+func (c *clientPaneData) WriteCellAt(dst *render.ScreenCell, col, row int, active bool) {
 	if c.cm != nil {
-		return render.ScreenCellFromCopyMode(c.cm.ViewportCellAt(col, row))
+		render.ScreenCellFromCopyModeInto(dst, c.cm.ViewportCellAt(col, row))
+		return
 	}
 	emu := c.displayEmulator()
 	cell := emu.CellAt(col, row)
-	sc := render.CellFromUV(cell)
+	render.CellFromUVInto(dst, cell)
 	if c.suppressCursor(active) {
-		stripCursorBlock(&sc, emu, col, row)
+		stripCursorBlock(dst, emu, col, row)
 	}
 	if c.prediction != nil {
-		confirmed := render.CellFromUV(c.emu.CellAt(col, row))
-		if predictionCellChanged(confirmed, sc) {
-			sc = applyPredictionStyle(sc, c.predictionStyle)
+		var confirmed render.ScreenCell
+		render.CellFromUVInto(&confirmed, c.emu.CellAt(col, row))
+		if predictionCellChanged(confirmed, *dst) {
+			applyPredictionStyleInPlace(dst, c.predictionStyle)
 		}
 	}
-	return sc
 }
 
 func (c *clientPaneData) CursorPos() (col, row int) {

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -6,6 +6,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	uv "github.com/charmbracelet/ultraviolet"
 	caputil "github.com/weill-labs/amux/internal/capture"
 	"github.com/weill-labs/amux/internal/config"
 	"github.com/weill-labs/amux/internal/copymode"
@@ -1113,29 +1114,29 @@ func (c *clientPaneData) RenderScreen(active bool) string {
 }
 
 func (c *clientPaneData) CellAt(col, row int, active bool) render.ScreenCell {
-	var sc render.ScreenCell
-	c.WriteCellAt(&sc, col, row, active)
-	return sc
+	char, link, style, width := c.CellFieldsAt(col, row, active)
+	return render.ScreenCell{Char: char, Link: link, Style: style, Width: width}
 }
 
-func (c *clientPaneData) WriteCellAt(dst *render.ScreenCell, col, row int, active bool) {
+func (c *clientPaneData) CellFieldsAt(col, row int, active bool) (string, uv.Link, uv.Style, int) {
 	if c.cm != nil {
-		render.ScreenCellFromCopyModeInto(dst, c.cm.ViewportCellAt(col, row))
-		return
+		return render.ScreenCellFieldsFromCopyMode(c.cm.ViewportCellAt(col, row))
 	}
 	emu := c.displayEmulator()
 	cell := emu.CellAt(col, row)
-	render.CellFromUVInto(dst, cell)
+	char, link, style, width := render.CellFieldsFromUV(cell)
+	sc := render.ScreenCell{Char: char, Link: link, Style: style, Width: width}
 	if c.suppressCursor(active) {
-		stripCursorBlock(dst, emu, col, row)
+		stripCursorBlock(&sc, emu, col, row)
 	}
 	if c.prediction != nil {
 		var confirmed render.ScreenCell
 		render.CellFromUVInto(&confirmed, c.emu.CellAt(col, row))
-		if predictionCellChanged(confirmed, *dst) {
-			applyPredictionStyleInPlace(dst, c.predictionStyle)
+		if predictionCellChanged(confirmed, sc) {
+			applyPredictionStyleInPlace(&sc, c.predictionStyle)
 		}
 	}
+	return sc.Char, sc.Link, sc.Style, sc.Width
 }
 
 func (c *clientPaneData) CursorPos() (col, row int) {

--- a/internal/client/predictor.go
+++ b/internal/client/predictor.go
@@ -454,15 +454,19 @@ func predictionCellChanged(confirmed, predicted render.ScreenCell) bool {
 }
 
 func applyPredictionStyle(cell render.ScreenCell, style localEchoStyle) render.ScreenCell {
+	applyPredictionStyleInPlace(&cell, style)
+	return cell
+}
+
+func applyPredictionStyleInPlace(cell *render.ScreenCell, style localEchoStyle) {
 	switch style {
 	case localEchoStyleUnderline:
 		if cell.Style.Underline == uv.UnderlineNone {
 			cell.Style.Underline = uv.UnderlineSingle
 		}
 	case localEchoStyleNone:
-		return cell
+		return
 	default:
 		cell.Style.Attrs |= uv.AttrFaint
 	}
-	return cell
 }

--- a/internal/client/predictor.go
+++ b/internal/client/predictor.go
@@ -453,11 +453,6 @@ func predictionCellChanged(confirmed, predicted render.ScreenCell) bool {
 	return !predicted.Equal(confirmed)
 }
 
-func applyPredictionStyle(cell render.ScreenCell, style localEchoStyle) render.ScreenCell {
-	applyPredictionStyleInPlace(&cell, style)
-	return cell
-}
-
 func applyPredictionStyleInPlace(cell *render.ScreenCell, style localEchoStyle) {
 	switch style {
 	case localEchoStyleUnderline:

--- a/internal/client/renderer_capture_snapshot.go
+++ b/internal/client/renderer_capture_snapshot.go
@@ -286,11 +286,16 @@ func (p *snapshotPaneData) RenderScreen(active bool) string {
 }
 
 func (p *snapshotPaneData) CellAt(col, row int, active bool) render.ScreenCell {
-	cell := paneBufferLineCell(p.pane.screen, row, col)
-	if !active && p.pane.hasCursorBlock && col == p.pane.cursorBlockCol && row == p.pane.cursorBlockRow {
-		stripSnapshotCursorBlock(&cell)
-	}
+	var cell render.ScreenCell
+	p.WriteCellAt(&cell, col, row, active)
 	return cell
+}
+
+func (p *snapshotPaneData) WriteCellAt(dst *render.ScreenCell, col, row int, active bool) {
+	paneBufferLineCellInto(dst, p.pane.screen, row, col)
+	if !active && p.pane.hasCursorBlock && col == p.pane.cursorBlockCol && row == p.pane.cursorBlockRow {
+		stripSnapshotCursorBlock(dst)
+	}
 }
 
 func stripSnapshotCursorBlock(cell *render.ScreenCell) {

--- a/internal/client/renderer_capture_snapshot.go
+++ b/internal/client/renderer_capture_snapshot.go
@@ -286,16 +286,16 @@ func (p *snapshotPaneData) RenderScreen(active bool) string {
 }
 
 func (p *snapshotPaneData) CellAt(col, row int, active bool) render.ScreenCell {
-	var cell render.ScreenCell
-	p.WriteCellAt(&cell, col, row, active)
-	return cell
+	char, link, style, width := p.CellFieldsAt(col, row, active)
+	return render.ScreenCell{Char: char, Link: link, Style: style, Width: width}
 }
 
-func (p *snapshotPaneData) WriteCellAt(dst *render.ScreenCell, col, row int, active bool) {
-	paneBufferLineCellInto(dst, p.pane.screen, row, col)
+func (p *snapshotPaneData) CellFieldsAt(col, row int, active bool) (string, uv.Link, uv.Style, int) {
+	cell := paneBufferLineCell(p.pane.screen, row, col)
 	if !active && p.pane.hasCursorBlock && col == p.pane.cursorBlockCol && row == p.pane.cursorBlockRow {
-		stripSnapshotCursorBlock(dst)
+		stripSnapshotCursorBlock(&cell)
 	}
+	return cell.Char, cell.Link, cell.Style, cell.Width
 }
 
 func stripSnapshotCursorBlock(cell *render.ScreenCell) {

--- a/internal/client/renderer_queries.go
+++ b/internal/client/renderer_queries.go
@@ -64,17 +64,26 @@ func (p paneBufferSnapshot) ScreenCellAt(col, row int) proto.Cell {
 }
 
 func paneBufferLineCell(lines []paneBufferLine, row, col int) render.ScreenCell {
+	var cell render.ScreenCell
+	paneBufferLineCellInto(&cell, lines, row, col)
+	return cell
+}
+
+func paneBufferLineCellInto(dst *render.ScreenCell, lines []paneBufferLine, row, col int) {
 	if row < 0 || row >= len(lines) {
-		return render.ScreenCell{Char: " ", Width: 1}
+		*dst = render.ScreenCell{Char: " ", Width: 1}
+		return
 	}
 	line := lines[row]
 	if len(line.cells) != 0 {
 		if col >= 0 && col < len(line.cells) {
-			return line.cells[col]
+			*dst = line.cells[col]
+			return
 		}
-		return render.ScreenCell{Char: " ", Width: 1}
+		*dst = render.ScreenCell{Char: " ", Width: 1}
+		return
 	}
-	return plainTextHistoryCell(line.text, col)
+	*dst = plainTextHistoryCell(line.text, col)
 }
 
 func plainTextHistoryCell(line string, col int) render.ScreenCell {

--- a/internal/mux/pane_emulator.go
+++ b/internal/mux/pane_emulator.go
@@ -24,14 +24,22 @@ type PaneRenderSnapshot struct {
 }
 
 func (s PaneRenderSnapshot) CellAt(col, row int) (uv.Cell, bool) {
-	if col < 0 || row < 0 || col >= s.Width || row >= s.Height {
+	cell, ok := s.CellPtrAt(col, row)
+	if !ok {
 		return uv.Cell{}, false
+	}
+	return *cell, true
+}
+
+func (s PaneRenderSnapshot) CellPtrAt(col, row int) (*uv.Cell, bool) {
+	if col < 0 || row < 0 || col >= s.Width || row >= s.Height {
+		return nil, false
 	}
 	idx := row*s.Width + col
 	if idx >= len(s.ScreenCells) {
-		return uv.Cell{}, false
+		return nil, false
 	}
-	return s.ScreenCells[idx], true
+	return &s.ScreenCells[idx], true
 }
 
 // wireScrollbackCallbacks connects the emulator's scrollback push/clear

--- a/internal/render/compositor_bench_test.go
+++ b/internal/render/compositor_bench_test.go
@@ -241,8 +241,8 @@ func BenchmarkBuildPaneContentCells(b *testing.B) {
 			},
 		},
 		{
-			name: "in_place_writer",
-			pane: &inPlacePaneData{
+			name: "field_reader",
+			pane: &fieldReaderPaneData{
 				styledPaneData: styledPaneData{
 					fakePaneData: fakePaneData{id: 1, name: "pane-1"},
 					cells:        rows,

--- a/internal/render/compositor_bench_test.go
+++ b/internal/render/compositor_bench_test.go
@@ -221,6 +221,50 @@ func BenchmarkCompositorDirtyPaneRepresentative(b *testing.B) {
 	}
 }
 
+func BenchmarkBuildPaneContentCells(b *testing.B) {
+	const (
+		width  = 160
+		height = 40
+	)
+	rows := benchScreenCellGrid(width, height, "x")
+	cell := mux.NewLeaf(&mux.Pane{ID: 1, Meta: mux.PaneMeta{Name: "pane-1"}}, 0, 0, width, height+mux.StatusLineRows)
+
+	tests := []struct {
+		name string
+		pane PaneData
+	}{
+		{
+			name: "value_fallback",
+			pane: &styledPaneData{
+				fakePaneData: fakePaneData{id: 1, name: "pane-1"},
+				cells:        rows,
+			},
+		},
+		{
+			name: "in_place_writer",
+			pane: &inPlacePaneData{
+				styledPaneData: styledPaneData{
+					fakePaneData: fakePaneData{id: 1, name: "pane-1"},
+					cells:        rows,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		b.Run(tt.name, func(b *testing.B) {
+			grid := NewScreenGrid(width, height+mux.StatusLineRows)
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				for row := 0; row < height; row++ {
+					buildPaneContentCells(grid, cell, row, true, tt.pane, nil)
+				}
+			}
+		})
+	}
+}
+
 func benchScreenCellGrid(w, h int, fill string) [][]ScreenCell {
 	rows := make([][]ScreenCell, h)
 	for row := range rows {

--- a/internal/render/compositor_test.go
+++ b/internal/render/compositor_test.go
@@ -102,20 +102,21 @@ func (s *styledPaneData) CellAt(col, row int, active bool) ScreenCell {
 	return s.cells[row][col]
 }
 
-type inPlacePaneData struct {
+type fieldReaderPaneData struct {
 	styledPaneData
 	valueReads int
-	writes     int
+	fieldReads int
 }
 
-func (p *inPlacePaneData) CellAt(col, row int, active bool) ScreenCell {
+func (p *fieldReaderPaneData) CellAt(col, row int, active bool) ScreenCell {
 	p.valueReads++
 	return p.styledPaneData.CellAt(col, row, active)
 }
 
-func (p *inPlacePaneData) WriteCellAt(dst *ScreenCell, col, row int, active bool) {
-	p.writes++
-	*dst = p.styledPaneData.CellAt(col, row, active)
+func (p *fieldReaderPaneData) CellFieldsAt(col, row int, active bool) (string, uv.Link, uv.Style, int) {
+	p.fieldReads++
+	cell := p.styledPaneData.CellAt(col, row, active)
+	return cell.Char, cell.Link, cell.Style, cell.Width
 }
 
 type countingPaneData struct {
@@ -917,7 +918,7 @@ func TestBuildPaneContentCellsDoesNotAllocateRowBuffer(t *testing.T) {
 	}
 }
 
-func TestBuildPaneContentCellsUsesInPlaceCellWriter(t *testing.T) {
+func TestBuildPaneContentCellsUsesFieldReaderFastPath(t *testing.T) {
 	t.Parallel()
 
 	const (
@@ -925,7 +926,7 @@ func TestBuildPaneContentCellsUsesInPlaceCellWriter(t *testing.T) {
 		height = 2
 	)
 	rows := benchScreenCellGrid(width, height, "x")
-	pane := &inPlacePaneData{
+	pane := &fieldReaderPaneData{
 		styledPaneData: styledPaneData{
 			fakePaneData: fakePaneData{id: 1, name: "pane-1"},
 			cells:        rows,
@@ -937,13 +938,13 @@ func TestBuildPaneContentCellsUsesInPlaceCellWriter(t *testing.T) {
 	buildPaneContentCells(grid, cell, 0, true, pane, nil)
 
 	if pane.valueReads != 0 {
-		t.Fatalf("CellAt reads = %d, want 0 when WriteCellAt is available", pane.valueReads)
+		t.Fatalf("CellAt reads = %d, want 0 when CellFieldsAt is available", pane.valueReads)
 	}
-	if pane.writes == 0 {
-		t.Fatal("WriteCellAt should be used for pane content")
+	if pane.fieldReads == 0 {
+		t.Fatal("CellFieldsAt should be used for pane content")
 	}
 	if got := grid.Get(1, mux.StatusLineRows); got.Char != "x" {
-		t.Fatalf("grid cell = %q, want in-place writer content", got.Char)
+		t.Fatalf("grid cell = %q, want field reader content", got.Char)
 	}
 }
 

--- a/internal/render/compositor_test.go
+++ b/internal/render/compositor_test.go
@@ -102,6 +102,22 @@ func (s *styledPaneData) CellAt(col, row int, active bool) ScreenCell {
 	return s.cells[row][col]
 }
 
+type inPlacePaneData struct {
+	styledPaneData
+	valueReads int
+	writes     int
+}
+
+func (p *inPlacePaneData) CellAt(col, row int, active bool) ScreenCell {
+	p.valueReads++
+	return p.styledPaneData.CellAt(col, row, active)
+}
+
+func (p *inPlacePaneData) WriteCellAt(dst *ScreenCell, col, row int, active bool) {
+	p.writes++
+	*dst = p.styledPaneData.CellAt(col, row, active)
+}
+
 type countingPaneData struct {
 	base      *fakePaneData
 	cellReads *int
@@ -898,6 +914,36 @@ func TestBuildPaneContentCellsDoesNotAllocateRowBuffer(t *testing.T) {
 	})
 	if allocs > 0 {
 		t.Fatalf("buildPaneContentCells allocated %.2f times per row; want no per-row buffer allocation", allocs)
+	}
+}
+
+func TestBuildPaneContentCellsUsesInPlaceCellWriter(t *testing.T) {
+	t.Parallel()
+
+	const (
+		width  = 12
+		height = 2
+	)
+	rows := benchScreenCellGrid(width, height, "x")
+	pane := &inPlacePaneData{
+		styledPaneData: styledPaneData{
+			fakePaneData: fakePaneData{id: 1, name: "pane-1"},
+			cells:        rows,
+		},
+	}
+	cell := mux.NewLeaf(&mux.Pane{ID: 1, Meta: mux.PaneMeta{Name: "pane-1"}}, 0, 0, width, height+mux.StatusLineRows)
+	grid := NewScreenGrid(width, height+mux.StatusLineRows)
+
+	buildPaneContentCells(grid, cell, 0, true, pane, nil)
+
+	if pane.valueReads != 0 {
+		t.Fatalf("CellAt reads = %d, want 0 when WriteCellAt is available", pane.valueReads)
+	}
+	if pane.writes == 0 {
+		t.Fatal("WriteCellAt should be used for pane content")
+	}
+	if got := grid.Get(1, mux.StatusLineRows); got.Char != "x" {
+		t.Fatalf("grid cell = %q, want in-place writer content", got.Char)
 	}
 }
 

--- a/internal/render/copymode_overlay.go
+++ b/internal/render/copymode_overlay.go
@@ -32,10 +32,16 @@ func ScreenCellFromCopyModeInto(dst *ScreenCell, cell proto.Cell) {
 	normalizeScreenCellInPlace(dst)
 }
 
-func normalizeScreenCell(cell ScreenCell) ScreenCell {
-	sc := cell
-	normalizeScreenCellInPlace(&sc)
-	return sc
+func ScreenCellFieldsFromCopyMode(cell proto.Cell) (string, uv.Link, uv.Style, int) {
+	char := cell.Char
+	if char == "" {
+		char = " "
+	}
+	width := cell.Width
+	if width < 0 {
+		width = 1
+	}
+	return char, uv.Link{}, cell.Style, width
 }
 
 func normalizeScreenCellInPlace(cell *ScreenCell) {

--- a/internal/render/copymode_overlay.go
+++ b/internal/render/copymode_overlay.go
@@ -15,28 +15,47 @@ var (
 )
 
 func ScreenCellFromCopyMode(cell proto.Cell) ScreenCell {
-	return normalizeScreenCell(ScreenCell{
+	sc := ScreenCell{
 		Char:  cell.Char,
 		Style: cell.Style,
 		Width: cell.Width,
-	})
+	}
+	normalizeScreenCellInPlace(&sc)
+	return sc
+}
+
+func ScreenCellFromCopyModeInto(dst *ScreenCell, cell proto.Cell) {
+	dst.Char = cell.Char
+	dst.Link = uv.Link{}
+	dst.Style = cell.Style
+	dst.Width = cell.Width
+	normalizeScreenCellInPlace(dst)
 }
 
 func normalizeScreenCell(cell ScreenCell) ScreenCell {
 	sc := cell
-	if sc.Char == "" {
-		sc.Char = " "
-	}
-	if sc.Width < 0 {
-		sc.Width = 1
-	}
+	normalizeScreenCellInPlace(&sc)
 	return sc
 }
 
+func normalizeScreenCellInPlace(cell *ScreenCell) {
+	if cell.Char == "" {
+		cell.Char = " "
+	}
+	if cell.Width < 0 {
+		cell.Width = 1
+	}
+}
+
 func applyCopyModeOverlay(base ScreenCell, overlay *proto.ViewportOverlay, col, row int) ScreenCell {
-	base = normalizeScreenCell(base)
+	applyCopyModeOverlayInPlace(&base, overlay, col, row)
+	return base
+}
+
+func applyCopyModeOverlayInPlace(base *ScreenCell, overlay *proto.ViewportOverlay, col, row int) {
+	normalizeScreenCellInPlace(base)
 	if overlay == nil {
-		return base
+		return
 	}
 
 	kind := copyModeHighlightAt(overlay, row, col)
@@ -53,8 +72,6 @@ func applyCopyModeOverlay(base ScreenCell, overlay *proto.ViewportOverlay, col, 
 	if overlay.Cursor == (proto.CursorPosition{Col: col, Row: row}) {
 		base.Style.Attrs |= uv.AttrReverse
 	}
-
-	return base
 }
 
 func copyModeHighlightAt(overlay *proto.ViewportOverlay, row, col int) proto.HighlightKind {

--- a/internal/render/panedata.go
+++ b/internal/render/panedata.go
@@ -39,3 +39,9 @@ type PaneData interface {
 	// when the user is actively typing a search in copy mode. Empty otherwise.
 	CopyModeSearch() string
 }
+
+// PaneCellWriter is an optional fast path for PaneData implementations that can
+// write a screen cell directly into compositor-owned storage.
+type PaneCellWriter interface {
+	WriteCellAt(dst *ScreenCell, col, row int, active bool)
+}

--- a/internal/render/panedata.go
+++ b/internal/render/panedata.go
@@ -1,6 +1,7 @@
 package render
 
 import (
+	uv "github.com/charmbracelet/ultraviolet"
 	"github.com/weill-labs/amux/internal/proto"
 )
 
@@ -40,8 +41,8 @@ type PaneData interface {
 	CopyModeSearch() string
 }
 
-// PaneCellWriter is an optional fast path for PaneData implementations that can
-// write a screen cell directly into compositor-owned storage.
-type PaneCellWriter interface {
-	WriteCellAt(dst *ScreenCell, col, row int, active bool)
+// PaneCellReader is an optional fast path for PaneData implementations that can
+// expose a cell without returning the full ScreenCell struct by value.
+type PaneCellReader interface {
+	CellFieldsAt(col, row int, active bool) (char string, link uv.Link, style uv.Style, width int)
 }

--- a/internal/render/screen.go
+++ b/internal/render/screen.go
@@ -50,6 +50,14 @@ func writeContinuationCell(dst, base *ScreenCell) {
 	dst.Width = 0
 }
 
+func writeScreenCellFields(dst *ScreenCell, char string, link uv.Link, style uv.Style, width int) {
+	dst.Char = char
+	dst.Link = link
+	dst.Style = style
+	dst.Width = width
+	normalizeScreenCellInPlace(dst)
+}
+
 // OOBWrite records a single out-of-bounds Set() call.
 type OOBWrite struct {
 	X, Y int
@@ -278,6 +286,17 @@ func CellFromUVInto(dst *ScreenCell, c *uv.Cell) {
 	cellFromUVValueInto(dst, c, true)
 }
 
+func CellFieldsFromUV(c *uv.Cell) (string, uv.Link, uv.Style, int) {
+	if c == nil {
+		return " ", uv.Link{}, uv.Style{}, 1
+	}
+	char := c.Content
+	if char == "" {
+		char = " "
+	}
+	return char, c.Link, c.Style, c.Width
+}
+
 // CellFromUVValue converts a VT library cell value to a ScreenCell.
 func CellFromUVValue(c uv.Cell, ok bool) ScreenCell {
 	var sc ScreenCell
@@ -491,8 +510,8 @@ func (c *Compositor) buildGridWithOverlayDirty(
 // rendered row collapses them into a single grapheme cluster. Re-pack the row
 // before diffing so RenderDiff matches the RenderFull path.
 func buildPaneContentCells(g *ScreenGrid, cell *mux.LayoutCell, row int, active bool, pd PaneData, copyOverlay *proto.ViewportOverlay) {
-	if writer, ok := pd.(PaneCellWriter); ok {
-		buildPaneContentCellsWithWriter(g, cell, row, active, writer, copyOverlay)
+	if reader, ok := pd.(PaneCellReader); ok {
+		buildPaneContentCellsWithReader(g, cell, row, active, reader, copyOverlay)
 		return
 	}
 
@@ -532,7 +551,7 @@ func buildPaneContentCells(g *ScreenGrid, cell *mux.LayoutCell, row int, active 
 	}
 }
 
-func buildPaneContentCellsWithWriter(g *ScreenGrid, cell *mux.LayoutCell, row int, active bool, writer PaneCellWriter, copyOverlay *proto.ViewportOverlay) {
+func buildPaneContentCellsWithReader(g *ScreenGrid, cell *mux.LayoutCell, row int, active bool, reader PaneCellReader, copyOverlay *proto.ViewportOverlay) {
 	y := cell.Y + mux.StatusLineRows + row
 	for col := 0; col < cell.W; col++ {
 		g.setBlank(cell.X+col, y)
@@ -540,20 +559,20 @@ func buildPaneContentCellsWithWriter(g *ScreenGrid, cell *mux.LayoutCell, row in
 
 	dstCol := 0
 	var lookahead paneContentLookahead
-	var base ScreenCell
+	var base, next ScreenCell
 	for srcCol := 0; srcCol < cell.W && dstCol < cell.W; {
-		paneContentCellAtWithLookaheadInto(&base, row, srcCol, active, writer, copyOverlay, &lookahead)
+		paneContentCellAtWithLookaheadInto(&base, row, srcCol, active, reader, copyOverlay, &lookahead)
 		if base.Width == 0 && base.Char == " " {
 			srcCol++
 			continue
 		}
 
 		dst := g.cellForWrite(cell.X+dstCol, y)
-		var scratch ScreenCell
+		var oobScratch ScreenCell
 		if dst == nil {
-			dst = &scratch
+			dst = &oobScratch
 		}
-		renderedWidth, nextSrc := compactRowCellInto(dst, cell.W, row, active, writer, copyOverlay, srcCol, &base, &lookahead)
+		renderedWidth, nextSrc := compactRowCellInto(dst, cell.W, row, active, reader, copyOverlay, srcCol, &base, &next, &lookahead)
 		if renderedWidth <= 0 {
 			renderedWidth = 1
 		}
@@ -597,8 +616,8 @@ func paneContentRowCells(width, row int, active bool, pd PaneData, copyOverlay *
 		blankScreenCell(&rowCells[i])
 	}
 
-	if writer, ok := pd.(PaneCellWriter); ok {
-		paneContentRowCellsWithWriter(rowCells, width, row, active, writer, copyOverlay)
+	if reader, ok := pd.(PaneCellReader); ok {
+		paneContentRowCellsWithReader(rowCells, width, row, active, reader, copyOverlay)
 		return rowCells
 	}
 
@@ -634,19 +653,19 @@ func paneContentRowCells(width, row int, active bool, pd PaneData, copyOverlay *
 	return rowCells
 }
 
-func paneContentRowCellsWithWriter(rowCells []ScreenCell, width, row int, active bool, writer PaneCellWriter, copyOverlay *proto.ViewportOverlay) {
+func paneContentRowCellsWithReader(rowCells []ScreenCell, width, row int, active bool, reader PaneCellReader, copyOverlay *proto.ViewportOverlay) {
 	dstCol := 0
 	var lookahead paneContentLookahead
-	var base ScreenCell
+	var base, next ScreenCell
 	for srcCol := 0; srcCol < width && dstCol < width; {
-		paneContentCellAtWithLookaheadInto(&base, row, srcCol, active, writer, copyOverlay, &lookahead)
+		paneContentCellAtWithLookaheadInto(&base, row, srcCol, active, reader, copyOverlay, &lookahead)
 		if base.Width == 0 && base.Char == " " {
 			srcCol++
 			continue
 		}
 
 		rendered := &rowCells[dstCol]
-		renderedWidth, nextSrc := compactRowCellInto(rendered, width, row, active, writer, copyOverlay, srcCol, &base, &lookahead)
+		renderedWidth, nextSrc := compactRowCellInto(rendered, width, row, active, reader, copyOverlay, srcCol, &base, &next, &lookahead)
 		if renderedWidth <= 0 {
 			renderedWidth = 1
 		}
@@ -668,8 +687,9 @@ func paneContentCellAt(row, col int, active bool, pd PaneData, copyOverlay *prot
 	return applyCopyModeOverlay(pd.CellAt(col, row, active), copyOverlay, col, row)
 }
 
-func paneContentCellAtInto(dst *ScreenCell, row, col int, active bool, writer PaneCellWriter, copyOverlay *proto.ViewportOverlay) {
-	writer.WriteCellAt(dst, col, row, active)
+func paneContentCellAtInto(dst *ScreenCell, row, col int, active bool, reader PaneCellReader, copyOverlay *proto.ViewportOverlay) {
+	char, link, style, width := reader.CellFieldsAt(col, row, active)
+	writeScreenCellFields(dst, char, link, style, width)
 	applyCopyModeOverlayInPlace(dst, copyOverlay, col, row)
 }
 
@@ -687,13 +707,13 @@ func paneContentCellAtWithLookahead(row, col int, active bool, pd PaneData, copy
 	return paneContentCellAt(row, col, active, pd, copyOverlay)
 }
 
-func paneContentCellAtWithLookaheadInto(dst *ScreenCell, row, col int, active bool, writer PaneCellWriter, copyOverlay *proto.ViewportOverlay, lookahead *paneContentLookahead) {
+func paneContentCellAtWithLookaheadInto(dst *ScreenCell, row, col int, active bool, reader PaneCellReader, copyOverlay *proto.ViewportOverlay, lookahead *paneContentLookahead) {
 	if lookahead != nil && lookahead.ok && lookahead.col == col {
 		lookahead.ok = false
 		copyScreenCell(dst, &lookahead.cell)
 		return
 	}
-	paneContentCellAtInto(dst, row, col, active, writer, copyOverlay)
+	paneContentCellAtInto(dst, row, col, active, reader, copyOverlay)
 }
 
 func compactRowCell(width, row int, active bool, pd PaneData, copyOverlay *proto.ViewportOverlay, srcCol int, base ScreenCell, lookahead *paneContentLookahead) (ScreenCell, int, int) {
@@ -752,7 +772,7 @@ func compactRowCell(width, row int, active bool, pd PaneData, copyOverlay *proto
 	return merged, mergedWidth, nextSrc
 }
 
-func compactRowCellInto(dst *ScreenCell, width, row int, active bool, writer PaneCellWriter, copyOverlay *proto.ViewportOverlay, srcCol int, base *ScreenCell, lookahead *paneContentLookahead) (int, int) {
+func compactRowCellInto(dst *ScreenCell, width, row int, active bool, reader PaneCellReader, copyOverlay *proto.ViewportOverlay, srcCol int, base, next *ScreenCell, lookahead *paneContentLookahead) (int, int) {
 	baseWidth := base.Width
 	if baseWidth <= 0 {
 		baseWidth = 1
@@ -763,19 +783,18 @@ func compactRowCellInto(dst *ScreenCell, width, row int, active bool, writer Pan
 	nextSrc := srcCol + baseWidth
 	candidate := base.Char
 
-	var next ScreenCell
 	for nextSrc < width {
-		paneContentCellAtInto(&next, row, nextSrc, active, writer, copyOverlay)
+		paneContentCellAtInto(next, row, nextSrc, active, reader, copyOverlay)
 		if next.Width == 0 && next.Char == " " {
 			nextSrc++
 			continue
 		}
 		if next.Char == " " || !dst.Style.Equal(&next.Style) || !dst.Link.Equal(&next.Link) {
-			storePaneContentLookahead(lookahead, nextSrc, &next)
+			storePaneContentLookahead(lookahead, nextSrc, next)
 			break
 		}
 		if asciiCellsCannotMerge(candidate, next.Char) {
-			storePaneContentLookahead(lookahead, nextSrc, &next)
+			storePaneContentLookahead(lookahead, nextSrc, next)
 			break
 		}
 
@@ -788,7 +807,7 @@ func compactRowCellInto(dst *ScreenCell, width, row int, active bool, writer Pan
 			zwjConcat := candidate + "\u200d" + next.Char
 			cluster, clusterWidth = ansi.FirstGraphemeCluster(zwjConcat, ansi.GraphemeWidth)
 			if cluster != zwjConcat {
-				storePaneContentLookahead(lookahead, nextSrc, &next)
+				storePaneContentLookahead(lookahead, nextSrc, next)
 				break
 			}
 			concat = zwjConcat

--- a/internal/render/screen.go
+++ b/internal/render/screen.go
@@ -29,6 +29,27 @@ func (c ScreenCell) Equal(o ScreenCell) bool {
 	return c.Char == o.Char && c.Width == o.Width && c.Style.Equal(&o.Style) && c.Link.Equal(&o.Link)
 }
 
+func blankScreenCell(dst *ScreenCell) {
+	dst.Char = " "
+	dst.Link = uv.Link{}
+	dst.Style = uv.Style{}
+	dst.Width = 1
+}
+
+func copyScreenCell(dst, src *ScreenCell) {
+	dst.Char = src.Char
+	dst.Link = src.Link
+	dst.Style = src.Style
+	dst.Width = src.Width
+}
+
+func writeContinuationCell(dst, base *ScreenCell) {
+	dst.Char = ""
+	dst.Link = base.Link
+	dst.Style = base.Style
+	dst.Width = 0
+}
+
 // OOBWrite records a single out-of-bounds Set() call.
 type OOBWrite struct {
 	X, Y int
@@ -46,7 +67,7 @@ type ScreenGrid struct {
 func NewScreenGrid(width, height int) *ScreenGrid {
 	cells := make([]ScreenCell, width*height)
 	for i := range cells {
-		cells[i] = ScreenCell{Char: " ", Width: 1}
+		blankScreenCell(&cells[i])
 	}
 	return &ScreenGrid{Width: width, Height: height, Cells: cells}
 }
@@ -69,13 +90,30 @@ func (g *ScreenGrid) Clone() *ScreenGrid {
 // Set writes a cell at (x, y). Out-of-bounds writes are silently ignored.
 // When Debug is true, OOB writes are also recorded for later inspection.
 func (g *ScreenGrid) Set(x, y int, cell ScreenCell) {
-	if x >= 0 && x < g.Width && y >= 0 && y < g.Height {
-		g.Cells[y*g.Width+x] = cell
+	if dst := g.cellForWrite(x, y); dst != nil {
+		copyScreenCell(dst, &cell)
 		return
 	}
 	if g.Debug {
 		g.oobWrites = append(g.oobWrites, OOBWrite{X: x, Y: y})
 	}
+}
+
+func (g *ScreenGrid) setBlank(x, y int) {
+	if dst := g.cellForWrite(x, y); dst != nil {
+		blankScreenCell(dst)
+		return
+	}
+	if g.Debug {
+		g.oobWrites = append(g.oobWrites, OOBWrite{X: x, Y: y})
+	}
+}
+
+func (g *ScreenGrid) cellForWrite(x, y int) *ScreenCell {
+	if x >= 0 && x < g.Width && y >= 0 && y < g.Height {
+		return &g.Cells[y*g.Width+x]
+	}
+	return nil
 }
 
 // Get reads the cell at (x, y). Out-of-bounds returns a space cell.
@@ -226,22 +264,45 @@ func emitDiffWithProfileState(changes []CellChange, profile termenv.Profile, sta
 
 // CellFromUV converts a VT library cell to a ScreenCell.
 func CellFromUV(c *uv.Cell) ScreenCell {
+	var sc ScreenCell
+	CellFromUVInto(&sc, c)
+	return sc
+}
+
+// CellFromUVInto converts a VT library cell into dst.
+func CellFromUVInto(dst *ScreenCell, c *uv.Cell) {
 	if c == nil {
-		return ScreenCell{Char: " ", Width: 1}
+		blankScreenCell(dst)
+		return
 	}
-	return CellFromUVValue(*c, true)
+	cellFromUVValueInto(dst, c, true)
 }
 
 // CellFromUVValue converts a VT library cell value to a ScreenCell.
 func CellFromUVValue(c uv.Cell, ok bool) ScreenCell {
-	if !ok {
-		return ScreenCell{Char: " ", Width: 1}
+	var sc ScreenCell
+	CellFromUVValueInto(&sc, c, ok)
+	return sc
+}
+
+// CellFromUVValueInto converts a VT library cell value into dst.
+func CellFromUVValueInto(dst *ScreenCell, c uv.Cell, ok bool) {
+	cellFromUVValueInto(dst, &c, ok)
+}
+
+func cellFromUVValueInto(dst *ScreenCell, c *uv.Cell, ok bool) {
+	if !ok || c == nil {
+		blankScreenCell(dst)
+		return
 	}
 	char := c.Content
 	if char == "" {
 		char = " "
 	}
-	return ScreenCell{Char: char, Link: c.Link, Style: c.Style, Width: c.Width}
+	dst.Char = char
+	dst.Link = c.Link
+	dst.Style = c.Style
+	dst.Width = c.Width
 }
 
 func (c *Compositor) buildGridWithOverlay(root *mux.LayoutCell, activePaneID uint32, lookup func(uint32) PaneData, overlay OverlayState) (*ScreenGrid, int) {
@@ -430,9 +491,14 @@ func (c *Compositor) buildGridWithOverlayDirty(
 // rendered row collapses them into a single grapheme cluster. Re-pack the row
 // before diffing so RenderDiff matches the RenderFull path.
 func buildPaneContentCells(g *ScreenGrid, cell *mux.LayoutCell, row int, active bool, pd PaneData, copyOverlay *proto.ViewportOverlay) {
+	if writer, ok := pd.(PaneCellWriter); ok {
+		buildPaneContentCellsWithWriter(g, cell, row, active, writer, copyOverlay)
+		return
+	}
+
 	y := cell.Y + mux.StatusLineRows + row
 	for col := 0; col < cell.W; col++ {
-		g.Set(cell.X+col, y, ScreenCell{Char: " ", Width: 1})
+		g.setBlank(cell.X+col, y)
 	}
 
 	dstCol := 0
@@ -466,6 +532,47 @@ func buildPaneContentCells(g *ScreenGrid, cell *mux.LayoutCell, row int, active 
 	}
 }
 
+func buildPaneContentCellsWithWriter(g *ScreenGrid, cell *mux.LayoutCell, row int, active bool, writer PaneCellWriter, copyOverlay *proto.ViewportOverlay) {
+	y := cell.Y + mux.StatusLineRows + row
+	for col := 0; col < cell.W; col++ {
+		g.setBlank(cell.X+col, y)
+	}
+
+	dstCol := 0
+	var lookahead paneContentLookahead
+	var base ScreenCell
+	for srcCol := 0; srcCol < cell.W && dstCol < cell.W; {
+		paneContentCellAtWithLookaheadInto(&base, row, srcCol, active, writer, copyOverlay, &lookahead)
+		if base.Width == 0 && base.Char == " " {
+			srcCol++
+			continue
+		}
+
+		dst := g.cellForWrite(cell.X+dstCol, y)
+		var scratch ScreenCell
+		if dst == nil {
+			dst = &scratch
+		}
+		renderedWidth, nextSrc := compactRowCellInto(dst, cell.W, row, active, writer, copyOverlay, srcCol, &base, &lookahead)
+		if renderedWidth <= 0 {
+			renderedWidth = 1
+		}
+		if renderedWidth > cell.W-dstCol {
+			blankScreenCell(dst)
+			break
+		}
+
+		for i := 1; i < renderedWidth && dstCol+i < cell.W; i++ {
+			if cont := g.cellForWrite(cell.X+dstCol+i, y); cont != nil {
+				writeContinuationCell(cont, dst)
+			}
+		}
+
+		dstCol += renderedWidth
+		srcCol = nextSrc
+	}
+}
+
 // clearPaneContentRows blanks rows in the cloned dirty grid that are no longer
 // visible for this pane so clipped panes cannot retain stale content from the
 // previous frame.
@@ -479,7 +586,7 @@ func clearPaneContentRows(g *ScreenGrid, cell *mux.LayoutCell, startRow, endRow 
 			continue
 		}
 		for col := 0; col < cell.W; col++ {
-			g.Set(cell.X+col, y, ScreenCell{Char: " ", Width: 1})
+			g.setBlank(cell.X+col, y)
 		}
 	}
 }
@@ -487,7 +594,12 @@ func clearPaneContentRows(g *ScreenGrid, cell *mux.LayoutCell, startRow, endRow 
 func paneContentRowCells(width, row int, active bool, pd PaneData, copyOverlay *proto.ViewportOverlay) []ScreenCell {
 	rowCells := make([]ScreenCell, width)
 	for i := range rowCells {
-		rowCells[i] = ScreenCell{Char: " ", Width: 1}
+		blankScreenCell(&rowCells[i])
+	}
+
+	if writer, ok := pd.(PaneCellWriter); ok {
+		paneContentRowCellsWithWriter(rowCells, width, row, active, writer, copyOverlay)
+		return rowCells
 	}
 
 	dstCol := 0
@@ -522,8 +634,43 @@ func paneContentRowCells(width, row int, active bool, pd PaneData, copyOverlay *
 	return rowCells
 }
 
+func paneContentRowCellsWithWriter(rowCells []ScreenCell, width, row int, active bool, writer PaneCellWriter, copyOverlay *proto.ViewportOverlay) {
+	dstCol := 0
+	var lookahead paneContentLookahead
+	var base ScreenCell
+	for srcCol := 0; srcCol < width && dstCol < width; {
+		paneContentCellAtWithLookaheadInto(&base, row, srcCol, active, writer, copyOverlay, &lookahead)
+		if base.Width == 0 && base.Char == " " {
+			srcCol++
+			continue
+		}
+
+		rendered := &rowCells[dstCol]
+		renderedWidth, nextSrc := compactRowCellInto(rendered, width, row, active, writer, copyOverlay, srcCol, &base, &lookahead)
+		if renderedWidth <= 0 {
+			renderedWidth = 1
+		}
+		if renderedWidth > width-dstCol {
+			blankScreenCell(rendered)
+			break
+		}
+
+		for i := 1; i < renderedWidth && dstCol+i < width; i++ {
+			writeContinuationCell(&rowCells[dstCol+i], rendered)
+		}
+
+		dstCol += renderedWidth
+		srcCol = nextSrc
+	}
+}
+
 func paneContentCellAt(row, col int, active bool, pd PaneData, copyOverlay *proto.ViewportOverlay) ScreenCell {
 	return applyCopyModeOverlay(pd.CellAt(col, row, active), copyOverlay, col, row)
+}
+
+func paneContentCellAtInto(dst *ScreenCell, row, col int, active bool, writer PaneCellWriter, copyOverlay *proto.ViewportOverlay) {
+	writer.WriteCellAt(dst, col, row, active)
+	applyCopyModeOverlayInPlace(dst, copyOverlay, col, row)
 }
 
 type paneContentLookahead struct {
@@ -538,6 +685,15 @@ func paneContentCellAtWithLookahead(row, col int, active bool, pd PaneData, copy
 		return lookahead.cell
 	}
 	return paneContentCellAt(row, col, active, pd, copyOverlay)
+}
+
+func paneContentCellAtWithLookaheadInto(dst *ScreenCell, row, col int, active bool, writer PaneCellWriter, copyOverlay *proto.ViewportOverlay, lookahead *paneContentLookahead) {
+	if lookahead != nil && lookahead.ok && lookahead.col == col {
+		lookahead.ok = false
+		copyScreenCell(dst, &lookahead.cell)
+		return
+	}
+	paneContentCellAtInto(dst, row, col, active, writer, copyOverlay)
 }
 
 func compactRowCell(width, row int, active bool, pd PaneData, copyOverlay *proto.ViewportOverlay, srcCol int, base ScreenCell, lookahead *paneContentLookahead) (ScreenCell, int, int) {
@@ -558,11 +714,11 @@ func compactRowCell(width, row int, active bool, pd PaneData, copyOverlay *proto
 			continue
 		}
 		if next.Char == " " || !merged.Style.Equal(&next.Style) || !merged.Link.Equal(&next.Link) {
-			storePaneContentLookahead(lookahead, nextSrc, next)
+			storePaneContentLookahead(lookahead, nextSrc, &next)
 			break
 		}
 		if asciiCellsCannotMerge(candidate, next.Char) {
-			storePaneContentLookahead(lookahead, nextSrc, next)
+			storePaneContentLookahead(lookahead, nextSrc, &next)
 			break
 		}
 
@@ -575,7 +731,7 @@ func compactRowCell(width, row int, active bool, pd PaneData, copyOverlay *proto
 			zwjConcat := candidate + "\u200d" + next.Char
 			cluster, clusterWidth = ansi.FirstGraphemeCluster(zwjConcat, ansi.GraphemeWidth)
 			if cluster != zwjConcat {
-				storePaneContentLookahead(lookahead, nextSrc, next)
+				storePaneContentLookahead(lookahead, nextSrc, &next)
 				break
 			}
 			concat = zwjConcat
@@ -596,12 +752,69 @@ func compactRowCell(width, row int, active bool, pd PaneData, copyOverlay *proto
 	return merged, mergedWidth, nextSrc
 }
 
-func storePaneContentLookahead(lookahead *paneContentLookahead, col int, cell ScreenCell) {
+func compactRowCellInto(dst *ScreenCell, width, row int, active bool, writer PaneCellWriter, copyOverlay *proto.ViewportOverlay, srcCol int, base *ScreenCell, lookahead *paneContentLookahead) (int, int) {
+	baseWidth := base.Width
+	if baseWidth <= 0 {
+		baseWidth = 1
+	}
+
+	copyScreenCell(dst, base)
+	mergedWidth := baseWidth
+	nextSrc := srcCol + baseWidth
+	candidate := base.Char
+
+	var next ScreenCell
+	for nextSrc < width {
+		paneContentCellAtInto(&next, row, nextSrc, active, writer, copyOverlay)
+		if next.Width == 0 && next.Char == " " {
+			nextSrc++
+			continue
+		}
+		if next.Char == " " || !dst.Style.Equal(&next.Style) || !dst.Link.Equal(&next.Link) {
+			storePaneContentLookahead(lookahead, nextSrc, &next)
+			break
+		}
+		if asciiCellsCannotMerge(candidate, next.Char) {
+			storePaneContentLookahead(lookahead, nextSrc, &next)
+			break
+		}
+
+		concat := candidate + next.Char
+		cluster, clusterWidth := ansi.FirstGraphemeCluster(concat, ansi.GraphemeWidth)
+		if cluster != concat {
+			// Some cursor-assembled emoji suffixes depend on an implicit ZWJ that
+			// never occupied its own source cell. Reinsert it when that produces
+			// the visible grapheme cluster the terminal rendered.
+			zwjConcat := candidate + "\u200d" + next.Char
+			cluster, clusterWidth = ansi.FirstGraphemeCluster(zwjConcat, ansi.GraphemeWidth)
+			if cluster != zwjConcat {
+				storePaneContentLookahead(lookahead, nextSrc, &next)
+				break
+			}
+			concat = zwjConcat
+		}
+
+		candidate = concat
+		dst.Char = candidate
+		dst.Width = clusterWidth
+		mergedWidth = clusterWidth
+
+		nextWidth := next.Width
+		if nextWidth <= 0 {
+			nextWidth = 1
+		}
+		nextSrc += nextWidth
+	}
+
+	return mergedWidth, nextSrc
+}
+
+func storePaneContentLookahead(lookahead *paneContentLookahead, col int, cell *ScreenCell) {
 	if lookahead == nil {
 		return
 	}
 	lookahead.col = col
-	lookahead.cell = cell
+	copyScreenCell(&lookahead.cell, cell)
 	lookahead.ok = true
 }
 

--- a/internal/server/server_capture_full.go
+++ b/internal/server/server_capture_full.go
@@ -124,21 +124,22 @@ func (p *serverPaneData) RenderScreen(active bool) string {
 }
 
 func (p *serverPaneData) CellAt(col, row int, active bool) render.ScreenCell {
-	var sc render.ScreenCell
-	p.WriteCellAt(&sc, col, row, active)
-	return sc
+	char, link, style, width := p.CellFieldsAt(col, row, active)
+	return render.ScreenCell{Char: char, Link: link, Style: style, Width: width}
 }
 
-func (p *serverPaneData) WriteCellAt(dst *render.ScreenCell, col, row int, active bool) {
+func (p *serverPaneData) CellFieldsAt(col, row int, active bool) (string, uv.Link, uv.Style, int) {
 	cell, ok := p.pane.render.CellPtrAt(col, row)
+	var sc render.ScreenCell
 	if ok {
-		render.CellFromUVInto(dst, cell)
+		render.CellFromUVInto(&sc, cell)
 	} else {
-		render.CellFromUVInto(dst, nil)
+		render.CellFromUVInto(&sc, nil)
 	}
 	if !active && p.pane.render.HasCursorBlock && col == p.pane.render.CursorBlockCol && row == p.pane.render.CursorBlockRow {
-		stripServerSnapshotCursorBlock(dst)
+		stripServerSnapshotCursorBlock(&sc)
 	}
+	return sc.Char, sc.Link, sc.Style, sc.Width
 }
 
 func stripServerSnapshotCursorBlock(cell *render.ScreenCell) {

--- a/internal/server/server_capture_full.go
+++ b/internal/server/server_capture_full.go
@@ -124,12 +124,21 @@ func (p *serverPaneData) RenderScreen(active bool) string {
 }
 
 func (p *serverPaneData) CellAt(col, row int, active bool) render.ScreenCell {
-	cell, ok := p.pane.render.CellAt(col, row)
-	sc := render.CellFromUVValue(cell, ok)
-	if !active && p.pane.render.HasCursorBlock && col == p.pane.render.CursorBlockCol && row == p.pane.render.CursorBlockRow {
-		stripServerSnapshotCursorBlock(&sc)
-	}
+	var sc render.ScreenCell
+	p.WriteCellAt(&sc, col, row, active)
 	return sc
+}
+
+func (p *serverPaneData) WriteCellAt(dst *render.ScreenCell, col, row int, active bool) {
+	cell, ok := p.pane.render.CellPtrAt(col, row)
+	if ok {
+		render.CellFromUVInto(dst, cell)
+	} else {
+		render.CellFromUVInto(dst, nil)
+	}
+	if !active && p.pane.render.HasCursorBlock && col == p.pane.render.CursorBlockCol && row == p.pane.render.CursorBlockRow {
+		stripServerSnapshotCursorBlock(dst)
+	}
 }
 
 func stripServerSnapshotCursorBlock(cell *render.ScreenCell) {


### PR DESCRIPTION
## Motivation

The client renderer was spending a large share of CPU in `runtime.duffcopy` while compositing pane content. The hot path copied `ScreenCell` values through `CellAt`, `paneContentCellAt`, `compactRowCell`, and `buildPaneContentCells` even when the compositor only needed to write fields into the destination grid.

## Summary

- Add a `PaneCellReader` fast path that exposes cell fields without returning `ScreenCell` by value.
- Thread field-based reads through client, server capture, pane snapshots, copy-mode overlays, prediction styling, and compositor row compaction.
- Keep the existing `CellAt` API as a compatibility fallback.
- Add a regression test and benchmark coverage for the compositor pane-content path.

## Baseline numbers

Hardware: AMD EPYC-Milan Processor, Linux amd64.

| Benchmark | Before | After | Notes |
| --- | ---: | ---: | --- |
| `BenchmarkBuildPaneContentCells/value_fallback` | 506,175 ns/op | 538,467 ns/op | Existing compatibility path, 0 allocs/op |
| `BenchmarkBuildPaneContentCells/field_reader` | n/a | 383,234 ns/op | New fast path, 0 allocs/op |
| `BenchmarkBuildPaneContentCells/in_place_writer` | 554,873 ns/op | n/a | Red-test placeholder before implementation |
| `BenchmarkCompositorDirtyPaneRepresentative` | 1,046,163 ns/op | 1,161,036 ns/op | Broader benchmark remained noisy and unchanged in allocations |

Client CPU profile after the change: `buildPaneContentCells` / `compactRowCellInto` accounted for 0.02s cumulative, 0.95% of a 2.10s sample. Overall `runtime.duffcopy` was still present at 0.53s, 25.24%, but the sampled cost was now dominated by the upstream VT scroll/delete-line path rather than the compositor functions called out in LAB-1948.

## Testing

- `go test ./internal/render -run TestBuildPaneContentCellsUsesFieldReaderFastPath -count=100`
- `go test ./internal/render -run TestBuildPaneContentCellsDoesNotAllocateRowBuffer -count=100`
- `go test ./internal/client -run TestPaneDataCellAt -count=100`
- `go test ./internal/render ./internal/client ./internal/server ./internal/mux -count=1`
- `go test ./... -timeout 120s`
- `make coverage` (total coverage 88.9%)
- `golangci-lint run ./...`
- `scripts/check-diff-coverage.sh` (total coverage 88.8%; diff coverage 78.29%)
- `go test ./internal/render -run '^$' -bench 'Benchmark(BuildPaneContentCells|CompositorDirtyPaneRepresentative)' -benchmem -count=5`
- `amux debug client-profile --duration 10s` on an isolated local session with three busy panes

## Review focus

- Whether `PaneCellReader` is the right compatibility shape for avoiding by-value `ScreenCell` copies without forcing all pane-data implementations to change at once.
- The field-copy helpers in `internal/render/screen.go`, especially wide-cell continuation handling and copy-mode overlay normalization.
- The client `CellFieldsAt` logic, which mirrors `CellAt` while avoiding temporary `ScreenCell` values.

Closes LAB-1948