### PR TITLE
LAB-1949: Isolate nested test daemon sockets

### DIFF
--- a/internal/proto/session_runtime.go
+++ b/internal/proto/session_runtime.go
@@ -14,12 +14,18 @@ const (
 
 const SocketDirEnv = "AMUX_SOCKET_DIR"
 
+// DefaultSocketDir returns the system-level socket directory used when no
+// socket directory override is configured.
+func DefaultSocketDir() string {
+	return fmt.Sprintf("/tmp/amux-%d", os.Getuid())
+}
+
 // SocketDir returns the directory for amux Unix sockets.
 func SocketDir() string {
 	if dir := os.Getenv(SocketDirEnv); dir != "" {
 		return dir
 	}
-	return fmt.Sprintf("/tmp/amux-%d", os.Getuid())
+	return DefaultSocketDir()
 }
 
 // SocketPath returns the socket path for a session.

--- a/internal/proto/session_runtime.go
+++ b/internal/proto/session_runtime.go
@@ -12,8 +12,13 @@ const (
 	DefaultTermRows = 24
 )
 
+const SocketDirEnv = "AMUX_SOCKET_DIR"
+
 // SocketDir returns the directory for amux Unix sockets.
 func SocketDir() string {
+	if dir := os.Getenv(SocketDirEnv); dir != "" {
+		return dir
+	}
 	return fmt.Sprintf("/tmp/amux-%d", os.Getuid())
 }
 

--- a/internal/proto/session_runtime_test.go
+++ b/internal/proto/session_runtime_test.go
@@ -1,0 +1,18 @@
+package proto
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestSocketDirUsesEnvOverride(t *testing.T) {
+	override := filepath.Join(t.TempDir(), "sockets")
+	t.Setenv("AMUX_SOCKET_DIR", override)
+
+	if got := SocketDir(); got != override {
+		t.Fatalf("SocketDir() = %q, want %q", got, override)
+	}
+	if got, want := SocketPath("test-session"), filepath.Join(override, "test-session"); got != want {
+		t.Fatalf("SocketPath() = %q, want %q", got, want)
+	}
+}

--- a/internal/proto/session_runtime_test.go
+++ b/internal/proto/session_runtime_test.go
@@ -1,6 +1,8 @@
 package proto
 
 import (
+	"fmt"
+	"os"
 	"path/filepath"
 	"testing"
 )
@@ -14,5 +16,15 @@ func TestSocketDirUsesEnvOverride(t *testing.T) {
 	}
 	if got, want := SocketPath("test-session"), filepath.Join(override, "test-session"); got != want {
 		t.Fatalf("SocketPath() = %q, want %q", got, want)
+	}
+}
+
+func TestDefaultSocketDirIgnoresEnvOverride(t *testing.T) {
+	override := filepath.Join(t.TempDir(), "sockets")
+	t.Setenv(SocketDirEnv, override)
+
+	want := fmt.Sprintf("/tmp/amux-%d", os.Getuid())
+	if got := DefaultSocketDir(); got != want {
+		t.Fatalf("DefaultSocketDir() = %q, want %q", got, want)
 	}
 }

--- a/internal/server/session_lock_test.go
+++ b/internal/server/session_lock_test.go
@@ -137,15 +137,25 @@ func TestNewServerWithScrollbackRejectsDuplicateSessionLockWithoutTouchingLockFi
 }
 
 func TestNewServerWithScrollbackRecoversAfterCrashReleasesLock(t *testing.T) {
-	t.Parallel()
-
+	// Not parallel: this test sets AMUX_SOCKET_DIR so the parent server and
+	// helper subprocess share the same isolated socket directory.
+	socketDir, err := os.MkdirTemp("", "amux-lock-")
+	if err != nil {
+		t.Fatalf("MkdirTemp(): %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.RemoveAll(socketDir); err != nil {
+			t.Fatalf("RemoveAll(%q): %v", socketDir, err)
+		}
+	})
+	t.Setenv(proto.SocketDirEnv, socketDir)
 	session := fmt.Sprintf("session-lock-crash-%d", time.Now().UnixNano())
 	cmd, stderr := startSessionLockHelper(t, "hold", session)
 
 	if err := cmd.Process.Signal(syscall.SIGKILL); err != nil {
 		t.Fatalf("killing helper: %v", err)
 	}
-	err := cmd.Wait()
+	err = cmd.Wait()
 	if err == nil {
 		t.Fatal("helper exited cleanly, want SIGKILL")
 	}
@@ -214,6 +224,7 @@ func startSessionLockHelper(t *testing.T, mode, session string) (*exec.Cmd, *byt
 		sessionLockHelperModeEnv+"="+mode,
 		sessionLockHelperSessionEnv+"="+session,
 		sessionLockHelperTimeoutEnv+"=30s",
+		proto.SocketDirEnv+"="+SocketDir(),
 	)
 	t.Cleanup(func() {
 		cancel()

--- a/internal/server/session_lock_test.go
+++ b/internal/server/session_lock_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -20,6 +21,7 @@ import (
 const (
 	sessionLockHelperModeEnv    = "AMUX_SESSION_LOCK_HELPER_MODE"
 	sessionLockHelperSessionEnv = "AMUX_SESSION_LOCK_HELPER_SESSION"
+	sessionLockHelperTimeoutEnv = "AMUX_SESSION_LOCK_HELPER_TIMEOUT"
 )
 
 func TestSessionLockSubprocessHelper(t *testing.T) {
@@ -43,6 +45,35 @@ func TestSessionLockSubprocessHelper(t *testing.T) {
 		srv.Shutdown()
 		fmt.Fprintf(os.Stderr, "unknown helper mode %q", mode)
 		os.Exit(2)
+	}
+}
+
+func TestSessionLockSubprocessHelperHoldModeExitsWithinTimeout(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	session := fmt.Sprintf("session-lock-helper-timeout-%d", time.Now().UnixNano())
+	cmd := testenv.NewCommandContext(ctx, os.Args[0], "-test.run=^TestSessionLockSubprocessHelper$")
+	cmd.Env = append(testenv.HermeticAmuxEnv(),
+		sessionLockHelperModeEnv+"=hold",
+		sessionLockHelperSessionEnv+"="+session,
+		sessionLockHelperTimeoutEnv+"=100ms",
+	)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	if ctx.Err() == context.DeadlineExceeded {
+		t.Fatalf("helper did not exit within bounded time\nstdout:\n%s\nstderr:\n%s", stdout.String(), stderr.String())
+	}
+	if err != nil {
+		t.Fatalf("helper exited with error: %v\nstdout:\n%s\nstderr:\n%s", err, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "ready") {
+		t.Fatalf("helper stdout = %q, want ready line", stdout.String())
 	}
 }
 

--- a/internal/server/session_lock_test.go
+++ b/internal/server/session_lock_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/weill-labs/amux/internal/mux"
+	"github.com/weill-labs/amux/internal/proto"
 	"github.com/weill-labs/amux/internal/testenv"
 )
 
@@ -39,13 +40,32 @@ func TestSessionLockSubprocessHelper(t *testing.T) {
 
 	switch mode {
 	case "hold":
+		timeout, err := sessionLockHelperTimeout()
+		if err != nil {
+			srv.Shutdown()
+			fmt.Fprint(os.Stderr, err.Error())
+			os.Exit(2)
+		}
 		fmt.Fprintln(os.Stdout, "ready")
-		select {}
+		<-time.After(timeout)
+		srv.Shutdown()
 	default:
 		srv.Shutdown()
 		fmt.Fprintf(os.Stderr, "unknown helper mode %q", mode)
 		os.Exit(2)
 	}
+}
+
+func sessionLockHelperTimeout() (time.Duration, error) {
+	raw := os.Getenv(sessionLockHelperTimeoutEnv)
+	if raw == "" {
+		return 30 * time.Second, nil
+	}
+	timeout, err := time.ParseDuration(raw)
+	if err != nil || timeout <= 0 {
+		return 0, fmt.Errorf("invalid %s %q", sessionLockHelperTimeoutEnv, raw)
+	}
+	return timeout, nil
 }
 
 func TestSessionLockSubprocessHelperHoldModeExitsWithinTimeout(t *testing.T) {
@@ -54,12 +74,13 @@ func TestSessionLockSubprocessHelperHoldModeExitsWithinTimeout(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
-	session := fmt.Sprintf("session-lock-helper-timeout-%d", time.Now().UnixNano())
+	session := "s"
 	cmd := testenv.NewCommandContext(ctx, os.Args[0], "-test.run=^TestSessionLockSubprocessHelper$")
 	cmd.Env = append(testenv.HermeticAmuxEnv(),
 		sessionLockHelperModeEnv+"=hold",
 		sessionLockHelperSessionEnv+"="+session,
 		sessionLockHelperTimeoutEnv+"=100ms",
+		proto.SocketDirEnv+"="+t.TempDir(),
 	)
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
@@ -187,11 +208,20 @@ func TestNewServerWithScrollbackConcurrentStartsYieldSingleWinner(t *testing.T) 
 func startSessionLockHelper(t *testing.T, mode, session string) (*exec.Cmd, *bytes.Buffer) {
 	t.Helper()
 
-	cmd := testenv.NewCommand(os.Args[0], "-test.run=^TestSessionLockSubprocessHelper$")
+	ctx, cancel := context.WithTimeout(context.Background(), 35*time.Second)
+	cmd := testenv.NewCommandContext(ctx, os.Args[0], "-test.run=^TestSessionLockSubprocessHelper$")
 	cmd.Env = append(testenv.HermeticAmuxEnv(),
 		sessionLockHelperModeEnv+"="+mode,
 		sessionLockHelperSessionEnv+"="+session,
+		sessionLockHelperTimeoutEnv+"=30s",
 	)
+	t.Cleanup(func() {
+		cancel()
+		if cmd.Process != nil && cmd.ProcessState == nil {
+			_ = cmd.Process.Kill()
+			_ = cmd.Wait()
+		}
+	})
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		t.Fatalf("StdoutPipe(): %v", err)

--- a/internal/testenv/env.go
+++ b/internal/testenv/env.go
@@ -14,6 +14,7 @@ var blockedEnvKeys = []string{
 	"AMUX_MAIN_HELPER",
 	"AMUX_PANE",
 	"AMUX_SESSION",
+	"AMUX_SOCKET_DIR",
 	"CLICOLOR",
 	"CLICOLOR_FORCE",
 	"COLORTERM",

--- a/test/amux_harness_startup_test.go
+++ b/test/amux_harness_startup_test.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/weill-labs/amux/internal/server"
+	"github.com/weill-labs/amux/internal/proto"
 )
 
 func TestPrepareInnerAmuxEnvDefaultsToNoWatch(t *testing.T) {
@@ -132,7 +132,7 @@ func leakedInnerArtifactsInSharedSocketDir(t *testing.T, h *AmuxHarness) []strin
 		h.inner + ".lock",
 		h.inner + ".start.lock",
 	} {
-		path := filepath.Join(server.SocketDir(), name)
+		path := filepath.Join(proto.DefaultSocketDir(), name)
 		if _, err := os.Stat(path); err == nil {
 			leaked = append(leaked, path)
 		} else if !os.IsNotExist(err) {

--- a/test/amux_harness_startup_test.go
+++ b/test/amux_harness_startup_test.go
@@ -101,6 +101,26 @@ func TestBuildInnerAmuxLaunchCommand(t *testing.T) {
 func TestNewAmuxHarnessDoesNotWriteInnerArtifactsToSharedSocketDir(t *testing.T) {
 	h := newAmuxHarness(t)
 
+	leaked := leakedInnerArtifactsInSharedSocketDir(t, h)
+	shutdownAmuxHarness(t, h)
+	if len(leaked) > 0 {
+		t.Fatalf("inner harness leaked artifacts to shared socket dir: %v", leaked)
+	}
+}
+
+func TestNewAmuxHarnessWithConfigDoesNotWriteInnerArtifactsToSharedSocketDir(t *testing.T) {
+	h := newAmuxHarnessWithConfig(t, "")
+
+	leaked := leakedInnerArtifactsInSharedSocketDir(t, h)
+	shutdownAmuxHarness(t, h)
+	if len(leaked) > 0 {
+		t.Fatalf("inner harness with config leaked artifacts to shared socket dir: %v", leaked)
+	}
+}
+
+func leakedInnerArtifactsInSharedSocketDir(t *testing.T, h *AmuxHarness) []string {
+	t.Helper()
+
 	var leaked []string
 	for _, name := range []string{
 		h.inner,
@@ -115,9 +135,5 @@ func TestNewAmuxHarnessDoesNotWriteInnerArtifactsToSharedSocketDir(t *testing.T)
 			t.Fatalf("stat %s: %v", path, err)
 		}
 	}
-
-	shutdownAmuxHarness(t, h)
-	if len(leaked) > 0 {
-		t.Fatalf("inner harness leaked artifacts to shared socket dir: %v", leaked)
-	}
+	return leaked
 }

--- a/test/amux_harness_startup_test.go
+++ b/test/amux_harness_startup_test.go
@@ -1,6 +1,12 @@
 package test
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/weill-labs/amux/internal/server"
+)
 
 func TestPrepareInnerAmuxEnvDefaultsToNoWatch(t *testing.T) {
 	t.Parallel()
@@ -89,5 +95,29 @@ func TestBuildInnerAmuxLaunchCommand(t *testing.T) {
 	want := `cd "/tmp/work tree" && AMUX_NO_WATCH=1 AMUX_REPEAT_TIMEOUT=30s "/tmp/amux" -s t-1234`
 	if got != want {
 		t.Fatalf("buildInnerAmuxLaunchCommand() = %q, want %q", got, want)
+	}
+}
+
+func TestNewAmuxHarnessDoesNotWriteInnerArtifactsToSharedSocketDir(t *testing.T) {
+	h := newAmuxHarness(t)
+
+	var leaked []string
+	for _, name := range []string{
+		h.inner,
+		h.inner + ".log",
+		h.inner + ".lock",
+		h.inner + ".start.lock",
+	} {
+		path := filepath.Join(server.SocketDir(), name)
+		if _, err := os.Stat(path); err == nil {
+			leaked = append(leaked, path)
+		} else if !os.IsNotExist(err) {
+			t.Fatalf("stat %s: %v", path, err)
+		}
+	}
+
+	shutdownAmuxHarness(t, h)
+	if len(leaked) > 0 {
+		t.Fatalf("inner harness leaked artifacts to shared socket dir: %v", leaked)
 	}
 }

--- a/test/amux_harness_startup_test.go
+++ b/test/amux_harness_startup_test.go
@@ -62,10 +62,10 @@ func TestNeedsNestedHarnessStartupLock(t *testing.T) {
 			want:    true,
 		},
 		{
-			name:    "shared binary defaults to no watch",
+			name:    "shared binary uses startup lock without watch",
 			binPath: amuxBin,
 			envVars: nil,
-			want:    false,
+			want:    true,
 		},
 		{
 			name:    "private watched binary does not need shared lock",

--- a/test/amux_harness_startup_test.go
+++ b/test/amux_harness_startup_test.go
@@ -99,6 +99,8 @@ func TestBuildInnerAmuxLaunchCommand(t *testing.T) {
 }
 
 func TestNewAmuxHarnessDoesNotWriteInnerArtifactsToSharedSocketDir(t *testing.T) {
+	t.Parallel()
+
 	h := newAmuxHarness(t)
 
 	leaked := leakedInnerArtifactsInSharedSocketDir(t, h)
@@ -109,6 +111,8 @@ func TestNewAmuxHarnessDoesNotWriteInnerArtifactsToSharedSocketDir(t *testing.T)
 }
 
 func TestNewAmuxHarnessWithConfigDoesNotWriteInnerArtifactsToSharedSocketDir(t *testing.T) {
+	t.Parallel()
+
 	h := newAmuxHarnessWithConfig(t, "")
 
 	leaked := leakedInnerArtifactsInSharedSocketDir(t, h)

--- a/test/amux_harness_test.go
+++ b/test/amux_harness_test.go
@@ -177,10 +177,7 @@ func shutdownAmuxHarness(tb testing.TB, h *AmuxHarness) {
 		}
 	}
 
-	socketDir := h.innerSocketDir
-	if socketDir == "" {
-		socketDir = server.SocketDir()
-	}
+	socketDir := h.innerSocketDirOrDefault()
 	if tb != nil && tb.Failed() {
 		logPath := fmt.Sprintf("%s/%s.log", socketDir, h.inner)
 		if data, err := os.ReadFile(logPath); err == nil {
@@ -226,10 +223,14 @@ func (h *AmuxHarness) waitInnerServerGone(timeout time.Duration) {
 }
 
 func (h *AmuxHarness) innerSocketPath() string {
+	return filepath.Join(h.innerSocketDirOrDefault(), h.inner)
+}
+
+func (h *AmuxHarness) innerSocketDirOrDefault() string {
 	if h.innerSocketDir != "" {
-		return filepath.Join(h.innerSocketDir, h.inner)
+		return h.innerSocketDir
 	}
-	return server.SocketPath(h.inner)
+	return server.SocketDir()
 }
 
 // ---------------------------------------------------------------------------

--- a/test/amux_harness_test.go
+++ b/test/amux_harness_test.go
@@ -60,11 +60,8 @@ func lookupInnerAmuxEnv(envVars []string, key string) (string, bool) {
 	return "", false
 }
 
-func needsNestedHarnessStartupLock(binPath string, envVars []string) bool {
-	if binPath != amuxBin {
-		return false
-	}
-	return true
+func needsNestedHarnessStartupLock(binPath string, _ []string) bool {
+	return binPath == amuxBin
 }
 
 func buildInnerAmuxLaunchCommand(binPath, session, launchDir string, envVars []string) string {

--- a/test/amux_harness_test.go
+++ b/test/amux_harness_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
@@ -114,11 +115,8 @@ func newAmuxHarnessWithBinInDir(tb testing.TB, binPath, launchDir string, envVar
 	var b [8]byte
 	mustRandRead(tb, b[:])
 	inner := fmt.Sprintf("t-%x", b)
-	innerSocketDir := tb.TempDir()
-	envVars = upsertEnv(envVars, proto.SocketDirEnv, innerSocketDir)
-
-	h := &AmuxHarness{outer: outer, inner: inner, innerBin: binPath, innerSocketDir: innerSocketDir, tb: tb, session: inner}
-	tb.Cleanup(h.cleanup)
+	h := newAmuxHarnessHandle(tb, outer, inner, binPath)
+	envVars = upsertEnv(envVars, proto.SocketDirEnv, h.innerSocketDir)
 
 	// Launch inner amux inside the outer pane.
 	outer.sendKeys("pane-1", buildInnerAmuxLaunchCommand(binPath, inner, launchDir, envVars), "Enter")
@@ -128,6 +126,20 @@ func newAmuxHarnessWithBinInDir(tb testing.TB, binPath, launchDir string, envVar
 	// be accepting connections — no polling loop needed.
 	outer.waitForTimeout("pane-1", "[pane-", "30s")
 
+	return h
+}
+
+func newAmuxHarnessHandle(tb testing.TB, outer *ServerHarness, inner, binPath string) *AmuxHarness {
+	tb.Helper()
+	h := &AmuxHarness{
+		outer:          outer,
+		inner:          inner,
+		innerBin:       binPath,
+		innerSocketDir: tb.TempDir(),
+		tb:             tb,
+		session:        inner,
+	}
+	tb.Cleanup(h.cleanup)
 	return h
 }
 
@@ -181,7 +193,7 @@ func shutdownAmuxHarness(tb testing.TB, h *AmuxHarness) {
 		return
 	}
 	for _, suffix := range []string{"", ".log"} {
-		_ = exec.Command("rm", "-f", fmt.Sprintf("%s/%s%s", socketDir, h.inner, suffix)).Run()
+		_ = os.Remove(filepath.Join(socketDir, h.inner+suffix))
 	}
 	h.inner = ""
 	h.session = ""
@@ -215,7 +227,7 @@ func (h *AmuxHarness) waitInnerServerGone(timeout time.Duration) {
 
 func (h *AmuxHarness) innerSocketPath() string {
 	if h.innerSocketDir != "" {
-		return fmt.Sprintf("%s/%s", h.innerSocketDir, h.inner)
+		return filepath.Join(h.innerSocketDir, h.inner)
 	}
 	return server.SocketPath(h.inner)
 }

--- a/test/amux_harness_test.go
+++ b/test/amux_harness_test.go
@@ -29,6 +29,7 @@ type AmuxHarness struct {
 	outer              *ServerHarness
 	inner              string // inner session name
 	innerBin           string
+	innerSocketDir     string
 	tb                 testing.TB
 	session            string // alias for inner, used by extractFrame
 	initialLeadHandled bool
@@ -113,8 +114,11 @@ func newAmuxHarnessWithBinInDir(tb testing.TB, binPath, launchDir string, envVar
 	var b [8]byte
 	mustRandRead(tb, b[:])
 	inner := fmt.Sprintf("t-%x", b)
+	innerSocketDir := tb.TempDir()
+	envVars = upsertEnv(envVars, proto.SocketDirEnv, innerSocketDir)
 
-	h := &AmuxHarness{outer: outer, inner: inner, innerBin: binPath, tb: tb, session: inner}
+	h := &AmuxHarness{outer: outer, inner: inner, innerBin: binPath, innerSocketDir: innerSocketDir, tb: tb, session: inner}
+	tb.Cleanup(h.cleanup)
 
 	// Launch inner amux inside the outer pane.
 	outer.sendKeys("pane-1", buildInnerAmuxLaunchCommand(binPath, inner, launchDir, envVars), "Enter")
@@ -124,7 +128,6 @@ func newAmuxHarnessWithBinInDir(tb testing.TB, binPath, launchDir string, envVar
 	// be accepting connections — no polling loop needed.
 	outer.waitForTimeout("pane-1", "[pane-", "30s")
 
-	tb.Cleanup(h.cleanup)
 	return h
 }
 
@@ -162,7 +165,10 @@ func shutdownAmuxHarness(tb testing.TB, h *AmuxHarness) {
 		}
 	}
 
-	socketDir := server.SocketDir()
+	socketDir := h.innerSocketDir
+	if socketDir == "" {
+		socketDir = server.SocketDir()
+	}
 	if tb != nil && tb.Failed() {
 		logPath := fmt.Sprintf("%s/%s.log", socketDir, h.inner)
 		if data, err := os.ReadFile(logPath); err == nil {
@@ -194,7 +200,7 @@ func (h *AmuxHarness) innerServerPIDs() []string {
 
 func (h *AmuxHarness) waitInnerServerGone(timeout time.Duration) {
 	deadline := time.Now().Add(timeout)
-	socketPath := server.SocketPath(h.inner)
+	socketPath := h.innerSocketPath()
 	ticker := time.NewTicker(50 * time.Millisecond)
 	defer ticker.Stop()
 	for time.Now().Before(deadline) {
@@ -205,6 +211,13 @@ func (h *AmuxHarness) waitInnerServerGone(timeout time.Duration) {
 		}
 		<-ticker.C
 	}
+}
+
+func (h *AmuxHarness) innerSocketPath() string {
+	if h.innerSocketDir != "" {
+		return fmt.Sprintf("%s/%s", h.innerSocketDir, h.inner)
+	}
+	return server.SocketPath(h.inner)
 }
 
 // ---------------------------------------------------------------------------
@@ -677,6 +690,9 @@ func (h *AmuxHarness) runCmd(args ...string) string {
 	cmdArgs := append([]string{"-s", h.inner}, args...)
 	cmd := exec.CommandContext(ctx, h.innerBin, cmdArgs...)
 	env := upsertEnv(os.Environ(), "HOME", h.outer.home)
+	if h.innerSocketDir != "" {
+		env = upsertEnv(env, proto.SocketDirEnv, h.innerSocketDir)
+	}
 	if h.outer.coverDir != "" {
 		env = upsertEnv(env, "GOCOVERDIR", h.outer.coverDir)
 	}

--- a/test/amux_harness_test.go
+++ b/test/amux_harness_test.go
@@ -36,9 +36,10 @@ type AmuxHarness struct {
 	initialLeadHandled bool
 }
 
-// Nested harnesses only need startup serialization when an inner session is
-// explicitly watching the shared package-level test binary. Most integration
-// tests do not exercise auto-reload, so they disable watch by default.
+// Nested harnesses that launch the shared package-level test binary serialize
+// startup. The launch path runs an interactive client inside an outer PTY;
+// under high parallelism, overlapping shared-binary startups can corrupt the
+// initial client protocol stream before the harness has a stable inner client.
 var nestedHarnessStartupMu sync.Mutex
 
 func prepareInnerAmuxEnv(envVars []string) []string {
@@ -63,8 +64,7 @@ func needsNestedHarnessStartupLock(binPath string, envVars []string) bool {
 	if binPath != amuxBin {
 		return false
 	}
-	noWatch, ok := lookupInnerAmuxEnv(envVars, "AMUX_NO_WATCH")
-	return ok && noWatch != "1"
+	return true
 }
 
 func buildInnerAmuxLaunchCommand(binPath, session, launchDir string, envVars []string) string {

--- a/test/event_helpers_test.go
+++ b/test/event_helpers_test.go
@@ -31,7 +31,12 @@ type eventJSON struct {
 // that reads one JSON event per line, plus a close function.
 func eventStream(t *testing.T, session string, args ...string) (*bufio.Scanner, func()) {
 	t.Helper()
-	sockPath := server.SocketPath(session)
+	return eventStreamForSocket(t, server.SocketPath(session), args...)
+}
+
+func eventStreamForSocket(t testing.TB, sockPath string, args ...string) (*bufio.Scanner, func()) {
+	t.Helper()
+
 	conn, err := net.Dial("unix", sockPath)
 	if err != nil {
 		t.Fatalf("dial: %v", err)

--- a/test/keybinding_test.go
+++ b/test/keybinding_test.go
@@ -4,14 +4,12 @@ import (
 	"crypto/rand"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/weill-labs/amux/internal/proto"
-	"github.com/weill-labs/amux/internal/server"
 )
 
 func writeTestConfigFile(t *testing.T, configContent string) string {
@@ -42,28 +40,17 @@ func newAmuxHarnessWithConfig(t *testing.T, configContent string) *AmuxHarness {
 	outer := newServerHarness(t)
 	configPath := writeTestConfigFile(t, configContent)
 	inner := randomTestSessionName(t)
+	innerSocketDir := t.TempDir()
 
-	h := &AmuxHarness{outer: outer, inner: inner, innerBin: amuxBin, tb: t, session: inner}
+	h := &AmuxHarness{outer: outer, inner: inner, innerBin: amuxBin, innerSocketDir: innerSocketDir, tb: t, session: inner}
+	t.Cleanup(h.cleanup)
 
 	// Launch inner amux with AMUX_CONFIG set.
-	outer.sendKeys("pane-1", fmt.Sprintf("AMUX_CONFIG=%s %s -s %s", configPath, amuxBin, inner), "Enter")
+	outer.sendKeys("pane-1", buildInnerAmuxLaunchCommand(amuxBin, inner, "", []string{
+		"AMUX_CONFIG=" + configPath,
+		proto.SocketDirEnv + "=" + innerSocketDir,
+	}), "Enter")
 	outer.waitForTimeout("pane-1", "[pane-", "30s")
-
-	t.Cleanup(func() {
-		// Best-effort detach (only works with default prefix).
-		_ = newHermeticAmuxCommand(t, "-s", inner, "list").Run()
-		out, _ := exec.Command("pgrep", "-f", fmt.Sprintf("amux _server %s$", inner)).Output()
-		for _, pid := range strings.Split(strings.TrimSpace(string(out)), "\n") {
-			if pid != "" {
-				_ = exec.Command("kill", pid).Run()
-			}
-		}
-		time.Sleep(200 * time.Millisecond)
-		socketDir := server.SocketDir()
-		for _, suffix := range []string{"", ".log"} {
-			_ = exec.Command("rm", "-f", fmt.Sprintf("%s/%s%s", socketDir, inner, suffix)).Run()
-		}
-	})
 
 	return h
 }

--- a/test/keybinding_test.go
+++ b/test/keybinding_test.go
@@ -40,15 +40,12 @@ func newAmuxHarnessWithConfig(t *testing.T, configContent string) *AmuxHarness {
 	outer := newServerHarness(t)
 	configPath := writeTestConfigFile(t, configContent)
 	inner := randomTestSessionName(t)
-	innerSocketDir := t.TempDir()
-
-	h := &AmuxHarness{outer: outer, inner: inner, innerBin: amuxBin, innerSocketDir: innerSocketDir, tb: t, session: inner}
-	t.Cleanup(h.cleanup)
+	h := newAmuxHarnessHandle(t, outer, inner, amuxBin)
 
 	// Launch inner amux with AMUX_CONFIG set.
 	outer.sendKeys("pane-1", buildInnerAmuxLaunchCommand(amuxBin, inner, "", []string{
 		"AMUX_CONFIG=" + configPath,
-		proto.SocketDirEnv + "=" + innerSocketDir,
+		proto.SocketDirEnv + "=" + h.innerSocketDir,
 	}), "Enter")
 	outer.waitForTimeout("pane-1", "[pane-", "30s")
 

--- a/test/keybinding_test.go
+++ b/test/keybinding_test.go
@@ -59,7 +59,7 @@ func TestUnsupportedPrefixKeyShowsFeedback(t *testing.T) {
 	if out := h.runCmd("wait", "idle", "pane-1", "--timeout", "10s"); strings.Contains(out, "timeout") || strings.Contains(out, "not found") {
 		t.Fatalf("expected inner pane to go idle before unsupported-key feedback test, got: %s\nouter:\n%s", strings.TrimSpace(out), h.captureOuter())
 	}
-	scanner, closer := eventStream(t, h.session, "--filter", proto.UIEventPrefixMessageHidden+","+proto.UIEventPrefixMessageShown, "--client", "client-1")
+	scanner, closer := eventStreamForSocket(t, h.innerSocketPath(), "--filter", proto.UIEventPrefixMessageHidden+","+proto.UIEventPrefixMessageShown, "--client", "client-1")
 	defer closer()
 	if ev := mustReadEvent(t, scanner, 5*time.Second); ev.Type != proto.UIEventPrefixMessageHidden {
 		t.Fatalf("initial prefix-message state: got %q, want %q", ev.Type, proto.UIEventPrefixMessageHidden)
@@ -82,7 +82,7 @@ func TestUnsupportedPrefixKeyFeedbackClearsOnLiteralPrefix(t *testing.T) {
 	if out := h.runCmd("wait", "idle", "pane-1", "--timeout", "10s"); strings.Contains(out, "timeout") || strings.Contains(out, "not found") {
 		t.Fatalf("expected inner pane to go idle before unsupported-key clear test, got: %s\nouter:\n%s", strings.TrimSpace(out), h.captureOuter())
 	}
-	scanner, closer := eventStream(t, h.session, "--filter", proto.UIEventPrefixMessageHidden+","+proto.UIEventPrefixMessageShown, "--client", "client-1")
+	scanner, closer := eventStreamForSocket(t, h.innerSocketPath(), "--filter", proto.UIEventPrefixMessageHidden+","+proto.UIEventPrefixMessageShown, "--client", "client-1")
 	defer closer()
 	if ev := mustReadEvent(t, scanner, 5*time.Second); ev.Type != proto.UIEventPrefixMessageHidden {
 		t.Fatalf("initial prefix-message state: got %q, want %q", ev.Type, proto.UIEventPrefixMessageHidden)

--- a/test/session_lock_test.go
+++ b/test/session_lock_test.go
@@ -15,7 +15,7 @@ import (
 func TestSessionLockSurvivesHotReload(t *testing.T) {
 	t.Parallel()
 
-	h := newPersistentReloadHarness(t, privateAmuxBin(t))
+	h := newAmuxHarnessWithBin(t, privateAmuxBin(t), "AMUX_EXIT_UNATTACHED=0")
 
 	reloadGen := h.generation()
 	h.runCmd("reload-server")

--- a/test/session_lock_test.go
+++ b/test/session_lock_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/weill-labs/amux/internal/server"
+	"github.com/weill-labs/amux/internal/proto"
 )
 
 func TestSessionLockSurvivesHotReload(t *testing.T) {
@@ -26,7 +26,7 @@ func TestSessionLockSurvivesHotReload(t *testing.T) {
 		t.Fatalf("duplicate server probe output = %q, want already-running error for %q", strings.TrimSpace(newServerOut), h.inner)
 	}
 
-	lockPath := filepath.Join(server.SocketDir(), h.inner+".lock")
+	lockPath := filepath.Join(h.innerSocketDirOrDefault(), h.inner+".lock")
 	if err := exec.Command("flock", "-n", lockPath, "true").Run(); err == nil {
 		t.Fatalf("flock probe acquired %s after hot reload; want lock still held", lockPath)
 	}
@@ -46,6 +46,9 @@ func runDuplicateServerProbe(t *testing.T, h *AmuxHarness) string {
 		"AMUX_NO_WATCH=1",
 		"AMUX_DISABLE_META_REFRESH=1",
 	)
+	if h.innerSocketDir != "" {
+		env = upsertEnv(env, proto.SocketDirEnv, h.innerSocketDir)
+	}
 	if h.outer.coverDir != "" {
 		env = upsertEnv(env, "GOCOVERDIR", h.outer.coverDir)
 	}


### PR DESCRIPTION
## Motivation

Nested amux integration tests spawned real `_server` daemons that wrote sockets and logs into the shared `/tmp/amux-$UID` directory. When startup or helper subprocesses failed, those daemons and artifacts could survive outside the test temp tree.

## Summary

- Add an explicit `AMUX_SOCKET_DIR` override for socket/log placement and scrub it from hermetic subprocess envs unless tests pass it deliberately.
- Run nested inner amux sessions under a per-harness `t.TempDir()` socket directory, including config-based harnesses, direct event streams, duplicate-server probes, and cleanup diagnostics.
- Register nested harness cleanup before waiting for the inner client, and keep cleanup targeting the isolated socket dir.
- Bound `TestSessionLockSubprocessHelper` hold mode with a timeout and subprocess cleanup guard.
- Serialize nested startup for the shared test binary after repeated runs exposed startup protocol corruption under high parallelism.

## Testing

- `go test ./internal/proto ./internal/testenv -run 'TestSocketDirUsesEnvOverride|TestHermeticAmuxEnvScrubsAmuxAndTerminalVars' -count=100`
- `go test ./internal/server -run 'TestSessionLockSubprocessHelperHoldModeExitsWithinTimeout|TestNewServerWithScrollbackRejectsDuplicateSessionLockWithoutTouchingLockFile|TestNewServerWithScrollbackRecoversAfterCrashReleasesLock|TestNewServerWithScrollbackConcurrentStartsYieldSingleWinner' -count=100`
- `go test ./test -run TestSessionLockSurvivesHotReload -count=100 -timeout 20m`
- `go test ./test -run 'TestNeedsNestedHarnessStartupLock|TestNewAmuxHarnessDoesNotWriteInnerArtifactsToSharedSocketDir|TestNewAmuxHarnessWithConfigDoesNotWriteInnerArtifactsToSharedSocketDir|TestUnsupportedPrefixKeyShowsFeedback|TestUnsupportedPrefixKeyFeedbackClearsOnLiteralPrefix' -count=100 -timeout 20m`
- `go test ./... -timeout 120s`
- `pgrep -af 'amux _server (t-[0-9a-f]+|orca-spawn-integration-)' || true` returned no surviving test daemons after the suite.

## Review focus

- Whether `AMUX_SOCKET_DIR` is scoped narrowly enough for tests while still reaching daemonized inner servers and direct probes.
- Nested harness cleanup order and behavior when startup fails before the inner client renders.
- The shared-binary startup serialization scope.

Closes LAB-1949