### PR TITLE
LAB-1958: Resolve remote pane names via ListPanes

### DIFF
--- a/internal/remote/resolve.go
+++ b/internal/remote/resolve.go
@@ -34,9 +34,6 @@ type ResolvePaneIDError struct {
 }
 
 func (e *ResolvePaneIDError) Error() string {
-	if e == nil {
-		return "pane name resolution failed"
-	}
 	if e.Kind == ResolvePaneIDAmbiguous {
 		parts := make([]string, 0, len(e.Matches))
 		for _, match := range e.Matches {
@@ -122,9 +119,6 @@ func bindConnDeadlineToContext(ctx context.Context, conn net.Conn) func() {
 }
 
 func listPanesLayout(msg *proto.Message) (*proto.LayoutSnapshot, error) {
-	if msg == nil {
-		return nil, fmt.Errorf("list panes: nil response")
-	}
 	if msg.Type == proto.MsgTypeCmdResult && msg.CmdErr != "" {
 		return nil, fmt.Errorf("list panes: %s", msg.CmdErr)
 	}

--- a/internal/remote/resolve.go
+++ b/internal/remote/resolve.go
@@ -3,6 +3,7 @@ package remote
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"strings"
@@ -65,7 +66,7 @@ func ResolvePaneID(ctx context.Context, conn net.Conn, session, name string) (ui
 		Type:    proto.MsgTypeListPanes,
 		Session: session,
 	}); err != nil {
-		if ctxErr := ctx.Err(); ctxErr != nil {
+		if ctxErr := contextErrorAfterConnIO(ctx, err); ctxErr != nil {
 			return 0, ctxErr
 		}
 		return 0, fmt.Errorf("list panes: %w", err)
@@ -73,7 +74,7 @@ func ResolvePaneID(ctx context.Context, conn net.Conn, session, name string) (ui
 
 	msg, err := proto.NewReader(conn).ReadMsg()
 	if err != nil {
-		if ctxErr := ctx.Err(); ctxErr != nil {
+		if ctxErr := contextErrorAfterConnIO(ctx, err); ctxErr != nil {
 			return 0, ctxErr
 		}
 		return 0, fmt.Errorf("read list panes response: %w", err)
@@ -116,6 +117,19 @@ func bindConnDeadlineToContext(ctx context.Context, conn net.Conn) func() {
 			_ = conn.SetDeadline(time.Time{})
 		}
 	}
+}
+
+func contextErrorAfterConnIO(ctx context.Context, err error) error {
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return ctxErr
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		if deadline, ok := ctx.Deadline(); ok && !time.Now().Before(deadline) {
+			return context.DeadlineExceeded
+		}
+	}
+	return nil
 }
 
 func listPanesLayout(msg *proto.Message) (*proto.LayoutSnapshot, error) {

--- a/internal/remote/resolve.go
+++ b/internal/remote/resolve.go
@@ -52,9 +52,6 @@ func ResolvePaneID(ctx context.Context, conn net.Conn, session, name string) (ui
 	if conn == nil {
 		return 0, fmt.Errorf("resolve pane name %q: nil connection", name)
 	}
-	if ctx == nil {
-		ctx = context.Background()
-	}
 	if err := ctx.Err(); err != nil {
 		return 0, err
 	}

--- a/internal/remote/resolve.go
+++ b/internal/remote/resolve.go
@@ -106,13 +106,20 @@ func bindConnDeadlineToContext(ctx context.Context, conn net.Conn) func() {
 			touchedDeadline = true
 		}
 	}
+	afterFuncDone := make(chan struct{})
 	stop := context.AfterFunc(ctx, func() {
+		defer close(afterFuncDone)
 		_ = conn.SetDeadline(time.Now())
 	})
 	return func() {
-		if !stop() || touchedDeadline {
-			_ = conn.SetDeadline(time.Time{})
+		if stop() {
+			if touchedDeadline {
+				_ = conn.SetDeadline(time.Time{})
+			}
+			return
 		}
+		<-afterFuncDone
+		_ = conn.SetDeadline(time.Time{})
 	}
 }
 

--- a/internal/remote/resolve.go
+++ b/internal/remote/resolve.go
@@ -1,0 +1,193 @@
+// Package remote contains client-side helpers for amux-to-amux federation.
+package remote
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strings"
+	"time"
+
+	"github.com/weill-labs/amux/internal/proto"
+)
+
+// ResolvePaneIDErrorKind identifies name-resolution failures that callers can
+// handle without string matching.
+type ResolvePaneIDErrorKind string
+
+const (
+	ResolvePaneIDNotFound  ResolvePaneIDErrorKind = "not_found"
+	ResolvePaneIDAmbiguous ResolvePaneIDErrorKind = "ambiguous"
+)
+
+// ResolvePaneIDMatch describes one leaf pane that matched a requested name.
+type ResolvePaneIDMatch struct {
+	ID   uint32
+	Name string
+}
+
+// ResolvePaneIDError reports a typed failure to resolve a pane name.
+type ResolvePaneIDError struct {
+	Name    string
+	Kind    ResolvePaneIDErrorKind
+	Matches []ResolvePaneIDMatch
+}
+
+func (e *ResolvePaneIDError) Error() string {
+	if e == nil {
+		return "pane name resolution failed"
+	}
+	if e.Kind == ResolvePaneIDAmbiguous {
+		parts := make([]string, 0, len(e.Matches))
+		for _, match := range e.Matches {
+			parts = append(parts, fmt.Sprintf("%s#%d", match.Name, match.ID))
+		}
+		return fmt.Sprintf("pane name %q is ambiguous (matches: %s)", e.Name, strings.Join(parts, ", "))
+	}
+	return fmt.Sprintf("pane name %q not found", e.Name)
+}
+
+// ResolvePaneID asks a remote amux server for its current leaf panes and
+// resolves name to the current pane ID. Callers should provide a fresh
+// connection because MsgTypeListPanes is a one-shot request.
+func ResolvePaneID(ctx context.Context, conn net.Conn, session, name string) (uint32, error) {
+	if conn == nil {
+		return 0, fmt.Errorf("resolve pane name %q: nil connection", name)
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return 0, err
+	}
+
+	cleanupDeadline := bindConnDeadlineToContext(ctx, conn)
+	defer cleanupDeadline()
+
+	if err := proto.NewWriter(conn).WriteMsg(&proto.Message{
+		Type:    proto.MsgTypeListPanes,
+		Session: session,
+	}); err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return 0, ctxErr
+		}
+		return 0, fmt.Errorf("list panes: %w", err)
+	}
+
+	msg, err := proto.NewReader(conn).ReadMsg()
+	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return 0, ctxErr
+		}
+		return 0, fmt.Errorf("read list panes response: %w", err)
+	}
+
+	layout, err := listPanesLayout(msg)
+	if err != nil {
+		return 0, err
+	}
+	return ResolvePaneIDFromLayout(layout, name)
+}
+
+// ResolvePaneIDFromLayout resolves name against the leaf panes represented by
+// a LayoutSnapshot. When Windows is populated, every window is searched and the
+// legacy active-window fields are ignored to avoid double-counting panes.
+func ResolvePaneIDFromLayout(layout *proto.LayoutSnapshot, name string) (uint32, error) {
+	matches := matchingLeafPanes(layout, name)
+	switch len(matches) {
+	case 1:
+		return matches[0].ID, nil
+	case 0:
+		return 0, &ResolvePaneIDError{Name: name, Kind: ResolvePaneIDNotFound}
+	default:
+		return 0, &ResolvePaneIDError{Name: name, Kind: ResolvePaneIDAmbiguous, Matches: matches}
+	}
+}
+
+func bindConnDeadlineToContext(ctx context.Context, conn net.Conn) func() {
+	touchedDeadline := false
+	if deadline, ok := ctx.Deadline(); ok {
+		if err := conn.SetDeadline(deadline); err == nil {
+			touchedDeadline = true
+		}
+	}
+	stop := context.AfterFunc(ctx, func() {
+		_ = conn.SetDeadline(time.Now())
+	})
+	return func() {
+		if !stop() || touchedDeadline {
+			_ = conn.SetDeadline(time.Time{})
+		}
+	}
+}
+
+func listPanesLayout(msg *proto.Message) (*proto.LayoutSnapshot, error) {
+	if msg == nil {
+		return nil, fmt.Errorf("list panes: nil response")
+	}
+	if msg.Type == proto.MsgTypeCmdResult && msg.CmdErr != "" {
+		return nil, fmt.Errorf("list panes: %s", msg.CmdErr)
+	}
+	if msg.Type != proto.MsgTypeLayout {
+		return nil, fmt.Errorf("list panes: unexpected response type %d", msg.Type)
+	}
+	if msg.Layout == nil {
+		return nil, fmt.Errorf("list panes: nil layout")
+	}
+	return msg.Layout, nil
+}
+
+func matchingLeafPanes(layout *proto.LayoutSnapshot, name string) []ResolvePaneIDMatch {
+	if layout == nil {
+		return nil
+	}
+
+	var matches []ResolvePaneIDMatch
+	seenLeafID := make(map[uint32]bool)
+	if len(layout.Windows) > 0 {
+		for _, window := range layout.Windows {
+			snapshots := paneSnapshotsByID(window.Panes)
+			for _, paneID := range leafPaneIDs(window.Root, seenLeafID) {
+				if pane, ok := snapshots[paneID]; ok && pane.Name == name {
+					matches = append(matches, ResolvePaneIDMatch{ID: pane.ID, Name: pane.Name})
+				}
+			}
+		}
+		return matches
+	}
+
+	snapshots := paneSnapshotsByID(layout.Panes)
+	for _, paneID := range leafPaneIDs(layout.Root, seenLeafID) {
+		if pane, ok := snapshots[paneID]; ok && pane.Name == name {
+			matches = append(matches, ResolvePaneIDMatch{ID: pane.ID, Name: pane.Name})
+		}
+	}
+	return matches
+}
+
+func paneSnapshotsByID(panes []proto.PaneSnapshot) map[uint32]proto.PaneSnapshot {
+	snapshots := make(map[uint32]proto.PaneSnapshot, len(panes))
+	for _, pane := range panes {
+		snapshots[pane.ID] = pane
+	}
+	return snapshots
+}
+
+func leafPaneIDs(root proto.CellSnapshot, seen map[uint32]bool) []uint32 {
+	var ids []uint32
+	walkLeafPaneIDs(root, seen, &ids)
+	return ids
+}
+
+func walkLeafPaneIDs(cell proto.CellSnapshot, seen map[uint32]bool, ids *[]uint32) {
+	if cell.IsLeaf {
+		if cell.PaneID != 0 && !seen[cell.PaneID] {
+			seen[cell.PaneID] = true
+			*ids = append(*ids, cell.PaneID)
+		}
+		return
+	}
+	for _, child := range cell.Children {
+		walkLeafPaneIDs(child, seen, ids)
+	}
+}

--- a/internal/remote/resolve_test.go
+++ b/internal/remote/resolve_test.go
@@ -1,0 +1,313 @@
+package remote
+
+import (
+	"context"
+	"errors"
+	"net"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/weill-labs/amux/internal/proto"
+)
+
+func TestResolvePaneIDRequestsListPanesAndResolvesFreshName(t *testing.T) {
+	t.Parallel()
+
+	firstID := resolvePaneIDFromOneShotListServer(t, "remote-session", "agent", layoutWithWindows(
+		windowWithPanes(paneDef{id: 10, name: "agent"}),
+	))
+	if firstID != 10 {
+		t.Fatalf("first resolve ID = %d, want 10", firstID)
+	}
+
+	secondID := resolvePaneIDFromOneShotListServer(t, "remote-session", "agent", layoutWithWindows(
+		windowWithPanes(paneDef{id: 20, name: "agent"}),
+	))
+	if secondID != 20 {
+		t.Fatalf("second resolve ID = %d, want 20", secondID)
+	}
+}
+
+func TestResolvePaneIDFromLayout(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		layout  *proto.LayoutSnapshot
+		pane    string
+		wantID  uint32
+		wantErr ResolvePaneIDErrorKind
+	}{
+		{
+			name: "resolves pane in inactive window",
+			layout: layoutWithWindows(
+				windowWithPanes(paneDef{id: 1, name: "local"}),
+				windowWithPanes(paneDef{id: 2, name: "remote"}),
+			),
+			pane:   "remote",
+			wantID: 2,
+		},
+		{
+			name: "ignores pane snapshots outside leaf layout",
+			layout: &proto.LayoutSnapshot{
+				Root:  leafCell(1),
+				Panes: []proto.PaneSnapshot{{ID: 1, Name: "real"}, {ID: 99, Name: "orphan"}},
+			},
+			pane:    "orphan",
+			wantErr: ResolvePaneIDNotFound,
+		},
+		{
+			name: "missing pane",
+			layout: layoutWithWindows(
+				windowWithPanes(paneDef{id: 1, name: "alpha"}),
+			),
+			pane:    "beta",
+			wantErr: ResolvePaneIDNotFound,
+		},
+		{
+			name: "ambiguous pane",
+			layout: layoutWithWindows(
+				windowWithPanes(paneDef{id: 1, name: "same"}, paneDef{id: 2, name: "same"}),
+			),
+			pane:    "same",
+			wantErr: ResolvePaneIDAmbiguous,
+		},
+		{
+			name:    "nil layout",
+			layout:  nil,
+			pane:    "missing",
+			wantErr: ResolvePaneIDNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := ResolvePaneIDFromLayout(tt.layout, tt.pane)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("ResolvePaneIDFromLayout() error = %v, want nil", err)
+				}
+				if got != tt.wantID {
+					t.Fatalf("ResolvePaneIDFromLayout() ID = %d, want %d", got, tt.wantID)
+				}
+				return
+			}
+
+			var resolveErr *ResolvePaneIDError
+			if !errors.As(err, &resolveErr) {
+				t.Fatalf("ResolvePaneIDFromLayout() error = %T %[1]v, want ResolvePaneIDError", err)
+			}
+			if resolveErr.Kind != tt.wantErr {
+				t.Fatalf("ResolvePaneIDError.Kind = %q, want %q", resolveErr.Kind, tt.wantErr)
+			}
+			if resolveErr.Name != tt.pane {
+				t.Fatalf("ResolvePaneIDError.Name = %q, want %q", resolveErr.Name, tt.pane)
+			}
+		})
+	}
+}
+
+func TestResolvePaneIDProtocolErrors(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		response *proto.Message
+		want     string
+	}{
+		{
+			name:     "server command error",
+			response: &proto.Message{Type: proto.MsgTypeCmdResult, CmdErr: "no session"},
+			want:     "no session",
+		},
+		{
+			name:     "unexpected message",
+			response: &proto.Message{Type: proto.MsgTypeNotify, Text: "not a layout"},
+			want:     "unexpected",
+		},
+		{
+			name:     "nil layout response",
+			response: &proto.Message{Type: proto.MsgTypeLayout},
+			want:     "nil layout",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			clientConn, requests := startResolveListServer(t, tt.response)
+			_, err := ResolvePaneID(context.Background(), clientConn, "remote-session", "agent")
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("ResolvePaneID() error = %v, want substring %q", err, tt.want)
+			}
+			assertListPanesRequest(t, <-requests, "remote-session")
+		})
+	}
+}
+
+func TestResolvePaneIDConnectionErrors(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil connection", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := ResolvePaneID(context.Background(), nil, "remote-session", "agent")
+		if err == nil || !strings.Contains(err.Error(), "nil connection") {
+			t.Fatalf("ResolvePaneID(nil) error = %v, want nil connection", err)
+		}
+	})
+
+	t.Run("context canceled before request", func(t *testing.T) {
+		t.Parallel()
+
+		serverConn, clientConn := net.Pipe()
+		t.Cleanup(func() { serverConn.Close() })
+		t.Cleanup(func() { clientConn.Close() })
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		_, err := ResolvePaneID(ctx, clientConn, "remote-session", "agent")
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("ResolvePaneID() error = %v, want context.Canceled", err)
+		}
+	})
+
+	t.Run("read error after request", func(t *testing.T) {
+		t.Parallel()
+
+		clientConn, requests := startResolveListServer(t, nil)
+		_, err := ResolvePaneID(context.Background(), clientConn, "remote-session", "agent")
+		if err == nil {
+			t.Fatal("ResolvePaneID() error = nil, want read error")
+		}
+		assertListPanesRequest(t, <-requests, "remote-session")
+	})
+}
+
+func resolvePaneIDFromOneShotListServer(t *testing.T, session, name string, layout *proto.LayoutSnapshot) uint32 {
+	t.Helper()
+
+	clientConn, requests := startResolveListServer(t, &proto.Message{Type: proto.MsgTypeLayout, Layout: layout})
+	got, err := ResolvePaneID(context.Background(), clientConn, session, name)
+	if err != nil {
+		t.Fatalf("ResolvePaneID() error = %v, want nil", err)
+	}
+	assertListPanesRequest(t, <-requests, session)
+	return got
+}
+
+func startResolveListServer(t *testing.T, response *proto.Message) (net.Conn, <-chan *proto.Message) {
+	t.Helper()
+
+	serverConn, clientConn := net.Pipe()
+	t.Cleanup(func() { clientConn.Close() })
+
+	requests := make(chan *proto.Message, 1)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		defer serverConn.Close()
+
+		_ = serverConn.SetDeadline(time.Now().Add(time.Second))
+		request, err := proto.NewReader(serverConn).ReadMsg()
+		if err == nil {
+			requests <- request
+		}
+		close(requests)
+
+		if response != nil {
+			_ = proto.NewWriter(serverConn).WriteMsg(response)
+		}
+	}()
+
+	t.Cleanup(func() {
+		clientConn.Close()
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+			t.Fatal("list server did not exit")
+		}
+	})
+
+	return clientConn, requests
+}
+
+func assertListPanesRequest(t *testing.T, got *proto.Message, wantSession string) {
+	t.Helper()
+
+	if got == nil {
+		t.Fatal("server received nil request")
+	}
+	if got.Type != proto.MsgTypeListPanes {
+		t.Fatalf("request type = %v, want MsgTypeListPanes", got.Type)
+	}
+	if got.Session != wantSession {
+		t.Fatalf("request session = %q, want %q", got.Session, wantSession)
+	}
+}
+
+type paneDef struct {
+	id   uint32
+	name string
+}
+
+func layoutWithWindows(windows ...proto.WindowSnapshot) *proto.LayoutSnapshot {
+	snap := &proto.LayoutSnapshot{Windows: windows}
+	if len(windows) > 0 {
+		snap.Root = windows[0].Root
+		snap.Panes = append([]proto.PaneSnapshot(nil), windows[0].Panes...)
+	}
+	return snap
+}
+
+func windowWithPanes(panes ...paneDef) proto.WindowSnapshot {
+	snapshots := make([]proto.PaneSnapshot, 0, len(panes))
+	ids := make([]uint32, 0, len(panes))
+	for _, pane := range panes {
+		snapshots = append(snapshots, proto.PaneSnapshot{ID: pane.id, Name: pane.name})
+		ids = append(ids, pane.id)
+	}
+	return proto.WindowSnapshot{Root: rootForLeafIDs(ids...), Panes: snapshots}
+}
+
+func rootForLeafIDs(ids ...uint32) proto.CellSnapshot {
+	if len(ids) == 0 {
+		return proto.CellSnapshot{IsLeaf: true}
+	}
+	if len(ids) == 1 {
+		return leafCell(ids[0])
+	}
+	children := make([]proto.CellSnapshot, 0, len(ids))
+	for _, id := range ids {
+		children = append(children, leafCell(id))
+	}
+	return proto.CellSnapshot{Dir: 1, Children: children}
+}
+
+func leafCell(id uint32) proto.CellSnapshot {
+	return proto.CellSnapshot{IsLeaf: true, Dir: -1, PaneID: id}
+}
+
+func TestRootForLeafIDsHelper(t *testing.T) {
+	t.Parallel()
+
+	got := rootForLeafIDs(1, 2)
+	want := proto.CellSnapshot{
+		Dir: 1,
+		Children: []proto.CellSnapshot{
+			{IsLeaf: true, Dir: -1, PaneID: 1},
+			{IsLeaf: true, Dir: -1, PaneID: 2},
+		},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("rootForLeafIDs() = %+v, want %+v", got, want)
+	}
+}

--- a/internal/remote/resolve_test.go
+++ b/internal/remote/resolve_test.go
@@ -110,6 +110,9 @@ func TestResolvePaneIDFromLayout(t *testing.T) {
 			if !errors.As(err, &resolveErr) {
 				t.Fatalf("ResolvePaneIDFromLayout() error = %T %[1]v, want ResolvePaneIDError", err)
 			}
+			if !strings.Contains(err.Error(), tt.pane) {
+				t.Fatalf("ResolvePaneIDFromLayout() error = %q, want pane name %q", err, tt.pane)
+			}
 			if resolveErr.Kind != tt.wantErr {
 				t.Fatalf("ResolvePaneIDError.Kind = %q, want %q", resolveErr.Kind, tt.wantErr)
 			}
@@ -220,6 +223,22 @@ func TestResolvePaneIDConnectionErrors(t *testing.T) {
 		}
 	})
 
+	t.Run("context deadline during write", func(t *testing.T) {
+		t.Parallel()
+
+		serverConn, clientConn := net.Pipe()
+		t.Cleanup(func() { serverConn.Close() })
+		t.Cleanup(func() { clientConn.Close() })
+
+		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+		defer cancel()
+
+		_, err := ResolvePaneID(ctx, clientConn, "remote-session", "agent")
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("ResolvePaneID() error = %v, want context.DeadlineExceeded", err)
+		}
+	})
+
 	t.Run("read error after request", func(t *testing.T) {
 		t.Parallel()
 
@@ -227,6 +246,20 @@ func TestResolvePaneIDConnectionErrors(t *testing.T) {
 		_, err := ResolvePaneID(context.Background(), clientConn, "remote-session", "agent")
 		if err == nil {
 			t.Fatal("ResolvePaneID() error = nil, want read error")
+		}
+		assertListPanesRequest(t, <-requests, "remote-session")
+	})
+
+	t.Run("context deadline during read", func(t *testing.T) {
+		t.Parallel()
+
+		clientConn, requests := startResolveReadOnlyListServer(t)
+		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+		defer cancel()
+
+		_, err := ResolvePaneID(ctx, clientConn, "remote-session", "agent")
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("ResolvePaneID() error = %v, want context.DeadlineExceeded", err)
 		}
 		assertListPanesRequest(t, <-requests, "remote-session")
 	})
@@ -277,6 +310,40 @@ func startResolveListServer(t *testing.T, response *proto.Message) (net.Conn, <-
 		case <-done:
 		case <-time.After(time.Second):
 			t.Fatal("list server did not exit")
+		}
+	})
+
+	return clientConn, requests
+}
+
+func startResolveReadOnlyListServer(t *testing.T) (net.Conn, <-chan *proto.Message) {
+	t.Helper()
+
+	serverConn, clientConn := net.Pipe()
+	t.Cleanup(func() { clientConn.Close() })
+
+	requests := make(chan *proto.Message, 1)
+	release := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		defer serverConn.Close()
+
+		request, err := proto.NewReader(serverConn).ReadMsg()
+		if err == nil {
+			requests <- request
+		}
+		close(requests)
+		<-release
+	}()
+
+	t.Cleanup(func() {
+		close(release)
+		clientConn.Close()
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+			t.Fatal("read-only list server did not exit")
 		}
 	})
 

--- a/internal/remote/resolve_test.go
+++ b/internal/remote/resolve_test.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"errors"
 	"net"
+	"slices"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -33,11 +35,12 @@ func TestResolvePaneIDFromLayout(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name    string
-		layout  *proto.LayoutSnapshot
-		pane    string
-		wantID  uint32
-		wantErr ResolvePaneIDErrorKind
+		name        string
+		layout      *proto.LayoutSnapshot
+		pane        string
+		wantID      uint32
+		wantErr     ResolvePaneIDErrorKind
+		wantMatches []uint32
 	}{
 		{
 			name: "resolves pane in inactive window",
@@ -79,8 +82,19 @@ func TestResolvePaneIDFromLayout(t *testing.T) {
 			layout: layoutWithWindows(
 				windowWithPanes(paneDef{id: 1, name: "same"}, paneDef{id: 2, name: "same"}),
 			),
-			pane:    "same",
-			wantErr: ResolvePaneIDAmbiguous,
+			pane:        "same",
+			wantErr:     ResolvePaneIDAmbiguous,
+			wantMatches: []uint32{1, 2},
+		},
+		{
+			name: "ambiguous pane across windows",
+			layout: layoutWithWindows(
+				windowWithPanes(paneDef{id: 1, name: "agent"}),
+				windowWithPanes(paneDef{id: 2, name: "agent"}),
+			),
+			pane:        "agent",
+			wantErr:     ResolvePaneIDAmbiguous,
+			wantMatches: []uint32{1, 2},
 		},
 		{
 			name:    "nil layout",
@@ -118,6 +132,10 @@ func TestResolvePaneIDFromLayout(t *testing.T) {
 			}
 			if resolveErr.Name != tt.pane {
 				t.Fatalf("ResolvePaneIDError.Name = %q, want %q", resolveErr.Name, tt.pane)
+			}
+			gotMatches := resolvePaneIDMatchIDs(resolveErr.Matches)
+			if !slices.Equal(gotMatches, tt.wantMatches) {
+				t.Fatalf("ResolvePaneIDError.Matches IDs = %v, want %v", gotMatches, tt.wantMatches)
 			}
 		})
 	}
@@ -246,6 +264,51 @@ func TestResolvePaneIDConnectionErrors(t *testing.T) {
 	})
 }
 
+func TestBindConnDeadlineToContextWaitsForAfterFuncBeforeClearing(t *testing.T) {
+	t.Parallel()
+
+	serverConn, clientConn := net.Pipe()
+	t.Cleanup(func() { serverConn.Close() })
+	t.Cleanup(func() { clientConn.Close() })
+
+	conn := newBlockingDeadlineConn(clientConn)
+	ctx, cancel := context.WithCancel(context.Background())
+	cleanup := bindConnDeadlineToContext(ctx, conn)
+
+	cancel()
+	select {
+	case <-conn.enteredNonZero:
+	case <-time.After(time.Second):
+		t.Fatal("deadline callback did not start")
+	}
+
+	done := make(chan struct{})
+	go func() {
+		cleanup()
+		close(done)
+	}()
+	select {
+	case <-done:
+		t.Fatal("cleanup returned before AfterFunc deadline write finished")
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	close(conn.releaseNonZero)
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("cleanup did not return")
+	}
+
+	deadlines := conn.deadlineSnapshot()
+	if len(deadlines) < 2 {
+		t.Fatalf("SetDeadline calls = %d, want at least 2", len(deadlines))
+	}
+	if !deadlines[len(deadlines)-1].IsZero() {
+		t.Fatalf("final deadline = %v, want cleared deadline", deadlines[len(deadlines)-1])
+	}
+}
+
 func resolvePaneIDFromOneShotListServer(t *testing.T, session, name string, layout *proto.LayoutSnapshot) uint32 {
 	t.Helper()
 
@@ -265,7 +328,6 @@ func startResolveListServer(t *testing.T, response *proto.Message) (net.Conn, <-
 	t.Helper()
 
 	serverConn, clientConn := net.Pipe()
-	t.Cleanup(func() { clientConn.Close() })
 
 	requests := make(chan *proto.Message, 1)
 	done := make(chan struct{})
@@ -301,7 +363,6 @@ func startResolveReadOnlyListServer(t *testing.T) (net.Conn, <-chan *proto.Messa
 	t.Helper()
 
 	serverConn, clientConn := net.Pipe()
-	t.Cleanup(func() { clientConn.Close() })
 
 	requests := make(chan *proto.Message, 1)
 	release := make(chan struct{})
@@ -343,6 +404,49 @@ func assertListPanesRequest(t *testing.T, got *proto.Message, wantSession string
 	if got.Session != wantSession {
 		t.Fatalf("request session = %q, want %q", got.Session, wantSession)
 	}
+}
+
+func resolvePaneIDMatchIDs(matches []ResolvePaneIDMatch) []uint32 {
+	ids := make([]uint32, 0, len(matches))
+	for _, match := range matches {
+		ids = append(ids, match.ID)
+	}
+	return ids
+}
+
+type blockingDeadlineConn struct {
+	net.Conn
+
+	mu             sync.Mutex
+	deadlines      []time.Time
+	enteredNonZero chan struct{}
+	releaseNonZero chan struct{}
+	enterOnce      sync.Once
+}
+
+func newBlockingDeadlineConn(conn net.Conn) *blockingDeadlineConn {
+	return &blockingDeadlineConn{
+		Conn:           conn,
+		enteredNonZero: make(chan struct{}),
+		releaseNonZero: make(chan struct{}),
+	}
+}
+
+func (c *blockingDeadlineConn) SetDeadline(deadline time.Time) error {
+	if !deadline.IsZero() {
+		c.enterOnce.Do(func() { close(c.enteredNonZero) })
+		<-c.releaseNonZero
+	}
+	c.mu.Lock()
+	c.deadlines = append(c.deadlines, deadline)
+	c.mu.Unlock()
+	return nil
+}
+
+func (c *blockingDeadlineConn) deadlineSnapshot() []time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]time.Time(nil), c.deadlines...)
 }
 
 type paneDef struct {

--- a/internal/remote/resolve_test.go
+++ b/internal/remote/resolve_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"net"
-	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -48,6 +47,15 @@ func TestResolvePaneIDFromLayout(t *testing.T) {
 			),
 			pane:   "remote",
 			wantID: 2,
+		},
+		{
+			name: "resolves pane in legacy layout",
+			layout: &proto.LayoutSnapshot{
+				Root:  leafCell(7),
+				Panes: []proto.PaneSnapshot{{ID: 7, Name: "legacy"}},
+			},
+			pane:   "legacy",
+			wantID: 7,
 		},
 		{
 			name: "ignores pane snapshots outside leaf layout",
@@ -180,6 +188,38 @@ func TestResolvePaneIDConnectionErrors(t *testing.T) {
 		}
 	})
 
+	t.Run("nil context uses background", func(t *testing.T) {
+		t.Parallel()
+
+		clientConn, requests := startResolveListServer(t, &proto.Message{
+			Type: proto.MsgTypeLayout,
+			Layout: layoutWithWindows(
+				windowWithPanes(paneDef{id: 11, name: "agent"}),
+			),
+		})
+		got, err := ResolvePaneID(nil, clientConn, "remote-session", "agent")
+		if err != nil {
+			t.Fatalf("ResolvePaneID() error = %v, want nil", err)
+		}
+		if got != 11 {
+			t.Fatalf("ResolvePaneID() ID = %d, want 11", got)
+		}
+		assertListPanesRequest(t, <-requests, "remote-session")
+	})
+
+	t.Run("write error before request", func(t *testing.T) {
+		t.Parallel()
+
+		serverConn, clientConn := net.Pipe()
+		serverConn.Close()
+		clientConn.Close()
+
+		_, err := ResolvePaneID(context.Background(), clientConn, "remote-session", "agent")
+		if err == nil || !strings.Contains(err.Error(), "list panes") {
+			t.Fatalf("ResolvePaneID() error = %v, want list panes write error", err)
+		}
+	})
+
 	t.Run("read error after request", func(t *testing.T) {
 		t.Parallel()
 
@@ -196,7 +236,10 @@ func resolvePaneIDFromOneShotListServer(t *testing.T, session, name string, layo
 	t.Helper()
 
 	clientConn, requests := startResolveListServer(t, &proto.Message{Type: proto.MsgTypeLayout, Layout: layout})
-	got, err := ResolvePaneID(context.Background(), clientConn, session, name)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	got, err := ResolvePaneID(ctx, clientConn, session, name)
 	if err != nil {
 		t.Fatalf("ResolvePaneID() error = %v, want nil", err)
 	}
@@ -294,20 +337,4 @@ func rootForLeafIDs(ids ...uint32) proto.CellSnapshot {
 
 func leafCell(id uint32) proto.CellSnapshot {
 	return proto.CellSnapshot{IsLeaf: true, Dir: -1, PaneID: id}
-}
-
-func TestRootForLeafIDsHelper(t *testing.T) {
-	t.Parallel()
-
-	got := rootForLeafIDs(1, 2)
-	want := proto.CellSnapshot{
-		Dir: 1,
-		Children: []proto.CellSnapshot{
-			{IsLeaf: true, Dir: -1, PaneID: 1},
-			{IsLeaf: true, Dir: -1, PaneID: 2},
-		},
-	}
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("rootForLeafIDs() = %+v, want %+v", got, want)
-	}
 }

--- a/internal/remote/resolve_test.go
+++ b/internal/remote/resolve_test.go
@@ -191,25 +191,6 @@ func TestResolvePaneIDConnectionErrors(t *testing.T) {
 		}
 	})
 
-	t.Run("nil context uses background", func(t *testing.T) {
-		t.Parallel()
-
-		clientConn, requests := startResolveListServer(t, &proto.Message{
-			Type: proto.MsgTypeLayout,
-			Layout: layoutWithWindows(
-				windowWithPanes(paneDef{id: 11, name: "agent"}),
-			),
-		})
-		got, err := ResolvePaneID(nil, clientConn, "remote-session", "agent")
-		if err != nil {
-			t.Fatalf("ResolvePaneID() error = %v, want nil", err)
-		}
-		if got != 11 {
-			t.Fatalf("ResolvePaneID() ID = %d, want 11", got)
-		}
-		assertListPanesRequest(t, <-requests, "remote-session")
-	})
-
 	t.Run("write error before request", func(t *testing.T) {
 		t.Parallel()
 


### PR DESCRIPTION
## Motivation

Federation stores remote pane names as the durable handle, but `MsgTypeAttachPane` remains ID-only. This adds the local bridge that lists a remote server's current leaf panes and resolves a pane name to the current pane ID before attach/reconnect code exists.

## Summary

- Add `internal/remote.ResolvePaneID` to issue `MsgTypeListPanes` over a fresh connection and resolve the returned layout by exact pane name.
- Add `ResolvePaneIDFromLayout` plus typed missing/ambiguous name errors for future MirrorManager callers.
- Walk layout leaves across multi-window snapshots and ignore orphan pane snapshots not present in the layout tree.
- Preserve the existing wire format; no `MsgTypeAttachPane`, `PaneOutput`, or `PaneHistory` changes.

## Testing

- `go test ./internal/remote -run 'TestResolvePaneID' -count=100`
- `go test ./internal/remote -cover`
- `go test ./internal/server -run 'TestMsgTypeListPanes|TestMsgTypeAttachPane'`
- `go test ./... -timeout 120s` failed locally in existing clipboard-over-nested-SSH integration tests: `TestCopyModeClipboardUsesOSC52WhenInnerClientRunsOverSSH` and `TestCopyModeClipboardUsesTmuxPassthroughWhenInnerClientRunsOverSSHInTmux`. Rerunning that failed slice reproduced the same OSC52/clipboard timeout failures; this PR only touches `internal/remote`.

## Review focus

- Whether `internal/remote` is the right package boundary for the foundation helper before the later Link/MirrorManager work.
- The exact-name matching semantics and typed error surface for missing/ambiguous pane names.
- The choice to derive resolvable panes from layout leaves rather than trusting every `PaneSnapshot` entry.

Closes LAB-1958
