### PR TITLE
Docs: codify CI-check merge gate and codex-pane idle detection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,6 +81,7 @@ Destructive actions that require user confirmation:
 When troubleshooting spawn or assignment failures, fix the specific problem (clean up duplicate panes, check amux state) rather than restarting orca.
 
 - **Recovery ≠ assignment**: restoring a codex process is a separate action from giving it work. After recovery, leave workers at idle prompts. Only assign specific, user-approved issues.
+- **Detecting when a codex pane finishes**: poll `amux capture` for the **absence** of the `esc to interrupt` line (shown as `Working (Ns • esc to interrupt)` while codex is busy). Do **not** key on the input-box placeholder (`Improve documentation in @filename`) — it is always present, even mid-task, so it false-signals "idle" immediately. Give codex a few seconds to pick up a submitted prompt before the first poll.
 
 ### Working In amux
 
@@ -161,6 +162,8 @@ Use matter-of-fact language. State what the PR does, not how good it is. Avoid v
 After opening a PR, run `scripts/watch-pr-ci.sh` once to wait for its required checks. For later updates to an open PR, prefer `scripts/push-and-watch-ci.sh` instead of bare `git push` so the CI watch step is not skipped.
 
 If CI fails, inspect the failed-check summary and failed-step logs from `scripts/watch-pr-ci.sh`, fix issues that plausibly come from your diff, rerun the relevant local tests, and push again. Repeat up to 3 attempts. If the failure looks flaky or unrelated to your change, say so explicitly with evidence instead of churning.
+
+Confirm the required `test` check actually passed before merging — do not treat the watch script's exit as proof. `scripts/watch-pr-ci.sh` can return a clean "no failed runs" message for a head SHA while `test` is still `pending` (it reports absence of failures, not presence of success). Before `gh pr merge`, run `gh pr checks <PR>` and verify `test` shows `pass` (not `pending`/`fail`).
 
 ### Review Before Done
 


### PR DESCRIPTION
## Motivation

Two operational learnings from the federation-spec session (PR #827 postmortem) that would have prevented near-misses:

1. I nearly merged PR #827 while the required `test` check was still `pending` — `scripts/watch-pr-ci.sh` had exited with a clean "no failed runs returned for head SHA" message. The script reports the *absence of failures*, not the *presence of success*, so a still-pending `test` reads as clean.
2. A watcher polling a codex pane for completion false-fired at 65s because it keyed on the input-box placeholder (`Improve documentation in @filename`), which is always present. The real busy indicator is the `esc to interrupt` line.

## Summary

- **PR CI Ownership**: added a rule to confirm `gh pr checks <PR>` shows `test=pass` before `gh pr merge`, rather than trusting the watch script's exit.
- **Working in amux**: added guidance to detect codex pane completion by polling for the *absence* of `esc to interrupt`, not the placeholder.

## Testing

Docs-only change. No code modified.

## Review focus

Whether the CI-gate wording is accurate to `scripts/watch-pr-ci.sh` behavior, and whether the codex-detection note belongs under the orca/worker bullets or elsewhere.