### PR TITLE
LAB-1957: Add remote link foundation

### DIFF
--- a/internal/cli/cli_doctor_health_test.go
+++ b/internal/cli/cli_doctor_health_test.go
@@ -201,6 +201,30 @@ func TestRunDoctorNamedChecksReportExpectedSeverities(t *testing.T) {
 	}
 }
 
+func TestDoctorConfigCheckFailsOnMalformedRemoteHost(t *testing.T) {
+	t.Parallel()
+
+	deps := newHealthyDoctorDeps(t, "unit")
+	configPath := deps.configPath()
+	content := `
+[remote.hosts.hetzner-1]
+ssh = "cweill@100.115.94.1"
+session = "main"
+`
+	if err := os.WriteFile(configPath, []byte(content), 0600); err != nil {
+		t.Fatalf("WriteFile(%q): %v", configPath, err)
+	}
+
+	report := runDoctor(context.Background(), "unit", doctorOptions{checkName: "config"}, deps)
+	if report.Overall != doctorStatusFail {
+		t.Fatalf("overall = %s, want fail\n%+v", report.Overall, report.Checks)
+	}
+	check := report.Checks[0]
+	if !strings.Contains(check.Hint, "remote.hosts.hetzner-1.socket_path is required") {
+		t.Fatalf("config hint = %q, want remote host validation error", check.Hint)
+	}
+}
+
 func TestDoctorSocketCheckFailsOnOwnerMismatch(t *testing.T) {
 	t.Parallel()
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
+	"strings"
 
 	"github.com/BurntSushi/toml"
 	"github.com/weill-labs/amux/internal/proto"
@@ -319,14 +321,21 @@ func (c *Config) EffectiveThemeIcons() string {
 }
 
 func ValidateRemoteHosts(hosts map[string]Host) error {
-	for name, host := range hosts {
-		if host.SSH == "" {
+	names := make([]string, 0, len(hosts))
+	for name := range hosts {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	for _, name := range names {
+		host := hosts[name]
+		if strings.TrimSpace(host.SSH) == "" {
 			return fmt.Errorf("remote.hosts.%s.ssh is required", name)
 		}
-		if host.Session == "" {
+		if strings.TrimSpace(host.Session) == "" {
 			return fmt.Errorf("remote.hosts.%s.session is required", name)
 		}
-		if host.SocketPath == "" {
+		if strings.TrimSpace(host.SocketPath) == "" {
 			return fmt.Errorf("remote.hosts.%s.socket_path is required", name)
 		}
 		if !filepath.IsAbs(host.SocketPath) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -111,12 +111,23 @@ type ThemeConfig struct {
 	Icons       *string `toml:"icons"`
 }
 
+type RemoteConfig struct {
+	Hosts map[string]Host `toml:"hosts"`
+}
+
+type Host struct {
+	SSH        string `toml:"ssh"`
+	Session    string `toml:"session"`
+	SocketPath string `toml:"socket_path"`
+}
+
 // Config is the top-level amux configuration.
 type Config struct {
 	ScrollbackLines *int         `toml:"scrollback_lines"`
 	Debug           DebugConfig  `toml:"debug"`
 	Client          ClientConfig `toml:"client"`
 	Theme           ThemeConfig  `toml:"theme"`
+	Remote          RemoteConfig `toml:"remote"`
 }
 
 // DefaultPath returns the default config file path.
@@ -166,6 +177,9 @@ func parseConfig(data []byte) (*Config, error) {
 		return nil, err
 	}
 	if _, err := ResolveThemeIcons(cfg.Theme.Icons); err != nil {
+		return nil, err
+	}
+	if err := ValidateRemoteHosts(cfg.Remote.Hosts); err != nil {
 		return nil, err
 	}
 
@@ -302,4 +316,22 @@ func (c *Config) EffectiveThemeIcons() string {
 		return ThemeIconsUnicode
 	}
 	return icons
+}
+
+func ValidateRemoteHosts(hosts map[string]Host) error {
+	for name, host := range hosts {
+		if host.SSH == "" {
+			return fmt.Errorf("remote.hosts.%s.ssh is required", name)
+		}
+		if host.Session == "" {
+			return fmt.Errorf("remote.hosts.%s.session is required", name)
+		}
+		if host.SocketPath == "" {
+			return fmt.Errorf("remote.hosts.%s.socket_path is required", name)
+		}
+		if !filepath.IsAbs(host.SocketPath) {
+			return fmt.Errorf("remote.hosts.%s.socket_path must be absolute", name)
+		}
+	}
+	return nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -329,16 +329,21 @@ func ValidateRemoteHosts(hosts map[string]Host) error {
 
 	for _, name := range names {
 		host := hosts[name]
-		if strings.TrimSpace(host.SSH) == "" {
+		ssh := strings.TrimSpace(host.SSH)
+		socketPath := strings.TrimSpace(host.SocketPath)
+		if ssh == "" {
 			return fmt.Errorf("remote.hosts.%s.ssh is required", name)
+		}
+		if strings.HasPrefix(ssh, "-") {
+			return fmt.Errorf("remote.hosts.%s.ssh must not start with '-'", name)
 		}
 		if strings.TrimSpace(host.Session) == "" {
 			return fmt.Errorf("remote.hosts.%s.session is required", name)
 		}
-		if strings.TrimSpace(host.SocketPath) == "" {
+		if socketPath == "" {
 			return fmt.Errorf("remote.hosts.%s.socket_path is required", name)
 		}
-		if !filepath.IsAbs(host.SocketPath) {
+		if !filepath.IsAbs(socketPath) {
 			return fmt.Errorf("remote.hosts.%s.socket_path must be absolute", name)
 		}
 	}

--- a/internal/config/config_fuzz_test.go
+++ b/internal/config/config_fuzz_test.go
@@ -23,6 +23,8 @@ func FuzzParseConfig(f *testing.F) {
 		[]byte("[theme]\nicons = \"unicode\"\n"),
 		[]byte("[theme]\nicons = \"powerline\"\n"),
 		[]byte("[theme]\nicons = \"\"\n"),
+		[]byte("[remote.hosts.dev]\nssh = \"cweill@example.test\"\nsession = \"main\"\nsocket_path = \"/tmp/amux-1000/main\"\n"),
+		[]byte("[remote.hosts.dev]\nssh = \"cweill@example.test\"\nsession = \"main\"\n"),
 		[]byte("scrollback_lines = 0\n"),
 		[]byte("[keys]\nprefix = \"C-b\"\n"),
 		[]byte("[keys.bind]\ns = \"split\"\n"),
@@ -66,5 +68,8 @@ func assertParsedConfigValid(t *testing.T, cfg *Config) {
 	}
 	if _, err := ResolveThemeIcons(cfg.Theme.Icons); err != nil {
 		t.Fatalf("theme.icons did not validate after parse: %v", err)
+	}
+	if err := ValidateRemoteHosts(cfg.Remote.Hosts); err != nil {
+		t.Fatalf("remote hosts did not validate after parse: %v", err)
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -406,6 +406,16 @@ socket_path = "/tmp/amux-1000/main"
 			wantErr: `remote.hosts.hetzner-1.session is required`,
 		},
 		{
+			name: "ssh starts with dash",
+			content: `
+[remote.hosts.hetzner-1]
+ssh = "-o ProxyCommand=malicious"
+session = "main"
+socket_path = "/tmp/amux-1000/main"
+`,
+			wantErr: `remote.hosts.hetzner-1.ssh must not start with '-'`,
+		},
+		{
 			name: "missing socket path",
 			content: `
 [remote.hosts.hetzner-1]
@@ -424,6 +434,16 @@ socket_path = "amux-main"
 `,
 			wantErr: `remote.hosts.hetzner-1.socket_path must be absolute`,
 		},
+		{
+			name: "trimmed absolute socket path",
+			content: `
+[remote.hosts.hetzner-1]
+ssh = "cweill@100.115.94.1"
+session = "main"
+socket_path = " /tmp/amux-1000/main "
+`,
+			wantErr: "",
+		},
 	}
 
 	for _, tt := range tests {
@@ -438,6 +458,12 @@ socket_path = "amux-main"
 			}
 
 			_, err := Load(path)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("Load() error = %v, want nil", err)
+				}
+				return
+			}
 			if err == nil || err.Error() != tt.wantErr {
 				t.Fatalf("Load() error = %v, want %q", err, tt.wantErr)
 			}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -111,6 +111,41 @@ status_style = "powerline"
 	}
 }
 
+func TestLoadRemoteHosts(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	content := `
+[remote.hosts.hetzner-1]
+ssh = "cweill@100.115.94.1"
+session = "main"
+socket_path = "/tmp/amux-1000/main"
+`
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	host, ok := cfg.Remote.Hosts["hetzner-1"]
+	if !ok {
+		t.Fatalf("Remote.Hosts missing hetzner-1: %+v", cfg.Remote.Hosts)
+	}
+	if host.SSH != "cweill@100.115.94.1" {
+		t.Fatalf("host.SSH = %q, want configured target", host.SSH)
+	}
+	if host.Session != "main" {
+		t.Fatalf("host.Session = %q, want main", host.Session)
+	}
+	if host.SocketPath != "/tmp/amux-1000/main" {
+		t.Fatalf("host.SocketPath = %q, want configured socket path", host.SocketPath)
+	}
+}
+
 func TestEffectiveStatusStyleDefaultsToCompact(t *testing.T) {
 	t.Parallel()
 
@@ -339,6 +374,72 @@ s = "split"
 			}
 			if got, want := err.Error(), tt.wantErr; got != want {
 				t.Fatalf("Load() error = %q, want %q", got, want)
+			}
+		})
+	}
+}
+
+func TestLoadRejectsInvalidRemoteHosts(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		content string
+		wantErr string
+	}{
+		{
+			name: "missing ssh target",
+			content: `
+[remote.hosts.hetzner-1]
+session = "main"
+socket_path = "/tmp/amux-1000/main"
+`,
+			wantErr: `remote.hosts.hetzner-1.ssh is required`,
+		},
+		{
+			name: "missing session",
+			content: `
+[remote.hosts.hetzner-1]
+ssh = "cweill@100.115.94.1"
+socket_path = "/tmp/amux-1000/main"
+`,
+			wantErr: `remote.hosts.hetzner-1.session is required`,
+		},
+		{
+			name: "missing socket path",
+			content: `
+[remote.hosts.hetzner-1]
+ssh = "cweill@100.115.94.1"
+session = "main"
+`,
+			wantErr: `remote.hosts.hetzner-1.socket_path is required`,
+		},
+		{
+			name: "relative socket path",
+			content: `
+[remote.hosts.hetzner-1]
+ssh = "cweill@100.115.94.1"
+session = "main"
+socket_path = "amux-main"
+`,
+			wantErr: `remote.hosts.hetzner-1.socket_path must be absolute`,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			dir := t.TempDir()
+			path := filepath.Join(dir, "config.toml")
+			if err := os.WriteFile(path, []byte(tt.content), 0644); err != nil {
+				t.Fatalf("WriteFile: %v", err)
+			}
+
+			_, err := Load(path)
+			if err == nil || err.Error() != tt.wantErr {
+				t.Fatalf("Load() error = %v, want %q", err, tt.wantErr)
 			}
 		})
 	}

--- a/internal/remote/link.go
+++ b/internal/remote/link.go
@@ -23,10 +23,11 @@ type Link struct {
 	host   config.Host
 	dialer Dialer
 
-	mu     sync.Mutex
-	conn   net.Conn
-	reader *proto.Reader
-	writer *proto.Writer
+	mu      sync.Mutex
+	writeMu sync.Mutex
+	conn    net.Conn
+	reader  *proto.Reader
+	writer  *proto.Writer
 }
 
 func NewLink(host config.Host, dialer Dialer) *Link {
@@ -40,6 +41,13 @@ func (l *Link) Connect(ctx context.Context) error {
 	if l == nil {
 		return errors.New("remote link is nil")
 	}
+	l.mu.Lock()
+	if l.conn != nil {
+		l.mu.Unlock()
+		return errors.New("remote link already connected")
+	}
+	l.mu.Unlock()
+
 	conn, err := l.dialer.Dial(ctx, l.host)
 	if err != nil {
 		return err
@@ -68,6 +76,9 @@ func (l *Link) ReadMsg() (*proto.Message, error) {
 }
 
 func (l *Link) WriteMsg(msg *proto.Message) error {
+	l.writeMu.Lock()
+	defer l.writeMu.Unlock()
+
 	l.mu.Lock()
 	writer := l.writer
 	l.mu.Unlock()

--- a/internal/remote/link.go
+++ b/internal/remote/link.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"os"
 	"os/exec"
+	"strings"
 	"sync"
 	"time"
 
@@ -146,20 +147,30 @@ func (p RetryPolicy) Delay(attempt int) time.Duration {
 
 type SSHDialer struct{}
 
+const (
+	sshCloseGrace = 2 * time.Second
+	sshKillWait   = 500 * time.Millisecond
+)
+
 func (SSHDialer) Dial(ctx context.Context, host config.Host) (net.Conn, error) {
-	if host.SSH == "" {
+	sshTarget := strings.TrimSpace(host.SSH)
+	socketPath := strings.TrimSpace(host.SocketPath)
+	if sshTarget == "" {
 		return nil, errors.New("ssh target is required")
 	}
-	if host.SocketPath == "" {
+	if strings.HasPrefix(sshTarget, "-") {
+		return nil, errors.New("ssh target must not start with '-'")
+	}
+	if socketPath == "" {
 		return nil, errors.New("socket path is required")
 	}
 
 	cmdCtx, cancel := context.WithCancel(ctx)
 	cmd := exec.CommandContext(cmdCtx, "ssh",
 		"-o", "BatchMode=yes",
-		host.SSH,
+		sshTarget,
 		"--",
-		"nc", "-U", host.SocketPath,
+		"nc", "-U", socketPath,
 	)
 	stdin, err := cmd.StdinPipe()
 	if err != nil {
@@ -213,19 +224,42 @@ func (c *commandConn) Write(p []byte) (int, error) {
 }
 
 func (c *commandConn) Close() error {
+	return c.closeWithTimeout(sshCloseGrace, sshKillWait)
+}
+
+func (c *commandConn) closeWithTimeout(grace, killWait time.Duration) error {
 	c.closeOnce.Do(func() {
-		_ = c.stdin.Close()
+		if c.cancel != nil {
+			defer c.cancel()
+		}
+		if c.stdin != nil {
+			_ = c.stdin.Close()
+		}
+		graceTimer := time.NewTimer(grace)
+		defer graceTimer.Stop()
+
 		select {
 		case err := <-c.waitCh:
 			c.closeErr = acceptableWaitErr(err)
-		case <-time.After(2 * time.Second):
-			c.cancel()
+		case <-graceTimer.C:
+			if c.cancel != nil {
+				c.cancel()
+			}
 			if c.cmd != nil && c.cmd.Process != nil {
 				_ = c.cmd.Process.Kill()
 			}
-			c.closeErr = acceptableWaitErr(<-c.waitCh)
+			killTimer := time.NewTimer(killWait)
+			defer killTimer.Stop()
+			select {
+			case err := <-c.waitCh:
+				c.closeErr = acceptableWaitErr(err)
+			case <-killTimer.C:
+				c.closeErr = errors.New("waiting for ssh process after kill: timeout")
+			}
 		}
-		_ = c.stdout.Close()
+		if c.stdout != nil {
+			_ = c.stdout.Close()
+		}
 	})
 	return c.closeErr
 }

--- a/internal/remote/link.go
+++ b/internal/remote/link.go
@@ -1,0 +1,257 @@
+package remote
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"os/exec"
+	"sync"
+	"time"
+
+	"github.com/weill-labs/amux/internal/config"
+	"github.com/weill-labs/amux/internal/proto"
+)
+
+type Dialer interface {
+	Dial(context.Context, config.Host) (net.Conn, error)
+}
+
+type Link struct {
+	host   config.Host
+	dialer Dialer
+
+	mu     sync.Mutex
+	conn   net.Conn
+	reader *proto.Reader
+	writer *proto.Writer
+}
+
+func NewLink(host config.Host, dialer Dialer) *Link {
+	if dialer == nil {
+		dialer = SSHDialer{}
+	}
+	return &Link{host: host, dialer: dialer}
+}
+
+func (l *Link) Connect(ctx context.Context) error {
+	if l == nil {
+		return errors.New("remote link is nil")
+	}
+	conn, err := l.dialer.Dial(ctx, l.host)
+	if err != nil {
+		return err
+	}
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.conn != nil {
+		_ = conn.Close()
+		return errors.New("remote link already connected")
+	}
+	l.conn = conn
+	l.reader = proto.NewReader(conn)
+	l.writer = proto.NewWriter(conn)
+	return nil
+}
+
+func (l *Link) ReadMsg() (*proto.Message, error) {
+	l.mu.Lock()
+	reader := l.reader
+	l.mu.Unlock()
+	if reader == nil {
+		return nil, net.ErrClosed
+	}
+	return reader.ReadMsg()
+}
+
+func (l *Link) WriteMsg(msg *proto.Message) error {
+	l.mu.Lock()
+	writer := l.writer
+	l.mu.Unlock()
+	if writer == nil {
+		return net.ErrClosed
+	}
+	return writer.WriteMsg(msg)
+}
+
+func (l *Link) Close() error {
+	if l == nil {
+		return nil
+	}
+	l.mu.Lock()
+	conn := l.conn
+	l.conn = nil
+	l.reader = nil
+	l.writer = nil
+	l.mu.Unlock()
+	if conn == nil {
+		return nil
+	}
+	return conn.Close()
+}
+
+type RetryPolicy struct {
+	MaxAttempts    int
+	InitialBackoff time.Duration
+	MaxBackoff     time.Duration
+}
+
+func DefaultRetryPolicy() RetryPolicy {
+	return RetryPolicy{
+		MaxAttempts:    5,
+		InitialBackoff: time.Second,
+		MaxBackoff:     30 * time.Second,
+	}
+}
+
+func (p RetryPolicy) Delay(attempt int) time.Duration {
+	if attempt < 1 {
+		attempt = 1
+	}
+	initial := p.InitialBackoff
+	if initial <= 0 {
+		initial = time.Second
+	}
+	maxDelay := p.MaxBackoff
+	if maxDelay <= 0 {
+		maxDelay = 30 * time.Second
+	}
+
+	delay := initial
+	for i := 1; i < attempt; i++ {
+		if delay >= maxDelay/2 {
+			return maxDelay
+		}
+		delay *= 2
+	}
+	if delay > maxDelay {
+		return maxDelay
+	}
+	return delay
+}
+
+type SSHDialer struct{}
+
+func (SSHDialer) Dial(ctx context.Context, host config.Host) (net.Conn, error) {
+	if host.SSH == "" {
+		return nil, errors.New("ssh target is required")
+	}
+	if host.SocketPath == "" {
+		return nil, errors.New("socket path is required")
+	}
+
+	cmdCtx, cancel := context.WithCancel(ctx)
+	cmd := exec.CommandContext(cmdCtx, "ssh",
+		"-o", "BatchMode=yes",
+		host.SSH,
+		"--",
+		"nc", "-U", host.SocketPath,
+	)
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		cancel()
+		return nil, fmt.Errorf("opening ssh stdin: %w", err)
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		cancel()
+		_ = stdin.Close()
+		return nil, fmt.Errorf("opening ssh stdout: %w", err)
+	}
+	if err := cmd.Start(); err != nil {
+		cancel()
+		_ = stdin.Close()
+		_ = stdout.Close()
+		return nil, fmt.Errorf("starting ssh: %w", err)
+	}
+
+	waitCh := make(chan error, 1)
+	go func() {
+		waitCh <- cmd.Wait()
+	}()
+
+	return &commandConn{
+		cmd:    cmd,
+		cancel: cancel,
+		stdin:  stdin,
+		stdout: stdout,
+		waitCh: waitCh,
+	}, nil
+}
+
+type commandConn struct {
+	cmd    *exec.Cmd
+	cancel context.CancelFunc
+	stdin  io.WriteCloser
+	stdout io.ReadCloser
+	waitCh <-chan error
+
+	closeOnce sync.Once
+	closeErr  error
+}
+
+func (c *commandConn) Read(p []byte) (int, error) {
+	return c.stdout.Read(p)
+}
+
+func (c *commandConn) Write(p []byte) (int, error) {
+	return c.stdin.Write(p)
+}
+
+func (c *commandConn) Close() error {
+	c.closeOnce.Do(func() {
+		_ = c.stdin.Close()
+		select {
+		case err := <-c.waitCh:
+			c.closeErr = acceptableWaitErr(err)
+		case <-time.After(2 * time.Second):
+			c.cancel()
+			if c.cmd != nil && c.cmd.Process != nil {
+				_ = c.cmd.Process.Kill()
+			}
+			c.closeErr = acceptableWaitErr(<-c.waitCh)
+		}
+		_ = c.stdout.Close()
+	})
+	return c.closeErr
+}
+
+func acceptableWaitErr(err error) error {
+	if err == nil {
+		return nil
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		return nil
+	}
+	return err
+}
+
+func (c *commandConn) LocalAddr() net.Addr {
+	return sshAddr("local")
+}
+
+func (c *commandConn) RemoteAddr() net.Addr {
+	return sshAddr("remote")
+}
+
+func (c *commandConn) SetDeadline(time.Time) error {
+	return os.ErrInvalid
+}
+
+func (c *commandConn) SetReadDeadline(time.Time) error {
+	return os.ErrInvalid
+}
+
+func (c *commandConn) SetWriteDeadline(time.Time) error {
+	return os.ErrInvalid
+}
+
+type sshAddr string
+
+func (a sshAddr) Network() string { return "ssh" }
+
+func (a sshAddr) String() string { return string(a) }

--- a/internal/remote/link_test.go
+++ b/internal/remote/link_test.go
@@ -35,6 +35,13 @@ func TestDefaultRetryPolicyDelays(t *testing.T) {
 	if got := policy.Delay(10); got != 30*time.Second {
 		t.Fatalf("Delay(10) = %v, want cap 30s", got)
 	}
+	custom := RetryPolicy{InitialBackoff: 0, MaxBackoff: 3 * time.Second}
+	if got := custom.Delay(0); got != time.Second {
+		t.Fatalf("custom Delay(0) = %v, want default initial 1s", got)
+	}
+	if got := (RetryPolicy{}).Delay(3); got != 4*time.Second {
+		t.Fatalf("zero-value Delay(3) = %v, want defaulted 4s", got)
+	}
 }
 
 func TestLinkConnectsWithInjectedDialer(t *testing.T) {
@@ -89,6 +96,51 @@ func TestLinkConnectSurfacesDialerError(t *testing.T) {
 	link := NewLink(config.Host{SSH: "test", Session: "main", SocketPath: "/tmp/amux-test"}, errorDialer{err: dialErr})
 	if err := link.Connect(context.Background()); !errors.Is(err, dialErr) {
 		t.Fatalf("Connect() error = %v, want %v", err, dialErr)
+	}
+}
+
+func TestLinkClosedState(t *testing.T) {
+	t.Parallel()
+
+	var nilLink *Link
+	if err := nilLink.Close(); err != nil {
+		t.Fatalf("nil Close() = %v, want nil", err)
+	}
+	if err := nilLink.Connect(context.Background()); err == nil {
+		t.Fatal("nil Connect() error = nil, want error")
+	}
+
+	link := NewLink(config.Host{SSH: "test", Session: "main", SocketPath: "/tmp/amux-test"}, nil)
+	if err := link.WriteMsg(&proto.Message{Type: proto.MsgTypeNotify}); !errors.Is(err, net.ErrClosed) {
+		t.Fatalf("WriteMsg before Connect = %v, want net.ErrClosed", err)
+	}
+	if _, err := link.ReadMsg(); !errors.Is(err, net.ErrClosed) {
+		t.Fatalf("ReadMsg before Connect = %v, want net.ErrClosed", err)
+	}
+}
+
+func TestSSHDialerRejectsMissingRequiredFields(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		host config.Host
+		want string
+	}{
+		{name: "ssh", host: config.Host{SocketPath: "/tmp/amux-test"}, want: "ssh target is required"},
+		{name: "socket", host: config.Host{SSH: "cweill@example.test"}, want: "socket path is required"},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := (SSHDialer{}).Dial(context.Background(), tt.host)
+			if err == nil || err.Error() != tt.want {
+				t.Fatalf("Dial() error = %v, want %q", err, tt.want)
+			}
+		})
 	}
 }
 

--- a/internal/remote/link_test.go
+++ b/internal/remote/link_test.go
@@ -93,7 +93,6 @@ func TestLinkConnectSurfacesDialerError(t *testing.T) {
 }
 
 func TestSSHDialerUsesConfiguredCommandAndStreamsProtocol(t *testing.T) {
-	t.Parallel()
 	if runtime.GOOS == "windows" {
 		t.Skip("fake ssh shell script requires Unix")
 	}

--- a/internal/remote/link_test.go
+++ b/internal/remote/link_test.go
@@ -156,6 +156,7 @@ func TestSSHDialerRejectsMissingRequiredFields(t *testing.T) {
 		want string
 	}{
 		{name: "ssh", host: config.Host{SocketPath: "/tmp/amux-test"}, want: "ssh target is required"},
+		{name: "ssh starts with dash", host: config.Host{SSH: "-o ProxyCommand=malicious", SocketPath: "/tmp/amux-test"}, want: "ssh target must not start with '-'"},
 		{name: "socket", host: config.Host{SSH: "cweill@example.test"}, want: "socket path is required"},
 	}
 
@@ -235,6 +236,49 @@ cat
 	}
 }
 
+func TestCommandConnCloseCancelsOnNormalExit(t *testing.T) {
+	t.Parallel()
+
+	cancelled := false
+	conn := &commandConn{
+		cancel: func() { cancelled = true },
+		stdin:  nopWriteCloser{},
+		stdout: nopReadCloser{},
+		waitCh: closedWait(nil),
+	}
+
+	if err := conn.closeWithTimeout(time.Second, time.Second); err != nil {
+		t.Fatalf("Close() = %v, want nil", err)
+	}
+	if !cancelled {
+		t.Fatal("cancel was not called on normal close")
+	}
+}
+
+func TestCommandConnCloseBoundsWaitAfterKill(t *testing.T) {
+	t.Parallel()
+
+	cancelled := false
+	conn := &commandConn{
+		cancel: func() { cancelled = true },
+		stdin:  nopWriteCloser{},
+		stdout: nopReadCloser{},
+		waitCh: make(chan error),
+	}
+
+	start := time.Now()
+	err := conn.closeWithTimeout(time.Millisecond, time.Millisecond)
+	if err == nil || !strings.Contains(err.Error(), "waiting for ssh process after kill") {
+		t.Fatalf("Close() = %v, want bounded kill-wait timeout", err)
+	}
+	if elapsed := time.Since(start); elapsed > 250*time.Millisecond {
+		t.Fatalf("Close() took %v, want bounded wait", elapsed)
+	}
+	if !cancelled {
+		t.Fatal("cancel was not called on forced close")
+	}
+}
+
 func TestCommandConnNetConnMethods(t *testing.T) {
 	t.Parallel()
 
@@ -273,6 +317,24 @@ func TestAcceptableWaitErr(t *testing.T) {
 	if err := acceptableWaitErr(plainErr); !errors.Is(err, plainErr) {
 		t.Fatalf("acceptableWaitErr(plainErr) = %v, want plainErr", err)
 	}
+}
+
+type nopWriteCloser struct{}
+
+func (nopWriteCloser) Write(p []byte) (int, error) { return len(p), nil }
+
+func (nopWriteCloser) Close() error { return nil }
+
+type nopReadCloser struct{}
+
+func (nopReadCloser) Read([]byte) (int, error) { return 0, errors.New("unexpected read") }
+
+func (nopReadCloser) Close() error { return nil }
+
+func closedWait(err error) <-chan error {
+	ch := make(chan error, 1)
+	ch <- err
+	return ch
 }
 
 type unixSocketDialer struct{}

--- a/internal/remote/link_test.go
+++ b/internal/remote/link_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -41,6 +42,9 @@ func TestDefaultRetryPolicyDelays(t *testing.T) {
 	}
 	if got := (RetryPolicy{}).Delay(3); got != 4*time.Second {
 		t.Fatalf("zero-value Delay(3) = %v, want defaulted 4s", got)
+	}
+	if got := (RetryPolicy{InitialBackoff: 2 * time.Second, MaxBackoff: 3 * time.Second}).Delay(2); got != 3*time.Second {
+		t.Fatalf("capped Delay(2) = %v, want 3s", got)
 	}
 }
 
@@ -99,6 +103,27 @@ func TestLinkConnectSurfacesDialerError(t *testing.T) {
 	}
 }
 
+func TestLinkRejectsSecondConnectWithoutRedialing(t *testing.T) {
+	t.Parallel()
+
+	client, server := net.Pipe()
+	defer server.Close()
+
+	dialer := &countingDialer{conn: client}
+	link := NewLink(config.Host{SSH: "test", Session: "main", SocketPath: "/tmp/amux-test"}, dialer)
+	if err := link.Connect(context.Background()); err != nil {
+		t.Fatalf("first Connect: %v", err)
+	}
+	t.Cleanup(func() { _ = link.Close() })
+
+	if err := link.Connect(context.Background()); err == nil || err.Error() != "remote link already connected" {
+		t.Fatalf("second Connect() error = %v, want already connected", err)
+	}
+	if dialer.calls != 1 {
+		t.Fatalf("dial calls = %d, want 1", dialer.calls)
+	}
+}
+
 func TestLinkClosedState(t *testing.T) {
 	t.Parallel()
 
@@ -116,6 +141,9 @@ func TestLinkClosedState(t *testing.T) {
 	}
 	if _, err := link.ReadMsg(); !errors.Is(err, net.ErrClosed) {
 		t.Fatalf("ReadMsg before Connect = %v, want net.ErrClosed", err)
+	}
+	if err := link.Close(); err != nil {
+		t.Fatalf("Close before Connect = %v, want nil", err)
 	}
 }
 
@@ -141,6 +169,20 @@ func TestSSHDialerRejectsMissingRequiredFields(t *testing.T) {
 				t.Fatalf("Dial() error = %v, want %q", err, tt.want)
 			}
 		})
+	}
+}
+
+func TestSSHDialerSurfacesStartError(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("PATH", dir)
+
+	_, err := (SSHDialer{}).Dial(context.Background(), config.Host{
+		SSH:        "cweill@example.test",
+		Session:    "main",
+		SocketPath: "/tmp/amux-test",
+	})
+	if err == nil || !strings.Contains(err.Error(), "starting ssh:") {
+		t.Fatalf("Dial() error = %v, want starting ssh error", err)
 	}
 }
 
@@ -193,6 +235,46 @@ cat
 	}
 }
 
+func TestCommandConnNetConnMethods(t *testing.T) {
+	t.Parallel()
+
+	conn := &commandConn{}
+	if got := conn.LocalAddr().Network(); got != "ssh" {
+		t.Fatalf("LocalAddr().Network() = %q, want ssh", got)
+	}
+	if got := conn.LocalAddr().String(); got != "local" {
+		t.Fatalf("LocalAddr().String() = %q, want local", got)
+	}
+	if got := conn.RemoteAddr().String(); got != "remote" {
+		t.Fatalf("RemoteAddr().String() = %q, want remote", got)
+	}
+	if err := conn.SetDeadline(time.Now()); !errors.Is(err, os.ErrInvalid) {
+		t.Fatalf("SetDeadline() = %v, want os.ErrInvalid", err)
+	}
+	if err := conn.SetReadDeadline(time.Now()); !errors.Is(err, os.ErrInvalid) {
+		t.Fatalf("SetReadDeadline() = %v, want os.ErrInvalid", err)
+	}
+	if err := conn.SetWriteDeadline(time.Now()); !errors.Is(err, os.ErrInvalid) {
+		t.Fatalf("SetWriteDeadline() = %v, want os.ErrInvalid", err)
+	}
+}
+
+func TestAcceptableWaitErr(t *testing.T) {
+	t.Parallel()
+
+	if err := acceptableWaitErr(nil); err != nil {
+		t.Fatalf("acceptableWaitErr(nil) = %v, want nil", err)
+	}
+	exitErr := exec.Command("sh", "-c", "exit 7").Run()
+	if err := acceptableWaitErr(exitErr); err != nil {
+		t.Fatalf("acceptableWaitErr(exitErr) = %v, want nil", err)
+	}
+	plainErr := errors.New("wait failed")
+	if err := acceptableWaitErr(plainErr); !errors.Is(err, plainErr) {
+		t.Fatalf("acceptableWaitErr(plainErr) = %v, want plainErr", err)
+	}
+}
+
 type unixSocketDialer struct{}
 
 func (unixSocketDialer) Dial(ctx context.Context, host config.Host) (net.Conn, error) {
@@ -205,6 +287,16 @@ type staticDialer struct {
 }
 
 func (d staticDialer) Dial(context.Context, config.Host) (net.Conn, error) {
+	return d.conn, nil
+}
+
+type countingDialer struct {
+	conn  net.Conn
+	calls int
+}
+
+func (d *countingDialer) Dial(context.Context, config.Host) (net.Conn, error) {
+	d.calls++
 	return d.conn, nil
 }
 

--- a/internal/remote/link_test.go
+++ b/internal/remote/link_test.go
@@ -1,0 +1,220 @@
+package remote
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/weill-labs/amux/internal/config"
+	"github.com/weill-labs/amux/internal/proto"
+)
+
+func TestDefaultRetryPolicyDelays(t *testing.T) {
+	t.Parallel()
+
+	policy := DefaultRetryPolicy()
+	if policy.MaxAttempts != 5 {
+		t.Fatalf("MaxAttempts = %d, want 5", policy.MaxAttempts)
+	}
+
+	var got []time.Duration
+	for attempt := 1; attempt <= policy.MaxAttempts; attempt++ {
+		got = append(got, policy.Delay(attempt))
+	}
+	want := []time.Duration{time.Second, 2 * time.Second, 4 * time.Second, 8 * time.Second, 16 * time.Second}
+	if fmt.Sprint(got) != fmt.Sprint(want) {
+		t.Fatalf("delays = %v, want %v", got, want)
+	}
+	if got := policy.Delay(10); got != 30*time.Second {
+		t.Fatalf("Delay(10) = %v, want cap 30s", got)
+	}
+}
+
+func TestLinkConnectsWithInjectedDialer(t *testing.T) {
+	t.Parallel()
+
+	socketPath := startRemoteEchoSocket(t)
+	host := config.Host{
+		SSH:        "ignored@example.test",
+		Session:    "main",
+		SocketPath: socketPath,
+	}
+	link := NewLink(host, unixSocketDialer{})
+	if err := link.Connect(context.Background()); err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	t.Cleanup(func() { _ = link.Close() })
+
+	if err := link.WriteMsg(&proto.Message{Type: proto.MsgTypeListPanes, Session: "main"}); err != nil {
+		t.Fatalf("WriteMsg: %v", err)
+	}
+	msg, err := link.ReadMsg()
+	if err != nil {
+		t.Fatalf("ReadMsg: %v", err)
+	}
+	if msg.Type != proto.MsgTypeNotify || msg.Text != "echo:main" {
+		t.Fatalf("message = %+v, want notify echo", msg)
+	}
+}
+
+func TestLinkCloseClosesInjectedConnection(t *testing.T) {
+	t.Parallel()
+
+	client, server := net.Pipe()
+	defer server.Close()
+
+	link := NewLink(config.Host{SSH: "test", Session: "main", SocketPath: "/tmp/amux-test"}, staticDialer{conn: client})
+	if err := link.Connect(context.Background()); err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	if err := link.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if _, err := server.Write([]byte("x")); err == nil {
+		t.Fatal("server Write succeeded after Link.Close, want closed pipe")
+	}
+}
+
+func TestLinkConnectSurfacesDialerError(t *testing.T) {
+	t.Parallel()
+
+	dialErr := errors.New("dial refused")
+	link := NewLink(config.Host{SSH: "test", Session: "main", SocketPath: "/tmp/amux-test"}, errorDialer{err: dialErr})
+	if err := link.Connect(context.Background()); !errors.Is(err, dialErr) {
+		t.Fatalf("Connect() error = %v, want %v", err, dialErr)
+	}
+}
+
+func TestSSHDialerUsesConfiguredCommandAndStreamsProtocol(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("fake ssh shell script requires Unix")
+	}
+
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "ssh.log")
+	fakeSSH := filepath.Join(dir, "ssh")
+	script := fmt.Sprintf(`#!/bin/sh
+printf 'args:%%s\n' "$*" >> %s
+trap 'printf exit >> %s' EXIT
+cat
+`, shellQuote(logPath), shellQuote(logPath))
+	if err := os.WriteFile(fakeSSH, []byte(script), 0755); err != nil {
+		t.Fatalf("WriteFile(fake ssh): %v", err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	host := config.Host{
+		SSH:        "cweill@example.test",
+		Session:    "main",
+		SocketPath: "/tmp/amux-1000/main",
+	}
+	link := NewLink(host, SSHDialer{})
+	if err := link.Connect(context.Background()); err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+
+	if err := link.WriteMsg(&proto.Message{Type: proto.MsgTypeNotify, Text: "hello"}); err != nil {
+		t.Fatalf("WriteMsg: %v", err)
+	}
+	msg, err := link.ReadMsg()
+	if err != nil {
+		t.Fatalf("ReadMsg: %v", err)
+	}
+	if msg.Type != proto.MsgTypeNotify || msg.Text != "hello" {
+		t.Fatalf("round trip = %+v, want echoed notify", msg)
+	}
+
+	if err := link.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	logData := readEventually(t, logPath, "exit")
+	wantArgs := "args:-o BatchMode=yes cweill@example.test -- nc -U /tmp/amux-1000/main"
+	if !strings.Contains(logData, wantArgs) {
+		t.Fatalf("fake ssh log = %q, want args %q", logData, wantArgs)
+	}
+}
+
+type unixSocketDialer struct{}
+
+func (unixSocketDialer) Dial(ctx context.Context, host config.Host) (net.Conn, error) {
+	var d net.Dialer
+	return d.DialContext(ctx, "unix", host.SocketPath)
+}
+
+type staticDialer struct {
+	conn net.Conn
+}
+
+func (d staticDialer) Dial(context.Context, config.Host) (net.Conn, error) {
+	return d.conn, nil
+}
+
+type errorDialer struct {
+	err error
+}
+
+func (d errorDialer) Dial(context.Context, config.Host) (net.Conn, error) {
+	return nil, d.err
+}
+
+func startRemoteEchoSocket(t *testing.T) string {
+	t.Helper()
+
+	socketPath := filepath.Join(t.TempDir(), "remote.sock")
+	ln, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+
+		reader := proto.NewReader(conn)
+		writer := proto.NewWriter(conn)
+		msg, err := reader.ReadMsg()
+		if err != nil {
+			return
+		}
+		_ = writer.WriteMsg(&proto.Message{Type: proto.MsgTypeNotify, Text: "echo:" + msg.Session})
+	}()
+
+	return socketPath
+}
+
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
+}
+
+func readEventually(t *testing.T, path, want string) string {
+	t.Helper()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		data, err := os.ReadFile(path)
+		if err == nil && strings.Contains(string(data), want) {
+			return string(data)
+		}
+		if time.Now().After(deadline) {
+			if err != nil {
+				t.Fatalf("ReadFile(%q): %v", path, err)
+			}
+			t.Fatalf("file %q did not contain %q:\n%s", path, want, data)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+var _ Dialer = unixSocketDialer{}


### PR DESCRIPTION
## Motivation

amux federation needs a small SSH-only foundation before mirror panes can be built. This adds the configured host shape and the link seam that later MirrorManager work can drive without requiring a live SSH daemon in tests.

## Summary

- Add minimal `[remote.hosts]` config parsing with `ssh`, `session`, and absolute `socket_path` validation.
- Add `internal/remote.Link`, injectable `Dialer`, default retry policy, and an SSH dialer that runs `ssh -o BatchMode=yes <target> -- nc -U <socket>`.
- Cover Dialer-injected local Unix socket use, fake-SSH lifecycle, retry delays, malformed config, and doctor config validation.

## Testing

- `go test ./internal/config -run 'TestLoadRemoteHosts|TestLoadRejectsInvalidRemoteHosts' -count=100`
- `go test ./internal/cli -run 'TestDoctorConfigCheckFailsOnMalformedRemoteHost' -count=100`
- `go test ./internal/remote -run 'TestDefaultRetryPolicyDelays|TestLink|TestSSHDialer|TestCommandConnNetConnMethods|TestAcceptableWaitErr' -count=100`
- `go test ./internal/config ./internal/cli ./internal/remote`
- `go vet ./internal/config ./internal/remote`
- `scripts/check-diff-coverage.sh` — diff coverage 91.22%; the coverage run reports existing failures in `TestCopyModeClipboardUsesOSC52WhenInnerClientRunsOverSSH` and `TestCopyModeClipboardUsesTmuxPassthroughWhenInnerClientRunsOverSSHInTmux`.
- `go test ./... -timeout 120s` — same two clipboard integration failures. I verified the same failing slice also fails on `origin/main`, so this appears unrelated to this branch.

## Review focus

- Whether `Link` exposes the right minimal surface for the upcoming MirrorManager without introducing a broader transport abstraction.
- SSH child teardown behavior in `SSHDialer` / `commandConn`.
- Remote host validation strictness, especially requiring an explicit absolute `socket_path`.

Closes LAB-1957
