### PR TITLE
LAB-1952: Add scoped pane attach protocol

### DIFF
--- a/internal/proto/gob_register.go
+++ b/internal/proto/gob_register.go
@@ -14,4 +14,8 @@ func init() {
 	gob.Register(ansi.IndexedColor(0))
 	gob.Register(ansi.RGBColor{})
 	gob.Register(color.RGBA{})
+	gob.Register(LayoutSnapshot{})
+	gob.Register(WindowSnapshot{})
+	gob.Register(PaneSnapshot{})
+	gob.Register(CellSnapshot{})
 }

--- a/internal/proto/wire.go
+++ b/internal/proto/wire.go
@@ -121,6 +121,10 @@ const (
 
 	// Server → Client — retained pane history bootstrap during attach.
 	MsgTypePaneHistory MsgType = 25
+
+	// Client → Server — restricted pane subscription support.
+	MsgTypeListPanes  MsgType = 26 // list leaf panes
+	MsgTypeAttachPane MsgType = 27 // subscribe to one pane
 )
 
 // Message is the wire protocol envelope. Only the fields relevant to

--- a/internal/proto/wire_low_coverage_test.go
+++ b/internal/proto/wire_low_coverage_test.go
@@ -138,6 +138,8 @@ func TestWriteReadMsgAllMessageTypes(t *testing.T) {
 		{name: "type keys", msg: Message{Type: MsgTypeTypeKeys, Input: []byte("abc")}},
 		{name: "ui event", msg: Message{Type: MsgTypeUIEvent, UIEvent: UIEventDisplayPanesShown}},
 		{name: "pane history", msg: Message{Type: MsgTypePaneHistory, PaneID: 4, History: []string{"one", "two"}}},
+		{name: "list panes", msg: Message{Type: MsgTypeListPanes}},
+		{name: "attach pane", msg: Message{Type: MsgTypeAttachPane, Session: "test-session", PaneID: 4}},
 	}
 
 	for _, tt := range tests {

--- a/internal/server/attach_pane_protocol_test.go
+++ b/internal/server/attach_pane_protocol_test.go
@@ -29,16 +29,7 @@ func newAttachPaneProtocolHarness(t *testing.T) *attachPaneProtocolHarness {
 
 	sess := newSession(t.Name())
 	stopCrashCheckpointLoop(t, sess)
-	t.Cleanup(func() {
-		sess.shutdown.Store(true)
-		stopSessionBackgroundLoops(t, sess)
-		for _, pane := range append([]*mux.Pane(nil), sess.Panes...) {
-			if pane != nil {
-				_ = pane.Close()
-				_ = pane.WaitClosed()
-			}
-		}
-	})
+	cleanupAttachPaneProtocolSession(t, sess)
 
 	writes1 := make(chan []byte, 4)
 	writes2 := make(chan []byte, 4)
@@ -62,16 +53,7 @@ func newSingleAttachPaneProtocolHarness(t *testing.T) *attachPaneProtocolHarness
 
 	sess := newSession(t.Name())
 	stopCrashCheckpointLoop(t, sess)
-	t.Cleanup(func() {
-		sess.shutdown.Store(true)
-		stopSessionBackgroundLoops(t, sess)
-		for _, pane := range append([]*mux.Pane(nil), sess.Panes...) {
-			if pane != nil {
-				_ = pane.Close()
-				_ = pane.WaitClosed()
-			}
-		}
-	})
+	cleanupAttachPaneProtocolSession(t, sess)
 
 	writes := make(chan []byte, 4)
 	pane := newAttachPaneProtocolPane(sess, 1, writes)
@@ -84,6 +66,21 @@ func newSingleAttachPaneProtocolHarness(t *testing.T) *attachPaneProtocolHarness
 		pane1:   pane,
 		writes1: writes,
 	}
+}
+
+func cleanupAttachPaneProtocolSession(t *testing.T, sess *Session) {
+	t.Helper()
+
+	t.Cleanup(func() {
+		sess.shutdown.Store(true)
+		stopSessionBackgroundLoops(t, sess)
+		for _, pane := range append([]*mux.Pane(nil), sess.Panes...) {
+			if pane != nil {
+				_ = pane.Close()
+				_ = pane.WaitClosed()
+			}
+		}
+	})
 }
 
 func newAttachPaneProtocolPane(sess *Session, id uint32, writes chan<- []byte) *mux.Pane {

--- a/internal/server/attach_pane_protocol_test.go
+++ b/internal/server/attach_pane_protocol_test.go
@@ -1,0 +1,317 @@
+package server
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/weill-labs/amux/internal/config"
+	"github.com/weill-labs/amux/internal/mux"
+	"github.com/weill-labs/amux/internal/proto"
+)
+
+type attachPaneProtocolHarness struct {
+	srv     *Server
+	sess    *Session
+	pane1   *mux.Pane
+	pane2   *mux.Pane
+	writes1 chan []byte
+	writes2 chan []byte
+}
+
+func newAttachPaneProtocolHarness(t *testing.T) *attachPaneProtocolHarness {
+	t.Helper()
+
+	sess := newSession(t.Name())
+	stopCrashCheckpointLoop(t, sess)
+	t.Cleanup(func() {
+		sess.shutdown.Store(true)
+		stopSessionBackgroundLoops(t, sess)
+		for _, pane := range []*mux.Pane{sess.findPaneByID(1), sess.findPaneByID(2)} {
+			if pane != nil {
+				_ = pane.Close()
+				_ = pane.WaitClosed()
+			}
+		}
+	})
+
+	writes1 := make(chan []byte, 4)
+	writes2 := make(chan []byte, 4)
+	pane1 := newAttachPaneProtocolPane(sess, 1, writes1)
+	pane2 := newAttachPaneProtocolPane(sess, 2, writes2)
+	window := newTestWindowWithPanes(t, sess, 1, "main", pane1, pane2)
+	setSessionLayoutForTest(t, sess, window.ID, []*mux.Window{window}, pane1, pane2)
+
+	return &attachPaneProtocolHarness{
+		srv:     &Server{sessions: map[string]*Session{sess.Name: sess}},
+		sess:    sess,
+		pane1:   pane1,
+		pane2:   pane2,
+		writes1: writes1,
+		writes2: writes2,
+	}
+}
+
+func newAttachPaneProtocolPane(sess *Session, id uint32, writes chan<- []byte) *mux.Pane {
+	return sess.ownPane(newProxyPane(id, mux.PaneMeta{
+		Name:  fmt.Sprintf(mux.PaneNameFormat, id),
+		Host:  mux.DefaultHost,
+		Color: config.AccentColor(id - 1),
+	}, 80, 23, sess.paneOutputCallback(), sess.paneExitCallback(), func(data []byte) (int, error) {
+		writes <- append([]byte(nil), data...)
+		return len(data), nil
+	}))
+}
+
+func startAttachPaneProtocolConn(t *testing.T, h *attachPaneProtocolHarness, paneID uint32) net.Conn {
+	t.Helper()
+
+	serverConn, clientConn := net.Pipe()
+	t.Cleanup(func() { clientConn.Close() })
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		h.srv.handleConn(serverConn)
+	}()
+	t.Cleanup(func() {
+		clientConn.Close()
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+			t.Fatalf("server connection did not close")
+		}
+	})
+
+	if err := writeMsgOnConn(clientConn, &Message{
+		Type:    MsgTypeAttachPane,
+		Session: h.sess.Name,
+		PaneID:  paneID,
+	}); err != nil {
+		t.Fatalf("write attach pane: %v", err)
+	}
+	return clientConn
+}
+
+func expectProtocolError(t *testing.T, conn net.Conn, contains string) {
+	t.Helper()
+
+	msg := readMsgWithTimeout(t, conn)
+	if msg.Type != MsgTypeCmdResult {
+		t.Fatalf("message type = %v, want CmdResult", msg.Type)
+	}
+	if !strings.Contains(msg.CmdErr, contains) {
+		t.Fatalf("CmdErr = %q, want substring %q", msg.CmdErr, contains)
+	}
+}
+
+func expectConnectionClosed(t *testing.T, conn net.Conn) {
+	t.Helper()
+
+	if err := conn.SetReadDeadline(time.Now().Add(time.Second)); err != nil {
+		t.Fatalf("SetReadDeadline: %v", err)
+	}
+	defer mustSetReadDeadline(t, conn, time.Time{})
+
+	msg, err := readMsgOnConn(conn)
+	if err == nil {
+		t.Fatalf("ReadMsg succeeded with %+v, want closed connection", msg)
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		t.Fatal("connection stayed open")
+	}
+	if errors.Is(err, io.EOF) || errors.Is(err, net.ErrClosed) || strings.Contains(err.Error(), "closed") {
+		return
+	}
+	t.Fatalf("ReadMsg error = %v, want closed connection", err)
+}
+
+func TestMsgTypeListPanesReturnsLeafPaneSnapshot(t *testing.T) {
+	t.Parallel()
+
+	h := newAttachPaneProtocolHarness(t)
+	orphan := newAttachPaneProtocolPane(h.sess, 99, make(chan []byte, 1))
+	mustSessionMutation(t, h.sess, func(sess *Session) {
+		sess.Panes = append(sess.Panes, orphan)
+	})
+
+	serverConn, clientConn := net.Pipe()
+	t.Cleanup(func() { clientConn.Close() })
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		h.srv.handleConn(serverConn)
+	}()
+
+	if err := writeMsgOnConn(clientConn, &Message{Type: MsgTypeListPanes, Session: h.sess.Name}); err != nil {
+		t.Fatalf("write list panes: %v", err)
+	}
+	msg := readMsgWithTimeout(t, clientConn)
+	if msg.Type != MsgTypeLayout {
+		t.Fatalf("message type = %v, want Layout", msg.Type)
+	}
+	if msg.Layout == nil {
+		t.Fatal("layout is nil")
+	}
+	got := paneSnapshotIDs(msg.Layout.Panes)
+	want := []uint32{1, 2}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("layout pane IDs = %v, want %v", got, want)
+	}
+	expectConnectionClosed(t, clientConn)
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("list panes connection did not close")
+	}
+}
+
+func TestMsgTypeAttachPaneScopesOutputAndInput(t *testing.T) {
+	t.Parallel()
+
+	h := newAttachPaneProtocolHarness(t)
+	conn := startAttachPaneProtocolConn(t, h, h.pane2.ID)
+
+	h.pane1.FeedOutput([]byte("pane-1-leak"))
+	h.pane2.FeedOutput([]byte("pane-2-visible"))
+	msg := readMsgWithTimeout(t, conn)
+	if msg.Type != MsgTypePaneOutput {
+		t.Fatalf("message type = %v, want PaneOutput", msg.Type)
+	}
+	if msg.PaneID != h.pane2.ID || string(msg.PaneData) != "pane-2-visible" {
+		t.Fatalf("pane output = pane %d %q, want pane 2 visible output", msg.PaneID, msg.PaneData)
+	}
+
+	if err := writeMsgOnConn(conn, &Message{Type: MsgTypeInputPane, PaneID: h.pane2.ID, PaneData: []byte("targeted")}); err != nil {
+		t.Fatalf("write scoped input: %v", err)
+	}
+	select {
+	case got := <-h.writes2:
+		if string(got) != "targeted" {
+			t.Fatalf("pane 2 input = %q, want targeted", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("targeted input did not reach pane 2")
+	}
+	select {
+	case got := <-h.writes1:
+		t.Fatalf("pane 1 received unexpected input %q", got)
+	default:
+	}
+}
+
+func TestMsgTypeAttachPaneRejectsRestrictedMessages(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		msg  *Message
+	}{
+		{name: "attach", msg: &Message{Type: MsgTypeAttach}},
+		{name: "attach pane again", msg: &Message{Type: MsgTypeAttachPane, PaneID: 2}},
+		{name: "command", msg: &Message{Type: MsgTypeCommand, CmdName: "split"}},
+		{name: "resize", msg: &Message{Type: MsgTypeResize, Cols: 120, Rows: 40}},
+		{name: "untargeted input", msg: &Message{Type: MsgTypeInput, Input: []byte("x")}},
+		{name: "ui event", msg: &Message{Type: MsgTypeUIEvent, UIEvent: proto.UIEventInputBusy}},
+		{name: "capture response", msg: &Message{Type: MsgTypeCaptureResponse, CmdOutput: "{}"}},
+		{name: "list panes", msg: &Message{Type: MsgTypeListPanes}},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newAttachPaneProtocolHarness(t)
+			conn := startAttachPaneProtocolConn(t, h, h.pane2.ID)
+
+			if err := writeMsgOnConn(conn, tt.msg); err != nil {
+				t.Fatalf("write restricted message: %v", err)
+			}
+			expectProtocolError(t, conn, "restricted pane connection")
+			expectConnectionClosed(t, conn)
+		})
+	}
+}
+
+func TestMsgTypeAttachPaneRejectsOtherPaneInputWithoutClosing(t *testing.T) {
+	t.Parallel()
+
+	h := newAttachPaneProtocolHarness(t)
+	conn := startAttachPaneProtocolConn(t, h, h.pane2.ID)
+
+	if err := writeMsgOnConn(conn, &Message{Type: MsgTypeInputPane, PaneID: h.pane1.ID, PaneData: []byte("wrong")}); err != nil {
+		t.Fatalf("write other pane input: %v", err)
+	}
+	expectProtocolError(t, conn, "pane 1")
+
+	select {
+	case got := <-h.writes1:
+		t.Fatalf("pane 1 received unexpected input %q", got)
+	default:
+	}
+	h.pane2.FeedOutput([]byte("still-live"))
+	msg := readMsgWithTimeout(t, conn)
+	if msg.Type != MsgTypePaneOutput || msg.PaneID != h.pane2.ID || string(msg.PaneData) != "still-live" {
+		t.Fatalf("message after nonfatal reject = %+v, want pane 2 output", msg)
+	}
+}
+
+func TestMsgTypeAttachPanePaneExitSendsExitAndCloses(t *testing.T) {
+	t.Parallel()
+
+	h := newAttachPaneProtocolHarness(t)
+	conn := startAttachPaneProtocolConn(t, h, h.pane2.ID)
+
+	h.sess.enqueuePaneExit(h.pane2.ID, "exit 0")
+	msg := readMsgWithTimeout(t, conn)
+	if msg.Type != MsgTypeExit {
+		t.Fatalf("message type = %v, want Exit", msg.Type)
+	}
+	expectConnectionClosed(t, conn)
+}
+
+func TestMsgTypeAttachPaneRejectsMissingPane(t *testing.T) {
+	t.Parallel()
+
+	h := newAttachPaneProtocolHarness(t)
+
+	serverConn, clientConn := net.Pipe()
+	t.Cleanup(func() { clientConn.Close() })
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		h.srv.handleConn(serverConn)
+	}()
+
+	if err := writeMsgOnConn(clientConn, &Message{
+		Type:    MsgTypeAttachPane,
+		Session: h.sess.Name,
+		PaneID:  99,
+	}); err != nil {
+		t.Fatalf("write missing attach pane: %v", err)
+	}
+	expectProtocolError(t, clientConn, "pane 99")
+	expectConnectionClosed(t, clientConn)
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("missing pane connection did not close")
+	}
+}
+
+func paneSnapshotIDs(panes []proto.PaneSnapshot) []uint32 {
+	ids := make([]uint32, 0, len(panes))
+	for _, pane := range panes {
+		ids = append(ids, pane.ID)
+	}
+	return ids
+}

--- a/internal/server/attach_pane_protocol_test.go
+++ b/internal/server/attach_pane_protocol_test.go
@@ -360,6 +360,7 @@ func TestMsgTypeAttachPaneRejectsRestrictedMessages(t *testing.T) {
 		msg  *Message
 	}{
 		{name: "attach", msg: &Message{Type: MsgTypeAttach}},
+		{name: "detach", msg: &Message{Type: MsgTypeDetach}},
 		{name: "attach pane again", msg: &Message{Type: MsgTypeAttachPane, PaneID: 2}},
 		{name: "command", msg: &Message{Type: MsgTypeCommand, CmdName: "split"}},
 		{name: "resize", msg: &Message{Type: MsgTypeResize, Cols: 120, Rows: 40}},
@@ -435,6 +436,58 @@ func TestMsgTypeAttachPaneLastPaneExitSendsExitAndCloses(t *testing.T) {
 		t.Fatalf("message type = %v, want Exit", msg.Type)
 	}
 	expectConnectionClosed(t, conn)
+}
+
+func TestMsgTypeAttachPaneSessionExitClosesAllScopedClients(t *testing.T) {
+	t.Parallel()
+
+	h := newSingleAttachPaneProtocolHarness(t)
+
+	serverConn1, clientConn1 := net.Pipe()
+	t.Cleanup(func() { clientConn1.Close() })
+	scopedPane1 := newClientConn(serverConn1)
+	scopedPane1.ID = "scoped-pane-1"
+	scopedPane1.restrictToPane(h.pane1.ID)
+	t.Cleanup(scopedPane1.Close)
+
+	serverConn2, clientConn2 := net.Pipe()
+	t.Cleanup(func() { clientConn2.Close() })
+	scopedPane2 := newClientConn(serverConn2)
+	scopedPane2.ID = "scoped-pane-2"
+	scopedPane2.restrictToPane(2)
+	t.Cleanup(scopedPane2.Close)
+
+	mustSessionMutation(t, h.sess, func(sess *Session) {
+		sess.ensureClientManager().setClientsForTest(scopedPane1, scopedPane2)
+	})
+
+	h.sess.enqueuePaneExit(h.pane1.ID, "exit 0")
+	for _, conn := range []net.Conn{clientConn1, clientConn2} {
+		msg := readAttachPaneMsgWithTimeout(t, conn)
+		if msg.Type != MsgTypeExit {
+			t.Fatalf("message type = %v, want Exit", msg.Type)
+		}
+		expectConnectionClosed(t, conn)
+	}
+}
+
+func TestCloseScopedPaneClientsDoesNotCloseUnscopedClientForZeroPaneID(t *testing.T) {
+	t.Parallel()
+
+	h := newSingleAttachPaneProtocolHarness(t)
+
+	serverConn, clientConn := net.Pipe()
+	t.Cleanup(func() { clientConn.Close() })
+	unscoped := newClientConn(serverConn)
+	unscoped.ID = "interactive"
+	t.Cleanup(unscoped.Close)
+
+	mustSessionMutation(t, h.sess, func(sess *Session) {
+		sess.ensureClientManager().setClientsForTest(unscoped)
+		sess.closeScopedPaneClients(0, &Message{Type: MsgTypeExit, Text: "pane exited"})
+	})
+
+	assertNoClientMessage(t, clientConn)
 }
 
 func TestMsgTypeAttachPaneRejectsMissingPane(t *testing.T) {

--- a/internal/server/attach_pane_protocol_test.go
+++ b/internal/server/attach_pane_protocol_test.go
@@ -32,7 +32,7 @@ func newAttachPaneProtocolHarness(t *testing.T) *attachPaneProtocolHarness {
 	t.Cleanup(func() {
 		sess.shutdown.Store(true)
 		stopSessionBackgroundLoops(t, sess)
-		for _, pane := range []*mux.Pane{sess.findPaneByID(1), sess.findPaneByID(2)} {
+		for _, pane := range append([]*mux.Pane(nil), sess.Panes...) {
 			if pane != nil {
 				_ = pane.Close()
 				_ = pane.WaitClosed()
@@ -54,6 +54,35 @@ func newAttachPaneProtocolHarness(t *testing.T) *attachPaneProtocolHarness {
 		pane2:   pane2,
 		writes1: writes1,
 		writes2: writes2,
+	}
+}
+
+func newSingleAttachPaneProtocolHarness(t *testing.T) *attachPaneProtocolHarness {
+	t.Helper()
+
+	sess := newSession(t.Name())
+	stopCrashCheckpointLoop(t, sess)
+	t.Cleanup(func() {
+		sess.shutdown.Store(true)
+		stopSessionBackgroundLoops(t, sess)
+		for _, pane := range append([]*mux.Pane(nil), sess.Panes...) {
+			if pane != nil {
+				_ = pane.Close()
+				_ = pane.WaitClosed()
+			}
+		}
+	})
+
+	writes := make(chan []byte, 4)
+	pane := newAttachPaneProtocolPane(sess, 1, writes)
+	window := newTestWindowWithPanes(t, sess, 1, "main", pane)
+	setSessionLayoutForTest(t, sess, window.ID, []*mux.Window{window}, pane)
+
+	return &attachPaneProtocolHarness{
+		srv:     &Server{sessions: map[string]*Session{sess.Name: sess}},
+		sess:    sess,
+		pane1:   pane,
+		writes1: writes,
 	}
 }
 
@@ -95,13 +124,34 @@ func startAttachPaneProtocolConn(t *testing.T, h *attachPaneProtocolHarness, pan
 	}); err != nil {
 		t.Fatalf("write attach pane: %v", err)
 	}
+	waitForScopedClient(t, h.sess, paneID)
 	return clientConn
+}
+
+func waitForScopedClient(t *testing.T, sess *Session, paneID uint32) {
+	t.Helper()
+
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if mustSessionQuery(t, sess, func(sess *Session) bool {
+			for _, cc := range sess.ensureClientManager().snapshotClients() {
+				if cc.isScopedToPane(paneID) {
+					return true
+				}
+			}
+			return false
+		}) {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for scoped client on pane %d", paneID)
 }
 
 func expectProtocolError(t *testing.T, conn net.Conn, contains string) {
 	t.Helper()
 
-	msg := readMsgWithTimeout(t, conn)
+	msg := readAttachPaneMsgWithTimeout(t, conn)
 	if msg.Type != MsgTypeCmdResult {
 		t.Fatalf("message type = %v, want CmdResult", msg.Type)
 	}
@@ -110,13 +160,39 @@ func expectProtocolError(t *testing.T, conn net.Conn, contains string) {
 	}
 }
 
-func expectConnectionClosed(t *testing.T, conn net.Conn) {
+func readAttachPaneMsgWithTimeout(t *testing.T, conn net.Conn) *Message {
 	t.Helper()
 
 	if err := conn.SetReadDeadline(time.Now().Add(time.Second)); err != nil {
 		t.Fatalf("SetReadDeadline: %v", err)
 	}
-	defer mustSetReadDeadline(t, conn, time.Time{})
+	defer func() {
+		if err := conn.SetReadDeadline(time.Time{}); err != nil && !strings.Contains(err.Error(), "closed") {
+			t.Fatalf("reset read deadline: %v", err)
+		}
+	}()
+
+	msg, err := readMsgOnConn(conn)
+	if err != nil {
+		t.Fatalf("ReadMsg: %v", err)
+	}
+	return msg
+}
+
+func expectConnectionClosed(t *testing.T, conn net.Conn) {
+	t.Helper()
+
+	if err := conn.SetReadDeadline(time.Now().Add(time.Second)); err != nil {
+		if strings.Contains(err.Error(), "closed") {
+			return
+		}
+		t.Fatalf("SetReadDeadline: %v", err)
+	}
+	defer func() {
+		if err := conn.SetReadDeadline(time.Time{}); err != nil && !strings.Contains(err.Error(), "closed") {
+			t.Fatalf("reset read deadline: %v", err)
+		}
+	}()
 
 	msg, err := readMsgOnConn(conn)
 	if err == nil {
@@ -152,7 +228,7 @@ func TestMsgTypeListPanesReturnsLeafPaneSnapshot(t *testing.T) {
 	if err := writeMsgOnConn(clientConn, &Message{Type: MsgTypeListPanes, Session: h.sess.Name}); err != nil {
 		t.Fatalf("write list panes: %v", err)
 	}
-	msg := readMsgWithTimeout(t, clientConn)
+	msg := readAttachPaneMsgWithTimeout(t, clientConn)
 	if msg.Type != MsgTypeLayout {
 		t.Fatalf("message type = %v, want Layout", msg.Type)
 	}
@@ -173,6 +249,78 @@ func TestMsgTypeListPanesReturnsLeafPaneSnapshot(t *testing.T) {
 	}
 }
 
+func TestScopedPaneProtocolRejectsMissingSession(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		msg  *Message
+	}{
+		{name: "list panes", msg: &Message{Type: MsgTypeListPanes, Session: "missing"}},
+		{name: "attach pane", msg: &Message{Type: MsgTypeAttachPane, Session: "missing", PaneID: 1}},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv := &Server{sessions: map[string]*Session{}}
+			serverConn, clientConn := net.Pipe()
+			t.Cleanup(func() { clientConn.Close() })
+			done := make(chan struct{})
+			go func() {
+				defer close(done)
+				srv.handleConn(serverConn)
+			}()
+
+			if err := writeMsgOnConn(clientConn, tt.msg); err != nil {
+				t.Fatalf("write message: %v", err)
+			}
+			expectProtocolError(t, clientConn, "no session")
+			expectConnectionClosed(t, clientConn)
+
+			select {
+			case <-done:
+			case <-time.After(time.Second):
+				t.Fatal("missing session connection did not close")
+			}
+		})
+	}
+}
+
+func TestMsgTypeListPanesRejectsSessionWithoutLayout(t *testing.T) {
+	t.Parallel()
+
+	sess := newSession(t.Name())
+	stopCrashCheckpointLoop(t, sess)
+	t.Cleanup(func() {
+		sess.shutdown.Store(true)
+		stopSessionBackgroundLoops(t, sess)
+	})
+	srv := &Server{sessions: map[string]*Session{sess.Name: sess}}
+
+	serverConn, clientConn := net.Pipe()
+	t.Cleanup(func() { clientConn.Close() })
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		srv.handleConn(serverConn)
+	}()
+
+	if err := writeMsgOnConn(clientConn, &Message{Type: MsgTypeListPanes, Session: sess.Name}); err != nil {
+		t.Fatalf("write list panes: %v", err)
+	}
+	expectProtocolError(t, clientConn, "no layout")
+	expectConnectionClosed(t, clientConn)
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("no-layout connection did not close")
+	}
+}
+
 func TestMsgTypeAttachPaneScopesOutputAndInput(t *testing.T) {
 	t.Parallel()
 
@@ -181,7 +329,7 @@ func TestMsgTypeAttachPaneScopesOutputAndInput(t *testing.T) {
 
 	h.pane1.FeedOutput([]byte("pane-1-leak"))
 	h.pane2.FeedOutput([]byte("pane-2-visible"))
-	msg := readMsgWithTimeout(t, conn)
+	msg := readAttachPaneMsgWithTimeout(t, conn)
 	if msg.Type != MsgTypePaneOutput {
 		t.Fatalf("message type = %v, want PaneOutput", msg.Type)
 	}
@@ -258,7 +406,7 @@ func TestMsgTypeAttachPaneRejectsOtherPaneInputWithoutClosing(t *testing.T) {
 	default:
 	}
 	h.pane2.FeedOutput([]byte("still-live"))
-	msg := readMsgWithTimeout(t, conn)
+	msg := readAttachPaneMsgWithTimeout(t, conn)
 	if msg.Type != MsgTypePaneOutput || msg.PaneID != h.pane2.ID || string(msg.PaneData) != "still-live" {
 		t.Fatalf("message after nonfatal reject = %+v, want pane 2 output", msg)
 	}
@@ -271,7 +419,21 @@ func TestMsgTypeAttachPanePaneExitSendsExitAndCloses(t *testing.T) {
 	conn := startAttachPaneProtocolConn(t, h, h.pane2.ID)
 
 	h.sess.enqueuePaneExit(h.pane2.ID, "exit 0")
-	msg := readMsgWithTimeout(t, conn)
+	msg := readAttachPaneMsgWithTimeout(t, conn)
+	if msg.Type != MsgTypeExit {
+		t.Fatalf("message type = %v, want Exit", msg.Type)
+	}
+	expectConnectionClosed(t, conn)
+}
+
+func TestMsgTypeAttachPaneLastPaneExitSendsExitAndCloses(t *testing.T) {
+	t.Parallel()
+
+	h := newSingleAttachPaneProtocolHarness(t)
+	conn := startAttachPaneProtocolConn(t, h, h.pane1.ID)
+
+	h.sess.enqueuePaneExit(h.pane1.ID, "exit 0")
+	msg := readAttachPaneMsgWithTimeout(t, conn)
 	if msg.Type != MsgTypeExit {
 		t.Fatalf("message type = %v, want Exit", msg.Type)
 	}

--- a/internal/server/capture_forward.go
+++ b/internal/server/capture_forward.go
@@ -94,6 +94,9 @@ func (s *Session) captureClientSnapshotForActor(req caputil.Request, actorPaneID
 	return enqueueSessionQueryOnState(s.context(), s, func(s *Session) (captureClientSnapshot, error) {
 		snap := captureClientSnapshot{}
 		for _, cc := range s.ensureClientManager().snapshotClients() {
+			if cc.isPaneScoped() {
+				continue
+			}
 			if cc.isBootstrapping() {
 				continue
 			}

--- a/internal/server/client_conn.go
+++ b/internal/server/client_conn.go
@@ -44,6 +44,7 @@ type clientConn struct {
 	typeKeyQueue       *pacedInputQueue
 	capabilities       proto.ClientCapabilities
 	colorProfile       string
+	scopedPaneID       uint32
 	predictions        map[uint32][]pendingPredictionEpoch
 	logger             *charmlog.Logger
 	bootstrapping      atomic.Bool
@@ -109,8 +110,38 @@ func (cc *clientConn) participatesInSizeNegotiation() bool {
 	return cc != nil && !cc.nonInteractive
 }
 
+func (cc *clientConn) restrictToPane(paneID uint32) {
+	cc.scopedPaneID = paneID
+	cc.nonInteractive = true
+}
+
+func (cc *clientConn) isPaneScoped() bool {
+	return cc != nil && cc.scopedPaneID != 0
+}
+
+func (cc *clientConn) isScopedToPane(paneID uint32) bool {
+	return cc != nil && cc.scopedPaneID == paneID
+}
+
+func (cc *clientConn) allowsServerMessage(msg *Message) bool {
+	if cc == nil || cc.scopedPaneID == 0 || msg == nil {
+		return true
+	}
+	switch msg.Type {
+	case MsgTypePaneOutput:
+		return msg.PaneID == cc.scopedPaneID
+	case MsgTypeCmdResult, MsgTypeExit:
+		return true
+	default:
+		return false
+	}
+}
+
 // Send enqueues a message to the client. Thread-safe.
 func (cc *clientConn) Send(msg *Message) error {
+	if !cc.allowsServerMessage(msg) {
+		return nil
+	}
 	return cc.ensureWriter().send(msg)
 }
 
@@ -166,18 +197,30 @@ func (cc *clientConn) finishBootstrap(minOutputSeq map[uint32]uint64) {
 }
 
 func (cc *clientConn) sendBroadcast(msg *Message) {
+	if !cc.allowsServerMessage(msg) {
+		return
+	}
 	cc.ensureWriter().sendBroadcast(msg)
 }
 
 func (cc *clientConn) sendBroadcastSync(msg *Message) {
+	if !cc.allowsServerMessage(msg) {
+		return
+	}
 	cc.ensureWriter().sendBroadcastSync(msg)
 }
 
 func (cc *clientConn) sendPaneOutput(msg *Message, paneID uint32, seq uint64) {
+	if !cc.allowsServerMessage(msg) {
+		return
+	}
 	cc.ensureWriter().sendPaneOutput(cc.decoratePaneOutput(msg, paneID), paneID, seq)
 }
 
 func (cc *clientConn) sendPaneMessage(msg *Message) {
+	if !cc.allowsServerMessage(msg) {
+		return
+	}
 	cc.ensureWriter().sendPaneMessage(msg)
 }
 
@@ -355,6 +398,13 @@ func (cc *clientConn) readLoop(srv *Server, sess *Session) {
 			return
 		}
 
+		if cc.isPaneScoped() {
+			if !cc.handlePaneScopedMessage(sess, msg) {
+				return
+			}
+			continue
+		}
+
 		switch msg.Type {
 		case MsgTypeInput:
 			sess.enqueueLiveInputWithEpoch(cc, msg.Input, msg.InputEpoch)
@@ -383,6 +433,26 @@ func (cc *clientConn) readLoop(srv *Server, sess *Session) {
 			sess.enqueueUIEvent(cc, msg.UIEvent)
 		}
 	}
+}
+
+func (cc *clientConn) handlePaneScopedMessage(sess *Session, msg *Message) bool {
+	if msg.Type != MsgTypeInputPane {
+		errMsg := fmt.Sprintf("restricted pane connection attached to pane %d rejected message type %d", cc.scopedPaneID, msg.Type)
+		cc.sendProtocolError(errMsg)
+		cc.markDisconnectReason(errMsg)
+		return false
+	}
+	if msg.PaneID != cc.scopedPaneID {
+		cc.sendProtocolError(fmt.Sprintf("restricted pane connection attached to pane %d cannot write pane %d", cc.scopedPaneID, msg.PaneID))
+		return true
+	}
+	sess.enqueueLiveInputPaneFromClient(cc, msg.PaneID, msg.PaneData, msg.InputEpoch)
+	return true
+}
+
+func (cc *clientConn) sendProtocolError(message string) {
+	_ = cc.Send(&Message{Type: MsgTypeCmdResult, CmdErr: message})
+	_ = cc.Flush()
 }
 
 // handleCommand dispatches CLI commands through the command registry.

--- a/internal/server/protocol.go
+++ b/internal/server/protocol.go
@@ -44,6 +44,10 @@ const (
 
 	// Server → Client — retained pane history bootstrap during attach.
 	MsgTypePaneHistory = proto.MsgTypePaneHistory
+
+	// Client → Server — restricted pane subscription support.
+	MsgTypeListPanes  = proto.MsgTypeListPanes
+	MsgTypeAttachPane = proto.MsgTypeAttachPane
 )
 
 // WriteMsg encodes and writes a message to w.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -846,9 +846,59 @@ func (s *Server) handleConn(conn net.Conn) {
 		s.handleAttach(cc, msg)
 	case MsgTypeCommand:
 		s.handleOneShot(cc, msg)
+	case MsgTypeListPanes:
+		s.handleListPanes(cc, msg)
+	case MsgTypeAttachPane:
+		s.handleAttachPane(cc, msg)
 	default:
 		cc.Close()
 	}
+}
+
+func (s *Server) sessionForProtocolMessage(msg *Message) *Session {
+	if msg != nil && msg.Session != "" {
+		return s.sessions[msg.Session]
+	}
+	return s.firstSession()
+}
+
+func (s *Server) handleListPanes(cc *clientConn, msg *Message) {
+	defer func() {
+		_ = cc.Flush()
+		cc.Close()
+	}()
+
+	sess := s.sessionForProtocolMessage(msg)
+	if sess == nil {
+		cc.sendProtocolError("no session")
+		return
+	}
+	snap, err := sess.queryListPanesSnapshot(cc.context())
+	if err != nil {
+		cc.sendProtocolError(err.Error())
+		return
+	}
+	_ = cc.Send(&Message{Type: MsgTypeLayout, Layout: snap})
+}
+
+func (s *Server) handleAttachPane(cc *clientConn, msg *Message) {
+	sess := s.sessionForProtocolMessage(msg)
+	if sess == nil {
+		cc.sendProtocolError("no session")
+		cc.Close()
+		return
+	}
+
+	cc.ID = fmt.Sprintf("client-%d", sess.ensureClientManager().nextClientOrdinal())
+	cc.logger = sess.logger.With("client_id", cc.ID)
+	cc.restrictToPane(msg.PaneID)
+
+	if err := sess.enqueueAttachPaneClient(cc, msg.PaneID); err != nil {
+		cc.sendProtocolError(err.Error())
+		cc.Close()
+		return
+	}
+	cc.readLoop(s, sess)
 }
 
 // handleAttach registers an attached client and starts its read loop.

--- a/internal/server/session_events_client.go
+++ b/internal/server/session_events_client.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/weill-labs/amux/internal/eventloop"
 	"github.com/weill-labs/amux/internal/proto"
@@ -41,6 +42,12 @@ type detachClientEvent struct {
 	reason string
 }
 
+type attachPaneClientEvent struct {
+	cc     *clientConn
+	paneID uint32
+	reply  chan error
+}
+
 func (e detachClientEvent) handle(_ context.Context, s *Session) {
 	if !s.hasClient(e.cc) {
 		return
@@ -48,7 +55,21 @@ func (e detachClientEvent) handle(_ context.Context, s *Session) {
 	s.appendConnectionLog(connectionLogEventDetach, e.cc.ID, e.cc.cols, e.cc.rows, e.cc.disconnectReasonValue())
 	s.emitClientDisconnectEvent(e.cc, e.reason)
 	s.logClientDisconnect(e.cc, e.cc.disconnectReasonValue())
+	if e.cc.isPaneScoped() {
+		s.removeClientWithoutLayout(e.cc)
+		return
+	}
 	s.removeClient(e.cc)
+}
+
+func (e attachPaneClientEvent) handle(_ context.Context, s *Session) {
+	if e.paneID == 0 || s.findWindowByPaneID(e.paneID) == nil {
+		e.reply <- fmt.Errorf("pane %d not found", e.paneID)
+		return
+	}
+	s.ensureClientManager().addClient(e.cc)
+	s.appendConnectionLog(connectionLogEventAttach, e.cc.ID, e.cc.cols, e.cc.rows, "")
+	e.reply <- nil
 }
 
 type resizeClientEvent struct {
@@ -149,6 +170,28 @@ func (s *Session) enqueueDetachClient(cc *clientConn, reason string) {
 	s.enqueueEvent(s.context(), detachClientEvent{cc: cc, reason: reason})
 }
 
+func (s *Session) enqueueAttachPaneClient(cc *clientConn, paneID uint32) error {
+	ctx := s.context()
+	if cc != nil {
+		ctx = cc.context()
+	}
+	reply := make(chan error, 1)
+	if !s.enqueueEvent(ctx, attachPaneClientEvent{cc: cc, paneID: paneID, reply: reply}) {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		return errSessionShuttingDown
+	}
+	select {
+	case err := <-reply:
+		return err
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-s.sessionEventDone:
+		return errSessionShuttingDown
+	}
+}
+
 func (s *Session) enqueueResizeClient(cc *clientConn, cols, rows int) {
 	ctx := s.context()
 	if cc != nil {
@@ -181,6 +224,16 @@ func (s *Session) enqueueLiveInputPaneFromClient(cc *clientConn, paneID uint32, 
 		ctx = cc.context()
 	}
 	return s.enqueueEvent(ctx, liveInputPaneEvent{cc: cc, paneID: paneID, data: append([]byte(nil), data...), epoch: epoch})
+}
+
+func (s *Session) queryListPanesSnapshot(ctx context.Context) (*proto.LayoutSnapshot, error) {
+	return enqueueSessionQueryOnState(ctx, s, func(s *Session) (*proto.LayoutSnapshot, error) {
+		snap := s.snapshotLayout(s.snapshotIdleState())
+		if snap == nil {
+			return nil, fmt.Errorf("no layout")
+		}
+		return snap, nil
+	})
 }
 
 // --- Event subscribe/unsubscribe through the event loop ---

--- a/internal/server/session_events_pane.go
+++ b/internal/server/session_events_pane.go
@@ -52,11 +52,29 @@ func (s *Session) handleFinalizedPaneRemoval(paneID uint32, closePane bool, reas
 	}
 	if removed.sendExit {
 		s.broadcastNow(&Message{Type: MsgTypeExit, Text: "session exited"})
+		s.closeScopedPaneClients(paneID, nil)
 		s.wantShutdown = true
 		return
 	}
+	s.closeScopedPaneClients(paneID, &Message{Type: MsgTypeExit, Text: "pane exited"})
 	if removed.broadcastLayout {
 		s.broadcastLayoutNow()
+	}
+}
+
+func (s *Session) closeScopedPaneClients(paneID uint32, exitMsg *Message) {
+	for _, cc := range s.ensureClientManager().snapshotClients() {
+		if !cc.isScopedToPane(paneID) {
+			continue
+		}
+		cc.markDisconnectReason("pane exited")
+		go func(cc *clientConn) {
+			if exitMsg != nil {
+				_ = cc.Send(exitMsg)
+			}
+			_ = cc.Flush()
+			cc.Close()
+		}(cc)
 	}
 }
 

--- a/internal/server/session_events_pane.go
+++ b/internal/server/session_events_pane.go
@@ -52,7 +52,7 @@ func (s *Session) handleFinalizedPaneRemoval(paneID uint32, closePane bool, reas
 	}
 	if removed.sendExit {
 		s.broadcastNow(&Message{Type: MsgTypeExit, Text: "session exited"})
-		s.closeScopedPaneClients(paneID, nil)
+		s.closeAllScopedPaneClients()
 		s.wantShutdown = true
 		return
 	}
@@ -64,18 +64,31 @@ func (s *Session) handleFinalizedPaneRemoval(paneID uint32, closePane bool, reas
 
 func (s *Session) closeScopedPaneClients(paneID uint32, exitMsg *Message) {
 	for _, cc := range s.ensureClientManager().snapshotClients() {
-		if !cc.isScopedToPane(paneID) {
+		if !cc.isPaneScoped() || !cc.isScopedToPane(paneID) {
 			continue
 		}
-		cc.markDisconnectReason("pane exited")
-		go func(cc *clientConn) {
-			if exitMsg != nil {
-				_ = cc.Send(exitMsg)
-			}
-			_ = cc.Flush()
-			cc.Close()
-		}(cc)
+		s.closeScopedPaneClient(cc, exitMsg)
 	}
+}
+
+func (s *Session) closeAllScopedPaneClients() {
+	for _, cc := range s.ensureClientManager().snapshotClients() {
+		if !cc.isPaneScoped() {
+			continue
+		}
+		s.closeScopedPaneClient(cc, nil)
+	}
+}
+
+func (s *Session) closeScopedPaneClient(cc *clientConn, exitMsg *Message) {
+	cc.markDisconnectReason("pane exited")
+	go func() {
+		if exitMsg != nil {
+			_ = cc.Send(exitMsg)
+		}
+		_ = cc.Flush()
+		cc.Close()
+	}()
 }
 
 type clipboardEvent struct {


### PR DESCRIPTION
## Motivation

LAB-1952 is a tracer bullet for amux federation: prove whether a scoped per-pane wire subscription can be added without tangling the existing whole-session broadcast paths. The restricted mode is a security boundary for future tunneled clients, so a scoped subscriber must not be able to drive normal session control messages.

## Summary

- Add `MsgTypeListPanes` and `MsgTypeAttachPane` to the wire protocol and server re-exports.
- Add a restricted pane-scoped connection mode that only forwards matching `MsgTypePaneOutput`, matching `MsgTypeInputPane`, explicit errors, and pane/session exits.
- Add server first-message handlers for listing leaf pane snapshots and attaching a single pane subscriber.
- Add table-driven protocol tests covering scoped output/input, filtered peer output, fatal restricted rejects, nonfatal wrong-pane input rejects, pane exit, missing pane, and missing/no-layout sessions.

## Tracer bullet measurement

| File | LOC added | LOC removed | Notes |
| -- | --: | --: | -- |
| `internal/proto/wire.go` | 4 | 0 | Defines `MsgTypeListPanes=26` and `MsgTypeAttachPane=27`. |
| `internal/proto/gob_register.go` | 4 | 0 | Registers existing layout snapshot concrete types for gob. |
| `internal/proto/wire_low_coverage_test.go` | 2 | 0 | Adds round-trip cases for the new message types. |
| `internal/server/protocol.go` | 4 | 0 | Re-exports the new message type constants. |
| `internal/server/server.go` | 50 | 0 | Adds first-message dispatch and small list/attach handlers. |
| `internal/server/client_conn.go` | 70 | 0 | Key number: scoped mode field, outbound filter, and restricted read-loop branch. |
| `internal/server/session_events_client.go` | 53 | 0 | Adds event-loop attach validation and list snapshot query. |
| `internal/server/session_events_pane.go` | 18 | 0 | Sends/closes scoped subscribers when their pane exits. |
| `internal/server/capture_forward.go` | 3 | 0 | Skips scoped subscribers as capture clients. |
| `internal/server/attach_pane_protocol_test.go` | 476 | 0 | New in-process protocol coverage for restricted mode. |

The per-pane subscription filter cleanly slots into the existing broadcast path. `Session.broadcastPaneOutputNow` did not need refactoring; it still fans out through each `clientConn`, and the new branch lives at the existing client send boundary in `clientConn.sendPaneOutput`, `sendPaneMessage`, `sendBroadcast`, and `Send`. Restricted client-to-server handling is a small branch in `clientConn.readLoop` via `handlePaneScopedMessage`, with first-message setup isolated to `Server.handleConn`, `handleListPanes`, and `handleAttachPane`. This is a clean branch in existing fanout/dispatch functions, not an invasive refactor that plumbs filters through session broadcast state.

## Testing

- `go test ./internal/proto ./internal/server -run 'Test(MsgTypeListPanes|MsgTypeAttachPane|ScopedPaneProtocol|WriteReadMsgAllMessageTypes)' -count=100`
- `scripts/check-diff-coverage.sh` (diff coverage 89.74%; command exited 0, but its integration phase reproduced the local clipboard failures below)
- `go test ./... -timeout 120s -skip 'TestCopyModeClipboardUses(OSC52WhenInnerClientRunsOverSSH|TmuxPassthroughWhenInnerClientRunsOverSSHInTmux)|TestRespawnCommandRestartsLocalPaneInPlace'`

Local full-suite caveats:

- `go test ./... -timeout 120s` failed once in `TestRespawnCommandRestartsLocalPaneInPlace`; exact rerun with `go test ./internal/server -run TestRespawnCommandRestartsLocalPaneInPlace -count=1` passed.
- The local environment consistently fails `TestCopyModeClipboardUsesOSC52WhenInnerClientRunsOverSSH` and `TestCopyModeClipboardUsesTmuxPassthroughWhenInnerClientRunsOverSSHInTmux`; both fail because the expected OSC52 clipboard sequence does not reach the outer pane. These tests are unrelated to the scoped attach protocol path.

## Review focus

- Confirm the restricted mode cannot escape via client-to-server messages after `MsgTypeAttachPane`.
- Check that the filter is truly scoped at the existing client send boundary and does not refactor session fanout.
- Verify `client_conn.go` remained small enough for the tracer bullet signal: +70/-0 LOC.
- Check error/close semantics for fatal rejects versus wrong-pane `MsgTypeInputPane`.

Closes LAB-1952
