### PR TITLE
LAB-1959: Add server-side mirror manager

### DIFF
--- a/internal/checkpoint/checkpoint.go
+++ b/internal/checkpoint/checkpoint.go
@@ -38,6 +38,14 @@ type PaneCheckpoint struct {
 	Screen       string    // RenderScreen() ANSI output for replay
 	CreatedAt    time.Time // Pane creation time (preserved across reloads)
 	IsProxy      bool      // true for remote proxy panes (no PTY/process)
+	RemoteRef    *RemoteRef
+}
+
+// RemoteRef is the durable handle for a mirror pane across hot reload.
+type RemoteRef struct {
+	Host     string
+	Session  string
+	PaneName string
 }
 
 // ServerCheckpoint captures the full server state for reload.

--- a/internal/checkpoint/checkpoint_test.go
+++ b/internal/checkpoint/checkpoint_test.go
@@ -54,12 +54,18 @@ func TestRoundTrip(t *testing.T) {
 				Screen: "hello world",
 			},
 			{
-				ID:     2,
-				Meta:   proto.PaneMeta{Name: "pane-2", Host: "remote", Task: "TASK-1", Color: "a6e3a1"},
-				PtmxFd: 7,
-				PID:    5678,
-				Cols:   39,
-				Rows:   22,
+				ID:      2,
+				Meta:    proto.PaneMeta{Name: "pane-2", Host: "remote", Task: "TASK-1", Color: "a6e3a1"},
+				PtmxFd:  -1,
+				PID:     0,
+				Cols:    39,
+				Rows:    22,
+				IsProxy: true,
+				RemoteRef: &RemoteRef{
+					Host:     "remote",
+					Session:  "main",
+					PaneName: "pane-1786",
+				},
 				History: []string{
 					"remote-old-1",
 				},
@@ -135,6 +141,9 @@ func TestRoundTrip(t *testing.T) {
 		}
 		if got.Screen != want.Screen {
 			t.Errorf("Pane[%d].Screen = %q, want %q", i, got.Screen, want.Screen)
+		}
+		if !reflect.DeepEqual(got.RemoteRef, want.RemoteRef) {
+			t.Errorf("Pane[%d].RemoteRef = %+v, want %+v", i, got.RemoteRef, want.RemoteRef)
 		}
 		gotPRs, gotIssues := metaCollections(t, got.Meta)
 		wantPRs, wantIssues := metaCollections(t, want.Meta)

--- a/internal/checkpoint/crash.go
+++ b/internal/checkpoint/crash.go
@@ -44,6 +44,7 @@ type CrashPaneState struct {
 	Command      string         `json:"current_command,omitempty"`
 	CreatedAt    time.Time      `json:"created_at"`
 	IsProxy      bool           `json:"is_proxy"`
+	RemoteRef    *RemoteRef     `json:"remote_ref,omitempty"`
 	Cwd          string         `json:"cwd,omitempty"`
 }
 

--- a/internal/checkpoint/crash_test.go
+++ b/internal/checkpoint/crash_test.go
@@ -66,6 +66,7 @@ func TestCrashRoundTrip(t *testing.T) {
 				Screen:    "$ echo test\ntest",
 				CreatedAt: now,
 				IsProxy:   true,
+				RemoteRef: &RemoteRef{Host: "remote", Session: "main", PaneName: "agent"},
 			},
 		},
 		Timestamp: now,
@@ -136,6 +137,9 @@ func TestCrashRoundTrip(t *testing.T) {
 		}
 		if got.IsProxy != want.IsProxy {
 			t.Errorf("PaneStates[%d].IsProxy = %v, want %v", i, got.IsProxy, want.IsProxy)
+		}
+		if !reflect.DeepEqual(got.RemoteRef, want.RemoteRef) {
+			t.Errorf("PaneStates[%d].RemoteRef = %+v, want %+v", i, got.RemoteRef, want.RemoteRef)
 		}
 		if got.Cwd != want.Cwd {
 			t.Errorf("PaneStates[%d].Cwd = %q, want %q", i, got.Cwd, want.Cwd)

--- a/internal/cli/server_bootstrap.go
+++ b/internal/cli/server_bootstrap.go
@@ -213,6 +213,7 @@ func RunServer(sessionName string, managedTakeover bool, buildVersion string) {
 			exitBootstrapError(logger, sessionName, "creating server failed", err)
 		}
 	}
+	s.ConfigureMirrors(cfg.Remote.Hosts, nil)
 
 	// Must be set before event loops can observe Env (e.g., exit-unattached).
 	s.Env = server.ReadServerEnv()

--- a/internal/server/attach_pane_protocol_test.go
+++ b/internal/server/attach_pane_protocol_test.go
@@ -96,6 +96,13 @@ func newAttachPaneProtocolPane(sess *Session, id uint32, writes chan<- []byte) *
 
 func startAttachPaneProtocolConn(t *testing.T, h *attachPaneProtocolHarness, paneID uint32) net.Conn {
 	t.Helper()
+	conn := startAttachPaneProtocolConnRaw(t, h, paneID)
+	drainAttachPaneBootstrap(t, conn, paneID)
+	return conn
+}
+
+func startAttachPaneProtocolConnRaw(t *testing.T, h *attachPaneProtocolHarness, paneID uint32) net.Conn {
+	t.Helper()
 
 	serverConn, clientConn := net.Pipe()
 	t.Cleanup(func() { clientConn.Close() })
@@ -123,6 +130,27 @@ func startAttachPaneProtocolConn(t *testing.T, h *attachPaneProtocolHarness, pan
 	}
 	waitForScopedClient(t, h.sess, paneID)
 	return clientConn
+}
+
+func drainAttachPaneBootstrap(t *testing.T, conn net.Conn, paneID uint32) {
+	t.Helper()
+
+	for {
+		msg := readAttachPaneMsgWithTimeout(t, conn)
+		switch msg.Type {
+		case MsgTypePaneHistory:
+			if msg.PaneID != paneID {
+				t.Fatalf("bootstrap history pane = %d, want %d", msg.PaneID, paneID)
+			}
+		case MsgTypePaneOutput:
+			if msg.PaneID != paneID {
+				t.Fatalf("bootstrap output pane = %d, want %d", msg.PaneID, paneID)
+			}
+			return
+		default:
+			t.Fatalf("bootstrap message type = %v, want history/output", msg.Type)
+		}
+	}
 }
 
 func waitForScopedClient(t *testing.T, sess *Session, paneID uint32) {
@@ -349,6 +377,40 @@ func TestMsgTypeAttachPaneScopesOutputAndInput(t *testing.T) {
 	case got := <-h.writes1:
 		t.Fatalf("pane 1 received unexpected input %q", got)
 	default:
+	}
+}
+
+func TestMsgTypeAttachPaneSendsHistoryBootstrap(t *testing.T) {
+	t.Parallel()
+
+	h := newSingleAttachPaneProtocolHarness(t)
+	if err := h.pane1.Resize(80, 2); err != nil {
+		t.Fatalf("Resize: %v", err)
+	}
+	h.pane1.FeedOutput([]byte("line-1\r\nline-2\r\nline-3\r\nline-4\r\n"))
+
+	conn := startAttachPaneProtocolConnRaw(t, h, h.pane1.ID)
+
+	msg := readAttachPaneMsgWithTimeout(t, conn)
+	if msg.Type != MsgTypePaneHistory {
+		t.Fatalf("first bootstrap message type = %v, want PaneHistory", msg.Type)
+	}
+	if msg.PaneID != h.pane1.ID {
+		t.Fatalf("history pane = %d, want %d", msg.PaneID, h.pane1.ID)
+	}
+	if len(msg.History) == 0 || msg.History[0] != "line-1" {
+		t.Fatalf("history = %#v, want retained line-1", msg.History)
+	}
+
+	msg = readAttachPaneMsgWithTimeout(t, conn)
+	if msg.Type != MsgTypePaneOutput {
+		t.Fatalf("second bootstrap message type = %v, want PaneOutput", msg.Type)
+	}
+	if msg.PaneID != h.pane1.ID {
+		t.Fatalf("output pane = %d, want %d", msg.PaneID, h.pane1.ID)
+	}
+	if !strings.Contains(string(msg.PaneData), "line-4") {
+		t.Fatalf("bootstrap output = %q, want latest screen", msg.PaneData)
 	}
 }
 

--- a/internal/server/checkpoint.go
+++ b/internal/server/checkpoint.go
@@ -78,6 +78,11 @@ func (s *Server) Reload(execPath string) error {
 			if p.IsProxy() {
 				pc.PtmxFd = -1
 				pc.PID = 0
+				if sess.mirror != nil {
+					if ref, ok := sess.mirror.RemoteRef(p.ID); ok {
+						pc.RemoteRef = ref
+					}
+				}
 			} else {
 				pc.PtmxFd = p.PtmxFd()
 				pc.PID = p.ProcessPid()
@@ -255,11 +260,12 @@ func NewServerFromCheckpointWithScrollbackConfigLogger(cp *checkpoint.ServerChec
 		onExit := sess.paneExitCallback()
 
 		if pc.IsProxy {
-			// Restore proxy pane with frozen content. The remote backing is gone
-			// after the "remote" feature removal, so writes are dropped.
+			writeOverride := func(data []byte) (int, error) { return len(data), nil }
+			if pc.RemoteRef != nil {
+				writeOverride = sess.mirrorWriteOverride(pc.ID)
+			}
 			pane = sess.ownPane(mux.NewProxyPaneWithScrollback(pc.ID, pc.Meta, pc.Cols, pc.Rows, sess.scrollbackLinesForHost(pc.Meta.Host),
-				onOutput, onExit,
-				func(data []byte) (int, error) { return len(data), nil },
+				onOutput, onExit, writeOverride,
 			))
 		} else {
 			var restoreErr error
@@ -283,6 +289,17 @@ func NewServerFromCheckpointWithScrollbackConfigLogger(cp *checkpoint.ServerChec
 		pane.ReplayScreen(pc.Screen)
 		paneMap[pc.ID] = pane
 		sess.Panes = append(sess.Panes, pane)
+		if pc.RemoteRef != nil {
+			if err := sess.trackMirrorPane(pane, *pc.RemoteRef); err != nil {
+				sess.logger.Warn("restored mirror tracking failed",
+					"event", "checkpoint_restore",
+					"checkpoint_kind", "reload",
+					"pane_id", pane.ID,
+					"pane_name", pane.Meta.Name,
+					"error", err,
+				)
+			}
+		}
 	}
 
 	if len(sess.Panes) == 0 {

--- a/internal/server/checkpoint_test.go
+++ b/internal/server/checkpoint_test.go
@@ -11,7 +11,9 @@ import (
 	"time"
 
 	"github.com/weill-labs/amux/internal/checkpoint"
+	"github.com/weill-labs/amux/internal/config"
 	"github.com/weill-labs/amux/internal/mux"
+	"github.com/weill-labs/amux/internal/proto"
 )
 
 func TestClearCloexecReturnsErrnoOnInvalidFD(t *testing.T) {
@@ -193,5 +195,86 @@ func TestServerShutdownPreservesCrashCheckpointForCrashRestore(t *testing.T) {
 	}
 	if len(restoredSess.Panes) != 2 {
 		t.Fatalf("restored panes = %d, want 2", len(restoredSess.Panes))
+	}
+}
+
+func TestBuildCrashCheckpointPreservesMirrorRemoteRef(t *testing.T) {
+	t.Parallel()
+
+	sess := newSession("mirror-crash-checkpoint")
+	defer stopSessionBackgroundLoops(t, sess)
+
+	ref := checkpoint.RemoteRef{Host: "remote", Session: "main", PaneName: "agent"}
+	mustSessionMutation(t, sess, func(sess *Session) {
+		pane := newProxyPane(1, mux.PaneMeta{Name: "mirror", Host: "remote", Color: config.AccentColor(0)}, 80, 23,
+			sess.paneOutputCallback(), sess.paneExitCallback(), sess.mirrorWriteOverride(1),
+		)
+		win := mux.NewWindow(pane, 80, 24)
+		win.ID = 1
+		win.Name = "window-1"
+		seedSessionPanesForTest(sess, pane)
+		sess.Windows = []*mux.Window{win}
+		sess.ActiveWindowID = win.ID
+		if err := sess.trackMirrorPane(pane, ref); err != nil {
+			t.Fatalf("trackMirrorPane: %v", err)
+		}
+	})
+
+	cp := sess.buildCrashCheckpoint()
+	if cp == nil || len(cp.PaneStates) != 1 {
+		t.Fatalf("crash checkpoint = %+v, want one pane state", cp)
+	}
+	if got := cp.PaneStates[0].RemoteRef; got == nil || *got != ref {
+		t.Fatalf("RemoteRef = %+v, want %+v", got, ref)
+	}
+}
+
+func TestCrashRestoreTracksMirrorRemoteRef(t *testing.T) {
+	t.Parallel()
+
+	sessionName := fmt.Sprintf("mirror-crash-restore-%d", time.Now().UnixNano())
+	ref := checkpoint.RemoteRef{Host: "remote", Session: "main", PaneName: "agent"}
+	cp := &checkpoint.CrashCheckpoint{
+		Version:       checkpoint.CrashVersion,
+		SessionName:   sessionName,
+		Counter:       1,
+		WindowCounter: 1,
+		Layout: proto.LayoutSnapshot{
+			SessionName:  sessionName,
+			Width:        80,
+			Height:       24,
+			ActivePaneID: 1,
+			Root: proto.CellSnapshot{
+				X: 0, Y: 0, W: 80, H: 24, IsLeaf: true, Dir: -1, PaneID: 1,
+			},
+			Panes: []proto.PaneSnapshot{{
+				ID:    1,
+				Name:  "mirror",
+				Host:  "remote",
+				Color: config.AccentColor(0),
+			}},
+		},
+		PaneStates: []checkpoint.CrashPaneState{{
+			ID:        1,
+			Meta:      mux.PaneMeta{Name: "mirror", Host: "remote", Color: config.AccentColor(0)},
+			Cols:      80,
+			Rows:      23,
+			Screen:    "cached remote screen",
+			IsProxy:   true,
+			RemoteRef: &ref,
+		}},
+		Timestamp: time.Now(),
+	}
+
+	restored, err := NewServerFromCrashCheckpointWithScrollback(sessionName, cp, "", mux.DefaultScrollbackLines)
+	if err != nil {
+		t.Fatalf("NewServerFromCrashCheckpointWithScrollback: %v", err)
+	}
+	defer restored.Shutdown()
+
+	restoredSess := restored.firstSession()
+	got, ok := restoredSess.mirror.RemoteRef(1)
+	if !ok || got == nil || *got != ref {
+		t.Fatalf("RemoteRef = (%+v, %v), want %+v true", got, ok, ref)
 	}
 }

--- a/internal/server/client_conn.go
+++ b/internal/server/client_conn.go
@@ -128,7 +128,7 @@ func (cc *clientConn) allowsServerMessage(msg *Message) bool {
 		return true
 	}
 	switch msg.Type {
-	case MsgTypePaneOutput:
+	case MsgTypePaneOutput, MsgTypePaneHistory, MsgTypeClipboard, MsgTypeBell:
 		return msg.PaneID == cc.scopedPaneID
 	case MsgTypeCmdResult, MsgTypeExit:
 		return true

--- a/internal/server/mirror/manager.go
+++ b/internal/server/mirror/manager.go
@@ -249,12 +249,12 @@ func (m *Manager) startLocked(ms *mirrorState) {
 	ms.running = true
 	paneID := ms.pane.ID
 	m.wg.Add(1)
-	go m.run(paneID)
+	go m.run(paneID, ms)
 }
 
-func (m *Manager) run(paneID uint32) {
+func (m *Manager) run(paneID uint32, owner *mirrorState) {
 	defer m.wg.Done()
-	defer m.markStopped(paneID)
+	defer m.markStopped(paneID, owner)
 
 	attempt := 0
 	first := true
@@ -262,20 +262,26 @@ func (m *Manager) run(paneID uint32) {
 		if err := m.ctx.Err(); err != nil {
 			return
 		}
+		if !m.isCurrent(paneID, owner) {
+			return
+		}
 		state := StateConnecting
 		if !first {
 			attempt++
 			if attempt > m.retryPolicy.MaxAttempts {
-				m.markDead(paneID, "remote connection retry budget exhausted")
+				m.markDeadForOwner(paneID, owner, "remote connection retry budget exhausted")
 				return
 			}
 			state = StateReconnecting
 			if !m.sleepBeforeRetry(attempt) {
 				return
 			}
+			if !m.isCurrent(paneID, owner) {
+				return
+			}
 		}
 
-		connected, terminal := m.attachAndRead(paneID, state)
+		connected, terminal := m.attachAndRead(paneID, owner, state)
 		if terminal {
 			return
 		}
@@ -286,12 +292,18 @@ func (m *Manager) run(paneID uint32) {
 	}
 }
 
-func (m *Manager) markStopped(paneID uint32) {
+func (m *Manager) markStopped(paneID uint32, owner *mirrorState) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	if ms := m.mirrors[paneID]; ms != nil {
+	if ms := m.mirrors[paneID]; ms != nil && ms == owner {
 		ms.running = false
 	}
+}
+
+func (m *Manager) isCurrent(paneID uint32, owner *mirrorState) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.mirrors[paneID] == owner
 }
 
 func (m *Manager) sleepBeforeRetry(attempt int) bool {
@@ -306,15 +318,15 @@ func (m *Manager) sleepBeforeRetry(attempt int) bool {
 	}
 }
 
-func (m *Manager) attachAndRead(paneID uint32, state State) (connected bool, terminal bool) {
-	host, ref, ok := m.prepareAttempt(paneID, state)
+func (m *Manager) attachAndRead(paneID uint32, owner *mirrorState, state State) (connected bool, terminal bool) {
+	host, ref, ok := m.prepareAttempt(paneID, owner, state)
 	if !ok {
 		return false, true
 	}
 
 	remotePaneID, err := m.resolvePaneID(host, ref)
 	if err != nil {
-		m.recordAttemptError(paneID, err)
+		m.recordAttemptErrorForOwner(paneID, owner, err)
 		return false, false
 	}
 
@@ -323,7 +335,7 @@ func (m *Manager) attachAndRead(paneID uint32, state State) (connected bool, ter
 
 	link := remote.NewLink(host, m.currentDialer())
 	if err := link.Connect(attachCtx); err != nil {
-		m.recordAttemptError(paneID, err)
+		m.recordAttemptErrorForOwner(paneID, owner, err)
 		return false, false
 	}
 	if err := link.WriteMsg(&proto.Message{
@@ -332,36 +344,36 @@ func (m *Manager) attachAndRead(paneID uint32, state State) (connected bool, ter
 		PaneID:  remotePaneID,
 	}); err != nil {
 		_ = link.Close()
-		m.recordAttemptError(paneID, err)
+		m.recordAttemptErrorForOwner(paneID, owner, err)
 		return false, false
 	}
 
-	generation, ok := m.markConnected(paneID, remotePaneID, link)
+	generation, ok := m.markConnectedForOwner(paneID, owner, remotePaneID, link)
 	if !ok {
 		_ = link.Close()
 		return true, true
 	}
 
-	err = m.readLoop(paneID, generation, link)
+	err = m.readLoop(paneID, owner, generation, link)
 	_ = link.Close()
 	if errors.Is(err, errRemotePaneExited) {
-		m.markDead(paneID, "remote pane exited")
+		m.markDeadForOwner(paneID, owner, "remote pane exited")
 		return true, true
 	}
 	if err != nil {
-		m.recordAttemptError(paneID, err)
-		if m.isTerminal(paneID) {
+		m.recordAttemptErrorForOwner(paneID, owner, err)
+		if m.isTerminal(paneID, owner) {
 			return true, true
 		}
 	}
 	return true, false
 }
 
-func (m *Manager) prepareAttempt(paneID uint32, state State) (config.Host, checkpoint.RemoteRef, bool) {
+func (m *Manager) prepareAttempt(paneID uint32, owner *mirrorState, state State) (config.Host, checkpoint.RemoteRef, bool) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	ms := m.mirrors[paneID]
-	if ms == nil || ms.state == StateDetached || ms.state == StateDead {
+	if ms == nil || (owner != nil && ms != owner) || ms.state == StateDetached || ms.state == StateDead {
 		return config.Host{}, checkpoint.RemoteRef{}, false
 	}
 	ms.state = state
@@ -395,6 +407,10 @@ func (m *Manager) currentDialer() remote.Dialer {
 }
 
 func (m *Manager) markConnected(paneID, remotePaneID uint32, link *remote.Link) (uint64, bool) {
+	return m.markConnectedForOwner(paneID, nil, remotePaneID, link)
+}
+
+func (m *Manager) markConnectedForOwner(paneID uint32, owner *mirrorState, remotePaneID uint32, link *remote.Link) (uint64, bool) {
 	var (
 		pane    *mux.Pane
 		oldLink *remote.Link
@@ -402,7 +418,7 @@ func (m *Manager) markConnected(paneID, remotePaneID uint32, link *remote.Link) 
 	)
 	m.mu.Lock()
 	ms := m.mirrors[paneID]
-	if ms == nil || ms.state == StateDetached || ms.state == StateDead {
+	if ms == nil || (owner != nil && ms != owner) || ms.state == StateDetached || ms.state == StateDead {
 		m.mu.Unlock()
 		return 0, false
 	}
@@ -427,19 +443,23 @@ func (m *Manager) markConnected(paneID, remotePaneID uint32, link *remote.Link) 
 	return gen, true
 }
 
-func (m *Manager) readLoop(paneID uint32, generation uint64, link *remote.Link) error {
+func (m *Manager) readLoop(paneID uint32, owner *mirrorState, generation uint64, link *remote.Link) error {
 	for {
 		msg, err := link.ReadMsg()
 		if err != nil {
 			return err
 		}
-		if err := m.applyMessage(paneID, generation, msg); err != nil {
+		if err := m.applyMessageForOwner(paneID, owner, generation, msg); err != nil {
 			return err
 		}
 	}
 }
 
 func (m *Manager) applyMessage(paneID uint32, generation uint64, msg *proto.Message) error {
+	return m.applyMessageForOwner(paneID, nil, generation, msg)
+}
+
+func (m *Manager) applyMessageForOwner(paneID uint32, owner *mirrorState, generation uint64, msg *proto.Message) error {
 	if msg == nil {
 		return nil
 	}
@@ -451,7 +471,7 @@ func (m *Manager) applyMessage(paneID uint32, generation uint64, msg *proto.Mess
 	)
 	m.mu.Lock()
 	ms := m.mirrors[paneID]
-	if ms == nil || generation != ms.generation {
+	if ms == nil || (owner != nil && ms != owner) || generation != ms.generation {
 		m.mu.Unlock()
 		return nil
 	}
@@ -472,11 +492,13 @@ func (m *Manager) applyMessage(paneID uint32, generation uint64, msg *proto.Mess
 	case proto.MsgTypeExit:
 		ms.state = StateDead
 		ms.lastErr = "remote pane exited"
+		ms.link = nil
 		pane = ms.pane
 	case proto.MsgTypeCmdResult:
 		if msg.CmdErr != "" {
 			ms.state = StateDead
 			ms.lastErr = msg.CmdErr
+			ms.link = nil
 			pane = ms.pane
 		}
 	default:
@@ -505,10 +527,14 @@ func (m *Manager) applyMessage(paneID uint32, generation uint64, msg *proto.Mess
 }
 
 func (m *Manager) markDead(paneID uint32, message string) {
+	m.markDeadForOwner(paneID, nil, message)
+}
+
+func (m *Manager) markDeadForOwner(paneID uint32, owner *mirrorState, message string) {
 	var pane *mux.Pane
 	m.mu.Lock()
 	ms := m.mirrors[paneID]
-	if ms == nil || ms.state == StateDetached || ms.state == StateDead {
+	if ms == nil || (owner != nil && ms != owner) || ms.state == StateDetached || ms.state == StateDead {
 		m.mu.Unlock()
 		return
 	}
@@ -526,20 +552,24 @@ func (m *Manager) markDead(paneID uint32, message string) {
 	}
 }
 
-func (m *Manager) isTerminal(paneID uint32) bool {
+func (m *Manager) isTerminal(paneID uint32, owner *mirrorState) bool {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	ms := m.mirrors[paneID]
-	return ms == nil || ms.state == StateDetached || ms.state == StateDead
+	return ms == nil || (owner != nil && ms != owner) || ms.state == StateDetached || ms.state == StateDead
 }
 
 func (m *Manager) recordAttemptError(paneID uint32, err error) {
+	m.recordAttemptErrorForOwner(paneID, nil, err)
+}
+
+func (m *Manager) recordAttemptErrorForOwner(paneID uint32, owner *mirrorState, err error) {
 	if err == nil {
 		return
 	}
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	if ms := m.mirrors[paneID]; ms != nil && ms.state != StateDetached && ms.state != StateDead {
+	if ms := m.mirrors[paneID]; ms != nil && (owner == nil || ms == owner) && ms.state != StateDetached && ms.state != StateDead {
 		ms.lastErr = err.Error()
 	}
 }

--- a/internal/server/mirror/manager.go
+++ b/internal/server/mirror/manager.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net"
 	"sync"
 	"time"
 
@@ -351,6 +350,9 @@ func (m *Manager) attachAndRead(paneID uint32, state State) (connected bool, ter
 	}
 	if err != nil {
 		m.recordAttemptError(paneID, err)
+		if m.isTerminal(paneID) {
+			return true, true
+		}
 	}
 	return true, false
 }
@@ -429,9 +431,6 @@ func (m *Manager) readLoop(paneID uint32, generation uint64, link *remote.Link) 
 	for {
 		msg, err := link.ReadMsg()
 		if err != nil {
-			if errors.Is(err, net.ErrClosed) {
-				return err
-			}
 			return err
 		}
 		if err := m.applyMessage(paneID, generation, msg); err != nil {
@@ -509,7 +508,7 @@ func (m *Manager) markDead(paneID uint32, message string) {
 	var pane *mux.Pane
 	m.mu.Lock()
 	ms := m.mirrors[paneID]
-	if ms == nil || ms.state == StateDetached {
+	if ms == nil || ms.state == StateDetached || ms.state == StateDead {
 		m.mu.Unlock()
 		return
 	}
@@ -525,6 +524,13 @@ func (m *Manager) markDead(paneID uint32, message string) {
 	if pane != nil && message != "" {
 		pane.FeedOutput([]byte("\r\n[" + message + "]\r\n"))
 	}
+}
+
+func (m *Manager) isTerminal(paneID uint32) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	ms := m.mirrors[paneID]
+	return ms == nil || ms.state == StateDetached || ms.state == StateDead
 }
 
 func (m *Manager) recordAttemptError(paneID uint32, err error) {

--- a/internal/server/mirror/manager.go
+++ b/internal/server/mirror/manager.go
@@ -559,10 +559,6 @@ func (m *Manager) isTerminal(paneID uint32, owner *mirrorState) bool {
 	return ms == nil || (owner != nil && ms != owner) || ms.state == StateDetached || ms.state == StateDead
 }
 
-func (m *Manager) recordAttemptError(paneID uint32, err error) {
-	m.recordAttemptErrorForOwner(paneID, nil, err)
-}
-
 func (m *Manager) recordAttemptErrorForOwner(paneID uint32, owner *mirrorState, err error) {
 	if err == nil {
 		return

--- a/internal/server/mirror/manager.go
+++ b/internal/server/mirror/manager.go
@@ -1,0 +1,584 @@
+package mirror
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"sync"
+	"time"
+
+	"github.com/weill-labs/amux/internal/checkpoint"
+	"github.com/weill-labs/amux/internal/config"
+	"github.com/weill-labs/amux/internal/mux"
+	"github.com/weill-labs/amux/internal/proto"
+	"github.com/weill-labs/amux/internal/remote"
+)
+
+type State string
+
+const (
+	StateConnecting   State = "connecting"
+	StateConnected    State = "connected"
+	StateReconnecting State = "reconnecting"
+	StateDead         State = "dead"
+	StateDetached     State = "detached"
+)
+
+const (
+	defaultAttachTimeout = 10 * time.Second
+)
+
+var errRemotePaneExited = errors.New("remote pane exited")
+
+type Config struct {
+	Hosts         map[string]config.Host
+	Dialer        remote.Dialer
+	RetryPolicy   remote.RetryPolicy
+	AttachTimeout time.Duration
+}
+
+type Snapshot struct {
+	State        State
+	Generation   uint64
+	RemotePaneID uint32
+	RemoteRef    checkpoint.RemoteRef
+	LastError    string
+}
+
+type Manager struct {
+	ctx    context.Context
+	cancel context.CancelFunc
+
+	mu            sync.Mutex
+	hosts         map[string]config.Host
+	dialer        remote.Dialer
+	retryPolicy   remote.RetryPolicy
+	attachTimeout time.Duration
+	mirrors       map[uint32]*mirrorState
+	wg            sync.WaitGroup
+}
+
+type mirrorState struct {
+	pane          *mux.Pane
+	ref           checkpoint.RemoteRef
+	state         State
+	generation    uint64
+	remotePaneID  uint32
+	link          *remote.Link
+	running       bool
+	bootstrapping bool
+	history       []string
+	lastErr       string
+}
+
+func NewManager(cfg Config) *Manager {
+	ctx, cancel := context.WithCancel(context.Background())
+	m := &Manager{
+		ctx:     ctx,
+		cancel:  cancel,
+		mirrors: make(map[uint32]*mirrorState),
+	}
+	m.Configure(cfg)
+	return m
+}
+
+func (m *Manager) Configure(cfg Config) {
+	if m == nil {
+		return
+	}
+	m.mu.Lock()
+	m.hosts = cloneHosts(cfg.Hosts)
+	m.dialer = cfg.Dialer
+	m.retryPolicy = normalizeRetryPolicy(cfg.RetryPolicy)
+	m.attachTimeout = cfg.AttachTimeout
+	if m.attachTimeout <= 0 {
+		m.attachTimeout = defaultAttachTimeout
+	}
+	var start []*mirrorState
+	for _, ms := range m.mirrors {
+		if ms.running || ms.state == StateDetached || ms.state == StateDead {
+			continue
+		}
+		if _, ok := m.hostForRefLocked(ms.ref); ok {
+			start = append(start, ms)
+		}
+	}
+	for _, ms := range start {
+		m.startLocked(ms)
+	}
+	m.mu.Unlock()
+}
+
+func (m *Manager) Close() {
+	if m == nil {
+		return
+	}
+	m.cancel()
+
+	m.mu.Lock()
+	links := make([]*remote.Link, 0, len(m.mirrors))
+	for _, ms := range m.mirrors {
+		if ms.link != nil {
+			links = append(links, ms.link)
+		}
+	}
+	m.mu.Unlock()
+
+	for _, link := range links {
+		_ = link.Close()
+	}
+	m.wg.Wait()
+}
+
+func (m *Manager) Track(pane *mux.Pane, ref checkpoint.RemoteRef) error {
+	if m == nil {
+		return fmt.Errorf("mirror manager is nil")
+	}
+	if pane == nil {
+		return fmt.Errorf("mirror pane is nil")
+	}
+	if ref.Host == "" {
+		return fmt.Errorf("remote host is required")
+	}
+	if ref.PaneName == "" {
+		return fmt.Errorf("remote pane name is required")
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	ms := &mirrorState{
+		pane:  pane,
+		ref:   ref,
+		state: StateConnecting,
+	}
+	m.mirrors[pane.ID] = ms
+	if _, ok := m.hostForRefLocked(ref); ok {
+		m.startLocked(ms)
+	} else {
+		ms.lastErr = fmt.Sprintf("remote host %q is not configured", ref.Host)
+	}
+	return nil
+}
+
+func (m *Manager) Detach(paneID uint32) {
+	if m == nil || paneID == 0 {
+		return
+	}
+	m.mu.Lock()
+	ms := m.mirrors[paneID]
+	if ms == nil {
+		m.mu.Unlock()
+		return
+	}
+	ms.state = StateDetached
+	ms.pane = nil
+	link := ms.link
+	ms.link = nil
+	m.mu.Unlock()
+	if link != nil {
+		_ = link.Close()
+	}
+}
+
+func (m *Manager) Write(paneID uint32, data []byte) (int, error) {
+	if len(data) == 0 {
+		return 0, nil
+	}
+	if m == nil {
+		return len(data), nil
+	}
+
+	m.mu.Lock()
+	ms := m.mirrors[paneID]
+	if ms == nil || ms.state != StateConnected || ms.link == nil || ms.remotePaneID == 0 {
+		m.mu.Unlock()
+		return len(data), nil
+	}
+	link := ms.link
+	remotePaneID := ms.remotePaneID
+	m.mu.Unlock()
+
+	if err := link.WriteMsg(&proto.Message{
+		Type:     proto.MsgTypeInputPane,
+		PaneID:   remotePaneID,
+		PaneData: append([]byte(nil), data...),
+	}); err != nil {
+		return 0, err
+	}
+	return len(data), nil
+}
+
+func (m *Manager) RemoteRef(paneID uint32) (*checkpoint.RemoteRef, bool) {
+	if m == nil {
+		return nil, false
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	ms := m.mirrors[paneID]
+	if ms == nil {
+		return nil, false
+	}
+	ref := ms.ref
+	return &ref, true
+}
+
+func (m *Manager) Snapshot(paneID uint32) (Snapshot, bool) {
+	if m == nil {
+		return Snapshot{}, false
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	ms := m.mirrors[paneID]
+	if ms == nil {
+		return Snapshot{}, false
+	}
+	return Snapshot{
+		State:        ms.state,
+		Generation:   ms.generation,
+		RemotePaneID: ms.remotePaneID,
+		RemoteRef:    ms.ref,
+		LastError:    ms.lastErr,
+	}, true
+}
+
+func (m *Manager) startLocked(ms *mirrorState) {
+	if ms == nil || ms.running || ms.state == StateDetached || ms.state == StateDead {
+		return
+	}
+	ms.running = true
+	paneID := ms.pane.ID
+	m.wg.Add(1)
+	go m.run(paneID)
+}
+
+func (m *Manager) run(paneID uint32) {
+	defer m.wg.Done()
+	defer m.markStopped(paneID)
+
+	attempt := 0
+	first := true
+	for {
+		if err := m.ctx.Err(); err != nil {
+			return
+		}
+		state := StateConnecting
+		if !first {
+			attempt++
+			if attempt > m.retryPolicy.MaxAttempts {
+				m.markDead(paneID, "remote connection retry budget exhausted")
+				return
+			}
+			state = StateReconnecting
+			if !m.sleepBeforeRetry(attempt) {
+				return
+			}
+		}
+
+		connected, terminal := m.attachAndRead(paneID, state)
+		if terminal {
+			return
+		}
+		first = false
+		if connected {
+			attempt = 0
+		}
+	}
+}
+
+func (m *Manager) markStopped(paneID uint32) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if ms := m.mirrors[paneID]; ms != nil {
+		ms.running = false
+	}
+}
+
+func (m *Manager) sleepBeforeRetry(attempt int) bool {
+	delay := m.retryPolicy.Delay(attempt)
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+		return true
+	case <-m.ctx.Done():
+		return false
+	}
+}
+
+func (m *Manager) attachAndRead(paneID uint32, state State) (connected bool, terminal bool) {
+	host, ref, ok := m.prepareAttempt(paneID, state)
+	if !ok {
+		return false, true
+	}
+
+	remotePaneID, err := m.resolvePaneID(host, ref)
+	if err != nil {
+		m.recordAttemptError(paneID, err)
+		return false, false
+	}
+
+	attachCtx, cancel := context.WithTimeout(m.ctx, m.attachTimeout)
+	defer cancel()
+
+	link := remote.NewLink(host, m.currentDialer())
+	if err := link.Connect(attachCtx); err != nil {
+		m.recordAttemptError(paneID, err)
+		return false, false
+	}
+	if err := link.WriteMsg(&proto.Message{
+		Type:    proto.MsgTypeAttachPane,
+		Session: remoteSession(host, ref),
+		PaneID:  remotePaneID,
+	}); err != nil {
+		_ = link.Close()
+		m.recordAttemptError(paneID, err)
+		return false, false
+	}
+
+	generation, ok := m.markConnected(paneID, remotePaneID, link)
+	if !ok {
+		_ = link.Close()
+		return true, true
+	}
+
+	err = m.readLoop(paneID, generation, link)
+	_ = link.Close()
+	if errors.Is(err, errRemotePaneExited) {
+		m.markDead(paneID, "remote pane exited")
+		return true, true
+	}
+	if err != nil {
+		m.recordAttemptError(paneID, err)
+	}
+	return true, false
+}
+
+func (m *Manager) prepareAttempt(paneID uint32, state State) (config.Host, checkpoint.RemoteRef, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	ms := m.mirrors[paneID]
+	if ms == nil || ms.state == StateDetached || ms.state == StateDead {
+		return config.Host{}, checkpoint.RemoteRef{}, false
+	}
+	ms.state = state
+	host, ok := m.hostForRefLocked(ms.ref)
+	if !ok {
+		ms.lastErr = fmt.Sprintf("remote host %q is not configured", ms.ref.Host)
+		return config.Host{}, ms.ref, false
+	}
+	return host, ms.ref, true
+}
+
+func (m *Manager) resolvePaneID(host config.Host, ref checkpoint.RemoteRef) (uint32, error) {
+	ctx, cancel := context.WithTimeout(m.ctx, m.attachTimeout)
+	defer cancel()
+
+	conn, err := m.currentDialer().Dial(ctx, host)
+	if err != nil {
+		return 0, err
+	}
+	defer conn.Close()
+	return remote.ResolvePaneID(ctx, conn, remoteSession(host, ref), ref.PaneName)
+}
+
+func (m *Manager) currentDialer() remote.Dialer {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.dialer != nil {
+		return m.dialer
+	}
+	return remote.SSHDialer{}
+}
+
+func (m *Manager) markConnected(paneID, remotePaneID uint32, link *remote.Link) (uint64, bool) {
+	var (
+		pane    *mux.Pane
+		oldLink *remote.Link
+		gen     uint64
+	)
+	m.mu.Lock()
+	ms := m.mirrors[paneID]
+	if ms == nil || ms.state == StateDetached || ms.state == StateDead {
+		m.mu.Unlock()
+		return 0, false
+	}
+	oldLink = ms.link
+	ms.generation++
+	gen = ms.generation
+	ms.remotePaneID = remotePaneID
+	ms.link = link
+	ms.state = StateConnected
+	ms.lastErr = ""
+	ms.history = nil
+	ms.bootstrapping = true
+	pane = ms.pane
+	m.mu.Unlock()
+
+	if oldLink != nil && oldLink != link {
+		_ = oldLink.Close()
+	}
+	if pane != nil {
+		pane.ResetState()
+	}
+	return gen, true
+}
+
+func (m *Manager) readLoop(paneID uint32, generation uint64, link *remote.Link) error {
+	for {
+		msg, err := link.ReadMsg()
+		if err != nil {
+			if errors.Is(err, net.ErrClosed) {
+				return err
+			}
+			return err
+		}
+		if err := m.applyMessage(paneID, generation, msg); err != nil {
+			return err
+		}
+	}
+}
+
+func (m *Manager) applyMessage(paneID uint32, generation uint64, msg *proto.Message) error {
+	if msg == nil {
+		return nil
+	}
+	var (
+		pane         *mux.Pane
+		data         []byte
+		history      []string
+		applyHistory bool
+	)
+	m.mu.Lock()
+	ms := m.mirrors[paneID]
+	if ms == nil || generation != ms.generation {
+		m.mu.Unlock()
+		return nil
+	}
+	switch msg.Type {
+	case proto.MsgTypePaneHistory:
+		if ms.bootstrapping && ms.history != nil {
+			ms.history = append(ms.history, msg.History...)
+		} else {
+			ms.history = append([]string(nil), msg.History...)
+		}
+		history = append([]string(nil), ms.history...)
+		applyHistory = true
+		pane = ms.pane
+	case proto.MsgTypePaneOutput:
+		ms.bootstrapping = false
+		data = append([]byte(nil), msg.PaneData...)
+		pane = ms.pane
+	case proto.MsgTypeExit:
+		ms.state = StateDead
+		ms.lastErr = "remote pane exited"
+		pane = ms.pane
+	case proto.MsgTypeCmdResult:
+		if msg.CmdErr != "" {
+			ms.state = StateDead
+			ms.lastErr = msg.CmdErr
+			pane = ms.pane
+		}
+	default:
+	}
+	m.mu.Unlock()
+
+	if applyHistory && pane != nil {
+		pane.SetRetainedHistory(history)
+	}
+	if data != nil && pane != nil {
+		pane.FeedOutput(data)
+	}
+	if msg.Type == proto.MsgTypeExit {
+		if pane != nil {
+			pane.FeedOutput([]byte("\r\n[remote pane exited]\r\n"))
+		}
+		return errRemotePaneExited
+	}
+	if msg.Type == proto.MsgTypeCmdResult && msg.CmdErr != "" {
+		if pane != nil {
+			pane.FeedOutput([]byte("\r\n[" + msg.CmdErr + "]\r\n"))
+		}
+		return fmt.Errorf("%s", msg.CmdErr)
+	}
+	return nil
+}
+
+func (m *Manager) markDead(paneID uint32, message string) {
+	var pane *mux.Pane
+	m.mu.Lock()
+	ms := m.mirrors[paneID]
+	if ms == nil || ms.state == StateDetached {
+		m.mu.Unlock()
+		return
+	}
+	ms.state = StateDead
+	ms.lastErr = message
+	link := ms.link
+	ms.link = nil
+	pane = ms.pane
+	m.mu.Unlock()
+	if link != nil {
+		_ = link.Close()
+	}
+	if pane != nil && message != "" {
+		pane.FeedOutput([]byte("\r\n[" + message + "]\r\n"))
+	}
+}
+
+func (m *Manager) recordAttemptError(paneID uint32, err error) {
+	if err == nil {
+		return
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if ms := m.mirrors[paneID]; ms != nil && ms.state != StateDetached && ms.state != StateDead {
+		ms.lastErr = err.Error()
+	}
+}
+
+func (m *Manager) hostForRefLocked(ref checkpoint.RemoteRef) (config.Host, bool) {
+	if m.hosts == nil {
+		return config.Host{}, false
+	}
+	host, ok := m.hosts[ref.Host]
+	if !ok {
+		return config.Host{}, false
+	}
+	if host.Session == "" {
+		host.Session = ref.Session
+	}
+	return host, true
+}
+
+func cloneHosts(src map[string]config.Host) map[string]config.Host {
+	if len(src) == 0 {
+		return nil
+	}
+	dst := make(map[string]config.Host, len(src))
+	for name, host := range src {
+		dst[name] = host
+	}
+	return dst
+}
+
+func normalizeRetryPolicy(policy remote.RetryPolicy) remote.RetryPolicy {
+	if policy.MaxAttempts <= 0 {
+		policy.MaxAttempts = remote.DefaultRetryPolicy().MaxAttempts
+	}
+	if policy.InitialBackoff <= 0 {
+		policy.InitialBackoff = remote.DefaultRetryPolicy().InitialBackoff
+	}
+	if policy.MaxBackoff <= 0 {
+		policy.MaxBackoff = remote.DefaultRetryPolicy().MaxBackoff
+	}
+	return policy
+}
+
+func remoteSession(host config.Host, ref checkpoint.RemoteRef) string {
+	if ref.Session != "" {
+		return ref.Session
+	}
+	return host.Session
+}

--- a/internal/server/mirror/manager_test.go
+++ b/internal/server/mirror/manager_test.go
@@ -1,0 +1,559 @@
+package mirror
+
+import (
+	"context"
+	"errors"
+	"net"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/weill-labs/amux/internal/checkpoint"
+	"github.com/weill-labs/amux/internal/config"
+	"github.com/weill-labs/amux/internal/mux"
+	"github.com/weill-labs/amux/internal/proto"
+	"github.com/weill-labs/amux/internal/remote"
+)
+
+func TestManagerDropsStaleGenerationFrames(t *testing.T) {
+	t.Parallel()
+
+	pane := mux.NewProxyPaneWithScrollback(1, mux.PaneMeta{Name: "mirror", Host: "remote"}, 80, 23, mux.DefaultScrollbackLines, nil, nil, func(data []byte) (int, error) {
+		return len(data), nil
+	})
+	t.Cleanup(func() {
+		_ = pane.Close()
+		_ = pane.WaitClosed()
+	})
+
+	mgr := NewManager(Config{})
+	t.Cleanup(mgr.Close)
+	if err := mgr.Track(pane, checkpoint.RemoteRef{Host: "remote", Session: "main", PaneName: "agent"}); err != nil {
+		t.Fatalf("Track: %v", err)
+	}
+
+	mgr.mu.Lock()
+	ms := mgr.mirrors[pane.ID]
+	ms.state = StateConnected
+	ms.generation = 1
+	mgr.mu.Unlock()
+
+	if err := mgr.applyMessage(pane.ID, 1, paneOutput("old-frame")); err != nil {
+		t.Fatalf("apply old generation: %v", err)
+	}
+	if !pane.ScreenContains("old-frame") {
+		t.Fatal("pane did not apply initial generation frame")
+	}
+
+	gen, ok := mgr.markConnected(pane.ID, 42, nil)
+	if !ok {
+		t.Fatal("markConnected returned ok=false")
+	}
+	if gen != 2 {
+		t.Fatalf("generation = %d, want 2", gen)
+	}
+
+	if err := mgr.applyMessage(pane.ID, 1, paneOutput("stale-frame")); err != nil {
+		t.Fatalf("apply stale generation: %v", err)
+	}
+	if err := mgr.applyMessage(pane.ID, 2, paneOutput("current-frame")); err != nil {
+		t.Fatalf("apply current generation: %v", err)
+	}
+	if pane.ScreenContains("stale-frame") {
+		t.Fatal("stale generation frame was applied")
+	}
+	if !pane.ScreenContains("current-frame") {
+		t.Fatal("current generation frame was not applied")
+	}
+}
+
+func TestManagerRetryBudgetEndsDead(t *testing.T) {
+	t.Parallel()
+
+	pane := mux.NewProxyPaneWithScrollback(1, mux.PaneMeta{Name: "mirror", Host: "remote"}, 80, 23, mux.DefaultScrollbackLines, nil, nil, func(data []byte) (int, error) {
+		return len(data), nil
+	})
+	t.Cleanup(func() {
+		_ = pane.Close()
+		_ = pane.WaitClosed()
+	})
+
+	mgr := NewManager(Config{
+		Hosts: map[string]config.Host{
+			"remote": {SSH: "ignored", Session: "main", SocketPath: "/tmp/amux-test"},
+		},
+		Dialer:      failingDialer{err: errors.New("dial failed")},
+		RetryPolicy: remoteRetryPolicyForTest(2),
+	})
+	t.Cleanup(mgr.Close)
+
+	if err := mgr.Track(pane, checkpoint.RemoteRef{Host: "remote", Session: "main", PaneName: "agent"}); err != nil {
+		t.Fatalf("Track: %v", err)
+	}
+
+	waitForMirrorState(t, mgr, pane.ID, StateDead)
+	snap, ok := mgr.Snapshot(pane.ID)
+	if !ok {
+		t.Fatal("mirror snapshot missing")
+	}
+	if snap.LastError != "remote connection retry budget exhausted" {
+		t.Fatalf("LastError = %q, want retry budget exhausted", snap.LastError)
+	}
+}
+
+func TestManagerAttachDialUsesAttemptTimeout(t *testing.T) {
+	t.Parallel()
+
+	pane := newMirrorTestPane(t)
+	dialer := &blockingAttachDialer{}
+	mgr := NewManager(Config{
+		Hosts: map[string]config.Host{
+			"remote": {SSH: "ignored", Session: "main", SocketPath: "/tmp/amux-test"},
+		},
+		Dialer:        dialer,
+		RetryPolicy:   remoteRetryPolicyForTest(1),
+		AttachTimeout: time.Millisecond,
+	})
+	t.Cleanup(mgr.Close)
+
+	if err := mgr.Track(pane, checkpoint.RemoteRef{Host: "remote", Session: "main", PaneName: "agent"}); err != nil {
+		t.Fatalf("Track: %v", err)
+	}
+
+	start := time.Now()
+	waitForMirrorState(t, mgr, pane.ID, StateDead)
+	if elapsed := time.Since(start); elapsed > 200*time.Millisecond {
+		t.Fatalf("mirror reached dead after %s, want attach timeout to bound blocked dial", elapsed)
+	}
+	if got := dialer.calls.Load(); got < 2 {
+		t.Fatalf("dial calls = %d, want resolve and attach dial", got)
+	}
+}
+
+func TestManagerDetachReportsDetachedState(t *testing.T) {
+	t.Parallel()
+
+	pane := mux.NewProxyPaneWithScrollback(1, mux.PaneMeta{Name: "mirror", Host: "remote"}, 80, 23, mux.DefaultScrollbackLines, nil, nil, func(data []byte) (int, error) {
+		return len(data), nil
+	})
+	t.Cleanup(func() {
+		_ = pane.Close()
+		_ = pane.WaitClosed()
+	})
+
+	mgr := NewManager(Config{})
+	t.Cleanup(mgr.Close)
+	if err := mgr.Track(pane, checkpoint.RemoteRef{Host: "remote", Session: "main", PaneName: "agent"}); err != nil {
+		t.Fatalf("Track: %v", err)
+	}
+
+	mgr.Detach(pane.ID)
+	snap, ok := mgr.Snapshot(pane.ID)
+	if !ok {
+		t.Fatal("detached mirror snapshot missing")
+	}
+	if snap.State != StateDetached {
+		t.Fatalf("state = %s, want %s", snap.State, StateDetached)
+	}
+}
+
+func TestManagerNilReceiversAndTrackValidation(t *testing.T) {
+	t.Parallel()
+
+	var nilMgr *Manager
+	nilMgr.Configure(Config{})
+	nilMgr.Close()
+	if err := nilMgr.Track(nil, checkpoint.RemoteRef{}); err == nil || err.Error() != "mirror manager is nil" {
+		t.Fatalf("nil Track error = %v, want mirror manager is nil", err)
+	}
+	if n, err := nilMgr.Write(1, []byte("drop")); err != nil || n != len("drop") {
+		t.Fatalf("nil Write = (%d, %v), want drop length and nil error", n, err)
+	}
+	if ref, ok := nilMgr.RemoteRef(1); ok || ref != nil {
+		t.Fatalf("nil RemoteRef = (%v, %v), want nil false", ref, ok)
+	}
+	if snap, ok := nilMgr.Snapshot(1); ok || snap.State != "" {
+		t.Fatalf("nil Snapshot = (%+v, %v), want zero false", snap, ok)
+	}
+
+	mgr := NewManager(Config{})
+	t.Cleanup(mgr.Close)
+	if err := mgr.Track(nil, checkpoint.RemoteRef{Host: "remote", PaneName: "agent"}); err == nil || err.Error() != "mirror pane is nil" {
+		t.Fatalf("nil pane Track error = %v, want mirror pane is nil", err)
+	}
+	pane := newMirrorTestPane(t)
+	tests := []struct {
+		name string
+		ref  checkpoint.RemoteRef
+		want string
+	}{
+		{name: "missing host", ref: checkpoint.RemoteRef{PaneName: "agent"}, want: "remote host is required"},
+		{name: "missing pane name", ref: checkpoint.RemoteRef{Host: "remote"}, want: "remote pane name is required"},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if err := mgr.Track(pane, tt.ref); err == nil || err.Error() != tt.want {
+				t.Fatalf("Track error = %v, want %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestManagerConfigureStartsDeferredMirror(t *testing.T) {
+	t.Parallel()
+
+	pane := newMirrorTestPane(t)
+	mgr := NewManager(Config{})
+	t.Cleanup(mgr.Close)
+	ref := checkpoint.RemoteRef{Host: "remote", Session: "main", PaneName: "agent"}
+	if err := mgr.Track(pane, ref); err != nil {
+		t.Fatalf("Track: %v", err)
+	}
+	snap, ok := mgr.Snapshot(pane.ID)
+	if !ok {
+		t.Fatal("mirror snapshot missing")
+	}
+	if snap.LastError != `remote host "remote" is not configured` {
+		t.Fatalf("LastError = %q, want missing host message", snap.LastError)
+	}
+
+	mgr.Configure(Config{
+		Hosts: map[string]config.Host{
+			"remote": {SSH: "ignored", Session: "main", SocketPath: "/tmp/amux-test"},
+		},
+		Dialer:      failingDialer{err: errors.New("dial failed")},
+		RetryPolicy: remoteRetryPolicyForTest(1),
+	})
+	waitForMirrorState(t, mgr, pane.ID, StateDead)
+}
+
+func TestManagerCloseClosesTrackedLinks(t *testing.T) {
+	t.Parallel()
+
+	link, _ := connectedTestLink(t)
+	mgr := NewManager(Config{})
+	mgr.mu.Lock()
+	mgr.mirrors[1] = &mirrorState{link: link}
+	mgr.mu.Unlock()
+
+	mgr.Close()
+	if err := link.WriteMsg(paneOutput("closed")); !errors.Is(err, net.ErrClosed) {
+		t.Fatalf("WriteMsg after Close error = %v, want net.ErrClosed", err)
+	}
+}
+
+func TestManagerDetachClosesActiveLink(t *testing.T) {
+	t.Parallel()
+
+	pane := newMirrorTestPane(t)
+	link, _ := connectedTestLink(t)
+	mgr := NewManager(Config{})
+	t.Cleanup(mgr.Close)
+	mgr.mu.Lock()
+	mgr.mirrors[pane.ID] = &mirrorState{
+		pane:         pane,
+		ref:          checkpoint.RemoteRef{Host: "remote", Session: "main", PaneName: "agent"},
+		state:        StateConnected,
+		link:         link,
+		remotePaneID: 9,
+	}
+	mgr.mu.Unlock()
+
+	mgr.Detach(pane.ID)
+	if err := link.WriteMsg(paneOutput("closed")); !errors.Is(err, net.ErrClosed) {
+		t.Fatalf("WriteMsg after Detach error = %v, want net.ErrClosed", err)
+	}
+}
+
+func TestManagerWriteRoutesConnectedInputAndDropsWhenDisconnected(t *testing.T) {
+	t.Parallel()
+
+	mgr := NewManager(Config{})
+	t.Cleanup(mgr.Close)
+	if n, err := mgr.Write(1, nil); err != nil || n != 0 {
+		t.Fatalf("empty Write = (%d, %v), want 0 nil", n, err)
+	}
+	if n, err := mgr.Write(1, []byte("drop")); err != nil || n != len("drop") {
+		t.Fatalf("disconnected Write = (%d, %v), want drop length nil", n, err)
+	}
+
+	link, serverConn := connectedTestLink(t)
+	mgr.mu.Lock()
+	mgr.mirrors[1] = &mirrorState{
+		state:        StateConnected,
+		link:         link,
+		remotePaneID: 42,
+	}
+	mgr.mu.Unlock()
+
+	msgCh := make(chan struct {
+		msg *proto.Message
+		err error
+	}, 1)
+	go func() {
+		msg, err := proto.NewReader(serverConn).ReadMsg()
+		msgCh <- struct {
+			msg *proto.Message
+			err error
+		}{msg: msg, err: err}
+	}()
+	if n, err := mgr.Write(1, []byte("hello")); err != nil || n != len("hello") {
+		t.Fatalf("connected Write = (%d, %v), want input length nil", n, err)
+	}
+	got := <-msgCh
+	if got.err != nil {
+		t.Fatalf("ReadMsg: %v", got.err)
+	}
+	msg := got.msg
+	if msg.Type != proto.MsgTypeInputPane || msg.PaneID != 42 || string(msg.PaneData) != "hello" {
+		t.Fatalf("input message = %+v, want pane 42 hello", msg)
+	}
+
+	_ = serverConn.Close()
+	if n, err := mgr.Write(1, []byte("closed")); err == nil || n != 0 {
+		t.Fatalf("closed Write = (%d, %v), want 0 error", n, err)
+	}
+}
+
+func TestManagerRemoteRefAndSnapshotMisses(t *testing.T) {
+	t.Parallel()
+
+	mgr := NewManager(Config{})
+	t.Cleanup(mgr.Close)
+	if ref, ok := mgr.RemoteRef(1); ok || ref != nil {
+		t.Fatalf("missing RemoteRef = (%v, %v), want nil false", ref, ok)
+	}
+	if snap, ok := mgr.Snapshot(1); ok || snap.State != "" {
+		t.Fatalf("missing Snapshot = (%+v, %v), want zero false", snap, ok)
+	}
+
+	pane := newMirrorTestPane(t)
+	ref := checkpoint.RemoteRef{Host: "remote", Session: "main", PaneName: "agent"}
+	if err := mgr.Track(pane, ref); err != nil {
+		t.Fatalf("Track: %v", err)
+	}
+	gotRef, ok := mgr.RemoteRef(pane.ID)
+	if !ok || gotRef == nil || *gotRef != ref {
+		t.Fatalf("RemoteRef = (%v, %v), want %v true", gotRef, ok, ref)
+	}
+}
+
+func TestManagerPrepareAttemptStopsWhenHostMissing(t *testing.T) {
+	t.Parallel()
+
+	pane := newMirrorTestPane(t)
+	mgr := NewManager(Config{})
+	t.Cleanup(mgr.Close)
+	if err := mgr.Track(pane, checkpoint.RemoteRef{Host: "remote", Session: "main", PaneName: "agent"}); err != nil {
+		t.Fatalf("Track: %v", err)
+	}
+
+	_, _, ok := mgr.prepareAttempt(pane.ID, StateConnecting)
+	if ok {
+		t.Fatal("prepareAttempt ok=true, want false for missing host")
+	}
+	snap, ok := mgr.Snapshot(pane.ID)
+	if !ok {
+		t.Fatal("mirror snapshot missing")
+	}
+	if snap.LastError != `remote host "remote" is not configured` {
+		t.Fatalf("LastError = %q, want missing host message", snap.LastError)
+	}
+}
+
+func TestManagerApplyMessageHistoryExitAndCommandError(t *testing.T) {
+	t.Parallel()
+
+	pane := newMirrorTestPane(t)
+	mgr := NewManager(Config{})
+	t.Cleanup(mgr.Close)
+	mgr.mu.Lock()
+	mgr.mirrors[pane.ID] = &mirrorState{
+		pane:       pane,
+		ref:        checkpoint.RemoteRef{Host: "remote", Session: "main", PaneName: "agent"},
+		state:      StateConnected,
+		generation: 1,
+	}
+	mgr.mu.Unlock()
+
+	if err := mgr.applyMessage(pane.ID, 1, nil); err != nil {
+		t.Fatalf("apply nil message: %v", err)
+	}
+	if err := mgr.applyMessage(pane.ID, 1, &proto.Message{Type: proto.MsgTypeLayout}); err != nil {
+		t.Fatalf("apply ignored message: %v", err)
+	}
+	if err := mgr.applyMessage(pane.ID, 1, &proto.Message{Type: proto.MsgTypePaneHistory, History: []string{"old-1", "old-2"}}); err != nil {
+		t.Fatalf("apply history: %v", err)
+	}
+	if got := pane.ScrollbackLines(); len(got) != 2 || got[0] != "old-1" || got[1] != "old-2" {
+		t.Fatalf("scrollback = %#v, want retained history", got)
+	}
+	if err := mgr.applyMessage(pane.ID, 1, &proto.Message{Type: proto.MsgTypeCmdResult, CmdErr: "attach failed"}); err == nil || err.Error() != "attach failed" {
+		t.Fatalf("apply command error = %v, want attach failed", err)
+	}
+	if !pane.ScreenContains("[attach failed]") {
+		t.Fatal("pane screen missing command error marker")
+	}
+
+	mgr.mu.Lock()
+	mgr.mirrors[pane.ID].state = StateConnected
+	mgr.mu.Unlock()
+	if err := mgr.applyMessage(pane.ID, 1, &proto.Message{Type: proto.MsgTypeExit}); !errors.Is(err, errRemotePaneExited) {
+		t.Fatalf("apply exit = %v, want errRemotePaneExited", err)
+	}
+	if !pane.ScreenContains("[remote pane exited]") {
+		t.Fatal("pane screen missing remote pane exited marker")
+	}
+}
+
+func TestManagerHistoryRefreshReplacesAfterBootstrap(t *testing.T) {
+	t.Parallel()
+
+	pane := newMirrorTestPane(t)
+	mgr := NewManager(Config{})
+	t.Cleanup(mgr.Close)
+	mgr.mu.Lock()
+	mgr.mirrors[pane.ID] = &mirrorState{
+		pane:          pane,
+		ref:           checkpoint.RemoteRef{Host: "remote", Session: "main", PaneName: "agent"},
+		state:         StateConnected,
+		generation:    1,
+		bootstrapping: true,
+	}
+	mgr.mu.Unlock()
+
+	if err := mgr.applyMessage(pane.ID, 1, &proto.Message{Type: proto.MsgTypePaneHistory, History: []string{"boot-1"}}); err != nil {
+		t.Fatalf("apply first bootstrap history: %v", err)
+	}
+	if err := mgr.applyMessage(pane.ID, 1, &proto.Message{Type: proto.MsgTypePaneHistory, History: []string{"boot-2"}}); err != nil {
+		t.Fatalf("apply second bootstrap history: %v", err)
+	}
+	if got := pane.ScrollbackLines(); len(got) != 2 || got[0] != "boot-1" || got[1] != "boot-2" {
+		t.Fatalf("bootstrap scrollback = %#v, want appended chunks", got)
+	}
+	if err := mgr.applyMessage(pane.ID, 1, paneOutput("screen")); err != nil {
+		t.Fatalf("apply bootstrap screen: %v", err)
+	}
+	if err := mgr.applyMessage(pane.ID, 1, &proto.Message{Type: proto.MsgTypePaneHistory, History: []string{"refreshed"}}); err != nil {
+		t.Fatalf("apply refreshed history: %v", err)
+	}
+	if got := pane.ScrollbackLines(); len(got) != 1 || got[0] != "refreshed" {
+		t.Fatalf("refreshed scrollback = %#v, want replaced history", got)
+	}
+}
+
+func TestManagerMarkConnectedRejectsTerminalMirror(t *testing.T) {
+	t.Parallel()
+
+	mgr := NewManager(Config{})
+	t.Cleanup(mgr.Close)
+	mgr.mu.Lock()
+	mgr.mirrors[1] = &mirrorState{state: StateDead}
+	mgr.mu.Unlock()
+	if gen, ok := mgr.markConnected(1, 42, nil); ok || gen != 0 {
+		t.Fatalf("markConnected dead = (%d, %v), want 0 false", gen, ok)
+	}
+}
+
+func paneOutput(text string) *proto.Message {
+	return &proto.Message{Type: proto.MsgTypePaneOutput, PaneData: []byte(text)}
+}
+
+func newMirrorTestPane(t *testing.T) *mux.Pane {
+	t.Helper()
+	pane := mux.NewProxyPaneWithScrollback(1, mux.PaneMeta{Name: "mirror", Host: "remote"}, 80, 23, mux.DefaultScrollbackLines, nil, nil, func(data []byte) (int, error) {
+		return len(data), nil
+	})
+	t.Cleanup(func() {
+		_ = pane.Close()
+		_ = pane.WaitClosed()
+	})
+	return pane
+}
+
+func connectedTestLink(t *testing.T) (*remote.Link, net.Conn) {
+	t.Helper()
+	dialer := &pipeDialer{conns: make(chan net.Conn, 1)}
+	link := remote.NewLink(config.Host{SSH: "ignored", Session: "main", SocketPath: "/tmp/amux-test"}, dialer)
+	if err := link.Connect(context.Background()); err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	serverConn := <-dialer.conns
+	t.Cleanup(func() {
+		_ = link.Close()
+		_ = serverConn.Close()
+	})
+	return link, serverConn
+}
+
+func remoteRetryPolicyForTest(max int) remote.RetryPolicy {
+	return remote.RetryPolicy{
+		MaxAttempts:    max,
+		InitialBackoff: time.Millisecond,
+		MaxBackoff:     time.Millisecond,
+	}
+}
+
+type failingDialer struct {
+	err error
+}
+
+func (d failingDialer) Dial(context.Context, config.Host) (net.Conn, error) {
+	return nil, d.err
+}
+
+type pipeDialer struct {
+	conns chan net.Conn
+}
+
+func (d *pipeDialer) Dial(context.Context, config.Host) (net.Conn, error) {
+	serverConn, clientConn := net.Pipe()
+	d.conns <- serverConn
+	return clientConn, nil
+}
+
+type blockingAttachDialer struct {
+	calls atomic.Int32
+}
+
+func (d *blockingAttachDialer) Dial(ctx context.Context, _ config.Host) (net.Conn, error) {
+	call := d.calls.Add(1)
+	if call%2 == 1 {
+		serverConn, clientConn := net.Pipe()
+		go serveResolvePane(serverConn, 42, "agent")
+		return clientConn, nil
+	}
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
+func serveResolvePane(conn net.Conn, paneID uint32, paneName string) {
+	defer conn.Close()
+	if _, err := proto.NewReader(conn).ReadMsg(); err != nil {
+		return
+	}
+	_ = proto.NewWriter(conn).WriteMsg(&proto.Message{
+		Type: proto.MsgTypeLayout,
+		Layout: &proto.LayoutSnapshot{
+			Root:  proto.CellSnapshot{IsLeaf: true, PaneID: paneID, Dir: -1},
+			Panes: []proto.PaneSnapshot{{ID: paneID, Name: paneName}},
+		},
+	})
+}
+
+func waitForMirrorState(t *testing.T, mgr *Manager, paneID uint32, want State) {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if snap, ok := mgr.Snapshot(paneID); ok && snap.State == want {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	if snap, ok := mgr.Snapshot(paneID); ok {
+		t.Fatalf("mirror state = %s, want %s (last error %q)", snap.State, want, snap.LastError)
+	}
+	t.Fatalf("mirror snapshot missing, want state %s", want)
+}

--- a/internal/server/mirror/manager_test.go
+++ b/internal/server/mirror/manager_test.go
@@ -18,13 +18,7 @@ import (
 func TestManagerDropsStaleGenerationFrames(t *testing.T) {
 	t.Parallel()
 
-	pane := mux.NewProxyPaneWithScrollback(1, mux.PaneMeta{Name: "mirror", Host: "remote"}, 80, 23, mux.DefaultScrollbackLines, nil, nil, func(data []byte) (int, error) {
-		return len(data), nil
-	})
-	t.Cleanup(func() {
-		_ = pane.Close()
-		_ = pane.WaitClosed()
-	})
+	pane := newMirrorTestPane(t, 1)
 
 	mgr := NewManager(Config{})
 	t.Cleanup(mgr.Close)
@@ -70,13 +64,7 @@ func TestManagerDropsStaleGenerationFrames(t *testing.T) {
 func TestManagerRetryBudgetEndsDead(t *testing.T) {
 	t.Parallel()
 
-	pane := mux.NewProxyPaneWithScrollback(1, mux.PaneMeta{Name: "mirror", Host: "remote"}, 80, 23, mux.DefaultScrollbackLines, nil, nil, func(data []byte) (int, error) {
-		return len(data), nil
-	})
-	t.Cleanup(func() {
-		_ = pane.Close()
-		_ = pane.WaitClosed()
-	})
+	pane := newMirrorTestPane(t, 1)
 
 	mgr := NewManager(Config{
 		Hosts: map[string]config.Host{
@@ -104,7 +92,7 @@ func TestManagerRetryBudgetEndsDead(t *testing.T) {
 func TestManagerAttachDialUsesAttemptTimeout(t *testing.T) {
 	t.Parallel()
 
-	pane := newMirrorTestPane(t)
+	pane := newMirrorTestPane(t, 1)
 	dialer := &blockingAttachDialer{}
 	mgr := NewManager(Config{
 		Hosts: map[string]config.Host{
@@ -130,16 +118,48 @@ func TestManagerAttachDialUsesAttemptTimeout(t *testing.T) {
 	}
 }
 
+func TestManagerAttachCommandErrorIsTerminal(t *testing.T) {
+	t.Parallel()
+
+	pane := newMirrorTestPane(t, 2)
+	dialer := &attachCommandErrorDialer{cmdErr: "attach failed"}
+	mgr := NewManager(Config{
+		Hosts: map[string]config.Host{
+			"remote": {SSH: "ignored", Session: "main", SocketPath: "/tmp/amux-test"},
+		},
+		Dialer:        dialer,
+		AttachTimeout: time.Second,
+	})
+	t.Cleanup(mgr.Close)
+
+	mgr.mu.Lock()
+	mgr.mirrors[pane.ID] = &mirrorState{
+		pane:  pane,
+		ref:   checkpoint.RemoteRef{Host: "remote", Session: "main", PaneName: "agent"},
+		state: StateConnecting,
+	}
+	mgr.mu.Unlock()
+
+	connected, terminal := mgr.attachAndRead(pane.ID, StateConnecting)
+	if !connected || !terminal {
+		t.Fatalf("attachAndRead = (%v, %v), want connected terminal after command error", connected, terminal)
+	}
+	if got := dialer.calls.Load(); got != 2 {
+		t.Fatalf("dial calls = %d, want resolve and attach only", got)
+	}
+	if !pane.ScreenContains("[attach failed]") {
+		t.Fatal("pane screen missing command error marker")
+	}
+	snap, ok := mgr.Snapshot(pane.ID)
+	if !ok || snap.State != StateDead {
+		t.Fatalf("snapshot = (%+v, %v), want dead mirror", snap, ok)
+	}
+}
+
 func TestManagerDetachReportsDetachedState(t *testing.T) {
 	t.Parallel()
 
-	pane := mux.NewProxyPaneWithScrollback(1, mux.PaneMeta{Name: "mirror", Host: "remote"}, 80, 23, mux.DefaultScrollbackLines, nil, nil, func(data []byte) (int, error) {
-		return len(data), nil
-	})
-	t.Cleanup(func() {
-		_ = pane.Close()
-		_ = pane.WaitClosed()
-	})
+	pane := newMirrorTestPane(t, 1)
 
 	mgr := NewManager(Config{})
 	t.Cleanup(mgr.Close)
@@ -181,7 +201,7 @@ func TestManagerNilReceiversAndTrackValidation(t *testing.T) {
 	if err := mgr.Track(nil, checkpoint.RemoteRef{Host: "remote", PaneName: "agent"}); err == nil || err.Error() != "mirror pane is nil" {
 		t.Fatalf("nil pane Track error = %v, want mirror pane is nil", err)
 	}
-	pane := newMirrorTestPane(t)
+	pane := newMirrorTestPane(t, 1)
 	tests := []struct {
 		name string
 		ref  checkpoint.RemoteRef
@@ -204,7 +224,7 @@ func TestManagerNilReceiversAndTrackValidation(t *testing.T) {
 func TestManagerConfigureStartsDeferredMirror(t *testing.T) {
 	t.Parallel()
 
-	pane := newMirrorTestPane(t)
+	pane := newMirrorTestPane(t, 1)
 	mgr := NewManager(Config{})
 	t.Cleanup(mgr.Close)
 	ref := checkpoint.RemoteRef{Host: "remote", Session: "main", PaneName: "agent"}
@@ -247,7 +267,7 @@ func TestManagerCloseClosesTrackedLinks(t *testing.T) {
 func TestManagerDetachClosesActiveLink(t *testing.T) {
 	t.Parallel()
 
-	pane := newMirrorTestPane(t)
+	pane := newMirrorTestPane(t, 1)
 	link, _ := connectedTestLink(t)
 	mgr := NewManager(Config{})
 	t.Cleanup(mgr.Close)
@@ -329,7 +349,7 @@ func TestManagerRemoteRefAndSnapshotMisses(t *testing.T) {
 		t.Fatalf("missing Snapshot = (%+v, %v), want zero false", snap, ok)
 	}
 
-	pane := newMirrorTestPane(t)
+	pane := newMirrorTestPane(t, 1)
 	ref := checkpoint.RemoteRef{Host: "remote", Session: "main", PaneName: "agent"}
 	if err := mgr.Track(pane, ref); err != nil {
 		t.Fatalf("Track: %v", err)
@@ -343,7 +363,7 @@ func TestManagerRemoteRefAndSnapshotMisses(t *testing.T) {
 func TestManagerPrepareAttemptStopsWhenHostMissing(t *testing.T) {
 	t.Parallel()
 
-	pane := newMirrorTestPane(t)
+	pane := newMirrorTestPane(t, 1)
 	mgr := NewManager(Config{})
 	t.Cleanup(mgr.Close)
 	if err := mgr.Track(pane, checkpoint.RemoteRef{Host: "remote", Session: "main", PaneName: "agent"}); err != nil {
@@ -366,7 +386,7 @@ func TestManagerPrepareAttemptStopsWhenHostMissing(t *testing.T) {
 func TestManagerApplyMessageHistoryExitAndCommandError(t *testing.T) {
 	t.Parallel()
 
-	pane := newMirrorTestPane(t)
+	pane := newMirrorTestPane(t, 1)
 	mgr := NewManager(Config{})
 	t.Cleanup(mgr.Close)
 	mgr.mu.Lock()
@@ -408,10 +428,40 @@ func TestManagerApplyMessageHistoryExitAndCommandError(t *testing.T) {
 	}
 }
 
+func TestManagerMarkDeadIsIdempotentAfterApplyMessageExit(t *testing.T) {
+	t.Parallel()
+
+	pane := newMirrorTestPane(t, 2)
+	mgr := NewManager(Config{})
+	t.Cleanup(mgr.Close)
+	mgr.mu.Lock()
+	mgr.mirrors[pane.ID] = &mirrorState{
+		pane:       pane,
+		ref:        checkpoint.RemoteRef{Host: "remote", Session: "main", PaneName: "agent"},
+		state:      StateConnected,
+		generation: 1,
+	}
+	mgr.mu.Unlock()
+
+	if err := mgr.applyMessage(pane.ID, 1, &proto.Message{Type: proto.MsgTypeExit}); !errors.Is(err, errRemotePaneExited) {
+		t.Fatalf("apply exit = %v, want errRemotePaneExited", err)
+	}
+	screenAfterApply, _ := pane.ScreenSnapshot()
+
+	mgr.markDead(pane.ID, "remote pane exited")
+	screenAfterMarkDead, _ := pane.ScreenSnapshot()
+	if screenAfterMarkDead != screenAfterApply {
+		t.Fatal("markDead wrote to pane when state was already StateDead")
+	}
+	if !pane.ScreenContains("[remote pane exited]") {
+		t.Fatal("pane screen missing remote pane exited marker")
+	}
+}
+
 func TestManagerHistoryRefreshReplacesAfterBootstrap(t *testing.T) {
 	t.Parallel()
 
-	pane := newMirrorTestPane(t)
+	pane := newMirrorTestPane(t, 1)
 	mgr := NewManager(Config{})
 	t.Cleanup(mgr.Close)
 	mgr.mu.Lock()
@@ -461,9 +511,9 @@ func paneOutput(text string) *proto.Message {
 	return &proto.Message{Type: proto.MsgTypePaneOutput, PaneData: []byte(text)}
 }
 
-func newMirrorTestPane(t *testing.T) *mux.Pane {
+func newMirrorTestPane(t *testing.T, id uint32) *mux.Pane {
 	t.Helper()
-	pane := mux.NewProxyPaneWithScrollback(1, mux.PaneMeta{Name: "mirror", Host: "remote"}, 80, 23, mux.DefaultScrollbackLines, nil, nil, func(data []byte) (int, error) {
+	pane := mux.NewProxyPaneWithScrollback(id, mux.PaneMeta{Name: "mirror", Host: "remote"}, 80, 23, mux.DefaultScrollbackLines, nil, nil, func(data []byte) (int, error) {
 		return len(data), nil
 	})
 	t.Cleanup(func() {
@@ -527,6 +577,33 @@ func (d *blockingAttachDialer) Dial(ctx context.Context, _ config.Host) (net.Con
 	}
 	<-ctx.Done()
 	return nil, ctx.Err()
+}
+
+type attachCommandErrorDialer struct {
+	calls  atomic.Int32
+	cmdErr string
+}
+
+func (d *attachCommandErrorDialer) Dial(_ context.Context, _ config.Host) (net.Conn, error) {
+	call := d.calls.Add(1)
+	serverConn, clientConn := net.Pipe()
+	if call == 1 {
+		go serveResolvePane(serverConn, 42, "agent")
+	} else {
+		go serveAttachCommandError(serverConn, d.cmdErr)
+	}
+	return clientConn, nil
+}
+
+func serveAttachCommandError(conn net.Conn, cmdErr string) {
+	defer conn.Close()
+	if _, err := proto.NewReader(conn).ReadMsg(); err != nil {
+		return
+	}
+	_ = proto.NewWriter(conn).WriteMsg(&proto.Message{
+		Type:   proto.MsgTypeCmdResult,
+		CmdErr: cmdErr,
+	})
 }
 
 func serveResolvePane(conn net.Conn, paneID uint32, paneName string) {

--- a/internal/server/mirror/manager_test.go
+++ b/internal/server/mirror/manager_test.go
@@ -132,15 +132,16 @@ func TestManagerAttachCommandErrorIsTerminal(t *testing.T) {
 	})
 	t.Cleanup(mgr.Close)
 
-	mgr.mu.Lock()
-	mgr.mirrors[pane.ID] = &mirrorState{
+	owner := &mirrorState{
 		pane:  pane,
 		ref:   checkpoint.RemoteRef{Host: "remote", Session: "main", PaneName: "agent"},
 		state: StateConnecting,
 	}
+	mgr.mu.Lock()
+	mgr.mirrors[pane.ID] = owner
 	mgr.mu.Unlock()
 
-	connected, terminal := mgr.attachAndRead(pane.ID, StateConnecting)
+	connected, terminal := mgr.attachAndRead(pane.ID, owner, StateConnecting)
 	if !connected || !terminal {
 		t.Fatalf("attachAndRead = (%v, %v), want connected terminal after command error", connected, terminal)
 	}
@@ -370,7 +371,7 @@ func TestManagerPrepareAttemptStopsWhenHostMissing(t *testing.T) {
 		t.Fatalf("Track: %v", err)
 	}
 
-	_, _, ok := mgr.prepareAttempt(pane.ID, StateConnecting)
+	_, _, ok := mgr.prepareAttempt(pane.ID, nil, StateConnecting)
 	if ok {
 		t.Fatal("prepareAttempt ok=true, want false for missing host")
 	}
@@ -455,6 +456,90 @@ func TestManagerMarkDeadIsIdempotentAfterApplyMessageExit(t *testing.T) {
 	}
 	if !pane.ScreenContains("[remote pane exited]") {
 		t.Fatal("pane screen missing remote pane exited marker")
+	}
+}
+
+func TestManagerOldOwnerCannotMutateRetrackedMirror(t *testing.T) {
+	t.Parallel()
+
+	pane := newMirrorTestPane(t, 3)
+	mgr := NewManager(Config{})
+	t.Cleanup(mgr.Close)
+	oldState := &mirrorState{
+		pane:       pane,
+		ref:        checkpoint.RemoteRef{Host: "remote", Session: "main", PaneName: "agent"},
+		state:      StateReconnecting,
+		generation: 1,
+		running:    true,
+	}
+	newState := &mirrorState{
+		pane:       pane,
+		ref:        oldState.ref,
+		state:      StateConnecting,
+		generation: 1,
+		running:    true,
+	}
+	mgr.mu.Lock()
+	mgr.mirrors[pane.ID] = newState
+	mgr.mu.Unlock()
+
+	mgr.markStopped(pane.ID, oldState)
+	if !newState.running {
+		t.Fatal("old goroutine marked retracked mirror as stopped")
+	}
+	if gen, ok := mgr.markConnectedForOwner(pane.ID, oldState, 42, nil); ok || gen != 0 {
+		t.Fatalf("old owner markConnected = (%d, %v), want 0 false", gen, ok)
+	}
+	if err := mgr.applyMessageForOwner(pane.ID, oldState, 1, paneOutput("old-frame")); err != nil {
+		t.Fatalf("old owner applyMessage: %v", err)
+	}
+	if pane.ScreenContains("old-frame") {
+		t.Fatal("old owner frame was applied to retracked mirror")
+	}
+	mgr.recordAttemptErrorForOwner(pane.ID, oldState, errors.New("old failure"))
+	if newState.lastErr != "" {
+		t.Fatalf("new mirror lastErr = %q, want unchanged", newState.lastErr)
+	}
+}
+
+func TestManagerTerminalMessagesClearStoredLink(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		msg  *proto.Message
+	}{
+		{name: "exit", msg: &proto.Message{Type: proto.MsgTypeExit}},
+		{name: "command error", msg: &proto.Message{Type: proto.MsgTypeCmdResult, CmdErr: "attach failed"}},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			pane := newMirrorTestPane(t, 4)
+			link, _ := connectedTestLink(t)
+			mgr := NewManager(Config{})
+			t.Cleanup(mgr.Close)
+			mgr.mu.Lock()
+			mgr.mirrors[pane.ID] = &mirrorState{
+				pane:       pane,
+				ref:        checkpoint.RemoteRef{Host: "remote", Session: "main", PaneName: "agent"},
+				state:      StateConnected,
+				generation: 1,
+				link:       link,
+			}
+			mgr.mu.Unlock()
+
+			_ = mgr.applyMessage(pane.ID, 1, tt.msg)
+
+			mgr.mu.Lock()
+			got := mgr.mirrors[pane.ID].link
+			mgr.mu.Unlock()
+			if got != nil {
+				t.Fatal("terminal message left stored link set")
+			}
+		})
 	}
 }
 

--- a/internal/server/mirror_integration_test.go
+++ b/internal/server/mirror_integration_test.go
@@ -1,0 +1,327 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"net"
+	"path/filepath"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/weill-labs/amux/internal/checkpoint"
+	"github.com/weill-labs/amux/internal/config"
+	"github.com/weill-labs/amux/internal/mux"
+	"github.com/weill-labs/amux/internal/proto"
+	"github.com/weill-labs/amux/internal/remote"
+	mirrorpkg "github.com/weill-labs/amux/internal/server/mirror"
+)
+
+func TestMirrorManagerHappyPath(t *testing.T) {
+	t.Parallel()
+
+	h := newMirrorIntegrationHarness(t)
+	defer h.cleanup()
+
+	mirrorPane := h.attachMirror(t)
+	h.waitMirrorState(t, mirrorPane.ID, mirrorpkg.StateConnected)
+
+	h.remotePane.FeedOutput([]byte("REMOTE-HAPPY-PATH"))
+	waitUntil(t, func() bool {
+		return mirrorPane.ScreenContains("REMOTE-HAPPY-PATH")
+	})
+
+	if _, err := mirrorPane.Write([]byte("input-to-remote")); err != nil {
+		t.Fatalf("mirror Write: %v", err)
+	}
+	select {
+	case got := <-h.remoteWrites:
+		if string(got) != "input-to-remote" {
+			t.Fatalf("remote input = %q, want input-to-remote", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("input did not reach remote pane")
+	}
+}
+
+func TestMirrorManagerRemotePaneKilledGoesDead(t *testing.T) {
+	t.Parallel()
+
+	h := newMirrorIntegrationHarness(t)
+	defer h.cleanup()
+
+	mirrorPane := h.attachMirror(t)
+	h.waitMirrorState(t, mirrorPane.ID, mirrorpkg.StateConnected)
+
+	h.remoteSess.enqueuePaneExit(h.remotePane.ID, "exit 0")
+	h.waitMirrorState(t, mirrorPane.ID, mirrorpkg.StateDead)
+}
+
+func TestMirrorManagerRemoteServerDropExhaustsRetryBudget(t *testing.T) {
+	t.Parallel()
+
+	h := newMirrorIntegrationHarness(t)
+	defer h.cleanup()
+
+	mirrorPane := h.attachMirror(t)
+	h.waitMirrorState(t, mirrorPane.ID, mirrorpkg.StateConnected)
+
+	h.dialer.fail.Store(true)
+	h.dialer.closeAll()
+	h.waitMirrorState(t, mirrorPane.ID, mirrorpkg.StateDead)
+}
+
+func TestMirrorManagerCheckpointRestoreRehydrates(t *testing.T) {
+	t.Parallel()
+
+	h := newMirrorIntegrationHarness(t)
+	defer h.cleanup()
+
+	restoreDir := t.TempDir()
+	sessionName := "mirror-restore-" + strconv.FormatInt(time.Now().UnixNano(), 10)
+	listenerPath := filepath.Join(restoreDir, "restore.sock")
+	ln, err := net.Listen("unix", listenerPath)
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	listenerFD, err := listenerFd(ln)
+	if err != nil {
+		t.Fatalf("listenerFd: %v", err)
+	}
+	restoreFD, err := syscall.Dup(listenerFD)
+	if err != nil {
+		t.Fatalf("dup listener fd: %v", err)
+	}
+	if err := ln.Close(); err != nil {
+		_ = syscall.Close(restoreFD)
+		t.Fatalf("closing original listener: %v", err)
+	}
+
+	ref := checkpoint.RemoteRef{Host: mirrorRemoteHostName, Session: h.remoteSess.Name, PaneName: h.remotePane.Meta.Name}
+	cp := &checkpoint.ServerCheckpoint{
+		Version:       checkpoint.ServerCheckpointVersion,
+		SessionName:   sessionName,
+		Counter:       1,
+		WindowCounter: 1,
+		ListenerFd:    restoreFD,
+		Layout:        protoLayoutForMirrorCheckpoint(sessionName),
+		Panes: []checkpoint.PaneCheckpoint{{
+			ID:        1,
+			Meta:      mux.PaneMeta{Name: "mirror-restored", Host: mirrorRemoteHostName, Color: config.AccentColor(0)},
+			PtmxFd:    -1,
+			Cols:      80,
+			Rows:      23,
+			IsProxy:   true,
+			RemoteRef: &ref,
+		}},
+	}
+
+	restored, err := NewServerFromCheckpointWithScrollback(cp, mux.DefaultScrollbackLines)
+	if err != nil {
+		t.Fatalf("NewServerFromCheckpointWithScrollback: %v", err)
+	}
+	defer restored.Shutdown()
+	restored.ConfigureMirrors(h.hosts(), h.dialer)
+
+	restoredSess := restored.firstSession()
+	if restoredSess == nil {
+		t.Fatal("restored server missing session")
+	}
+	var restoredPane *mux.Pane
+	waitUntil(t, func() bool {
+		restoredPane = restoredSess.findPaneByID(1)
+		if restoredPane == nil {
+			return false
+		}
+		snap, ok := restoredSess.mirror.Snapshot(restoredPane.ID)
+		return ok && snap.State == mirrorpkg.StateConnected
+	})
+
+	h.remotePane.FeedOutput([]byte("CHECKPOINT-REHYDRATED"))
+	waitUntil(t, func() bool {
+		return restoredPane.ScreenContains("CHECKPOINT-REHYDRATED")
+	})
+}
+
+const mirrorRemoteHostName = "remote"
+
+type mirrorIntegrationHarness struct {
+	localSrv     *Server
+	localSess    *Session
+	remoteSrv    *Server
+	remoteSess   *Session
+	remotePane   *mux.Pane
+	remoteWrites chan []byte
+	dialer       *serverDialer
+	cleanup      func()
+}
+
+func newMirrorIntegrationHarness(t *testing.T) *mirrorIntegrationHarness {
+	t.Helper()
+
+	remoteSrv, remoteSess, remoteCleanup := newCommandTestSession(t)
+	remoteWrites := make(chan []byte, 8)
+	remotePane := newProxyPane(1, mux.PaneMeta{
+		Name:  "remote-agent",
+		Host:  mux.DefaultHost,
+		Color: config.AccentColor(0),
+	}, 80, 23, remoteSess.paneOutputCallback(), remoteSess.paneExitCallback(), func(data []byte) (int, error) {
+		remoteWrites <- append([]byte(nil), data...)
+		return len(data), nil
+	})
+	remotePane = remoteSess.ownPane(remotePane)
+	remoteWindow := newTestWindowWithPanes(t, remoteSess, 1, "remote-window", remotePane)
+	setSessionLayoutForTest(t, remoteSess, remoteWindow.ID, []*mux.Window{remoteWindow}, remotePane)
+
+	localSrv, localSess, localCleanup := newCommandTestSession(t)
+	localPane := newTestPane(localSess, 1, "local")
+	localWindow := newTestWindowWithPanes(t, localSess, 1, "local-window", localPane)
+	setSessionLayoutForTest(t, localSess, localWindow.ID, []*mux.Window{localWindow}, localPane)
+
+	dialer := &serverDialer{srv: remoteSrv}
+	localSess.mirror.Configure(mirrorpkg.Config{
+		Hosts:       mirrorHosts(remoteSess.Name),
+		Dialer:      dialer,
+		RetryPolicy: mirrorRetryPolicyForTest(),
+	})
+
+	return &mirrorIntegrationHarness{
+		localSrv:     localSrv,
+		localSess:    localSess,
+		remoteSrv:    remoteSrv,
+		remoteSess:   remoteSess,
+		remotePane:   remotePane,
+		remoteWrites: remoteWrites,
+		dialer:       dialer,
+		cleanup: func() {
+			localSess.mirror.Close()
+			remoteCleanup()
+			localCleanup()
+		},
+	}
+}
+
+func (h *mirrorIntegrationHarness) hosts() map[string]config.Host {
+	return mirrorHosts(h.remoteSess.Name)
+}
+
+func (h *mirrorIntegrationHarness) attachMirror(t *testing.T) *mux.Pane {
+	t.Helper()
+	ref := checkpoint.RemoteRef{
+		Host:     mirrorRemoteHostName,
+		Session:  h.remoteSess.Name,
+		PaneName: h.remotePane.Meta.Name,
+	}
+	pane, err := enqueueSessionQueryOnState(h.localSess.context(), h.localSess, func(sess *Session) (*mux.Pane, error) {
+		w := sess.activeWindow()
+		if w == nil {
+			return nil, errors.New("missing local window")
+		}
+		pane, err := sess.prepareMirrorPane(mux.PaneMeta{Name: "mirror-agent"}, ref, w.Width, mux.PaneContentHeight(w.Height))
+		if err != nil {
+			return nil, err
+		}
+		if _, err := w.SplitPaneWithOptions(w.ActivePane.ID, mux.SplitHorizontal, pane, mux.SplitOptions{}); err != nil {
+			sess.removePane(pane.ID)
+			sess.closePaneAsync(pane)
+			return nil, err
+		}
+		if err := sess.trackMirrorPane(pane, ref); err != nil {
+			return nil, err
+		}
+		sess.broadcastLayoutNow()
+		return pane, nil
+	})
+	if err != nil {
+		t.Fatalf("attach mirror: %v", err)
+	}
+	return pane
+}
+
+func (h *mirrorIntegrationHarness) waitMirrorState(t *testing.T, paneID uint32, want mirrorpkg.State) {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if snap, ok := h.localSess.mirror.Snapshot(paneID); ok && snap.State == want {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	if snap, ok := h.localSess.mirror.Snapshot(paneID); ok {
+		t.Fatalf("mirror state = %s, want %s (last error %q)", snap.State, want, snap.LastError)
+	}
+	t.Fatalf("mirror %d missing, want state %s", paneID, want)
+}
+
+func mirrorHosts(session string) map[string]config.Host {
+	return map[string]config.Host{
+		mirrorRemoteHostName: {
+			SSH:        "ignored",
+			Session:    session,
+			SocketPath: "/tmp/amux-mirror-test",
+		},
+	}
+}
+
+func mirrorRetryPolicyForTest() remote.RetryPolicy {
+	return remote.RetryPolicy{
+		MaxAttempts:    2,
+		InitialBackoff: time.Millisecond,
+		MaxBackoff:     time.Millisecond,
+	}
+}
+
+func protoLayoutForMirrorCheckpoint(sessionName string) proto.LayoutSnapshot {
+	return proto.LayoutSnapshot{
+		SessionName:  sessionName,
+		Width:        80,
+		Height:       23,
+		ActivePaneID: 1,
+		Root: proto.CellSnapshot{
+			X: 0, Y: 0, W: 80, H: 23, IsLeaf: true, Dir: -1, PaneID: 1,
+		},
+		Panes: []proto.PaneSnapshot{{
+			ID:    1,
+			Name:  "mirror-restored",
+			Host:  mirrorRemoteHostName,
+			Color: config.AccentColor(0),
+		}},
+	}
+}
+
+type serverDialer struct {
+	srv *Server
+
+	fail  atomic.Bool
+	mu    sync.Mutex
+	conns []net.Conn
+}
+
+func (d *serverDialer) Dial(ctx context.Context, _ config.Host) (net.Conn, error) {
+	if d.fail.Load() {
+		return nil, errors.New("remote server unavailable")
+	}
+	serverConn, clientConn := net.Pipe()
+	d.mu.Lock()
+	d.conns = append(d.conns, clientConn)
+	d.mu.Unlock()
+	go d.srv.handleConn(serverConn)
+	go func() {
+		<-ctx.Done()
+		_ = clientConn.Close()
+	}()
+	return clientConn, nil
+}
+
+func (d *serverDialer) closeAll() {
+	d.mu.Lock()
+	conns := append([]net.Conn(nil), d.conns...)
+	d.conns = nil
+	d.mu.Unlock()
+	for _, conn := range conns {
+		_ = conn.Close()
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -15,9 +15,12 @@ import (
 	"github.com/muesli/termenv"
 	"github.com/weill-labs/amux/internal/auditlog"
 	"github.com/weill-labs/amux/internal/checkpoint"
+	"github.com/weill-labs/amux/internal/config"
 	"github.com/weill-labs/amux/internal/debugowner"
 	"github.com/weill-labs/amux/internal/mux"
 	"github.com/weill-labs/amux/internal/proto"
+	"github.com/weill-labs/amux/internal/remote"
+	"github.com/weill-labs/amux/internal/server/mirror"
 	"github.com/weill-labs/amux/internal/termprofile"
 )
 
@@ -96,6 +99,11 @@ type Session struct {
 	// client so the result reflects client-side emulator state.
 	// The event loop owns the single in-flight request and queued requests.
 	capture *captureForwarder
+
+	// Mirror management owns remote-pane proxy state machines. It is created
+	// with the session so checkpoint restore can register mirror panes while
+	// panes are being reconstructed.
+	mirror *mirror.Manager
 
 	// Crash checkpoint coordination owns debounce/periodic scheduling and disk writes.
 	checkpointCoordinator crashCheckpointCoordinator
@@ -498,11 +506,27 @@ func newSessionWithScrollbackConfigLogger(name string, scrollback ScrollbackConf
 	sess.terminalEventState = make(map[uint32]paneTerminalEventState)
 	sess.waiters = newWaiterManager()
 	sess.capture = newCaptureForwarder()
+	sess.mirror = mirror.NewManager(mirror.Config{})
 	sess.input = newInputRouter()
 	sess.checkpointCoordinator = newSessionCheckpointCoordinator(sess)
 	sess.undo = newUndoManager(undoManagerConfig{})
 	sess.startEventLoop()
 	return sess
+}
+
+func (s *Server) ConfigureMirrors(hosts map[string]config.Host, dialer remote.Dialer) {
+	if s == nil {
+		return
+	}
+	for _, sess := range s.sessions {
+		if sess == nil || sess.mirror == nil {
+			continue
+		}
+		sess.mirror.Configure(mirror.Config{
+			Hosts:  hosts,
+			Dialer: dialer,
+		})
+	}
 }
 
 func (s *Session) scrollbackLinesForHost(host string) int {
@@ -783,6 +807,9 @@ func (s *Server) shutdown() {
 		// Stop crash checkpoint loop and wait for it to exit.
 		// The shutdown flag prevents any further writes.
 		sess.stopCrashCheckpointLoop()
+		if sess.mirror != nil {
+			sess.mirror.Close()
+		}
 
 		panes := make([]*mux.Pane, len(sess.Panes))
 		copy(panes, sess.Panes)
@@ -892,12 +919,33 @@ func (s *Server) handleAttachPane(cc *clientConn, msg *Message) {
 	cc.ID = fmt.Sprintf("client-%d", sess.ensureClientManager().nextClientOrdinal())
 	cc.logger = sess.logger.With("client_id", cc.ID)
 	cc.restrictToPane(msg.PaneID)
+	cc.startBootstrap()
 
-	if err := sess.enqueueAttachPaneClient(cc, msg.PaneID); err != nil {
-		cc.sendProtocolError(err.Error())
+	res := sess.enqueueAttachPaneClient(cc, msg.PaneID)
+	if res.err != nil {
+		cc.sendProtocolError(res.err.Error())
 		cc.Close()
 		return
 	}
+	if len(res.snapshot.styledHistory) > 0 {
+		messages, err := chunkPaneHistoryMessages(res.snapshot.paneID, res.snapshot.styledHistory, paneHistoryChunkThreshold, false)
+		if err != nil {
+			cc.sendProtocolError(err.Error())
+			cc.Close()
+			return
+		}
+		for _, historyMsg := range messages {
+			if err := cc.Send(historyMsg); err != nil {
+				cc.Close()
+				return
+			}
+		}
+	}
+	if err := cc.Send(&Message{Type: MsgTypePaneOutput, PaneID: res.snapshot.paneID, PaneData: res.snapshot.screen}); err != nil {
+		cc.Close()
+		return
+	}
+	cc.finishBootstrap(map[uint32]uint64{res.snapshot.paneID: res.snapshot.outputSeq})
 	cc.readLoop(s, sess)
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -312,6 +312,10 @@ func (s *Session) buildCrashCheckpoint() *checkpoint.CrashCheckpoint {
 
 			if !p.IsProxy() {
 				cwdWork = append(cwdWork, pidEntry{index: i, pane: p, pid: p.ProcessPid()})
+			} else if s.mirror != nil {
+				if ref, ok := s.mirror.RemoteRef(p.ID); ok {
+					ps.RemoteRef = ref
+				}
 			}
 
 			cp.PaneStates[i] = ps
@@ -613,11 +617,13 @@ func newServerFromCrashCheckpointWithScrollbackConfigListenerLogger(sessionName 
 		onExit := sess.paneExitCallback()
 
 		if ps.IsProxy {
-			// Restore proxy pane with frozen content. The remote backing is gone
-			// after the "remote" feature removal, so writes are dropped.
+			writeOverride := func(data []byte) (int, error) { return len(data), nil }
+			if ps.RemoteRef != nil {
+				writeOverride = sess.mirrorWriteOverride(ps.ID)
+			}
 			pane = sess.ownPane(mux.NewProxyPaneWithScrollback(ps.ID, ps.Meta, ps.Cols, ps.Rows, sess.scrollbackLinesForHost(ps.Meta.Host),
 				onOutput, onExit,
-				func(data []byte) (int, error) { return len(data), nil },
+				writeOverride,
 			))
 		} else {
 			meta := ps.Meta
@@ -651,6 +657,17 @@ func newServerFromCrashCheckpointWithScrollbackConfigListenerLogger(sessionName 
 
 		paneMap[ps.ID] = pane
 		sess.Panes = append(sess.Panes, pane)
+		if ps.RemoteRef != nil {
+			if err := sess.trackMirrorPane(pane, *ps.RemoteRef); err != nil {
+				sess.logger.Warn("restored mirror tracking failed",
+					"event", "checkpoint_restore",
+					"checkpoint_kind", "crash",
+					"pane_id", pane.ID,
+					"pane_name", pane.Meta.Name,
+					"error", err,
+				)
+			}
+		}
 	}
 
 	if len(sess.Panes) == 0 {

--- a/internal/server/session_events_client.go
+++ b/internal/server/session_events_client.go
@@ -45,7 +45,12 @@ type detachClientEvent struct {
 type attachPaneClientEvent struct {
 	cc     *clientConn
 	paneID uint32
-	reply  chan error
+	reply  chan attachPaneClientResult
+}
+
+type attachPaneClientResult struct {
+	snapshot attachPaneSnapshot
+	err      error
 }
 
 func (e detachClientEvent) handle(_ context.Context, s *Session) {
@@ -63,13 +68,24 @@ func (e detachClientEvent) handle(_ context.Context, s *Session) {
 }
 
 func (e attachPaneClientEvent) handle(_ context.Context, s *Session) {
-	if e.paneID == 0 || s.findWindowByPaneID(e.paneID) == nil {
-		e.reply <- fmt.Errorf("pane %d not found", e.paneID)
+	pane := s.findPaneByID(e.paneID)
+	if e.paneID == 0 || pane == nil || s.findWindowByPaneID(e.paneID) == nil {
+		e.reply <- attachPaneClientResult{err: fmt.Errorf("pane %d not found", e.paneID)}
 		return
 	}
 	s.ensureClientManager().addClient(e.cc)
 	s.appendConnectionLog(connectionLogEventAttach, e.cc.ID, e.cc.cols, e.cc.rows, "")
-	e.reply <- nil
+	history, screen, seq, historyVersion, historyCache := pane.StyledHistoryScreenSnapshotWithCache()
+	e.reply <- attachPaneClientResult{
+		snapshot: attachPaneSnapshot{
+			paneID:         pane.ID,
+			styledHistory:  history,
+			historyVersion: historyVersion,
+			historyCache:   historyCache,
+			screen:         []byte(screen),
+			outputSeq:      seq,
+		},
+	}
 }
 
 type resizeClientEvent struct {
@@ -170,25 +186,25 @@ func (s *Session) enqueueDetachClient(cc *clientConn, reason string) {
 	s.enqueueEvent(s.context(), detachClientEvent{cc: cc, reason: reason})
 }
 
-func (s *Session) enqueueAttachPaneClient(cc *clientConn, paneID uint32) error {
+func (s *Session) enqueueAttachPaneClient(cc *clientConn, paneID uint32) attachPaneClientResult {
 	ctx := s.context()
 	if cc != nil {
 		ctx = cc.context()
 	}
-	reply := make(chan error, 1)
+	reply := make(chan attachPaneClientResult, 1)
 	if !s.enqueueEvent(ctx, attachPaneClientEvent{cc: cc, paneID: paneID, reply: reply}) {
 		if err := ctx.Err(); err != nil {
-			return err
+			return attachPaneClientResult{err: err}
 		}
-		return errSessionShuttingDown
+		return attachPaneClientResult{err: errSessionShuttingDown}
 	}
 	select {
-	case err := <-reply:
-		return err
+	case res := <-reply:
+		return res
 	case <-ctx.Done():
-		return ctx.Err()
+		return attachPaneClientResult{err: ctx.Err()}
 	case <-s.sessionEventDone:
-		return errSessionShuttingDown
+		return attachPaneClientResult{err: errSessionShuttingDown}
 	}
 }
 

--- a/internal/server/session_events_pane.go
+++ b/internal/server/session_events_pane.go
@@ -38,6 +38,9 @@ func (s *Session) handleFinalizedPaneRemoval(paneID uint32, closePane bool, reas
 	if removed.pane == nil {
 		return
 	}
+	if s.mirror != nil {
+		s.mirror.Detach(paneID)
+	}
 	s.appendPaneLog(paneLogEventExit, removed.pane, reason)
 	s.emitEvent(Event{
 		Type:     EventPaneExit,

--- a/internal/server/session_pane.go
+++ b/internal/server/session_pane.go
@@ -387,6 +387,9 @@ func (s *Session) softClosePane(paneID uint32) paneRemovalResult {
 	delete(s.terminalEventState, paneID)
 	s.ensureIdleTracker().StopPane(paneID)
 	s.prunePaneEventSubs(pane.Meta.Name)
+	if s.mirror != nil {
+		s.mirror.Detach(paneID)
+	}
 
 	s.ensureUndoManager().trackSoftClosedPane(pane, s.enqueueUndoExpiry)
 
@@ -403,6 +406,13 @@ func (s *Session) undoClosePane() (pane *mux.Pane, err error) {
 
 	// Re-add to Session.Panes so it's visible again.
 	s.Panes = append(s.Panes, pane)
+	if s.mirror != nil && pane.IsProxy() {
+		if ref, ok := s.mirror.RemoteRef(pane.ID); ok && ref != nil {
+			if err := s.trackMirrorPane(pane, *ref); err != nil {
+				return nil, err
+			}
+		}
+	}
 
 	// Re-insert into the active window.
 	w := s.activeWindow()

--- a/internal/server/session_pane.go
+++ b/internal/server/session_pane.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/weill-labs/amux/internal/checkpoint"
 	"github.com/weill-labs/amux/internal/config"
 	"github.com/weill-labs/amux/internal/mux"
 	"github.com/weill-labs/amux/internal/proto"
@@ -154,6 +155,43 @@ func (s *Session) preparePendingLocalPane(srv *Server, meta mux.PaneMeta, cols, 
 	s.appendPaneLog(paneLogEventCreate, pane, "")
 	s.logPaneCreate(pane, "local")
 	return pane, s.newLocalPaneBuildRequest(id, meta, cols, rows, colorProfile), nil
+}
+
+func (s *Session) mirrorWriteOverride(paneID uint32) func([]byte) (int, error) {
+	return func(data []byte) (int, error) {
+		if s == nil || s.mirror == nil {
+			return len(data), nil
+		}
+		return s.mirror.Write(paneID, data)
+	}
+}
+
+func (s *Session) prepareMirrorPane(meta mux.PaneMeta, ref checkpoint.RemoteRef, cols, rows int) (*mux.Pane, error) {
+	if ref.Host == "" {
+		return nil, fmt.Errorf("remote host is required")
+	}
+	if ref.PaneName == "" {
+		return nil, fmt.Errorf("remote pane name is required")
+	}
+	if meta.Host == "" {
+		meta.Host = ref.Host
+	}
+	id, meta := s.reserveLocalPaneMeta(meta)
+	pane := mux.NewProxyPaneWithScrollback(id, meta, cols, rows, s.scrollbackLinesForHost(meta.Host),
+		s.paneOutputCallback(), s.paneExitCallback(), s.mirrorWriteOverride(id))
+	pane = s.configureLocalPane(pane, nil)
+
+	s.Panes = append(s.Panes, pane)
+	s.appendPaneLog(paneLogEventCreate, pane, "")
+	s.logPaneCreate(pane, "mirror")
+	return pane, nil
+}
+
+func (s *Session) trackMirrorPane(pane *mux.Pane, ref checkpoint.RemoteRef) error {
+	if s == nil || s.mirror == nil {
+		return fmt.Errorf("mirror manager is not configured")
+	}
+	return s.mirror.Track(pane, ref)
 }
 
 func (s *Session) startPendingLocalPaneBuild(srv *Server, placeholder *mux.Pane, req localPaneBuildRequest, done chan error) {

--- a/internal/server/undo_close_test.go
+++ b/internal/server/undo_close_test.go
@@ -5,7 +5,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/weill-labs/amux/internal/checkpoint"
+	"github.com/weill-labs/amux/internal/config"
 	"github.com/weill-labs/amux/internal/mux"
+	mirrorpkg "github.com/weill-labs/amux/internal/server/mirror"
 )
 
 // waitUndoStackEmpty polls the session event loop until the undo stack is empty
@@ -162,5 +165,91 @@ func TestUndoGracePeriodExpiry(t *testing.T) {
 	res = runTestCommand(t, srv, sess, "undo")
 	if res.cmdErr == "" || !strings.Contains(res.cmdErr, "no closed pane") {
 		t.Fatalf("undo after expiry should fail, got output=%q err=%q", res.output, res.cmdErr)
+	}
+}
+
+func TestSoftClosePaneDetachesMirrorDuringUndoWindow(t *testing.T) {
+	t.Parallel()
+
+	_, sess, cleanup := newCommandTestSession(t)
+	defer cleanup()
+
+	ref := checkpoint.RemoteRef{Host: "remote", Session: "main", PaneName: "agent"}
+	pane1 := newTestPane(sess, 1, "pane-1")
+	pane2 := newProxyPane(2, mux.PaneMeta{Name: "mirror", Host: "remote", Color: config.AccentColor(0)}, 80, 23,
+		sess.paneOutputCallback(), sess.paneExitCallback(), sess.mirrorWriteOverride(2),
+	)
+	window := newTestWindowWithPanes(t, sess, 1, "main", pane1, pane2)
+	setSessionLayoutForTest(t, sess, window.ID, []*mux.Window{window}, pane1, pane2)
+
+	mustSessionMutation(t, sess, func(sess *Session) {
+		if err := sess.trackMirrorPane(pane2, ref); err != nil {
+			t.Fatalf("trackMirrorPane: %v", err)
+		}
+		sess.softClosePane(pane2.ID)
+	})
+
+	got := mustSessionQuery(t, sess, func(sess *Session) struct {
+		snap mirrorpkg.Snapshot
+		ok   bool
+	} {
+		snap, ok := sess.mirror.Snapshot(pane2.ID)
+		return struct {
+			snap mirrorpkg.Snapshot
+			ok   bool
+		}{snap: snap, ok: ok}
+	})
+	if !got.ok {
+		t.Fatal("mirror snapshot missing")
+	}
+	snap := got.snap
+	if snap.State != mirrorpkg.StateDetached {
+		t.Fatalf("mirror state after soft close = %s, want %s", snap.State, mirrorpkg.StateDetached)
+	}
+}
+
+func TestUndoClosePaneRetracksSoftClosedMirror(t *testing.T) {
+	t.Parallel()
+
+	_, sess, cleanup := newCommandTestSession(t)
+	defer cleanup()
+
+	ref := checkpoint.RemoteRef{Host: "remote", Session: "main", PaneName: "agent"}
+	pane1 := newTestPane(sess, 1, "pane-1")
+	pane2 := newProxyPane(2, mux.PaneMeta{Name: "mirror", Host: "remote", Color: config.AccentColor(0)}, 80, 23,
+		sess.paneOutputCallback(), sess.paneExitCallback(), sess.mirrorWriteOverride(2),
+	)
+	window := newTestWindowWithPanes(t, sess, 1, "main", pane1, pane2)
+	setSessionLayoutForTest(t, sess, window.ID, []*mux.Window{window}, pane1, pane2)
+
+	mustSessionMutation(t, sess, func(sess *Session) {
+		if err := sess.trackMirrorPane(pane2, ref); err != nil {
+			t.Fatalf("trackMirrorPane: %v", err)
+		}
+		sess.softClosePane(pane2.ID)
+		if _, err := sess.undoClosePane(); err != nil {
+			t.Fatalf("undoClosePane: %v", err)
+		}
+	})
+
+	got := mustSessionQuery(t, sess, func(sess *Session) struct {
+		snap mirrorpkg.Snapshot
+		ok   bool
+	} {
+		snap, ok := sess.mirror.Snapshot(pane2.ID)
+		return struct {
+			snap mirrorpkg.Snapshot
+			ok   bool
+		}{snap: snap, ok: ok}
+	})
+	if !got.ok {
+		t.Fatal("mirror snapshot missing")
+	}
+	snap := got.snap
+	if snap.State == mirrorpkg.StateDetached {
+		t.Fatalf("mirror state after undo = %s, want retracked mirror", snap.State)
+	}
+	if snap.RemoteRef != ref {
+		t.Fatalf("RemoteRef = %+v, want %+v", snap.RemoteRef, ref)
 	}
 }

--- a/test/mirror_manager_test.go
+++ b/test/mirror_manager_test.go
@@ -1,0 +1,84 @@
+package test
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/weill-labs/amux/internal/checkpoint"
+	"github.com/weill-labs/amux/internal/config"
+	"github.com/weill-labs/amux/internal/mux"
+	"github.com/weill-labs/amux/internal/server"
+	mirrorpkg "github.com/weill-labs/amux/internal/server/mirror"
+)
+
+func TestMirrorManagerHarnessPairHappyPath(t *testing.T) {
+	t.Parallel()
+
+	local, remote := newServerHarnessPair(t)
+	_ = local
+	remote.runCmd("rename", "pane-1", "remote-agent")
+
+	pane := mux.NewProxyPaneWithScrollback(1, mux.PaneMeta{Name: "mirror", Host: "remote"}, 80, 23, mux.DefaultScrollbackLines, nil, nil, func(data []byte) (int, error) {
+		return len(data), nil
+	})
+	t.Cleanup(func() {
+		_ = pane.Close()
+		_ = pane.WaitClosed()
+	})
+
+	mgr := mirrorpkg.NewManager(mirrorpkg.Config{
+		Hosts: map[string]config.Host{
+			"remote": {
+				SSH:        "ignored",
+				Session:    remote.session,
+				SocketPath: server.SocketPath(remote.session),
+			},
+		},
+		Dialer: mirrorHarnessDialer{},
+	})
+	t.Cleanup(mgr.Close)
+
+	if err := mgr.Track(pane, checkpoint.RemoteRef{Host: "remote", Session: remote.session, PaneName: "remote-agent"}); err != nil {
+		t.Fatalf("Track: %v", err)
+	}
+	waitForHarnessMirrorState(t, mgr, pane.ID, mirrorpkg.StateConnected)
+
+	remote.runCmd("send-keys", "remote-agent", "printf MIRROR_PAIR_OUTPUT", "Enter")
+	waitUntilHarnessMirror(t, func() bool {
+		return pane.ScreenContains("MIRROR_PAIR_OUTPUT")
+	})
+
+	if _, err := pane.Write([]byte("printf MIRROR_PAIR_INPUT\r")); err != nil {
+		t.Fatalf("mirror pane Write: %v", err)
+	}
+	remote.runCmd("wait", "content", "remote-agent", "MIRROR_PAIR_INPUT", "--timeout", "5s")
+}
+
+type mirrorHarnessDialer struct{}
+
+func (mirrorHarnessDialer) Dial(ctx context.Context, host config.Host) (net.Conn, error) {
+	var d net.Dialer
+	return d.DialContext(ctx, "unix", host.SocketPath)
+}
+
+func waitForHarnessMirrorState(t *testing.T, mgr *mirrorpkg.Manager, paneID uint32, want mirrorpkg.State) {
+	t.Helper()
+	waitUntilHarnessMirror(t, func() bool {
+		snap, ok := mgr.Snapshot(paneID)
+		return ok && snap.State == want
+	})
+}
+
+func waitUntilHarnessMirror(t *testing.T, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("condition was not met")
+}


### PR DESCRIPTION
## Motivation
LAB-1959 adds the server-side mirror manager described in the federation spec so local panes can mirror remote amux panes through the existing attach-pane protocol while preserving hot reload behavior.

## Summary
- Add `internal/server/mirror.Manager` with connecting, connected, reconnecting, dead, and detached mirror states.
- Resolve remote panes by name before each attach, then attach by pane ID through `remote.Link`.
- Restore mirror panes from checkpointed `RemoteRef` metadata while leaving old proxy panes as frozen stubs.
- Bootstrap scoped pane attaches with retained history plus current screen output so mirrors can rehydrate state.
- Cover manager state transitions, stale generation filtering, checkpoint restore rehydration, harness-pair input/output forwarding, and review-fix regressions for terminal exits, undo detach, owner races, and crash RemoteRef restore.

## Testing
- `go test ./internal/server/mirror -run 'TestManager' -count=100`
- `go test ./internal/server -run 'TestSoftClosePaneDetachesMirrorDuringUndoWindow|TestUndoClosePaneRetracksSoftClosedMirror|TestBuildCrashCheckpointPreservesMirrorRemoteRef|TestCrashRestoreTracksMirrorRemoteRef' -count=100`
- `go test ./internal/checkpoint -run TestCrashRoundTrip -count=100`
- `go test ./test -run TestParallelAudit`
- `go test ./internal/server -run 'TestMirrorManager|TestMsgTypeAttachPaneSendsHistoryBootstrap' -count=100`
- `go test ./internal/checkpoint ./internal/server/mirror ./internal/server -run 'TestRoundTrip|TestManager|TestMirrorManager|TestMsgTypeAttachPaneSendsHistoryBootstrap'`
- `go test ./internal/checkpoint -run TestRoundTrip -count=100`
- `go test ./test -run TestMirrorManagerHarnessPairHappyPath -count=100`
- `go test $(go list ./... | grep -v '/test$') -timeout 120s`
- `scripts/check-diff-coverage.sh` (diff coverage 87.43%; the script still reported the same two SSH clipboard integration failures listed below before completing the diff gate)

Known unrelated local failures:
- `go test ./... -timeout 120s` fails in `TestCopyModeClipboardUsesTmuxPassthroughWhenInnerClientRunsOverSSHInTmux`: raw outer pane output does not include tmux-wrapped OSC 52.
- `go test ./... -timeout 120s` fails in `TestCopyModeClipboardUsesOSC52WhenInnerClientRunsOverSSH`: `wait-clipboard timed out`.

## Review focus
- Mirror generation handling around reconnects and stale output drops.
- Checkpoint restore behavior for `RemoteRef` mirror panes versus old proxy panes without remote metadata.
- Attach-pane bootstrap ordering for retained history and current screen output.

Closes LAB-1959



