### PR TITLE
LAB-1955: Prioritize foreground pane rendering

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -434,6 +434,9 @@ type RenderMsg struct {
 	Text        string
 	Local       localRenderFunc
 	Reply       chan any
+	QueuedAt    time.Time
+
+	queueLatencyRecorded bool
 }
 
 type localRenderFunc func(*ClientRenderer) localRenderResult
@@ -558,6 +561,21 @@ func collectPaneOutputBatch(first *RenderMsg, msgCh <-chan *RenderMsg) (batch []
 	}
 }
 
+func stampRenderMsgQueuedAt(msg *RenderMsg, now time.Time) {
+	if msg == nil || !msg.QueuedAt.IsZero() {
+		return
+	}
+	msg.QueuedAt = now
+}
+
+func (cr *ClientRenderer) recordRenderMsgQueueLatency(msg *RenderMsg, now time.Time) {
+	if msg == nil || msg.QueuedAt.IsZero() || msg.queueLatencyRecorded {
+		return
+	}
+	msg.queueLatencyRecorded = true
+	cr.frameStats.recordActorQueueLatency(now.Sub(msg.QueuedAt))
+}
+
 func (cr *ClientRenderer) handleRenderMsg(msg *RenderMsg) []clientEffect {
 	switch msg.Typ {
 	case RenderMsgLayout:
@@ -675,6 +693,32 @@ func (cr *ClientRenderer) handlePaneOutputBatch(msgs []*RenderMsg) ([]clientEffe
 	}
 	effects = append(effects, clientEffect{kind: clientEffectScheduleRender})
 	return effects, totalBytes
+}
+
+func (cr *ClientRenderer) splitPriorityPaneOutputBatch(msgs []*RenderMsg) (priority []*RenderMsg, background []*RenderMsg, ok bool) {
+	if len(msgs) < 2 {
+		return nil, nil, false
+	}
+	activePaneID := cr.renderer.ActivePaneID()
+	if !cr.shouldPrioritizePaneOutput(activePaneID) {
+		return nil, nil, false
+	}
+	for _, msg := range msgs {
+		if msg.PaneID == activePaneID {
+			priority = append(priority, msg)
+		} else {
+			background = append(background, msg)
+		}
+	}
+	return priority, background, len(priority) != 0 && len(background) != 0
+}
+
+func (cr *ClientRenderer) executePaneOutputBatch(state *clientRenderLoopState, batch []*RenderMsg, write func(string)) bool {
+	effects, bytes := cr.handlePaneOutputBatch(batch)
+	if len(effects) != 0 && state.recordPaneOutput(bytes, cr.renderOverflowThreshold()) {
+		cr.RequestFullRedraw()
+	}
+	return cr.executeRenderEffects(state, effects, write)
 }
 
 func (cr *ClientRenderer) handleLocalRenderMsg(state *clientRenderLoopState, msg *RenderMsg, write func(string)) bool {
@@ -802,6 +846,7 @@ func (cr *ClientRenderer) RenderCoalesced(msgCh <-chan *RenderMsg, write func(st
 					return
 				}
 				msg = next
+				cr.recordRenderMsgQueueLatency(msg, time.Now())
 			case <-cr.renderStop:
 				return
 			case <-state.renderC:
@@ -809,6 +854,7 @@ func (cr *ClientRenderer) RenderCoalesced(msgCh <-chan *RenderMsg, write func(st
 				continue
 			}
 		}
+		cr.recordRenderMsgQueueLatency(msg, time.Now())
 
 		if msg.Typ == RenderMsgLocalAction {
 			if cr.handleLocalRenderMsg(state, msg, write) {
@@ -818,12 +864,20 @@ func (cr *ClientRenderer) RenderCoalesced(msgCh <-chan *RenderMsg, write func(st
 		}
 		if msg.Typ == RenderMsgPaneOutput {
 			batch, next, closed := collectPaneOutputBatch(msg, msgCh)
-			pendingMsg = next
-			effects, bytes := cr.handlePaneOutputBatch(batch)
-			if len(effects) != 0 && state.recordPaneOutput(bytes, cr.renderOverflowThreshold()) {
-				cr.RequestFullRedraw()
+			pickup := time.Now()
+			for _, queued := range batch[1:] {
+				cr.recordRenderMsgQueueLatency(queued, pickup)
 			}
-			if cr.executeRenderEffects(state, effects, write) {
+			cr.recordRenderMsgQueueLatency(next, pickup)
+			pendingMsg = next
+			if priority, background, ok := cr.splitPriorityPaneOutputBatch(batch); ok {
+				if cr.executePaneOutputBatch(state, priority, write) {
+					return
+				}
+				if cr.executePaneOutputBatch(state, background, write) {
+					return
+				}
+			} else if cr.executePaneOutputBatch(state, batch, write) {
 				return
 			}
 			if closed {

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -867,7 +867,6 @@ func (cr *ClientRenderer) RenderCoalesced(msgCh <-chan *RenderMsg, write func(st
 			for _, queued := range batch[1:] {
 				cr.recordRenderMsgQueueLatency(queued, pickup)
 			}
-			cr.recordRenderMsgQueueLatency(next, pickup)
 			pendingMsg = next
 			if priority, background, ok := cr.splitPriorityPaneOutputBatch(batch); ok {
 				if cr.executePaneOutputBatch(state, priority, write) {

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -1105,7 +1105,7 @@ func (cr *ClientRenderer) PrepareLocalEchoInput(data []byte, now time.Time) (uin
 // It renders from the client-side emulators and returns a response message.
 func (cr *ClientRenderer) HandleCaptureRequest(args []string, agentStatus map[uint32]proto.PaneAgentStatus) *proto.Message {
 	if isDebugFramesClientQuery(args) {
-		return clientFrameStatsResponse(cr.frameStats)
+		return clientFrameStatsResponse(&cr.frameStats)
 	}
 	req := caputil.ParseArgs(args)
 	if !req.FormatJSON || req.IncludeANSI || req.ColorMap || req.DisplayMode || req.ClientMode {

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -846,7 +846,6 @@ func (cr *ClientRenderer) RenderCoalesced(msgCh <-chan *RenderMsg, write func(st
 					return
 				}
 				msg = next
-				cr.recordRenderMsgQueueLatency(msg, time.Now())
 			case <-cr.renderStop:
 				return
 			case <-state.renderC:

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -1911,6 +1911,49 @@ func TestRenderCoalescedPrioritizesActivePaneCursorOnlyOutputAfterLocalInput(t *
 	<-done
 }
 
+func TestRenderCoalescedPriorityLaneRendersActiveBeforeQueuedBackground(t *testing.T) {
+	t.Parallel()
+
+	cr := NewClientRenderer(80, 24)
+	cr.HandleLayout(twoPane80x23())
+	cr.RenderDiff()
+	cr.renderFrameInterval = time.Hour
+	cr.renderPriorityWindow = time.Hour
+	cr.MarkLocalInput()
+
+	msgCh := make(chan *RenderMsg, 4)
+	msgCh <- &RenderMsg{Typ: RenderMsgPaneOutput, PaneID: 2, Data: []byte("background")}
+	msgCh <- &RenderMsg{Typ: RenderMsgPaneOutput, PaneID: 1, Data: []byte("typed")}
+	msgCh <- &RenderMsg{Typ: RenderMsgExit}
+
+	rendered := make(chan string, 4)
+	done := make(chan struct{})
+	go func() {
+		cr.RenderCoalesced(msgCh, func(frame string) {
+			rendered <- frame
+		})
+		close(done)
+	}()
+
+	select {
+	case frame := <-rendered:
+		if !strings.Contains(frame, "typed") {
+			t.Fatalf("first frame = %q, want active pane output", frame)
+		}
+		if strings.Contains(frame, "background") {
+			t.Fatalf("first frame included queued background output before foreground priority lane:\n%q", frame)
+		}
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("priority lane did not render the active pane promptly")
+	}
+
+	select {
+	case <-done:
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("render loop did not exit")
+	}
+}
+
 func TestRenderCoalescedDoesNotPrioritizeBackgroundPaneAfterLocalInput(t *testing.T) {
 	t.Parallel()
 

--- a/internal/client/frame_stats.go
+++ b/internal/client/frame_stats.go
@@ -104,7 +104,7 @@ func (s *clientFrameStats) snapshot() clientFrameStatsSnapshot {
 
 func (s *clientFrameStats) format() string {
 	snap := s.snapshot()
-	if snap.sampleCount == 0 {
+	if snap.sampleCount == 0 && len(snap.actorQueueLatencies) == 0 {
 		return "no frame samples recorded yet"
 	}
 
@@ -121,26 +121,33 @@ func (s *clientFrameStats) format() string {
 
 	var b strings.Builder
 	fmt.Fprintf(&b, "samples: %d\n", snap.sampleCount)
-	fmt.Fprintf(&b, "frame duration: p50 %s  p95 %s  p99 %s\n",
-		percentileDuration(durations, 50),
-		percentileDuration(durations, 95),
-		percentileDuration(durations, 99),
-	)
-	fmt.Fprintf(&b, "cells diffed: p50 %d  p95 %d  p99 %d\n",
-		percentileInt(cells, 50),
-		percentileInt(cells, 95),
-		percentileInt(cells, 99),
-	)
-	fmt.Fprintf(&b, "ansi bytes emitted: p50 %d  p95 %d  p99 %d\n",
-		percentileInt(ansiBytes, 50),
-		percentileInt(ansiBytes, 95),
-		percentileInt(ansiBytes, 99),
-	)
-	fmt.Fprintf(&b, "panes composited: p50 %d  p95 %d  p99 %d\n",
-		percentileInt(panes, 50),
-		percentileInt(panes, 95),
-		percentileInt(panes, 99),
-	)
+	if snap.sampleCount == 0 {
+		b.WriteString("frame duration: no samples\n")
+		b.WriteString("cells diffed: no samples\n")
+		b.WriteString("ansi bytes emitted: no samples\n")
+		b.WriteString("panes composited: no samples\n")
+	} else {
+		fmt.Fprintf(&b, "frame duration: p50 %s  p95 %s  p99 %s\n",
+			percentileDuration(durations, 50),
+			percentileDuration(durations, 95),
+			percentileDuration(durations, 99),
+		)
+		fmt.Fprintf(&b, "cells diffed: p50 %d  p95 %d  p99 %d\n",
+			percentileInt(cells, 50),
+			percentileInt(cells, 95),
+			percentileInt(cells, 99),
+		)
+		fmt.Fprintf(&b, "ansi bytes emitted: p50 %d  p95 %d  p99 %d\n",
+			percentileInt(ansiBytes, 50),
+			percentileInt(ansiBytes, 95),
+			percentileInt(ansiBytes, 99),
+		)
+		fmt.Fprintf(&b, "panes composited: p50 %d  p95 %d  p99 %d\n",
+			percentileInt(panes, 50),
+			percentileInt(panes, 95),
+			percentileInt(panes, 99),
+		)
+	}
 	if len(snap.actorQueueLatencies) == 0 {
 		b.WriteString("actor queueing latency: no samples\n")
 	} else {
@@ -155,12 +162,16 @@ func (s *clientFrameStats) format() string {
 	if recentStart < 0 {
 		recentStart = 0
 	}
-	b.WriteString("last 100 frame times (oldest -> newest): ")
-	for i, sample := range snap.samples[recentStart:] {
-		if i > 0 {
-			b.WriteString(", ")
+	if snap.sampleCount == 0 {
+		b.WriteString("last 100 frame times (oldest -> newest): no samples")
+	} else {
+		b.WriteString("last 100 frame times (oldest -> newest): ")
+		for i, sample := range snap.samples[recentStart:] {
+			if i > 0 {
+				b.WriteString(", ")
+			}
+			b.WriteString(sample.frameDuration.String())
 		}
-		b.WriteString(sample.frameDuration.String())
 	}
 	return b.String()
 }

--- a/internal/client/frame_stats.go
+++ b/internal/client/frame_stats.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"slices"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/weill-labs/amux/internal/proto"
@@ -22,6 +23,7 @@ type clientFrameSample struct {
 }
 
 type clientFrameStats struct {
+	mu                   sync.Mutex
 	samples              [clientFrameStatsWindowSize]clientFrameSample
 	next                 int
 	count                int
@@ -38,6 +40,9 @@ type clientFrameStatsSnapshot struct {
 }
 
 func (s *clientFrameStats) record(sample clientFrameSample) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	s.samples[s.next] = sample
 	s.next = (s.next + 1) % len(s.samples)
 	if s.count < len(s.samples) {
@@ -49,6 +54,10 @@ func (s *clientFrameStats) recordActorQueueLatency(latency time.Duration) {
 	if latency < 0 {
 		return
 	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	s.actorQueueLatencies[s.actorQueueNext] = latency
 	s.actorQueueNext = (s.actorQueueNext + 1) % len(s.actorQueueLatencies)
 	if s.actorQueueSampleSize < len(s.actorQueueLatencies) {
@@ -57,6 +66,9 @@ func (s *clientFrameStats) recordActorQueueLatency(latency time.Duration) {
 }
 
 func (s *clientFrameStats) snapshot() clientFrameStatsSnapshot {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	if s.count == 0 && s.actorQueueSampleSize == 0 {
 		return clientFrameStatsSnapshot{}
 	}
@@ -197,7 +209,7 @@ func isDebugFramesClientQuery(args []string) bool {
 	return len(args) == 1 && args[0] == proto.ClientQueryDebugFramesArg
 }
 
-func clientFrameStatsResponse(stats clientFrameStats) *proto.Message {
+func clientFrameStatsResponse(stats *clientFrameStats) *proto.Message {
 	return &proto.Message{
 		Type:      proto.MsgTypeCaptureResponse,
 		CmdOutput: stats.format() + "\n",

--- a/internal/client/frame_stats.go
+++ b/internal/client/frame_stats.go
@@ -22,14 +22,19 @@ type clientFrameSample struct {
 }
 
 type clientFrameStats struct {
-	samples [clientFrameStatsWindowSize]clientFrameSample
-	next    int
-	count   int
+	samples              [clientFrameStatsWindowSize]clientFrameSample
+	next                 int
+	count                int
+	actorQueueLatencies  [clientFrameStatsWindowSize]time.Duration
+	actorQueueNext       int
+	actorQueueSampleSize int
 }
 
 type clientFrameStatsSnapshot struct {
-	sampleCount int
-	samples     []clientFrameSample
+	sampleCount           int
+	samples               []clientFrameSample
+	actorQueueSampleCount int
+	actorQueueLatencies   []time.Duration
 }
 
 func (s *clientFrameStats) record(sample clientFrameSample) {
@@ -40,24 +45,48 @@ func (s *clientFrameStats) record(sample clientFrameSample) {
 	}
 }
 
+func (s *clientFrameStats) recordActorQueueLatency(latency time.Duration) {
+	if latency < 0 {
+		return
+	}
+	s.actorQueueLatencies[s.actorQueueNext] = latency
+	s.actorQueueNext = (s.actorQueueNext + 1) % len(s.actorQueueLatencies)
+	if s.actorQueueSampleSize < len(s.actorQueueLatencies) {
+		s.actorQueueSampleSize++
+	}
+}
+
 func (s *clientFrameStats) snapshot() clientFrameStatsSnapshot {
-	if s.count == 0 {
+	if s.count == 0 && s.actorQueueSampleSize == 0 {
 		return clientFrameStatsSnapshot{}
 	}
 
-	start := s.next - s.count
-	if start < 0 {
-		start += len(s.samples)
+	frameStart := s.next - s.count
+	if frameStart < 0 {
+		frameStart += len(s.samples)
 	}
 
 	out := make([]clientFrameSample, 0, s.count)
 	for i := 0; i < s.count; i++ {
-		idx := (start + i) % len(s.samples)
+		idx := (frameStart + i) % len(s.samples)
 		out = append(out, s.samples[idx])
 	}
+
+	queueStart := s.actorQueueNext - s.actorQueueSampleSize
+	if queueStart < 0 {
+		queueStart += len(s.actorQueueLatencies)
+	}
+
+	queueLatencies := make([]time.Duration, 0, s.actorQueueSampleSize)
+	for i := 0; i < s.actorQueueSampleSize; i++ {
+		idx := (queueStart + i) % len(s.actorQueueLatencies)
+		queueLatencies = append(queueLatencies, s.actorQueueLatencies[idx])
+	}
 	return clientFrameStatsSnapshot{
-		sampleCount: s.count,
-		samples:     out,
+		sampleCount:           s.count,
+		samples:               out,
+		actorQueueSampleCount: s.actorQueueSampleSize,
+		actorQueueLatencies:   queueLatencies,
 	}
 }
 
@@ -100,6 +129,15 @@ func (s *clientFrameStats) format() string {
 		percentileInt(panes, 95),
 		percentileInt(panes, 99),
 	)
+	if len(snap.actorQueueLatencies) == 0 {
+		b.WriteString("actor queueing latency: no samples\n")
+	} else {
+		fmt.Fprintf(&b, "actor queueing latency: p50 %s  p95 %s  p99 %s\n",
+			percentileDuration(snap.actorQueueLatencies, 50),
+			percentileDuration(snap.actorQueueLatencies, 95),
+			percentileDuration(snap.actorQueueLatencies, 99),
+		)
+	}
 
 	recentStart := len(snap.samples) - clientFrameStatsRecentSize
 	if recentStart < 0 {

--- a/internal/client/frame_stats_test.go
+++ b/internal/client/frame_stats_test.go
@@ -42,6 +42,26 @@ func TestClientFrameStatsFormatIncludesPercentilesAndRecentFrames(t *testing.T) 
 	}
 }
 
+func TestClientFrameStatsFormatIncludesActorQueueingLatencyPercentiles(t *testing.T) {
+	t.Parallel()
+
+	var stats clientFrameStats
+	stats.record(clientFrameSample{
+		frameDuration:   time.Millisecond,
+		cellsDiffed:     10,
+		ansiBytes:       100,
+		panesComposited: 1,
+	})
+	for i := 1; i <= 5; i++ {
+		stats.recordActorQueueLatency(time.Duration(i) * time.Millisecond)
+	}
+
+	got := stats.format()
+	if !strings.Contains(got, "actor queueing latency: p50 3ms  p95 5ms  p99 5ms") {
+		t.Fatalf("format missing actor queueing latency percentiles:\n%s", got)
+	}
+}
+
 func TestRenderNowRecordsFrameStats(t *testing.T) {
 	t.Parallel()
 
@@ -92,4 +112,44 @@ func TestHandleCaptureRequestDebugFrames(t *testing.T) {
 			t.Fatalf("debug frames output missing %q:\n%s", want, resp.CmdOutput)
 		}
 	}
+}
+
+func TestRenderCoalescedRecordsActorQueueLatency(t *testing.T) {
+	t.Parallel()
+
+	cr := buildTestRenderer(t)
+	cr.renderFrameInterval = time.Millisecond
+	msgCh := make(chan *RenderMsg, 2)
+	rendered := make(chan struct{}, 1)
+	done := make(chan struct{})
+
+	go func() {
+		cr.RenderCoalesced(msgCh, func(string) {
+			rendered <- struct{}{}
+		})
+		close(done)
+	}()
+
+	if !sendRenderMsg(msgCh, nil, &RenderMsg{
+		Typ:    RenderMsgPaneOutput,
+		PaneID: 1,
+		Data:   []byte("queued output"),
+	}) {
+		t.Fatal("sendRenderMsg returned false")
+	}
+
+	select {
+	case <-rendered:
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("queued pane output did not render")
+	}
+
+	snap := cr.frameStats.snapshot()
+	if snap.actorQueueSampleCount == 0 {
+		t.Fatal("actorQueueSampleCount = 0, want queued message latency sample")
+	}
+
+	msgCh <- &RenderMsg{Typ: RenderMsgExit}
+	close(msgCh)
+	<-done
 }

--- a/internal/client/frame_stats_test.go
+++ b/internal/client/frame_stats_test.go
@@ -62,6 +62,25 @@ func TestClientFrameStatsFormatIncludesActorQueueingLatencyPercentiles(t *testin
 	}
 }
 
+func TestClientFrameStatsFormatIncludesQueueLatencyWithoutFrameSamples(t *testing.T) {
+	t.Parallel()
+
+	var stats clientFrameStats
+	stats.recordActorQueueLatency(2 * time.Millisecond)
+
+	got := stats.format()
+	for _, want := range []string{
+		"samples: 0",
+		"frame duration: no samples",
+		"actor queueing latency: p50 2ms  p95 2ms  p99 2ms",
+		"last 100 frame times (oldest -> newest): no samples",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("format missing %q:\n%s", want, got)
+		}
+	}
+}
+
 func TestRenderNowRecordsFrameStats(t *testing.T) {
 	t.Parallel()
 
@@ -147,6 +166,60 @@ func TestRenderCoalescedRecordsActorQueueLatency(t *testing.T) {
 	snap := cr.frameStats.snapshot()
 	if snap.actorQueueSampleCount == 0 {
 		t.Fatal("actorQueueSampleCount = 0, want queued message latency sample")
+	}
+
+	msgCh <- &RenderMsg{Typ: RenderMsgExit}
+	close(msgCh)
+	<-done
+}
+
+func TestRenderCoalescedPendingMsgQueueLatencyIncludesPriorityRenderTime(t *testing.T) {
+	t.Parallel()
+
+	cr := NewClientRenderer(80, 24)
+	cr.HandleLayout(twoPane80x23())
+	cr.RenderDiff()
+	cr.renderFrameInterval = time.Hour
+	cr.renderPriorityWindow = time.Hour
+	cr.MarkLocalInput()
+
+	msgCh := make(chan *RenderMsg, 4)
+	sendRenderMsg(msgCh, nil, &RenderMsg{Typ: RenderMsgPaneOutput, PaneID: 2, Data: []byte("background")})
+	sendRenderMsg(msgCh, nil, &RenderMsg{Typ: RenderMsgPaneOutput, PaneID: 1, Data: []byte("typed")})
+	reply := make(chan any, 1)
+	sendRenderMsg(msgCh, nil, &RenderMsg{
+		Typ:   RenderMsgLocalAction,
+		Local: func(*ClientRenderer) localRenderResult { return localRenderResult{} },
+		Reply: reply,
+	})
+
+	done := make(chan struct{})
+	firstWrite := true
+	const slowRender = 80 * time.Millisecond
+	go func() {
+		cr.RenderCoalesced(msgCh, func(string) {
+			if firstWrite {
+				firstWrite = false
+				time.Sleep(slowRender)
+			}
+		})
+		close(done)
+	}()
+
+	select {
+	case <-reply:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("pending local action did not run")
+	}
+
+	var maxLatency time.Duration
+	for _, latency := range cr.frameStats.snapshot().actorQueueLatencies {
+		if latency > maxLatency {
+			maxLatency = latency
+		}
+	}
+	if maxLatency < slowRender/2 {
+		t.Fatalf("max actor queue latency = %v, want it to include slow priority render time %v", maxLatency, slowRender)
 	}
 
 	msgCh <- &RenderMsg{Typ: RenderMsgExit}

--- a/internal/client/frame_stats_test.go
+++ b/internal/client/frame_stats_test.go
@@ -32,6 +32,7 @@ func TestClientFrameStatsFormatIncludesPercentilesAndRecentFrames(t *testing.T) 
 		"cells diffed",
 		"ansi bytes emitted",
 		"panes composited",
+		"actor queueing latency",
 		"last 100 frame times (oldest -> newest): 21ms, 22ms",
 		"119ms, 120ms",
 	} {

--- a/internal/client/local_render.go
+++ b/internal/client/local_render.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"os"
+	"time"
 
 	"github.com/weill-labs/amux/internal/config"
 )
@@ -22,6 +23,7 @@ func applyLocalRenderResultDirect(cr *ClientRenderer, result localRenderResult) 
 }
 
 func sendRenderMsg(msgCh chan<- *RenderMsg, stop <-chan struct{}, msg *RenderMsg) bool {
+	stampRenderMsgQueuedAt(msg, time.Now())
 	if stop == nil {
 		msgCh <- msg
 		return true

--- a/internal/client/renderer.go
+++ b/internal/client/renderer.go
@@ -795,7 +795,7 @@ func (r *Renderer) resizeSnapshotEmulators(next *rendererSnapshot, emulators map
 // the live client (main package) and the headless test client.
 func (r *Renderer) HandleCaptureRequest(args []string, agentStatus map[uint32]proto.PaneAgentStatus) *proto.Message {
 	if isDebugFramesClientQuery(args) {
-		return clientFrameStatsResponse(clientFrameStats{})
+		return clientFrameStatsResponse(&clientFrameStats{})
 	}
 	req := caputil.ParseArgs(args)
 	if err := caputil.ValidateScreenRequest(req); err != nil {

--- a/internal/client/renderer_bench_test.go
+++ b/internal/client/renderer_bench_test.go
@@ -527,7 +527,7 @@ func BenchmarkRenderCoalescedForegroundWithNoisyBackground(b *testing.B) {
 	<-done
 
 	if b.N > 0 {
-		b.ReportMetric(float64((foregroundLatency/time.Duration(b.N)).Nanoseconds()), "fg-ns/op")
+		b.ReportMetric(float64((foregroundLatency / time.Duration(b.N)).Nanoseconds()), "fg-ns/op")
 	}
 }
 

--- a/internal/client/renderer_bench_test.go
+++ b/internal/client/renderer_bench_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/weill-labs/amux/internal/config"
 	"github.com/weill-labs/amux/internal/mux"
@@ -453,6 +454,81 @@ func BenchmarkPaneOutputCaptureRefreshBurst(b *testing.B) {
 			r.HandlePaneOutputBatchInfo(items)
 		}
 	})
+}
+
+func BenchmarkRenderCoalescedForegroundWithNoisyBackground(b *testing.B) {
+	const (
+		width              = 160
+		layoutHeight       = 31
+		backgroundMessages = 64
+		payloadVariants    = 256
+	)
+
+	backgroundPayloads := make([][]byte, payloadVariants)
+	foregroundPayloads := make([][]byte, payloadVariants)
+	for i := range payloadVariants {
+		backgroundPayloads[i] = []byte(fmt.Sprintf("\x1b[2;1Hbackground noisy tick %03d", i))
+		foregroundPayloads[i] = []byte(fmt.Sprintf("\x1b[1;1Htyped foreground %03d", i))
+	}
+
+	cr := NewClientRenderer(width, layoutHeight+1)
+	defer cr.renderer.Close()
+	cr.HandleLayout(benchLayoutSnapshot(2, width, layoutHeight))
+	cr.RenderDiff()
+	cr.renderFrameInterval = time.Hour
+	cr.renderPriorityWindow = time.Hour
+
+	msgCh := make(chan *RenderMsg, backgroundMessages+4)
+	rendered := make(chan time.Duration, 4)
+	done := make(chan struct{})
+	var frameStart time.Time
+	go func() {
+		cr.RenderCoalesced(msgCh, func(string) {
+			rendered <- time.Since(frameStart)
+		})
+		close(done)
+	}()
+
+	var foregroundLatency time.Duration
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		cr.MarkLocalInput()
+		frameStart = time.Now()
+		for j := 0; j < backgroundMessages; j++ {
+			msgCh <- &RenderMsg{
+				Typ:    RenderMsgPaneOutput,
+				PaneID: 2,
+				Data:   backgroundPayloads[(i+j)%payloadVariants],
+			}
+		}
+		msgCh <- &RenderMsg{
+			Typ:    RenderMsgPaneOutput,
+			PaneID: 1,
+			Data:   foregroundPayloads[i%payloadVariants],
+		}
+		foregroundLatency += <-rendered
+
+		callLocalRenderAction[struct{}](cr, msgCh, func(*ClientRenderer) localRenderResult {
+			return renderNowResult()
+		})
+		for {
+			select {
+			case <-rendered:
+			default:
+				goto drained
+			}
+		}
+	drained:
+	}
+	b.StopTimer()
+	msgCh <- &RenderMsg{Typ: RenderMsgExit}
+	close(msgCh)
+	<-done
+
+	if b.N > 0 {
+		b.ReportMetric(float64((foregroundLatency/time.Duration(b.N)).Nanoseconds()), "fg-ns/op")
+	}
 }
 
 func BenchmarkCapturePaneRenderSnapshotRender(b *testing.B) {


### PR DESCRIPTION
## Motivation

LAB-1948 removed the per-cell copy amplifier, but foreground typing can still queue behind background pane output because the attached client render loop drains pane output, updates emulator capture state, and composites on one goroutine. This PR takes the narrow follow-up direction from LAB-1955: prioritize the focused pane's post-input output without changing the larger renderer architecture.

## Summary

- Add a foreground-pane priority lane for mixed pane-output batches in the existing client render loop.
- Identify foreground work as output for the current active pane while the recent local-input priority window is active.
- Enforce priority by splitting a mixed batch into active-pane work first, rendering that minimal dirty set immediately, then processing background panes afterward.
- Add actor queueing latency to `amux debug frames`, measured from render-message enqueue to render-loop pickup.
- Guard debug-frame stats with a mutex so forwarded debug-frame requests can safely read while the render loop records samples.
- Add a benchmark for foreground input alongside noisy background output.

## Design summary

The priority lane stays inside the existing renderer actor/render loop. When a coalesced batch contains active-pane output and background-pane output, and the active pane is inside the recent local-input window, the render loop preserves per-pane order but relaxes cross-pane ordering: active-pane messages are applied and rendered first, while background messages remain queued for the next step. This keeps input echo and cursor-only updates ahead of background capture/composite work without introducing worker pools, off-actor snapshots, or a drain/composite split.

Foreground pane identification comes from `Renderer.ActivePaneID()`. Prioritization is gated by `MarkLocalInput()`/`RenderPriorityWindow`, so noisy focused-pane processes do not bypass the frame budget unless they are plausibly responding to local input.

Preserved invariants:

- Per-pane output remains causally ordered.
- Diff-renderer copy-on-write grid semantics are untouched.
- Background panes remain frame-budgeted when no active-pane local-input echo is present.

Carefully relaxed invariant:

- Cross-pane ordering inside one coalesced pane-output batch may be reordered when the active pane has recent local input. This is intentional and limited to perceived-latency-sensitive foreground output.

Deferred LAB-1955 directions for separate PRs:

- Split PTY drain from composite.
- Parallel per-pane compositing.
- Off-actor snapshot serving via copy-on-write grid.

## Baseline numbers

Hardware: AMD EPYC-Milan Processor, Linux (`goos=linux`, `goarch=amd64`). Benchmark: `go test ./internal/client -run '^$' -bench '^BenchmarkRenderCoalescedForegroundWithNoisyBackground$' -benchtime=200ms -count=1`.

| Version | ns/op | foreground latency | B/op | allocs/op |
| --- | ---: | ---: | ---: | ---: |
| Baseline before priority split | 1,021,370 | 579,486 fg-ns/op | 1,361,273 | 302 |
| After priority split | 793,565 | 343,204 fg-ns/op | 1,363,206 | 308 |

Additional after runs with `-benchtime=500ms -count=3` reported `341,463-361,543 fg-ns/op`.

## Testing

- `go test ./internal/client -run 'Test(ClientFrameStatsFormatIncludesPercentilesAndRecentFrames|ClientFrameStatsFormatIncludesActorQueueingLatencyPercentiles|RenderCoalescedRecordsActorQueueLatency|RenderCoalescedPriorityLaneRendersActiveBeforeQueuedBackground)' -count=100`
- `go test -race ./internal/client -count=1`
- `go test ./internal/client -run '^$' -bench '^BenchmarkRenderCoalescedForegroundWithNoisyBackground$' -benchtime=500ms -count=3`
- `go test ./internal/client -run '^$' -bench '^BenchmarkRenderCoalescedForegroundWithNoisyBackground$' -benchtime=200ms -count=1`
- `go test ./... -timeout 120s`
- `make coverage`

## Review focus

- Whether the active-pane gating is narrow enough: active pane plus recent local input only.
- Whether the cross-pane ordering relaxation is acceptable for a coalesced batch.
- Whether the debug-frame queueing metric is named and measured clearly enough for dashboard triage.

Closes LAB-1955
