### PR TITLE
LAB-1970: Redesign modal overlays for crush-style visual parity

### DIFF
--- a/internal/client/attach.go
+++ b/internal/client/attach.go
@@ -1356,7 +1356,7 @@ func runSessionWithDeps(sessionName string, getTermSize func(int) (int, int, err
 				// ChooserActive() is an atomic snapshot read. Re-check on the
 				// render loop before mutating chooser state so a queued layout can
 				// hide the chooser first without racing the input goroutine.
-				result := handleChooserInputOnRenderLoop(cr, msgCh, normalizeLocalInput(raw))
+				result := handleChooserInputOnRenderLoop(cr, msgCh, normalizeChooserInput(raw))
 				if !result.handled {
 					// If the chooser disappeared between the snapshot read above and
 					// the render-loop action, drop this key instead of forwarding it

--- a/internal/client/chooser.go
+++ b/internal/client/chooser.go
@@ -8,6 +8,7 @@ import (
 	"github.com/charmbracelet/bubbles/list"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/weill-labs/amux/internal/bubblesutil"
+	"github.com/weill-labs/amux/internal/config"
 	"github.com/weill-labs/amux/internal/proto"
 	"github.com/weill-labs/amux/internal/render"
 )
@@ -24,6 +25,11 @@ type chooserItem struct {
 	filterValue string
 	selectable  bool
 	header      bool // window grouping row in tree mode
+	icon        string
+	iconColor   string
+	textColor   string
+	desc        string
+	rule        bool
 	command     string
 	args        []string
 }
@@ -333,28 +339,14 @@ func (cr *ClientRenderer) selectChooser() chooserCommand {
 
 func (st *chooserState) rebuild() {
 	items := make([]chooserItem, 0, len(st.windows)*2)
+	treeMode := st.mode == chooserModeTree
 	for _, ws := range st.windows {
-		treeMode := st.mode == chooserModeTree
-		windowItem := chooserItem{
-			text:        formatChooserWindowRow(ws, ws.ID == st.activeWinID, treeMode),
-			filterValue: chooserWindowFilterValue(ws, treeMode),
-			selectable:  true,
-			header:      treeMode,
-			command:     "select-window",
-			args:        []string{strconv.Itoa(ws.Index)},
-		}
-		items = append(items, windowItem)
-		if st.mode != chooserModeTree {
+		items = append(items, chooserWindowItem(ws, ws.ID == st.activeWinID, treeMode))
+		if !treeMode {
 			continue
 		}
 		for _, ps := range ws.Panes {
-			items = append(items, chooserItem{
-				text:        formatChooserPaneRow(ps, ps.ID == ws.ActivePaneID),
-				filterValue: chooserPaneFilterValue(ps),
-				selectable:  true,
-				command:     "focus",
-				args:        []string{ps.Name},
-			})
+			items = append(items, chooserPaneItem(ps, ps.ID == ws.ActivePaneID))
 		}
 	}
 	st.items = items
@@ -423,6 +415,11 @@ func (st *chooserState) overlayRows(screenW, screenH int) ([]render.ChooserOverl
 			Text:       row.text,
 			Selectable: row.selectable,
 			Header:     row.header,
+			Icon:       row.icon,
+			IconColor:  row.iconColor,
+			TextColor:  row.textColor,
+			Desc:       row.desc,
+			Rule:       row.rule,
 		})
 	}
 	return rows, model.Index()
@@ -472,17 +469,60 @@ func chooserHasSelectableItems(items []list.Item) bool {
 	return false
 }
 
-func formatChooserWindowRow(ws proto.WindowSnapshot, active, header bool) string {
-	label := strconv.Itoa(ws.Index) + ":" + chooserWindowName(ws) + " (" + chooserPaneCount(len(ws.Panes)) + ")"
-	if header {
-		// Tree-mode window grouping rows are bold with no marker.
-		return label
+// chooserWindowItem builds the row for a window. In tree mode it is a bold
+// section header with a trailing rule; in window mode it is a plain selectable
+// row, marked with a status dot when it is the active window.
+func chooserWindowItem(ws proto.WindowSnapshot, active, treeMode bool) chooserItem {
+	item := chooserItem{
+		text:        strconv.Itoa(ws.Index) + ":" + chooserWindowName(ws) + " (" + chooserPaneCount(len(ws.Panes)) + ")",
+		filterValue: chooserWindowFilterValue(ws, treeMode),
+		selectable:  true,
+		command:     "select-window",
+		args:        []string{strconv.Itoa(ws.Index)},
 	}
-	marker := " "
-	if active {
-		marker = "●"
+	switch {
+	case treeMode:
+		item.header = true
+		item.rule = true
+	case active:
+		item.icon = render.DefaultIconSet().PaneActive
+		item.iconColor = config.BlueHex
 	}
-	return marker + " " + label
+	return item
+}
+
+// chooserPaneItem builds the row for a pane: a colored status icon, the pane
+// name in its assigned color, and a dim branch/task suffix.
+func chooserPaneItem(ps proto.PaneSnapshot, active bool) chooserItem {
+	icons := render.DefaultIconSet()
+	icon := icons.PaneBusy
+	switch {
+	case ps.Lead:
+		icon = icons.PaneLead
+	case active:
+		icon = icons.PaneActive
+	case ps.Idle:
+		icon = icons.PaneIdle
+	}
+	iconColor := ps.Color
+	if ps.Idle && !active && !ps.Lead {
+		iconColor = config.DimColorHex
+	}
+	desc := ps.GitBranch
+	if desc == "" {
+		desc = ps.Task
+	}
+	return chooserItem{
+		text:        ps.Name,
+		filterValue: chooserPaneFilterValue(ps),
+		selectable:  true,
+		icon:        icon,
+		iconColor:   iconColor,
+		textColor:   ps.Color,
+		desc:        desc,
+		command:     "focus",
+		args:        []string{ps.Name},
+	}
 }
 
 // chooserPaneCount renders a grammatically correct pane count.
@@ -498,19 +538,4 @@ func chooserWindowName(ws proto.WindowSnapshot) string {
 		return ws.Name + "Z"
 	}
 	return ws.Name
-}
-
-func formatChooserPaneRow(ps proto.PaneSnapshot, active bool) string {
-	marker := " "
-	if active {
-		marker = "●"
-	}
-	text := "  " + marker + " " + ps.Name
-	if ps.Host != "" && ps.Host != "local" {
-		text += " @" + ps.Host
-	}
-	if ps.Task != "" {
-		text += " " + ps.Task
-	}
-	return text
 }

--- a/internal/client/chooser.go
+++ b/internal/client/chooser.go
@@ -166,6 +166,8 @@ func (cr *ClientRenderer) HandleChooserInput(raw []byte) chooserCommand {
 			result = cr.pageChooser(-1)
 		case tea.KeyPgDown:
 			result = cr.pageChooser(1)
+		case tea.KeyTab, tea.KeyShiftTab:
+			cr.toggleChooserMode()
 		case tea.KeyRunes:
 			// j/k are intentionally NOT movement keys: they must be typeable
 			// into the filter query. Use Ctrl+J/Ctrl+K (mapped to Down/Up by
@@ -204,12 +206,36 @@ func (cr *ClientRenderer) chooserOverlayFromSnapshot(state *clientSnapshot) *ren
 	}
 	screenW, screenH := cr.chooserScreenSize()
 	rows, selected := state.ui.chooser.overlayRows(screenW, screenH)
+	toggleSelected := 0
+	if state.ui.chooser.mode == chooserModeWindow {
+		toggleSelected = 1
+	}
 	return &render.ChooserOverlay{
-		Title:    state.ui.chooser.mode.title(),
+		Title:    "Choose",
 		Query:    state.ui.chooser.query.Value,
 		Rows:     rows,
 		Selected: selected,
+		Toggle:   &render.ChooserToggle{Options: []string{"Tree", "Window"}, Selected: toggleSelected},
 	}
+}
+
+// toggleChooserMode flips between tree and window views in place, preserving
+// the filter query.
+func (cr *ClientRenderer) toggleChooserMode() {
+	cr.updateState(func(next *clientSnapshot) clientUIResult {
+		if next.ui.chooser == nil {
+			return clientUIResult{}
+		}
+		next.ui.chooser = cloneChooserState(next.ui.chooser)
+		if next.ui.chooser.mode == chooserModeWindow {
+			next.ui.chooser.mode = chooserModeTree
+		} else {
+			next.ui.chooser.mode = chooserModeWindow
+		}
+		next.ui.chooser.rebuild()
+		next.ui.dirty = true
+		return clientUIResult{}
+	})
 }
 
 func (cr *ClientRenderer) moveChooser(delta int) chooserCommand {

--- a/internal/client/chooser.go
+++ b/internal/client/chooser.go
@@ -39,6 +39,7 @@ type chooserState struct {
 	query       bubblesutil.TextInputState
 	windows     []proto.WindowSnapshot
 	activeWinID uint32
+	icons       render.IconSet
 	items       []chooserItem
 	selected    int
 }
@@ -111,6 +112,7 @@ func (cr *ClientRenderer) ShowChooser(mode chooserMode) bool {
 		mode:        mode,
 		windows:     windows,
 		activeWinID: activeWinID,
+		icons:       cr.IconSet(),
 	}
 	state.rebuild()
 
@@ -371,12 +373,12 @@ func (st *chooserState) rebuild() {
 	items := make([]chooserItem, 0, len(st.windows)*2)
 	treeMode := st.mode == chooserModeTree
 	for _, ws := range st.windows {
-		items = append(items, chooserWindowItem(ws, ws.ID == st.activeWinID, treeMode))
+		items = append(items, chooserWindowItem(ws, ws.ID == st.activeWinID, treeMode, st.icons))
 		if !treeMode {
 			continue
 		}
 		for _, ps := range ws.Panes {
-			items = append(items, chooserPaneItem(ps, ps.ID == ws.ActivePaneID))
+			items = append(items, chooserPaneItem(ps, ps.ID == ws.ActivePaneID, st.icons))
 		}
 	}
 	st.items = items
@@ -464,11 +466,9 @@ func (cr *ClientRenderer) chooserScreenSize() (int, int) {
 }
 
 func chooserListHeight(screenH int) int {
-	height := screenH - 7
-	if height < 1 {
-		return 1
-	}
-	return height
+	// Match the chrome's visible-row window so PgUp/PgDn steps line up with
+	// what is actually drawn.
+	return render.ChooserRowLimit(screenH)
 }
 
 func chooserWindowFilterValue(ws proto.WindowSnapshot, includePanes bool) string {
@@ -502,7 +502,7 @@ func chooserHasSelectableItems(items []list.Item) bool {
 // chooserWindowItem builds the row for a window. In tree mode it is a bold
 // section header with a trailing rule; in window mode it is a plain selectable
 // row, marked with a status dot when it is the active window.
-func chooserWindowItem(ws proto.WindowSnapshot, active, treeMode bool) chooserItem {
+func chooserWindowItem(ws proto.WindowSnapshot, active, treeMode bool, icons render.IconSet) chooserItem {
 	item := chooserItem{
 		text:        strconv.Itoa(ws.Index) + ":" + chooserWindowName(ws) + " (" + chooserPaneCount(len(ws.Panes)) + ")",
 		filterValue: chooserWindowFilterValue(ws, treeMode),
@@ -515,7 +515,7 @@ func chooserWindowItem(ws proto.WindowSnapshot, active, treeMode bool) chooserIt
 		item.header = true
 		item.rule = true
 	case active:
-		item.icon = render.DefaultIconSet().PaneActive
+		item.icon = icons.PaneActive
 		item.iconColor = config.BlueHex
 	}
 	return item
@@ -523,8 +523,7 @@ func chooserWindowItem(ws proto.WindowSnapshot, active, treeMode bool) chooserIt
 
 // chooserPaneItem builds the row for a pane: a colored status icon, the pane
 // name in its assigned color, and a dim branch/task suffix.
-func chooserPaneItem(ps proto.PaneSnapshot, active bool) chooserItem {
-	icons := render.DefaultIconSet()
+func chooserPaneItem(ps proto.PaneSnapshot, active bool, icons render.IconSet) chooserItem {
 	icon := icons.PaneBusy
 	switch {
 	case ps.Lead:

--- a/internal/client/chooser.go
+++ b/internal/client/chooser.go
@@ -333,13 +333,17 @@ func (cr *ClientRenderer) applyChooserQueryKey(msg tea.KeyMsg) {
 // selectChooserRowAt moves the selection to absRow (an index into the visible
 // rows) and confirms it — used for click-to-choose.
 func (cr *ClientRenderer) selectChooserRowAt(absRow int) chooserCommand {
-	cr.updateChooserSelection(func(model *list.Model) chooserCommand {
+	if cmd := cr.updateChooserSelection(func(model *list.Model) chooserCommand {
 		if absRow < 0 || absRow >= len(model.VisibleItems()) {
 			return chooserCommand{bell: true}
 		}
 		model.Select(absRow)
 		return chooserCommand{}
-	})
+	}); cmd.bell {
+		// The row went out of range (e.g. the filter changed under us); ring
+		// the bell instead of confirming whatever happens to be selected.
+		return cmd
+	}
 	return cr.selectChooser()
 }
 

--- a/internal/client/chooser.go
+++ b/internal/client/chooser.go
@@ -23,6 +23,7 @@ type chooserItem struct {
 	text        string
 	filterValue string
 	selectable  bool
+	header      bool // window grouping row in tree mode
 	command     string
 	args        []string
 }
@@ -160,14 +161,9 @@ func (cr *ClientRenderer) HandleChooserInput(raw []byte) chooserCommand {
 		case tea.KeyPgDown:
 			result = cr.pageChooser(1)
 		case tea.KeyRunes:
-			if len(msg.Runes) == 1 && msg.Runes[0] == 'j' {
-				result = cr.moveChooser(1)
-				continue
-			}
-			if len(msg.Runes) == 1 && msg.Runes[0] == 'k' {
-				result = cr.moveChooser(-1)
-				continue
-			}
+			// j/k are intentionally NOT movement keys: they must be typeable
+			// into the filter query. Use Ctrl+J/Ctrl+K (mapped to Down/Up by
+			// normalizeChooserInput) or the arrow keys to move the selection.
 			if len(msg.Runes) == 1 && msg.Runes[0] == 'q' && cr.chooserQueryValue() == "" {
 				cr.HideChooser()
 				return chooserCommand{}
@@ -302,6 +298,19 @@ func (cr *ClientRenderer) applyChooserQueryKey(msg tea.KeyMsg) {
 	})
 }
 
+// selectChooserRowAt moves the selection to absRow (an index into the visible
+// rows) and confirms it — used for click-to-choose.
+func (cr *ClientRenderer) selectChooserRowAt(absRow int) chooserCommand {
+	cr.updateChooserSelection(func(model *list.Model) chooserCommand {
+		if absRow < 0 || absRow >= len(model.VisibleItems()) {
+			return chooserCommand{bell: true}
+		}
+		model.Select(absRow)
+		return chooserCommand{}
+	})
+	return cr.selectChooser()
+}
+
 func (cr *ClientRenderer) selectChooser() chooserCommand {
 	screenW, screenH := cr.chooserScreenSize()
 	command, result := updateClientStateValue(cr, func(next *clientSnapshot) (chooserCommand, clientUIResult) {
@@ -325,10 +334,12 @@ func (cr *ClientRenderer) selectChooser() chooserCommand {
 func (st *chooserState) rebuild() {
 	items := make([]chooserItem, 0, len(st.windows)*2)
 	for _, ws := range st.windows {
+		treeMode := st.mode == chooserModeTree
 		windowItem := chooserItem{
-			text:        formatChooserWindowRow(ws, ws.ID == st.activeWinID),
-			filterValue: chooserWindowFilterValue(ws, st.mode == chooserModeTree),
+			text:        formatChooserWindowRow(ws, ws.ID == st.activeWinID, treeMode),
+			filterValue: chooserWindowFilterValue(ws, treeMode),
 			selectable:  true,
+			header:      treeMode,
 			command:     "select-window",
 			args:        []string{strconv.Itoa(ws.Index)},
 		}
@@ -411,6 +422,7 @@ func (st *chooserState) overlayRows(screenW, screenH int) ([]render.ChooserOverl
 		rows = append(rows, render.ChooserOverlayRow{
 			Text:       row.text,
 			Selectable: row.selectable,
+			Header:     row.header,
 		})
 	}
 	return rows, model.Index()
@@ -460,12 +472,25 @@ func chooserHasSelectableItems(items []list.Item) bool {
 	return false
 }
 
-func formatChooserWindowRow(ws proto.WindowSnapshot, active bool) string {
+func formatChooserWindowRow(ws proto.WindowSnapshot, active, header bool) string {
+	label := strconv.Itoa(ws.Index) + ":" + chooserWindowName(ws) + " (" + chooserPaneCount(len(ws.Panes)) + ")"
+	if header {
+		// Tree-mode window grouping rows are bold with no marker.
+		return label
+	}
 	marker := " "
 	if active {
-		marker = "*"
+		marker = "●"
 	}
-	return marker + " " + strconv.Itoa(ws.Index) + ":" + chooserWindowName(ws) + " (" + strconv.Itoa(len(ws.Panes)) + " panes)"
+	return marker + " " + label
+}
+
+// chooserPaneCount renders a grammatically correct pane count.
+func chooserPaneCount(n int) string {
+	if n == 1 {
+		return "1 pane"
+	}
+	return strconv.Itoa(n) + " panes"
 }
 
 func chooserWindowName(ws proto.WindowSnapshot) string {
@@ -478,7 +503,7 @@ func chooserWindowName(ws proto.WindowSnapshot) string {
 func formatChooserPaneRow(ps proto.PaneSnapshot, active bool) string {
 	marker := " "
 	if active {
-		marker = "*"
+		marker = "●"
 	}
 	text := "  " + marker + " " + ps.Name
 	if ps.Host != "" && ps.Host != "local" {

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/charmbracelet/x/ansi"
 	"github.com/charmbracelet/x/vt"
+	"github.com/weill-labs/amux/internal/config"
 	"github.com/weill-labs/amux/internal/mux"
 	"github.com/weill-labs/amux/internal/proto"
 	"github.com/weill-labs/amux/internal/render"
@@ -2331,7 +2332,7 @@ func TestChooseTreeFilterAndSelection(t *testing.T) {
 	if len(overlay.Rows) < 2 {
 		t.Fatalf("filtered rows = %+v, want grouped window + pane rows", overlay.Rows)
 	}
-	if overlay.Rows[1].Text != "  ● pane-2 @gpu-box train" && overlay.Rows[1].Text != "    pane-2 @gpu-box train" {
+	if overlay.Rows[1].Text != "pane-2" || overlay.Rows[1].Desc != "train" {
 		t.Fatalf("unexpected filtered pane row: %+v", overlay.Rows[1])
 	}
 
@@ -2362,20 +2363,28 @@ func TestFormatChooserRowsPolish(t *testing.T) {
 	onePane := proto.WindowSnapshot{Index: 1, Name: "amux", Panes: []proto.PaneSnapshot{{}}}
 	twoPane := proto.WindowSnapshot{Index: 2, Name: "orca", Panes: []proto.PaneSnapshot{{}, {}}}
 
-	if got := formatChooserWindowRow(onePane, true, true); got != "1:amux (1 pane)" {
-		t.Errorf("tree header row = %q, want %q", got, "1:amux (1 pane)")
+	// Tree-mode window: bold header with a rule, grammatically correct count.
+	if got := chooserWindowItem(onePane, true, true); got.text != "1:amux (1 pane)" || !got.header || !got.rule {
+		t.Errorf("tree window item = %+v, want text %q, header+rule", got, "1:amux (1 pane)")
 	}
-	if got := formatChooserWindowRow(twoPane, true, false); got != "● 2:orca (2 panes)" {
-		t.Errorf("active window-mode row = %q, want %q", got, "● 2:orca (2 panes)")
+	// Window-mode active window: status dot, no rule.
+	if got := chooserWindowItem(twoPane, true, false); got.text != "2:orca (2 panes)" || got.icon == "" || got.rule {
+		t.Errorf("active window item = %+v, want text %q with an icon and no rule", got, "2:orca (2 panes)")
 	}
-	if got := formatChooserWindowRow(twoPane, false, false); got != "  2:orca (2 panes)" {
-		t.Errorf("inactive window-mode row = %q, want %q", got, "  2:orca (2 panes)")
+	// Window-mode inactive: no icon.
+	if got := chooserWindowItem(twoPane, false, false); got.icon != "" {
+		t.Errorf("inactive window item should have no icon, got %q", got.icon)
 	}
-	if got := formatChooserPaneRow(proto.PaneSnapshot{Name: "pane-1"}, true); got != "  ● pane-1" {
-		t.Errorf("active pane row = %q, want %q", got, "  ● pane-1")
+
+	// Active pane: colored icon + name + dim branch.
+	active := chooserPaneItem(proto.PaneSnapshot{Name: "pane-1", Color: "f5e0dc", GitBranch: "main"}, true)
+	if active.text != "pane-1" || active.icon == "" || active.iconColor != "f5e0dc" || active.textColor != "f5e0dc" || active.desc != "main" {
+		t.Errorf("active pane item = %+v, want name pane-1, colored icon/text, desc main", active)
 	}
-	if got := formatChooserPaneRow(proto.PaneSnapshot{Name: "pane-2"}, false); got != "    pane-2" {
-		t.Errorf("inactive pane row = %q, want %q", got, "    pane-2")
+	// Idle inactive pane: dim icon.
+	idle := chooserPaneItem(proto.PaneSnapshot{Name: "pane-2", Idle: true}, false)
+	if idle.iconColor != config.DimColorHex {
+		t.Errorf("idle pane icon color = %q, want dim %q", idle.iconColor, config.DimColorHex)
 	}
 }
 

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -2331,7 +2331,7 @@ func TestChooseTreeFilterAndSelection(t *testing.T) {
 	if len(overlay.Rows) < 2 {
 		t.Fatalf("filtered rows = %+v, want grouped window + pane rows", overlay.Rows)
 	}
-	if overlay.Rows[1].Text != "  * pane-2 @gpu-box train" && overlay.Rows[1].Text != "    pane-2 @gpu-box train" {
+	if overlay.Rows[1].Text != "  ● pane-2 @gpu-box train" && overlay.Rows[1].Text != "    pane-2 @gpu-box train" {
 		t.Fatalf("unexpected filtered pane row: %+v", overlay.Rows[1])
 	}
 
@@ -2349,10 +2349,33 @@ func TestChooseTreeNavigationSelectsPane(t *testing.T) {
 		t.Fatal("ShowChooser tree should succeed")
 	}
 	cr.HandleChooserInput([]byte("pane-3"))
-	cr.HandleChooserInput([]byte("j"))
+	cr.HandleChooserInput([]byte("\x1b[B")) // Down arrow (j now types into the filter)
 	cmd := cr.selectChooser()
 	if cmd.command != "focus" || len(cmd.args) != 1 || cmd.args[0] != "pane-3" {
 		t.Fatalf("pane selection = %+v, want focus pane-3", cmd)
+	}
+}
+
+func TestFormatChooserRowsPolish(t *testing.T) {
+	t.Parallel()
+
+	onePane := proto.WindowSnapshot{Index: 1, Name: "amux", Panes: []proto.PaneSnapshot{{}}}
+	twoPane := proto.WindowSnapshot{Index: 2, Name: "orca", Panes: []proto.PaneSnapshot{{}, {}}}
+
+	if got := formatChooserWindowRow(onePane, true, true); got != "1:amux (1 pane)" {
+		t.Errorf("tree header row = %q, want %q", got, "1:amux (1 pane)")
+	}
+	if got := formatChooserWindowRow(twoPane, true, false); got != "● 2:orca (2 panes)" {
+		t.Errorf("active window-mode row = %q, want %q", got, "● 2:orca (2 panes)")
+	}
+	if got := formatChooserWindowRow(twoPane, false, false); got != "  2:orca (2 panes)" {
+		t.Errorf("inactive window-mode row = %q, want %q", got, "  2:orca (2 panes)")
+	}
+	if got := formatChooserPaneRow(proto.PaneSnapshot{Name: "pane-1"}, true); got != "  ● pane-1" {
+		t.Errorf("active pane row = %q, want %q", got, "  ● pane-1")
+	}
+	if got := formatChooserPaneRow(proto.PaneSnapshot{Name: "pane-2"}, false); got != "    pane-2" {
+		t.Errorf("inactive pane row = %q, want %q", got, "    pane-2")
 	}
 }
 
@@ -2374,7 +2397,7 @@ func TestChooseWindowSupportsHomeAndEndKeys(t *testing.T) {
 	if !cr.ShowChooser(chooserModeWindow) {
 		t.Fatal("ShowChooser window should succeed after reselection")
 	}
-	cr.HandleChooserInput([]byte("j"))
+	cr.HandleChooserInput([]byte("\x1b[B")) // Down arrow (j now types into the filter)
 	if got := cr.HandleChooserInput([]byte("\x1b[H")); got.bell {
 		t.Fatalf("Home key should navigate the chooser, got %+v", got)
 	}

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -2214,12 +2214,12 @@ func TestChooseWindowOverlayDisplayOnly(t *testing.T) {
 	cr.RenderDiff()
 
 	display := cr.CaptureDisplay()
-	if !strings.Contains(display, "choose-window") || !strings.Contains(display, "1:editor") {
+	if !strings.Contains(display, "Choose") || !strings.Contains(display, "1:editor") {
 		t.Fatalf("display capture should include chooser overlay, got:\n%s", display)
 	}
 
 	plain := cr.Capture(true)
-	if strings.Contains(plain, "choose-window") {
+	if strings.Contains(plain, "Choose") {
 		t.Fatalf("plain capture should not include chooser overlay, got:\n%s", plain)
 	}
 }
@@ -2385,6 +2385,37 @@ func TestFormatChooserRowsPolish(t *testing.T) {
 	idle := chooserPaneItem(proto.PaneSnapshot{Name: "pane-2", Idle: true}, false)
 	if idle.iconColor != config.DimColorHex {
 		t.Errorf("idle pane icon color = %q, want dim %q", idle.iconColor, config.DimColorHex)
+	}
+}
+
+func TestChooserTabTogglesTreeWindow(t *testing.T) {
+	t.Parallel()
+
+	cr := buildMultiWindowRenderer(t)
+	if !cr.ShowChooser(chooserModeWindow) {
+		t.Fatal("ShowChooser window should succeed")
+	}
+	if ov := cr.chooserOverlay(); ov.Toggle == nil || ov.Toggle.Selected != 1 {
+		t.Fatalf("window mode toggle = %+v, want Window selected (1)", ov.Toggle)
+	}
+
+	// Tab switches to tree view in place; the toggle reflects it.
+	if cmd := cr.HandleChooserInput([]byte{'\t'}); cmd.bell {
+		t.Fatalf("tab should switch view, got %+v", cmd)
+	}
+	ov := cr.chooserOverlay()
+	if ov.Toggle == nil || ov.Toggle.Selected != 0 {
+		t.Fatalf("after tab, toggle = %+v, want Tree selected (0)", ov.Toggle)
+	}
+	// Tree view groups panes under windows, so it has more rows than window view.
+	if len(ov.Rows) <= 2 {
+		t.Fatalf("tree view rows = %d, want panes grouped under windows", len(ov.Rows))
+	}
+
+	// Tab again returns to window view.
+	cr.HandleChooserInput([]byte{'\t'})
+	if ov := cr.chooserOverlay(); ov.Toggle.Selected != 1 {
+		t.Fatalf("second tab should return to Window view, toggle = %+v", ov.Toggle)
 	}
 }
 

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -2364,27 +2364,32 @@ func TestFormatChooserRowsPolish(t *testing.T) {
 	twoPane := proto.WindowSnapshot{Index: 2, Name: "orca", Panes: []proto.PaneSnapshot{{}, {}}}
 
 	// Tree-mode window: bold header with a rule, grammatically correct count.
-	if got := chooserWindowItem(onePane, true, true); got.text != "1:amux (1 pane)" || !got.header || !got.rule {
+	if got := chooserWindowItem(onePane, true, true, render.UnicodeIconSet()); got.text != "1:amux (1 pane)" || !got.header || !got.rule {
 		t.Errorf("tree window item = %+v, want text %q, header+rule", got, "1:amux (1 pane)")
 	}
 	// Window-mode active window: status dot, no rule.
-	if got := chooserWindowItem(twoPane, true, false); got.text != "2:orca (2 panes)" || got.icon == "" || got.rule {
+	if got := chooserWindowItem(twoPane, true, false, render.UnicodeIconSet()); got.text != "2:orca (2 panes)" || got.icon == "" || got.rule {
 		t.Errorf("active window item = %+v, want text %q with an icon and no rule", got, "2:orca (2 panes)")
 	}
 	// Window-mode inactive: no icon.
-	if got := chooserWindowItem(twoPane, false, false); got.icon != "" {
+	if got := chooserWindowItem(twoPane, false, false, render.UnicodeIconSet()); got.icon != "" {
 		t.Errorf("inactive window item should have no icon, got %q", got.icon)
 	}
 
 	// Active pane: colored icon + name + dim branch.
-	active := chooserPaneItem(proto.PaneSnapshot{Name: "pane-1", Color: "f5e0dc", GitBranch: "main"}, true)
+	active := chooserPaneItem(proto.PaneSnapshot{Name: "pane-1", Color: "f5e0dc", GitBranch: "main"}, true, render.UnicodeIconSet())
 	if active.text != "pane-1" || active.icon == "" || active.iconColor != "f5e0dc" || active.textColor != "f5e0dc" || active.desc != "main" {
 		t.Errorf("active pane item = %+v, want name pane-1, colored icon/text, desc main", active)
 	}
 	// Idle inactive pane: dim icon.
-	idle := chooserPaneItem(proto.PaneSnapshot{Name: "pane-2", Idle: true}, false)
+	idle := chooserPaneItem(proto.PaneSnapshot{Name: "pane-2", Idle: true}, false, render.UnicodeIconSet())
 	if idle.iconColor != config.DimColorHex {
 		t.Errorf("idle pane icon color = %q, want dim %q", idle.iconColor, config.DimColorHex)
+	}
+	// The configured icon set is honored (not hard-coded to Unicode).
+	asciiItem := chooserPaneItem(proto.PaneSnapshot{Name: "pane-3"}, true, render.ASCIIIconSet())
+	if asciiItem.icon != render.ASCIIIconSet().PaneActive {
+		t.Errorf("pane icon = %q, want ASCII active glyph %q", asciiItem.icon, render.ASCIIIconSet().PaneActive)
 	}
 }
 

--- a/internal/client/helpers_extra_test.go
+++ b/internal/client/helpers_extra_test.go
@@ -208,11 +208,12 @@ func TestChooserNavigationCoverageHelpers(t *testing.T) {
 	if !cr.ShowChooser(chooserModeWindow) {
 		t.Fatal("ShowChooser window should succeed")
 	}
+	// j/k must type into the filter query rather than move the selection.
 	if got := cr.HandleChooserInput([]byte("k")); got.bell {
-		t.Fatalf("k should wrap to the last row, got %+v", got)
+		t.Fatalf("k should type into the filter, got %+v", got)
 	}
-	if cmd := cr.selectChooser(); cmd.command != "select-window" || len(cmd.args) != 1 || cmd.args[0] != "2" {
-		t.Fatalf("selection after k wrap = %+v, want window 2", cmd)
+	if q := cr.chooserQueryValue(); q != "k" {
+		t.Fatalf("chooserQueryValue() after typing k = %q, want %q", q, "k")
 	}
 
 	if !cr.ShowChooser(chooserModeWindow) {

--- a/internal/client/helpers_extra_test.go
+++ b/internal/client/helpers_extra_test.go
@@ -121,8 +121,8 @@ func TestChooserHelpersAndInputBranches(t *testing.T) {
 	}
 
 	overlay := cr.chooserOverlay()
-	if overlay == nil || overlay.Title != "choose-tree" {
-		t.Fatalf("chooserOverlay = %+v, want choose-tree overlay", overlay)
+	if overlay == nil || overlay.Title != "Choose" || overlay.Toggle == nil || overlay.Toggle.Selected != 0 {
+		t.Fatalf("chooserOverlay = %+v, want Choose overlay with Tree toggle selected", overlay)
 	}
 
 	if cmd := cr.HandleChooserInput([]byte{0x1b, '[', 'B'}); cmd.bell || cmd.command != "" {

--- a/internal/client/input_dispatch_test.go
+++ b/internal/client/input_dispatch_test.go
@@ -2430,3 +2430,82 @@ func TestCopyModeCopySelectionAppendsCopyBuffer(t *testing.T) {
 		t.Fatalf("copyBuffer = %q, want %q", got, "hell")
 	}
 }
+
+func TestHandleChooserMouseEventInactivePassesThrough(t *testing.T) {
+	t.Parallel()
+
+	cr := buildMultiWindowRenderer(t)
+	ev := mouse.Event{Action: mouse.Press, Button: mouse.ButtonLeft}
+	if handleChooserMouseEvent(ev, cr, nil, nil) {
+		t.Fatal("mouse event should not be consumed when the chooser is inactive")
+	}
+}
+
+func TestHandleChooserMouseEventWheelAndOutsideClick(t *testing.T) {
+	t.Parallel()
+
+	cr := buildMultiWindowRenderer(t)
+	msgCh := startTestRenderLoop(t, cr)
+	if !cr.ShowChooser(chooserModeWindow) {
+		t.Fatal("ShowChooser window should succeed")
+	}
+
+	if !handleChooserMouseEvent(mouse.Event{Button: mouse.ScrollDown}, cr, nil, msgCh) {
+		t.Fatal("wheel events should be consumed while the chooser is open")
+	}
+	if !cr.ChooserActive() {
+		t.Fatal("chooser should remain open after a scroll wheel event")
+	}
+
+	if !handleChooserMouseEvent(mouse.Event{Action: mouse.Press, Button: mouse.ButtonLeft, X: 0, Y: 0}, cr, nil, msgCh) {
+		t.Fatal("clicks should be consumed while the chooser is open")
+	}
+	if cr.ChooserActive() {
+		t.Fatal("a left click outside the modal should dismiss the chooser")
+	}
+}
+
+func TestHandleChooserMouseEventClickRowSendsCommand(t *testing.T) {
+	t.Parallel()
+
+	cr := buildMultiWindowRenderer(t)
+	msgCh := startTestRenderLoop(t, cr)
+	if !cr.ShowChooser(chooserModeWindow) {
+		t.Fatal("ShowChooser window should succeed")
+	}
+
+	overlay := cr.chooserOverlay()
+	screenW, screenH := cr.chooserScreenSize()
+	clickX, clickY, found := 0, 0, false
+	for y := 0; y < screenH && !found; y++ {
+		if _, onRow, _ := render.ChooserRowAtPoint(screenW, screenH, overlay, screenW/2, y); onRow {
+			clickX, clickY, found = screenW/2, y, true
+		}
+	}
+	if !found {
+		t.Fatal("expected at least one clickable row in the chooser")
+	}
+
+	clientConn, serverConn := net.Pipe()
+	t.Cleanup(func() {
+		clientConn.Close()
+		serverConn.Close()
+	})
+	sender := newMessageSender(clientConn)
+	t.Cleanup(sender.Close)
+
+	done := make(chan struct{})
+	go func() {
+		handleChooserMouseEvent(mouse.Event{Action: mouse.Press, Button: mouse.ButtonLeft, X: clickX, Y: clickY}, cr, sender, msgCh)
+		close(done)
+	}()
+
+	msg := readCommandMessage(t, serverConn)
+	if msg.CmdName != "select-window" {
+		t.Fatalf("clicking a window row sent %q, want select-window", msg.CmdName)
+	}
+	<-done
+	if cr.ChooserActive() {
+		t.Fatal("choosing a row by click should dismiss the chooser")
+	}
+}

--- a/internal/client/input_keys.go
+++ b/internal/client/input_keys.go
@@ -63,6 +63,46 @@ func normalizeLocalInput(raw []byte) []byte {
 	return out
 }
 
+// normalizeChooserInput is like normalizeLocalInput but maps Ctrl+J/Ctrl+K to
+// Down/Up arrows so they move the chooser selection. Plain j/k are left as text
+// so they can be typed into the filter query. Ctrl+J cannot be distinguished
+// from Enter once folded to a legacy byte (both 0x0A), so the remap happens
+// here at the decoded-event layer where the Ctrl modifier is still explicit
+// (kitty keyboard protocol).
+func normalizeChooserInput(raw []byte) []byte {
+	out := make([]byte, 0, len(raw))
+	for _, decoded := range decodeInputEvents(raw) {
+		if key, ok := decoded.event.(uv.KeyPressEvent); ok {
+			if seq := chooserMoveSequenceForCtrlJK(key); len(seq) > 0 {
+				out = append(out, seq...)
+				continue
+			}
+			if legacy := legacyBytesForKeyPress(key); len(legacy) > 0 {
+				out = append(out, legacy...)
+				continue
+			}
+		}
+		out = append(out, decoded.raw...)
+	}
+	return out
+}
+
+// chooserMoveSequenceForCtrlJK returns the Down/Up arrow escape sequence for
+// Ctrl+J/Ctrl+K, or nil for any other key.
+func chooserMoveSequenceForCtrlJK(key uv.KeyPressEvent) []byte {
+	k := key.Key()
+	if normalizedLegacyKeyMod(k.Mod) != uv.ModCtrl {
+		return nil
+	}
+	switch k.Code {
+	case 'j':
+		return []byte{0x1b, '[', 'B'} // Down
+	case 'k':
+		return []byte{0x1b, '[', 'A'} // Up
+	}
+	return nil
+}
+
 func forwardedBytesForDecodedInput(decoded decodedInputEvent) []byte {
 	if key, ok := decoded.event.(uv.KeyPressEvent); ok {
 		if legacy := legacyPaneBytesForKeyPress(key); len(legacy) > 0 {

--- a/internal/client/input_keys_test.go
+++ b/internal/client/input_keys_test.go
@@ -102,6 +102,52 @@ func TestNormalizeLocalInput(t *testing.T) {
 	}
 }
 
+func TestNormalizeChooserInput(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input []byte
+		want  []byte
+	}{
+		{
+			name:  "kitty ctrl-j maps to down arrow",
+			input: []byte("\x1b[106;5u"),
+			want:  []byte("\x1b[B"),
+		},
+		{
+			name:  "kitty ctrl-k maps to up arrow",
+			input: []byte("\x1b[107;5u"),
+			want:  []byte("\x1b[A"),
+		},
+		{
+			name:  "plain j stays text for the filter",
+			input: []byte("j"),
+			want:  []byte("j"),
+		},
+		{
+			name:  "plain k stays text for the filter",
+			input: []byte("k"),
+			want:  []byte("k"),
+		},
+		{
+			name:  "other ctrl keys are unaffected",
+			input: []byte("\x1b[97;5u"), // ctrl-a
+			want:  []byte{0x01},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := normalizeChooserInput(tt.input); !bytes.Equal(got, tt.want) {
+				t.Fatalf("normalizeChooserInput(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestSplitTrailingIncompleteUTF8(t *testing.T) {
 	t.Parallel()
 

--- a/internal/client/mouse.go
+++ b/internal/client/mouse.go
@@ -671,12 +671,50 @@ func resolvePaneWindowTabDropTarget(cr *ClientRenderer, layout *mux.LayoutCell, 
 	}, true
 }
 
+// handleChooserMouseEvent handles mouse input while the chooser modal is open.
+// The modal is exclusive: when active it consumes every mouse event so clicks
+// never leak through to panes. Scroll wheel moves the selection; a left click
+// on a row chooses it; a left click outside the box dismisses the chooser.
+func handleChooserMouseEvent(ev mouse.Event, cr *ClientRenderer, sender *messageSender, msgCh chan<- *RenderMsg) bool {
+	if !cr.ChooserActive() {
+		return false
+	}
+	switch {
+	case ev.Button == mouse.ScrollUp:
+		cr.moveChooser(-1)
+		rerenderOverlay(cr, msgCh)
+	case ev.Button == mouse.ScrollDown:
+		cr.moveChooser(1)
+		rerenderOverlay(cr, msgCh)
+	case ev.Action == mouse.Press && ev.Button == mouse.ButtonLeft:
+		screenW, screenH := cr.chooserScreenSize()
+		absRow, onRow, inside := render.ChooserRowAtPoint(screenW, screenH, cr.chooserOverlay(), ev.X, ev.Y)
+		switch {
+		case !inside:
+			cr.HideChooser()
+			rerenderOverlay(cr, msgCh)
+		case onRow:
+			cmd := cr.selectChooserRowAt(absRow)
+			if cmd.command != "" && sender != nil {
+				sender.Command(cmd.command, cmd.args)
+			}
+			rerenderOverlay(cr, msgCh)
+		}
+	}
+	// Exclusive: swallow all mouse events while the chooser is open.
+	return true
+}
+
 // handleMouseEvent dispatches a parsed mouse event to the appropriate action:
 // click-to-focus, border drag, or scroll wheel.
 func handleMouseEvent(ev mouse.Event, cr *ClientRenderer, sender *messageSender, drag *dragState, msgCh chan<- *RenderMsg) {
 	if drag == nil {
 		drag = &dragState{}
 	}
+	if handleChooserMouseEvent(ev, cr, sender, msgCh) {
+		return
+	}
+
 	layout := cr.VisibleLayout()
 
 	if layout == nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -78,6 +78,8 @@ const (
 	Surface0Hex  = "313244" // Surface 0 — status bar background
 	Surface1Hex  = "45475a" // Surface 1 — pressed status bar background
 	BlueHex      = "89b4fa" // Blue — active tab highlight
+	MauveHex     = "cba6f7" // Mauve — modal accent (selection bar, borders)
+	FooterKeyHex = "858392" // muted gray-mauve — modal footer key names (matches crush)
 	GreenHex     = "a6e3a1" // Green — status indicator
 	YellowHex    = "f9e2af" // Yellow — status indicator
 	RedHex       = "f38ba8" // Red — status indicator

--- a/internal/render/dialog_chrome.go
+++ b/internal/render/dialog_chrome.go
@@ -1,0 +1,439 @@
+package render
+
+import (
+	"strings"
+
+	uv "github.com/charmbracelet/ultraviolet"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/muesli/termenv"
+	"github.com/weill-labs/amux/internal/config"
+)
+
+// dialogChrome is the shared, rounded-border modal frame used by the chooser
+// (prefix+w / prefix+s) and the text-input prompt (prefix+, / prefix+.). It
+// composites cells directly into a ScreenGrid so it overlays pane content and
+// participates in the diff renderer. See docs in findings.md / LAB-1970.
+//
+// Vertical structure (top to bottom):
+//
+//	╭ title ──────────── toggle ╮   top border (title embedded)
+//	│ > query                   │   query line   (showQuery)
+//	│ subtitle                  │   subtitle     (subtitle != "")
+//	│ rows...                   │   content rows
+//	│ footer                    │   footer       (footer != "")
+//	╰───────────────────────────╯   bottom border
+type dialogChrome struct {
+	title     string
+	toggle    *dialogToggle // optional ◉/○ selector, right-aligned in title bar
+	subtitle  string        // optional contextual line under the title
+	showQuery bool          // render a "> query" filter line
+	query     string
+	rows      []dialogRow
+	footer    []footerHint  // keybinding hints, drawn just above the bottom border
+	scroll    *dialogScroll // optional scrollbar state for overflowing row sets
+}
+
+// dialogScroll describes the visible window into a larger row set so a
+// scrollbar can be drawn. rows passed in dialogChrome are the visible slice.
+type dialogScroll struct {
+	total   int // total rows in the full set
+	offset  int // index of the first visible row within the full set
+	visible int // number of visible rows (== len(rows))
+}
+
+// footerHint is one "key label" pair in the footer. The key is rendered bold
+// and bright; the label is dim — matching crush's footer styling.
+type footerHint struct {
+	key   string
+	label string
+}
+
+// footerText renders the hints as a plain "key label • key label" string,
+// used for width measurement.
+func footerText(hints []footerHint) string {
+	parts := make([]string, len(hints))
+	for i, h := range hints {
+		parts[i] = h.key + " " + h.label
+	}
+	return strings.Join(parts, " • ")
+}
+
+type dialogRowKind int
+
+const (
+	dialogRowNormal dialogRowKind = iota
+	dialogRowSelected
+	dialogRowDim
+	dialogRowSection
+	dialogRowHeader
+)
+
+// dialogRow is one content line. desc is an optional dimmed suffix.
+type dialogRow struct {
+	text string
+	desc string
+	kind dialogRowKind
+}
+
+// dialogToggle is the radio-style mode selector embedded in the title bar.
+// Glyphs are sourced from an IconSet so they respect the configured theme.
+type dialogToggle struct {
+	options  []string
+	selected int
+	on, off  string // selected / unselected glyph (from IconSet)
+}
+
+// newDialogToggle builds a toggle using the default icon set's radio glyphs.
+func newDialogToggle(selected int, options ...string) *dialogToggle {
+	icons := DefaultIconSet()
+	return &dialogToggle{options: options, selected: selected, on: icons.ToggleOn, off: icons.ToggleOff}
+}
+
+func (t dialogToggle) display() string {
+	parts := make([]string, len(t.options))
+	for i, opt := range t.options {
+		glyph := t.off
+		if i == t.selected {
+			glyph = t.on
+		}
+		parts[i] = glyph + " " + opt
+	}
+	return strings.Join(parts, "  ")
+}
+
+// dialogRect is the placed bounding box of a chrome, in screen cells.
+type dialogRect struct {
+	X, Y, W, H int
+}
+
+// dialogStyles holds the per-element cell styles for a chrome.
+type dialogStyles struct {
+	border    uv.Style
+	title     uv.Style
+	text      uv.Style
+	dim       uv.Style
+	selected  uv.Style
+	section   uv.Style
+	header    uv.Style // bold grouping rows (window names in the tree)
+	footer    uv.Style // dim label text and the • separator
+	footerKey uv.Style // bold, bright key names (enter, esc, ↑/↓)
+}
+
+func defaultDialogStyles() dialogStyles {
+	surface := hexToColor(config.Surface0Hex)
+	text := hexToColor(config.TextColorHex)
+	mauve := hexToColor(config.MauveHex)
+	dim := hexToColor(config.DimColorHex)
+	return dialogStyles{
+		border:    uv.Style{Fg: mauve, Bg: surface, Attrs: uv.AttrBold},
+		title:     uv.Style{Fg: mauve, Bg: surface, Attrs: uv.AttrBold},
+		text:      uv.Style{Fg: text, Bg: surface},
+		dim:       uv.Style{Fg: dim, Bg: surface},
+		selected:  uv.Style{Fg: surface, Bg: mauve, Attrs: uv.AttrBold},
+		section:   uv.Style{Fg: hexToColor(config.BlueHex), Bg: surface, Attrs: uv.AttrBold},
+		header:    uv.Style{Fg: text, Bg: surface, Attrs: uv.AttrBold},
+		footer:    uv.Style{Fg: dim, Bg: surface},
+		footerKey: uv.Style{Fg: hexToColor(config.FooterKeyHex), Bg: surface, Attrs: uv.AttrBold},
+	}
+}
+
+// runeDisplayWidth returns the terminal column width of a single rune.
+func runeDisplayWidth(r rune) int {
+	return ansi.StringWidth(string(r))
+}
+
+// placeRunes writes s into the grid starting at (x, y), advancing by each
+// rune's *display width* (not byte length) and emitting a continuation cell
+// after wide glyphs. It stops at maxX (exclusive). Returns the ending x.
+//
+// This is the fix for the historical byte-indexed placement loop: multi-byte
+// border/box glyphs land at their true display column.
+func placeRunes(g *ScreenGrid, x, y, maxX int, s string, style uv.Style) int {
+	for _, r := range s {
+		w := runeDisplayWidth(r)
+		if w == 0 {
+			continue
+		}
+		if x+w > maxX {
+			break
+		}
+		g.Set(x, y, ScreenCell{Char: string(r), Width: w, Style: style})
+		if w == 2 {
+			g.Set(x+1, y, ScreenCell{Char: "", Width: 0, Style: style})
+		}
+		x += w
+	}
+	return x
+}
+
+// computeLayout sizes and centers the chrome for a screen of the given
+// dimensions. It returns the bounding rect, the screen-y of the first list
+// row (bodyTop), and ok=false if the chrome does not fit. place() and the
+// mouse hit-test both go through here so rendered and clickable geometry match.
+func (d dialogChrome) computeLayout(screenW, screenH int) (dialogRect, int, bool) {
+	if screenW <= 0 || screenH <= 0 {
+		return dialogRect{}, 0, false
+	}
+
+	contentW := d.contentWidth()
+	margin := chooserModalMinMargin
+	maxContent := screenW - margin*2 - 4
+	if maxContent < 6 {
+		return dialogRect{}, 0, false
+	}
+	if maxByCap := chooserModalMaxWidth - 4; contentW > maxByCap {
+		contentW = maxByCap
+	}
+	if contentW > maxContent {
+		contentW = maxContent
+	}
+
+	// Blank separator rows around the list give it breathing room. They only
+	// appear when there is a list, so the text-input prompt stays compact.
+	hasHeader := d.showQuery || d.subtitle != ""
+	spaceBeforeList := len(d.rows) > 0 && hasHeader
+	spaceAfterList := len(d.rows) > 0 && len(d.footer) > 0
+
+	w := contentW + 4 // border + pad on each side
+	h := 2            // top + bottom borders
+	if d.showQuery {
+		h++
+	}
+	if d.subtitle != "" {
+		h++
+	}
+	if spaceBeforeList {
+		h++
+	}
+	h += len(d.rows)
+	if spaceAfterList {
+		h++
+	}
+	if len(d.footer) > 0 {
+		h++
+	}
+	if h > screenH-margin*2 {
+		return dialogRect{}, 0, false
+	}
+
+	rect := dialogRect{X: max((screenW-w)/2, 0), Y: max((screenH-h)/2, 0), W: w, H: h}
+
+	bodyTop := rect.Y + 1
+	if d.showQuery {
+		bodyTop++
+	}
+	if d.subtitle != "" {
+		bodyTop++
+	}
+	if spaceBeforeList {
+		bodyTop++
+	}
+	return rect, bodyTop, true
+}
+
+// place composites the chrome centered in g and returns its bounding rect.
+// A zero rect means the chrome did not fit and nothing was drawn.
+func (d dialogChrome) place(g *ScreenGrid, st dialogStyles) dialogRect {
+	if g == nil {
+		return dialogRect{}
+	}
+	rect, _, ok := d.computeLayout(g.Width, g.Height)
+	if !ok {
+		return dialogRect{}
+	}
+
+	spaceBeforeList := len(d.rows) > 0 && (d.showQuery || d.subtitle != "")
+	spaceAfterList := len(d.rows) > 0 && len(d.footer) > 0
+
+	d.drawTopBorder(g, rect, st)
+	cy := rect.Y + 1
+	if d.showQuery {
+		d.drawContentRow(g, rect, cy, "> "+d.query, "", st.text, st)
+		cy++
+	}
+	if d.subtitle != "" {
+		d.drawContentRow(g, rect, cy, d.subtitle, "", st.dim, st)
+		cy++
+	}
+	if spaceBeforeList {
+		d.drawContentRow(g, rect, cy, "", "", st.text, st)
+		cy++
+	}
+	bodyTop := cy
+	for _, row := range d.rows {
+		rowStyle := st.text
+		switch row.kind {
+		case dialogRowSelected:
+			rowStyle = st.selected
+		case dialogRowDim:
+			rowStyle = st.dim
+		case dialogRowSection:
+			rowStyle = st.section
+		case dialogRowHeader:
+			rowStyle = st.header
+		}
+		d.drawContentRow(g, rect, cy, row.text, row.desc, rowStyle, st)
+		cy++
+	}
+	d.drawScrollbar(g, rect, bodyTop, len(d.rows), st)
+	if spaceAfterList {
+		d.drawContentRow(g, rect, cy, "", "", st.text, st)
+		cy++
+	}
+	if len(d.footer) > 0 {
+		d.drawFooter(g, rect, cy, st)
+	}
+	d.drawBottomBorder(g, rect, st)
+	return rect
+}
+
+// emitDialogChrome places the chrome into a scratch grid and writes its rect to
+// buf as styled ANSI. This lets the direct-ANSI render path (RenderFull) reuse
+// the exact same cell placement as the grid/diff path, so both stay in sync.
+func emitDialogChrome(buf *strings.Builder, screenW, screenH int, d dialogChrome, profile termenv.Profile) {
+	if buf == nil || screenW <= 0 || screenH <= 0 {
+		return
+	}
+	g := NewScreenGrid(screenW, screenH)
+	rect := d.place(g, defaultDialogStyles())
+	if rect.W <= 0 || rect.H <= 0 {
+		return
+	}
+	changes := make([]CellChange, 0, rect.W*rect.H)
+	for y := rect.Y; y < rect.Y+rect.H; y++ {
+		for x := rect.X; x < rect.X+rect.W; x++ {
+			changes = append(changes, CellChange{X: x, Y: y, Cell: g.Get(x, y)})
+		}
+	}
+	state := emittedCellState{}
+	buf.WriteString(emitDiffWithProfileState(changes, profile, &state, true))
+	buf.WriteString(Reset)
+}
+
+// contentWidth returns the display width needed for the interior content.
+func (d dialogChrome) contentWidth() int {
+	w := 0
+	consider := func(s string) {
+		if cw := ansi.StringWidth(s); cw > w {
+			w = cw
+		}
+	}
+	if d.showQuery {
+		consider("> " + d.query)
+	}
+	consider(d.subtitle)
+	for _, row := range d.rows {
+		consider(rowDisplay(row))
+	}
+	consider(footerText(d.footer))
+	// The title sits in the top border row; reserve room for it (+ toggle).
+	titleBar := d.title
+	if d.toggle != nil {
+		titleBar = d.title + "  " + d.toggle.display()
+	}
+	consider(titleBar)
+	return w
+}
+
+func rowDisplay(r dialogRow) string {
+	if r.desc != "" {
+		return r.text + "  " + r.desc
+	}
+	return r.text
+}
+
+func (d dialogChrome) drawTopBorder(g *ScreenGrid, rect dialogRect, st dialogStyles) {
+	right := rect.X + rect.W - 1
+	g.Set(rect.X, rect.Y, ScreenCell{Char: "╭", Width: 1, Style: st.border})
+	for x := rect.X + 1; x < right; x++ {
+		g.Set(x, rect.Y, ScreenCell{Char: "─", Width: 1, Style: st.border})
+	}
+	g.Set(right, rect.Y, ScreenCell{Char: "╮", Width: 1, Style: st.border})
+
+	// Title, padded with spaces, overlays the fill starting after the corner.
+	titleEnd := placeRunes(g, rect.X+1, rect.Y, right, " "+d.title+" ", st.title)
+
+	// Toggle, right-aligned with a one-cell gap before the corner.
+	if d.toggle != nil {
+		disp := d.toggle.display()
+		start := right - 1 - ansi.StringWidth(disp)
+		if start > titleEnd {
+			placeRunes(g, start, rect.Y, right, disp, st.title)
+		}
+	}
+}
+
+func (d dialogChrome) drawBottomBorder(g *ScreenGrid, rect dialogRect, st dialogStyles) {
+	right := rect.X + rect.W - 1
+	bottom := rect.Y + rect.H - 1
+	g.Set(rect.X, bottom, ScreenCell{Char: "╰", Width: 1, Style: st.border})
+	for x := rect.X + 1; x < right; x++ {
+		g.Set(x, bottom, ScreenCell{Char: "─", Width: 1, Style: st.border})
+	}
+	g.Set(right, bottom, ScreenCell{Char: "╯", Width: 1, Style: st.border})
+}
+
+// drawContentRow draws one interior row: vertical borders, a full-width
+// background fill (so accent bars reach edge to edge), the padded text, and an
+// optional dimmed description suffix.
+func (d dialogChrome) drawContentRow(g *ScreenGrid, rect dialogRect, y int, text, desc string, rowStyle uv.Style, st dialogStyles) {
+	right := rect.X + rect.W - 1
+	g.Set(rect.X, y, ScreenCell{Char: "│", Width: 1, Style: st.border})
+	g.Set(right, y, ScreenCell{Char: "│", Width: 1, Style: st.border})
+	for x := rect.X + 1; x < right; x++ {
+		g.Set(x, y, ScreenCell{Char: " ", Width: 1, Style: rowStyle})
+	}
+	// One-space gutter after the left border, then the text.
+	endX := placeRunes(g, rect.X+2, y, right, text, rowStyle)
+	if desc != "" {
+		descStyle := uv.Style{Fg: hexToColor(config.DimColorHex), Bg: rowStyle.Bg}
+		placeRunes(g, endX+2, y, right, desc, descStyle)
+	}
+}
+
+// drawScrollbar draws a track (│) with a proportional thumb (┃) in the gutter
+// just inside the right border, spanning the bodyRows body rows starting at
+// bodyTop. It is a no-op unless the row set overflows the visible window.
+func (d dialogChrome) drawScrollbar(g *ScreenGrid, rect dialogRect, bodyTop, bodyRows int, st dialogStyles) {
+	s := d.scroll
+	if s == nil || bodyRows <= 0 || s.total <= s.visible || s.total <= 0 {
+		return
+	}
+	col := rect.X + rect.W - 2 // one cell inside the right border
+
+	thumbLen := min(max(bodyRows*s.visible/s.total, 1), bodyRows)
+	thumbPos := 0
+	if denom := s.total - s.visible; denom > 0 {
+		thumbPos = (bodyRows - thumbLen) * s.offset / denom
+	}
+
+	for i := range bodyRows {
+		glyph := "│"
+		style := st.dim
+		if i >= thumbPos && i < thumbPos+thumbLen {
+			glyph = "┃"
+			style = st.border // accent-colored thumb
+		}
+		g.Set(col, bodyTop+i, ScreenCell{Char: glyph, Width: 1, Style: style})
+	}
+}
+
+// drawFooter renders the keybinding hints with bold/bright keys, dim labels,
+// and a dim " • " between hints — matching crush's footer styling.
+func (d dialogChrome) drawFooter(g *ScreenGrid, rect dialogRect, y int, st dialogStyles) {
+	right := rect.X + rect.W - 1
+	g.Set(rect.X, y, ScreenCell{Char: "│", Width: 1, Style: st.border})
+	g.Set(right, y, ScreenCell{Char: "│", Width: 1, Style: st.border})
+	for x := rect.X + 1; x < right; x++ {
+		g.Set(x, y, ScreenCell{Char: " ", Width: 1, Style: st.footer})
+	}
+	x := rect.X + 2
+	for i, h := range d.footer {
+		if i > 0 {
+			x = placeRunes(g, x, y, right, " • ", st.footer)
+		}
+		x = placeRunes(g, x, y, right, h.key, st.footerKey)
+		x = placeRunes(g, x, y, right, " ", st.footer)
+		x = placeRunes(g, x, y, right, h.label, st.footer)
+	}
+}

--- a/internal/render/dialog_chrome.go
+++ b/internal/render/dialog_chrome.go
@@ -1,6 +1,7 @@
 package render
 
 import (
+	"image/color"
 	"strings"
 
 	uv "github.com/charmbracelet/ultraviolet"
@@ -68,11 +69,19 @@ const (
 	dialogRowHeader
 )
 
-// dialogRow is one content line. desc is an optional dimmed suffix.
+// dialogRow is one content line. icon is an optional leading glyph (with its
+// own color), text is the main label (optionally colored), desc is a dimmed
+// suffix, and rule fills the trailing width with a horizontal line (section
+// headers). Per-row colors are suppressed on the selected row so the accent
+// bar stays legible.
 type dialogRow struct {
-	text string
-	desc string
-	kind dialogRowKind
+	text      string
+	desc      string
+	kind      dialogRowKind
+	icon      string
+	iconColor color.Color
+	textColor color.Color
+	rule      bool
 }
 
 // dialogToggle is the radio-style mode selector embedded in the title bar.
@@ -248,15 +257,15 @@ func (d dialogChrome) place(g *ScreenGrid, st dialogStyles) dialogRect {
 	d.drawTopBorder(g, rect, st)
 	cy := rect.Y + 1
 	if d.showQuery {
-		d.drawContentRow(g, rect, cy, "> "+d.query, "", st.text, st)
+		d.drawContentRow(g, rect, cy, dialogRow{text: "> " + d.query}, st.text, st)
 		cy++
 	}
 	if d.subtitle != "" {
-		d.drawContentRow(g, rect, cy, d.subtitle, "", st.dim, st)
+		d.drawContentRow(g, rect, cy, dialogRow{text: d.subtitle}, st.dim, st)
 		cy++
 	}
 	if spaceBeforeList {
-		d.drawContentRow(g, rect, cy, "", "", st.text, st)
+		d.drawContentRow(g, rect, cy, dialogRow{}, st.text, st)
 		cy++
 	}
 	bodyTop := cy
@@ -272,12 +281,12 @@ func (d dialogChrome) place(g *ScreenGrid, st dialogStyles) dialogRect {
 		case dialogRowHeader:
 			rowStyle = st.header
 		}
-		d.drawContentRow(g, rect, cy, row.text, row.desc, rowStyle, st)
+		d.drawContentRow(g, rect, cy, row, rowStyle, st)
 		cy++
 	}
 	d.drawScrollbar(g, rect, bodyTop, len(d.rows), st)
 	if spaceAfterList {
-		d.drawContentRow(g, rect, cy, "", "", st.text, st)
+		d.drawContentRow(g, rect, cy, dialogRow{}, st.text, st)
 		cy++
 	}
 	if len(d.footer) > 0 {
@@ -336,10 +345,14 @@ func (d dialogChrome) contentWidth() int {
 }
 
 func rowDisplay(r dialogRow) string {
-	if r.desc != "" {
-		return r.text + "  " + r.desc
+	s := r.text
+	if r.icon != "" {
+		s = r.icon + " " + s
 	}
-	return r.text
+	if r.desc != "" {
+		s += "  " + r.desc
+	}
+	return s
 }
 
 func (d dialogChrome) drawTopBorder(g *ScreenGrid, rect dialogRect, st dialogStyles) {
@@ -376,18 +389,41 @@ func (d dialogChrome) drawBottomBorder(g *ScreenGrid, rect dialogRect, st dialog
 // drawContentRow draws one interior row: vertical borders, a full-width
 // background fill (so accent bars reach edge to edge), the padded text, and an
 // optional dimmed description suffix.
-func (d dialogChrome) drawContentRow(g *ScreenGrid, rect dialogRect, y int, text, desc string, rowStyle uv.Style, st dialogStyles) {
+func (d dialogChrome) drawContentRow(g *ScreenGrid, rect dialogRect, y int, row dialogRow, rowStyle uv.Style, st dialogStyles) {
 	right := rect.X + rect.W - 1
 	g.Set(rect.X, y, ScreenCell{Char: "│", Width: 1, Style: st.border})
 	g.Set(right, y, ScreenCell{Char: "│", Width: 1, Style: st.border})
 	for x := rect.X + 1; x < right; x++ {
 		g.Set(x, y, ScreenCell{Char: " ", Width: 1, Style: rowStyle})
 	}
-	// One-space gutter after the left border, then the text.
-	endX := placeRunes(g, rect.X+2, y, right, text, rowStyle)
-	if desc != "" {
-		descStyle := uv.Style{Fg: hexToColor(config.DimColorHex), Bg: rowStyle.Bg}
-		placeRunes(g, endX+2, y, right, desc, descStyle)
+
+	// Per-row colors clash with the accent selection bar, so suppress them when
+	// this row is selected.
+	selected := row.kind == dialogRowSelected
+	dimStyle := uv.Style{Fg: hexToColor(config.DimColorHex), Bg: rowStyle.Bg}
+
+	// One-space gutter after the left border, then an optional colored icon.
+	x := rect.X + 2
+	if row.icon != "" {
+		iconStyle := rowStyle
+		if row.iconColor != nil && !selected {
+			iconStyle.Fg = row.iconColor
+		}
+		x = placeRunes(g, x, y, right, row.icon+" ", iconStyle)
+	}
+
+	textStyle := rowStyle
+	if row.textColor != nil && !selected {
+		textStyle.Fg = row.textColor
+	}
+	endX := placeRunes(g, x, y, right, row.text, textStyle)
+
+	if row.rule {
+		for rx := endX + 1; rx < right-1; rx++ {
+			g.Set(rx, y, ScreenCell{Char: "─", Width: 1, Style: dimStyle})
+		}
+	} else if row.desc != "" {
+		placeRunes(g, endX+2, y, right, row.desc, dimStyle)
 	}
 }
 

--- a/internal/render/dialog_chrome_test.go
+++ b/internal/render/dialog_chrome_test.go
@@ -148,6 +148,48 @@ func TestDialogChromeToggleRendered(t *testing.T) {
 	}
 }
 
+// TestDialogChromeIconColorAndRule verifies a content row renders a colored
+// leading icon, a colored name, a dim desc, and that a rule row fills the
+// trailing width with ─.
+func TestDialogChromeIconColorAndRule(t *testing.T) {
+	t.Parallel()
+
+	mauve := hexToColor(config.MauveHex)
+	chrome := dialogChrome{
+		title:     "Choose Window",
+		showQuery: true,
+		rows: []dialogRow{
+			{text: "amux", kind: dialogRowHeader, rule: true},
+			{text: "pane-1", desc: "main", icon: "●", iconColor: mauve, textColor: mauve},
+		},
+		footer: []footerHint{{key: "esc", label: "close"}},
+	}
+
+	g := NewScreenGrid(60, 16)
+	rect := chrome.place(g, defaultDialogStyles())
+	body := gridRectToText(g, rect.X, rect.Y, rect.W, rect.H)
+
+	for _, want := range []string{"amux", "──", "● pane-1", "main"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("rendered chrome missing %q:\n%s", want, body)
+		}
+	}
+
+	// The icon cell should carry its own color.
+	iconFound := false
+	for y := rect.Y; y < rect.Y+rect.H && !iconFound; y++ {
+		for x := rect.X; x < rect.X+rect.W; x++ {
+			if c := g.Get(x, y); c.Char == "●" && c.Style.Fg == mauve {
+				iconFound = true
+				break
+			}
+		}
+	}
+	if !iconFound {
+		t.Error("expected a ● icon cell painted with its iconColor")
+	}
+}
+
 // TestDialogChromeListSpacers verifies blank separator rows sit between the
 // query/header and the list, and between the list and the footer.
 func TestDialogChromeListSpacers(t *testing.T) {

--- a/internal/render/dialog_chrome_test.go
+++ b/internal/render/dialog_chrome_test.go
@@ -1,0 +1,260 @@
+package render
+
+import (
+	"strings"
+	"testing"
+
+	uv "github.com/charmbracelet/ultraviolet"
+	"github.com/weill-labs/amux/internal/config"
+)
+
+// buildSampleChrome returns a chrome with a title, a query line, a few rows
+// (one selected), and a footer — enough to exercise every cell kind.
+func buildSampleChrome() dialogChrome {
+	return dialogChrome{
+		title:     "Choose Window",
+		showQuery: true,
+		query:     "ed",
+		rows: []dialogRow{
+			{text: "pane-1", desc: "~/github/amux", kind: dialogRowNormal},
+			{text: "pane-2", desc: "editor", kind: dialogRowSelected},
+			{text: "pane-3", desc: "logs", kind: dialogRowNormal},
+		},
+		footer: []footerHint{{key: "↑/↓", label: "choose"}, {key: "enter", label: "open"}, {key: "esc", label: "close"}},
+	}
+}
+
+// TestDialogChromeRoundedBorders verifies the box uses rounded Unicode corners
+// rather than the old ASCII "+ - |" set.
+func TestDialogChromeRoundedBorders(t *testing.T) {
+	t.Parallel()
+
+	g := NewScreenGrid(80, 24)
+	rect := buildSampleChrome().place(g, defaultDialogStyles())
+
+	if rect.W <= 0 || rect.H <= 0 {
+		t.Fatalf("place returned empty rect: %+v", rect)
+	}
+
+	corners := []struct {
+		name string
+		x, y int
+		want string
+	}{
+		{"top-left", rect.X, rect.Y, "╭"},
+		{"top-right", rect.X + rect.W - 1, rect.Y, "╮"},
+		{"bottom-left", rect.X, rect.Y + rect.H - 1, "╰"},
+		{"bottom-right", rect.X + rect.W - 1, rect.Y + rect.H - 1, "╯"},
+	}
+	for _, c := range corners {
+		if got := g.Get(c.x, c.y).Char; got != c.want {
+			t.Errorf("%s corner at (%d,%d) = %q, want %q", c.name, c.x, c.y, got, c.want)
+		}
+	}
+}
+
+// TestDialogChromeBordersAtDisplayColumns is the regression guard for the
+// byte-indexed placement loop. Multi-byte border glyphs (╭ = 3 bytes) must
+// land at the correct *display column*, so the right border │ must appear at
+// exactly X+W-1 on every interior row — never shifted by byte width.
+func TestDialogChromeBordersAtDisplayColumns(t *testing.T) {
+	t.Parallel()
+
+	g := NewScreenGrid(80, 24)
+	rect := buildSampleChrome().place(g, defaultDialogStyles())
+
+	for y := rect.Y; y < rect.Y+rect.H; y++ {
+		if got := g.Get(rect.X, y).Char; got != "╭" && got != "│" && got != "╰" {
+			t.Errorf("left border at (%d,%d) = %q, want a vertical/corner glyph", rect.X, y, got)
+		}
+		if got := g.Get(rect.X+rect.W-1, y).Char; got != "╮" && got != "│" && got != "╯" {
+			t.Errorf("right border at (%d,%d) = %q, want a vertical/corner glyph", rect.X+rect.W-1, y, got)
+		}
+	}
+}
+
+// TestDialogChromeInteriorPadding verifies content is not flush against the
+// border — there is a one-space gutter after the left border.
+func TestDialogChromeInteriorPadding(t *testing.T) {
+	t.Parallel()
+
+	g := NewScreenGrid(80, 24)
+	rect := buildSampleChrome().place(g, defaultDialogStyles())
+
+	// First interior content row (the query line) sits at Y+1.
+	row := rect.Y + 1
+	if got := g.Get(rect.X, row).Char; got != "│" {
+		t.Fatalf("left border at row %d = %q, want │", row, got)
+	}
+	if got := g.Get(rect.X+1, row).Char; got != " " {
+		t.Errorf("interior gutter at (%d,%d) = %q, want a space", rect.X+1, row, got)
+	}
+}
+
+// TestDialogChromeSelectionUsesMauveAccent verifies the selected row is painted
+// with a Mauve background fill rather than the old inverted TextColor bar.
+func TestDialogChromeSelectionUsesMauveAccent(t *testing.T) {
+	t.Parallel()
+
+	g := NewScreenGrid(80, 24)
+	rect := buildSampleChrome().place(g, defaultDialogStyles())
+
+	want := hexToColor(config.MauveHex)
+	found := false
+	for y := rect.Y; y < rect.Y+rect.H && !found; y++ {
+		for x := rect.X + 1; x < rect.X+rect.W-1; x++ {
+			if g.Get(x, y).Style.Bg == want {
+				found = true
+				break
+			}
+		}
+	}
+	if !found {
+		t.Errorf("no cell painted with Mauve (%s) background; selection accent missing", config.MauveHex)
+	}
+}
+
+// TestDialogChromeFooterRendered verifies the keybinding footer appears inside
+// the box, just above the bottom border.
+func TestDialogChromeFooterRendered(t *testing.T) {
+	t.Parallel()
+
+	g := NewScreenGrid(80, 24)
+	chrome := buildSampleChrome()
+	rect := chrome.place(g, defaultDialogStyles())
+
+	boxText := gridRectToText(g, rect.X, rect.Y, rect.W, rect.H)
+	if !strings.Contains(boxText, "esc close") {
+		t.Errorf("footer text missing from box:\n%s", boxText)
+	}
+}
+
+// TestDialogChromeToggleRendered verifies the title-bar radio toggle renders
+// both options with the selected one marked, using IconSet glyphs.
+func TestDialogChromeToggleRendered(t *testing.T) {
+	t.Parallel()
+
+	chrome := buildSampleChrome()
+	chrome.toggle = newDialogToggle(0, "Tree", "Window")
+
+	g := NewScreenGrid(80, 24)
+	rect := chrome.place(g, defaultDialogStyles())
+
+	topRow := gridRectToText(g, rect.X, rect.Y, rect.W, 1)
+	for _, want := range []string{"Tree", "Window", DefaultIconSet().ToggleOn, DefaultIconSet().ToggleOff} {
+		if !strings.Contains(topRow, want) {
+			t.Errorf("title row missing %q: %q", want, topRow)
+		}
+	}
+}
+
+// TestDialogChromeListSpacers verifies blank separator rows sit between the
+// query/header and the list, and between the list and the footer.
+func TestDialogChromeListSpacers(t *testing.T) {
+	t.Parallel()
+
+	g := NewScreenGrid(60, 20)
+	rect := buildSampleChrome().place(g, defaultDialogStyles())
+
+	// Row layout: top, query, spacer, rows×3, spacer, footer, bottom.
+	queryRow := rect.Y + 1
+	spacerBefore := queryRow + 1
+	firstRow := spacerBefore + 1
+	footerRow := rect.Y + rect.H - 2
+	spacerAfter := footerRow - 1
+
+	interiorBlank := func(y int) bool {
+		for x := rect.X + 1; x < rect.X+rect.W-1; x++ {
+			if c := g.Get(x, y).Char; c != " " && c != "" {
+				return false
+			}
+		}
+		return true
+	}
+
+	if !interiorBlank(spacerBefore) {
+		t.Errorf("expected blank spacer row between query and list at y=%d:\n%s", spacerBefore, gridRectToText(g, rect.X, spacerBefore, rect.W, 1))
+	}
+	if !interiorBlank(spacerAfter) {
+		t.Errorf("expected blank spacer row between list and footer at y=%d:\n%s", spacerAfter, gridRectToText(g, rect.X, spacerAfter, rect.W, 1))
+	}
+	// The first list row should have content (not blank).
+	if interiorBlank(firstRow) {
+		t.Errorf("first list row at y=%d should not be blank", firstRow)
+	}
+}
+
+// TestDialogChromeScrollbar verifies that when the row set overflows the
+// visible window, a scrollbar thumb (┃) and track (│) render inside the right
+// edge of the body.
+func TestDialogChromeScrollbar(t *testing.T) {
+	t.Parallel()
+
+	chrome := buildSampleChrome()
+	// 3 visible rows out of 12 total, window starting at offset 3.
+	chrome.scroll = &dialogScroll{total: 12, offset: 3, visible: len(chrome.rows)}
+
+	g := NewScreenGrid(80, 24)
+	rect := chrome.place(g, defaultDialogStyles())
+
+	col := rect.X + rect.W - 2 // gutter just inside the right border
+	var thumb, track bool
+	for y := rect.Y; y < rect.Y+rect.H; y++ {
+		switch g.Get(col, y).Char {
+		case "┃":
+			thumb = true
+		case "│":
+			track = true
+		}
+	}
+	if !thumb {
+		t.Error("expected a scrollbar thumb (┃) inside the right edge")
+	}
+	if !track {
+		t.Error("expected a scrollbar track (│) inside the right edge")
+	}
+}
+
+// TestDialogChromeFooterKeysBold verifies footer key glyphs are bold while the
+// dim labels are not — the crush-style two-weight footer.
+func TestDialogChromeFooterKeysBold(t *testing.T) {
+	t.Parallel()
+
+	g := NewScreenGrid(80, 24)
+	rect := buildSampleChrome().place(g, defaultDialogStyles())
+
+	footerY := rect.Y + rect.H - 2 // footer sits just above the bottom border
+	keyBold, labelPlain := false, false
+	for x := rect.X + 1; x < rect.X+rect.W-1; x++ {
+		cell := g.Get(x, footerY)
+		switch cell.Char {
+		case "e", "n", "t", "r", "c": // glyphs within "enter"/"esc" keys
+			if cell.Style.Attrs&uv.AttrBold != 0 {
+				keyBold = true
+			}
+		case "o", "p": // glyphs within the "open"/"choose" labels
+			if cell.Style.Attrs&uv.AttrBold == 0 {
+				labelPlain = true
+			}
+		}
+	}
+	if !keyBold {
+		t.Error("expected at least one bold key glyph in footer")
+	}
+	if !labelPlain {
+		t.Error("expected label glyphs to be non-bold in footer")
+	}
+}
+
+// TestDialogChromeTitleRendered verifies the title is embedded in the top border row.
+func TestDialogChromeTitleRendered(t *testing.T) {
+	t.Parallel()
+
+	g := NewScreenGrid(80, 24)
+	rect := buildSampleChrome().place(g, defaultDialogStyles())
+
+	topRow := gridRectToText(g, rect.X, rect.Y, rect.W, 1)
+	if !strings.Contains(topRow, "Choose Window") {
+		t.Errorf("title missing from top border row: %q", topRow)
+	}
+}

--- a/internal/render/icons.go
+++ b/internal/render/icons.go
@@ -18,6 +18,8 @@ type IconSet struct {
 	Issue         string
 	Task          string
 	CopyMode      string
+	ToggleOn      string // modal title-bar radio, selected
+	ToggleOff     string // modal title-bar radio, unselected
 }
 
 // IconSetPreset pairs a validated config name with its renderer glyphs.
@@ -66,6 +68,8 @@ func UnicodeIconSet() IconSet {
 		Issue:         "",
 		Task:          "",
 		CopyMode:      "[copy]",
+		ToggleOn:      "◉",
+		ToggleOff:     "○",
 	}
 }
 
@@ -85,6 +89,8 @@ func ASCIIIconSet() IconSet {
 		Issue:         "I",
 		Task:          "T",
 		CopyMode:      "C",
+		ToggleOn:      "(*)",
+		ToggleOff:     "( )",
 	}
 }
 
@@ -104,6 +110,8 @@ func NerdFontIconSet() IconSet {
 		Issue:         "\uf41b",
 		Task:          "\ueb67",
 		CopyMode:      "\ueac0",
+		ToggleOn:      "\uf192", // nf-fa-dot_circle_o
+		ToggleOff:     "\uf10c", // nf-fa-circle_o
 	}
 }
 

--- a/internal/render/icons_test.go
+++ b/internal/render/icons_test.go
@@ -143,6 +143,8 @@ func TestNerdFontIconSetUsesPublishedGlyphs(t *testing.T) {
 		Issue:         "\uf41b", // nf-oct-issue_opened
 		Task:          "\ueb67", // nf-cod-tasklist
 		CopyMode:      "\ueac0", // nf-cod-clippy
+		ToggleOn:      "\uf192", // nf-fa-dot_circle_o
+		ToggleOff:     "\uf10c", // nf-fa-circle_o
 	}
 	if got := NerdFontIconSet(); got != want {
 		t.Fatalf("NerdFontIconSet() = %#v, want %#v", got, want)

--- a/internal/render/modaloverlay.go
+++ b/internal/render/modaloverlay.go
@@ -39,16 +39,23 @@ func chooserChrome(screenH int, overlay *ChooserOverlay) dialogChrome {
 		rows = append(rows, row)
 	}
 
+	footer := []footerHint{
+		{key: "↑/↓", label: "choose"},
+		{key: "enter", label: "open"},
+		{key: "esc", label: "close"},
+	}
+	if overlay.Toggle != nil {
+		footer = append([]footerHint{{key: "tab", label: "switch"}}, footer...)
+	}
 	chrome := dialogChrome{
 		title:     overlay.Title,
 		showQuery: true,
 		query:     overlay.Query,
 		rows:      rows,
-		footer: []footerHint{
-			{key: "↑/↓", label: "choose"},
-			{key: "enter", label: "open"},
-			{key: "esc", label: "close"},
-		},
+		footer:    footer,
+	}
+	if overlay.Toggle != nil {
+		chrome.toggle = newDialogToggle(overlay.Toggle.Selected, overlay.Toggle.Options...)
 	}
 	if len(overlay.Rows) > len(rows) {
 		chrome.scroll = &dialogScroll{total: len(overlay.Rows), offset: start, visible: len(rows)}

--- a/internal/render/modaloverlay.go
+++ b/internal/render/modaloverlay.go
@@ -9,15 +9,26 @@ import (
 const (
 	chooserModalMaxWidth  = 80
 	chooserModalMinMargin = 2
+	// chooserChromeOverhead is the count of non-list rows the chooser chrome
+	// always draws: top + bottom borders, the query line, the two list
+	// spacers, and the footer. The visible-row window must leave room for them
+	// or computeLayout rejects the box and nothing renders.
+	chooserChromeOverhead = 6
 )
+
+// chooserRowLimit is the maximum number of list rows that fit on a screen of
+// the given height. Both chooserChrome (windowing) and ChooserRowAtPoint
+// (hit-testing) use it so clickable geometry can never drift from what is
+// drawn.
+func chooserRowLimit(screenH int) int {
+	return max(screenH-chooserModalMinMargin*2-chooserChromeOverhead, 1)
+}
 
 // chooserChrome converts a ChooserOverlay into the shared dialogChrome,
 // windowing the rows around the selection so a long list fits on screen and
 // driving a scrollbar for the overflow.
 func chooserChrome(screenH int, overlay *ChooserOverlay) dialogChrome {
-	rowLimit := max(screenH-chooserModalMinMargin*2-3, 1)
-
-	start, end := chooserVisibleWindow(len(overlay.Rows), overlay.Selected, rowLimit)
+	start, end := chooserVisibleWindow(len(overlay.Rows), overlay.Selected, chooserRowLimit(screenH))
 	rows := make([]dialogRow, 0, end-start)
 	for i := start; i < end; i++ {
 		src := overlay.Rows[i]
@@ -95,8 +106,7 @@ func ChooserRowAtPoint(screenW, screenH int, overlay *ChooserOverlay, x, y int) 
 		return 0, false, false
 	}
 
-	rowLimit := max(screenH-chooserModalMinMargin*2-3, 1)
-	start, end := chooserVisibleWindow(len(overlay.Rows), overlay.Selected, rowLimit)
+	start, end := chooserVisibleWindow(len(overlay.Rows), overlay.Selected, chooserRowLimit(screenH))
 	idx := y - bodyTop
 	if idx < 0 || idx >= end-start {
 		return 0, false, true

--- a/internal/render/modaloverlay.go
+++ b/internal/render/modaloverlay.go
@@ -3,9 +3,7 @@ package render
 import (
 	"strings"
 
-	uv "github.com/charmbracelet/ultraviolet"
 	"github.com/muesli/termenv"
-	"github.com/weill-labs/amux/internal/config"
 )
 
 const (
@@ -13,34 +11,92 @@ const (
 	chooserModalMinMargin = 2
 )
 
-type chooserRowStyle string
+// chooserChrome converts a ChooserOverlay into the shared dialogChrome,
+// windowing the rows around the selection so a long list fits on screen and
+// driving a scrollbar for the overflow.
+func chooserChrome(screenH int, overlay *ChooserOverlay) dialogChrome {
+	rowLimit := max(screenH-chooserModalMinMargin*2-3, 1)
 
-const (
-	chooserRowBorder   chooserRowStyle = "border"
-	chooserRowNormal   chooserRowStyle = "row"
-	chooserRowSelected chooserRowStyle = "selected"
-	chooserRowDim      chooserRowStyle = "dim"
-)
+	start, end := chooserVisibleWindow(len(overlay.Rows), overlay.Selected, rowLimit)
+	rows := make([]dialogRow, 0, end-start)
+	for i := start; i < end; i++ {
+		src := overlay.Rows[i]
+		row := dialogRow{text: src.Text, kind: dialogRowNormal}
+		switch {
+		case i == overlay.Selected && src.Selectable:
+			row.kind = dialogRowSelected
+		case src.Header:
+			row.kind = dialogRowHeader
+		case !src.Selectable:
+			row.kind = dialogRowDim
+		}
+		rows = append(rows, row)
+	}
+
+	chrome := dialogChrome{
+		title:     overlay.Title,
+		showQuery: true,
+		query:     overlay.Query,
+		rows:      rows,
+		footer: []footerHint{
+			{key: "↑/↓", label: "choose"},
+			{key: "enter", label: "open"},
+			{key: "esc", label: "close"},
+		},
+	}
+	if len(overlay.Rows) > len(rows) {
+		chrome.scroll = &dialogScroll{total: len(overlay.Rows), offset: start, visible: len(rows)}
+	}
+	return chrome
+}
+
+// chooserVisibleWindow returns the [start, end) slice of rows to show, centering
+// the selection when the full set overflows rowLimit.
+func chooserVisibleWindow(count, selected, rowLimit int) (int, int) {
+	if count <= rowLimit {
+		return 0, count
+	}
+	start := max(selected-rowLimit/2, 0)
+	end := start + rowLimit
+	if end > count {
+		end = count
+		start = end - rowLimit
+	}
+	return start, end
+}
+
+// ChooserRowAtPoint maps a screen point to the chooser modal. inside reports
+// whether the point falls within the modal box; onRow and absRow are valid when
+// it lands on a selectable list row. It reuses computeLayout so the clickable
+// geometry matches exactly what is rendered.
+func ChooserRowAtPoint(screenW, screenH int, overlay *ChooserOverlay, x, y int) (absRow int, onRow, inside bool) {
+	if overlay == nil {
+		return 0, false, false
+	}
+	chrome := chooserChrome(screenH, overlay)
+	rect, bodyTop, ok := chrome.computeLayout(screenW, screenH)
+	if !ok {
+		return 0, false, false
+	}
+	if x < rect.X || x >= rect.X+rect.W || y < rect.Y || y >= rect.Y+rect.H {
+		return 0, false, false
+	}
+
+	rowLimit := max(screenH-chooserModalMinMargin*2-3, 1)
+	start, end := chooserVisibleWindow(len(overlay.Rows), overlay.Selected, rowLimit)
+	idx := y - bodyTop
+	if idx < 0 || idx >= end-start {
+		return 0, false, true
+	}
+	absRow = start + idx
+	return absRow, overlay.Rows[absRow].Selectable, true
+}
 
 func buildChooserOverlayCells(g *ScreenGrid, overlay *ChooserOverlay) {
 	if overlay == nil {
 		return
 	}
-	lines, styles, x, y := chooserOverlayLayout(g.Width, g.Height, overlay)
-	if len(lines) == 0 {
-		return
-	}
-	borderStyle := uv.Style{Fg: hexToColor(config.TextColorHex), Bg: hexToColor(config.Surface0Hex), Attrs: uv.AttrBold}
-	textStyle := uv.Style{Fg: hexToColor(config.TextColorHex), Bg: hexToColor(config.Surface0Hex)}
-	dimStyle := uv.Style{Fg: hexToColor(config.DimColorHex), Bg: hexToColor(config.Surface0Hex)}
-	selectedStyle := uv.Style{Fg: hexToColor(config.Surface0Hex), Bg: hexToColor(config.TextColorHex), Attrs: uv.AttrBold}
-
-	for row, line := range lines {
-		for col, r := range line {
-			style := chooserCellStyle(styles[row], col == 0 || col == len(line)-1, borderStyle, textStyle, dimStyle, selectedStyle)
-			g.Set(x+col, y+row, ScreenCell{Char: string(r), Width: 1, Style: style})
-		}
-	}
+	chooserChrome(g.Height, overlay).place(g, defaultDialogStyles())
 }
 
 func renderChooserOverlay(buf *strings.Builder, width, height int, overlay *ChooserOverlay) {
@@ -51,131 +107,5 @@ func renderChooserOverlayWithProfile(buf *strings.Builder, width, height int, ov
 	if overlay == nil {
 		return
 	}
-	lines, _, x, y := chooserOverlayLayout(width, height, overlay)
-	if len(lines) == 0 {
-		return
-	}
-	surface0Bg := bgHexSequence(config.Surface0Hex, profile)
-	textFg := fgHexSequence(config.TextColorHex, profile)
-	for row, line := range lines {
-		writeCursorTo(buf, y+row+1, x+1)
-		if row == 0 || row == len(lines)-1 {
-			buf.WriteString(surface0Bg + Bold + textFg)
-		} else {
-			buf.WriteString(surface0Bg + textFg)
-		}
-		buf.WriteString(line)
-		buf.WriteString(Reset)
-	}
-}
-
-func chooserOverlayLayout(screenW, screenH int, overlay *ChooserOverlay) ([]string, []chooserRowStyle, int, int) {
-	if overlay == nil || screenW <= 0 || screenH <= 0 {
-		return nil, nil, 0, 0
-	}
-	title := " " + overlay.Title + " "
-	query := "> " + overlay.Query
-	if overlay.Query == "" {
-		query = "> "
-	}
-	width := len(title)
-	if len(query) > width {
-		width = len(query)
-	}
-	for _, row := range overlay.Rows {
-		if len(row.Text) > width {
-			width = len(row.Text)
-		}
-	}
-	width += 2
-	maxWidth := screenW - chooserModalMinMargin*2
-	if maxWidth < 10 {
-		return nil, nil, 0, 0
-	}
-	if width > chooserModalMaxWidth {
-		width = chooserModalMaxWidth
-	}
-	if width > maxWidth {
-		width = maxWidth
-	}
-
-	rowLimit := screenH - chooserModalMinMargin*2 - 3
-	if rowLimit < 1 {
-		return nil, nil, 0, 0
-	}
-	start := 0
-	end := len(overlay.Rows)
-	if end-start > rowLimit {
-		start = overlay.Selected - rowLimit/2
-		if start < 0 {
-			start = 0
-		}
-		end = start + rowLimit
-		if end > len(overlay.Rows) {
-			end = len(overlay.Rows)
-			start = end - rowLimit
-		}
-	}
-
-	lines := make([]string, 0, end-start+3)
-	styles := make([]chooserRowStyle, 0, end-start+3)
-	lines = append(lines, "+"+padOrTrim(title, width-2)+"+")
-	styles = append(styles, chooserRowBorder)
-	lines = append(lines, "|"+padOrTrim(query, width-2)+"|")
-	styles = append(styles, chooserRowNormal)
-	for i := start; i < end; i++ {
-		row := overlay.Rows[i]
-		lines = append(lines, "|"+padOrTrim(row.Text, width-2)+"|")
-		style := chooserRowNormal
-		if !row.Selectable {
-			style = chooserRowDim
-		}
-		if i == overlay.Selected && row.Selectable {
-			style = chooserRowSelected
-		}
-		styles = append(styles, style)
-	}
-	lines = append(lines, "+"+strings.Repeat("-", width-2)+"+")
-	styles = append(styles, chooserRowBorder)
-
-	height := len(lines)
-	if height > screenH-chooserModalMinMargin*2 {
-		return nil, nil, 0, 0
-	}
-	x := (screenW - width) / 2
-	y := (screenH - height) / 2
-	if x < 0 {
-		x = 0
-	}
-	if y < 0 {
-		y = 0
-	}
-	return lines, styles, x, y
-}
-
-func chooserCellStyle(rowStyle chooserRowStyle, border bool, borderStyle, textStyle, dimStyle, selectedStyle uv.Style) uv.Style {
-	if border {
-		return borderStyle
-	}
-	switch rowStyle {
-	case chooserRowSelected:
-		return selectedStyle
-	case chooserRowDim:
-		return dimStyle
-	default:
-		return textStyle
-	}
-}
-
-func padOrTrim(s string, width int) string {
-	if width <= 0 {
-		return ""
-	}
-	if len(s) > width {
-		return s[:width]
-	}
-	if len(s) < width {
-		return s + strings.Repeat(" ", width-len(s))
-	}
-	return s
+	emitDialogChrome(buf, width, height, chooserChrome(height, overlay), profile)
 }

--- a/internal/render/modaloverlay.go
+++ b/internal/render/modaloverlay.go
@@ -21,7 +21,13 @@ func chooserChrome(screenH int, overlay *ChooserOverlay) dialogChrome {
 	rows := make([]dialogRow, 0, end-start)
 	for i := start; i < end; i++ {
 		src := overlay.Rows[i]
-		row := dialogRow{text: src.Text, kind: dialogRowNormal}
+		row := dialogRow{text: src.Text, desc: src.Desc, icon: src.Icon, rule: src.Rule, kind: dialogRowNormal}
+		if src.IconColor != "" {
+			row.iconColor = hexToColor(src.IconColor)
+		}
+		if src.TextColor != "" {
+			row.textColor = hexToColor(src.TextColor)
+		}
 		switch {
 		case i == overlay.Selected && src.Selectable:
 			row.kind = dialogRowSelected

--- a/internal/render/modaloverlay.go
+++ b/internal/render/modaloverlay.go
@@ -16,11 +16,11 @@ const (
 	chooserChromeOverhead = 6
 )
 
-// chooserRowLimit is the maximum number of list rows that fit on a screen of
+// ChooserRowLimit is the maximum number of list rows that fit on a screen of
 // the given height. Both chooserChrome (windowing) and ChooserRowAtPoint
 // (hit-testing) use it so clickable geometry can never drift from what is
 // drawn.
-func chooserRowLimit(screenH int) int {
+func ChooserRowLimit(screenH int) int {
 	return max(screenH-chooserModalMinMargin*2-chooserChromeOverhead, 1)
 }
 
@@ -28,7 +28,7 @@ func chooserRowLimit(screenH int) int {
 // windowing the rows around the selection so a long list fits on screen and
 // driving a scrollbar for the overflow.
 func chooserChrome(screenH int, overlay *ChooserOverlay) dialogChrome {
-	start, end := chooserVisibleWindow(len(overlay.Rows), overlay.Selected, chooserRowLimit(screenH))
+	start, end := chooserVisibleWindow(len(overlay.Rows), overlay.Selected, ChooserRowLimit(screenH))
 	rows := make([]dialogRow, 0, end-start)
 	for i := start; i < end; i++ {
 		src := overlay.Rows[i]
@@ -106,7 +106,7 @@ func ChooserRowAtPoint(screenW, screenH int, overlay *ChooserOverlay, x, y int) 
 		return 0, false, false
 	}
 
-	start, end := chooserVisibleWindow(len(overlay.Rows), overlay.Selected, chooserRowLimit(screenH))
+	start, end := chooserVisibleWindow(len(overlay.Rows), overlay.Selected, ChooserRowLimit(screenH))
 	idx := y - bodyTop
 	if idx < 0 || idx >= end-start {
 		return 0, false, true

--- a/internal/render/overlay.go
+++ b/internal/render/overlay.go
@@ -31,7 +31,12 @@ type ChooserOverlay struct {
 type ChooserOverlayRow struct {
 	Text       string
 	Selectable bool
-	Header     bool // window grouping row in tree mode — rendered bold
+	Header     bool   // window grouping row in tree mode — rendered bold
+	Icon       string // optional leading status glyph
+	IconColor  string // hex for the icon (empty → inherit row color)
+	TextColor  string // hex for the main text (empty → inherit row color)
+	Desc       string // dim trailing metadata (branch, task)
+	Rule       bool   // fill trailing width with a horizontal rule (section header)
 }
 
 // TextInputOverlay is a client-local modal prompt rendered above the layout.

--- a/internal/render/overlay.go
+++ b/internal/render/overlay.go
@@ -31,6 +31,7 @@ type ChooserOverlay struct {
 type ChooserOverlayRow struct {
 	Text       string
 	Selectable bool
+	Header     bool // window grouping row in tree mode — rendered bold
 }
 
 // TextInputOverlay is a client-local modal prompt rendered above the layout.

--- a/internal/render/overlay.go
+++ b/internal/render/overlay.go
@@ -25,6 +25,13 @@ type ChooserOverlay struct {
 	Query    string
 	Rows     []ChooserOverlayRow
 	Selected int
+	Toggle   *ChooserToggle // optional Tree/Window mode selector in the title bar
+}
+
+// ChooserToggle is the title-bar mode selector (e.g. Tree / Window).
+type ChooserToggle struct {
+	Options  []string
+	Selected int
 }
 
 // ChooserOverlayRow is one rendered row in the chooser modal.

--- a/internal/render/overlay_extra_test.go
+++ b/internal/render/overlay_extra_test.go
@@ -104,6 +104,38 @@ func TestChooserRowAtPoint(t *testing.T) {
 	}
 }
 
+// TestChooserChromeFitsTallList is the regression guard for the rowLimit
+// off-by-overhead bug: a list far taller than the screen must still window
+// down and render, never collapse to a blank box.
+func TestChooserChromeFitsTallList(t *testing.T) {
+	t.Parallel()
+
+	rows := make([]ChooserOverlayRow, 50)
+	for i := range rows {
+		rows[i] = ChooserOverlayRow{Text: "row", Selectable: true}
+	}
+	overlay := &ChooserOverlay{
+		Title:    "Choose",
+		Rows:     rows,
+		Selected: 40,
+		Toggle:   &ChooserToggle{Options: []string{"Tree", "Window"}, Selected: 0},
+	}
+	const w, h = 80, 24
+
+	g := NewScreenGrid(w, h)
+	rect := chooserChrome(h, overlay).place(g, defaultDialogStyles())
+	if rect.W <= 0 || rect.H <= 0 {
+		t.Fatal("chooser must still render with a tall list (regression: blank box)")
+	}
+	if rect.H > h-chooserModalMinMargin*2 {
+		t.Fatalf("box height %d exceeds the screen budget %d", rect.H, h-chooserModalMinMargin*2)
+	}
+	// The selected row must be within the windowed slice that was drawn.
+	if got := chooserRowLimit(h); got < 1 {
+		t.Fatalf("chooserRowLimit(%d) = %d, want >= 1", h, got)
+	}
+}
+
 func TestChooserOverlayRendersChrome(t *testing.T) {
 	t.Parallel()
 

--- a/internal/render/overlay_extra_test.go
+++ b/internal/render/overlay_extra_test.go
@@ -2,7 +2,6 @@ package render
 
 import (
 	"reflect"
-	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -11,12 +10,13 @@ import (
 	"github.com/weill-labs/amux/internal/mux"
 )
 
-func TestChooserOverlayLayoutGuardsAndWindowing(t *testing.T) {
+func TestChooserOverlayGuardsAndWindowing(t *testing.T) {
 	t.Parallel()
 
-	t.Run("guards", func(t *testing.T) {
+	t.Run("guards draw nothing", func(t *testing.T) {
 		t.Parallel()
 
+		row := []ChooserOverlayRow{{Text: "a", Selectable: true}}
 		tests := []struct {
 			name    string
 			width   int
@@ -24,9 +24,8 @@ func TestChooserOverlayLayoutGuardsAndWindowing(t *testing.T) {
 			overlay *ChooserOverlay
 		}{
 			{name: "nil overlay", width: 20, height: 10},
-			{name: "non-positive width", width: 0, height: 10, overlay: &ChooserOverlay{Title: "x"}},
-			{name: "tiny width", width: 8, height: 10, overlay: &ChooserOverlay{Title: "x"}},
-			{name: "tiny height", width: 20, height: 4, overlay: &ChooserOverlay{Title: "x"}},
+			{name: "tiny width", width: 8, height: 10, overlay: &ChooserOverlay{Title: "x", Rows: row}},
+			{name: "tiny height", width: 20, height: 4, overlay: &ChooserOverlay{Title: "x", Rows: row}},
 		}
 
 		for _, tt := range tests {
@@ -34,9 +33,10 @@ func TestChooserOverlayLayoutGuardsAndWindowing(t *testing.T) {
 			t.Run(tt.name, func(t *testing.T) {
 				t.Parallel()
 
-				lines, styles, x, y := chooserOverlayLayout(tt.width, tt.height, tt.overlay)
-				if lines != nil || styles != nil || x != 0 || y != 0 {
-					t.Fatalf("chooserOverlayLayout(%d, %d, %+v) = (%v, %v, %d, %d), want nil layout", tt.width, tt.height, tt.overlay, lines, styles, x, y)
+				grid := NewScreenGrid(tt.width, tt.height)
+				buildChooserOverlayCells(grid, tt.overlay)
+				if got := strings.TrimSpace(gridToText(grid)); got != "" {
+					t.Fatalf("expected nothing drawn, got %q", got)
 				}
 			})
 		}
@@ -45,34 +45,66 @@ func TestChooserOverlayLayoutGuardsAndWindowing(t *testing.T) {
 	t.Run("windows selected row into view", func(t *testing.T) {
 		t.Parallel()
 
-		rows := make([]ChooserOverlayRow, 10)
-		for i := range rows {
-			rows[i] = ChooserOverlayRow{Text: "row-" + string(rune('0'+i)), Selectable: true}
+		start, end := chooserVisibleWindow(10, 8, 5)
+		if start != 5 || end != 10 {
+			t.Fatalf("chooserVisibleWindow(10,8,5) = (%d,%d), want (5,10)", start, end)
 		}
-		overlay := &ChooserOverlay{
-			Title:    "choose-tree",
-			Query:    "pane",
-			Rows:     rows,
-			Selected: 8,
+		if 8 < start || 8 >= end {
+			t.Fatalf("selected row 8 not within window [%d,%d)", start, end)
 		}
+	})
 
-		lines, styles, x, y := chooserOverlayLayout(30, 12, overlay)
-		if len(lines) != 8 {
-			t.Fatalf("len(lines) = %d, want 8", len(lines))
-		}
-		if x <= 0 || y <= 0 {
-			t.Fatalf("layout origin = (%d, %d), want centered positive coordinates", x, y)
-		}
-		if !strings.Contains(lines[2], "row-5") || !strings.Contains(lines[6], "row-9") {
-			t.Fatalf("visible rows = %q .. %q, want rows 5 through 9", lines[2], lines[6])
-		}
-		if styles[5] != chooserRowSelected {
-			t.Fatalf("selected row style = %q, want %q", styles[5], chooserRowSelected)
+	t.Run("no windowing when rows fit", func(t *testing.T) {
+		t.Parallel()
+
+		start, end := chooserVisibleWindow(3, 1, 10)
+		if start != 0 || end != 3 {
+			t.Fatalf("chooserVisibleWindow(3,1,10) = (%d,%d), want (0,3)", start, end)
 		}
 	})
 }
 
-func TestChooserOverlayRenderAndCells(t *testing.T) {
+func TestChooserRowAtPoint(t *testing.T) {
+	t.Parallel()
+
+	overlay := &ChooserOverlay{
+		Title: "choose-window",
+		Rows: []ChooserOverlayRow{
+			{Text: "1:amux (2 panes)", Selectable: true, Header: true},
+			{Text: "  ● pane-1", Selectable: true},
+			{Text: "  pane-2", Selectable: true},
+		},
+		Selected: 1,
+	}
+	const screenW, screenH = 60, 20
+
+	_, bodyTop, ok := chooserChrome(screenH, overlay).computeLayout(screenW, screenH)
+	if !ok {
+		t.Fatal("chooser layout should fit")
+	}
+
+	// Click the second list row (bodyTop is the first row).
+	if absRow, onRow, inside := ChooserRowAtPoint(screenW, screenH, overlay, screenW/2, bodyTop+1); !inside || !onRow || absRow != 1 {
+		t.Fatalf("click row 1 = (abs=%d, onRow=%v, inside=%v), want (1,true,true)", absRow, onRow, inside)
+	}
+
+	// Click the top border: inside the box, but not on a row.
+	if _, onRow, inside := ChooserRowAtPoint(screenW, screenH, overlay, screenW/2, 0); inside && onRow {
+		t.Fatal("a point above the modal should not register as a row")
+	}
+
+	// Click far outside the modal.
+	if _, _, inside := ChooserRowAtPoint(screenW, screenH, overlay, 0, 0); inside {
+		t.Fatal("click at (0,0) should be outside the modal")
+	}
+
+	// nil overlay.
+	if _, _, inside := ChooserRowAtPoint(screenW, screenH, nil, screenW/2, bodyTop); inside {
+		t.Fatal("nil overlay should never be inside")
+	}
+}
+
+func TestChooserOverlayRendersChrome(t *testing.T) {
 	t.Parallel()
 
 	overlay := &ChooserOverlay{
@@ -86,33 +118,20 @@ func TestChooserOverlayRenderAndCells(t *testing.T) {
 		Selected: 2,
 	}
 
-	lines, _, x, y := chooserOverlayLayout(32, 12, overlay)
-	if len(lines) == 0 {
-		t.Fatal("chooserOverlayLayout returned no lines")
-	}
-
-	grid := NewScreenGrid(32, 12)
+	grid := NewScreenGrid(60, 16)
 	buildChooserOverlayCells(grid, overlay)
 	text := gridToText(grid)
-	for _, line := range lines {
-		if !strings.Contains(text, line) {
-			t.Fatalf("grid text missing overlay line %q:\n%s", line, text)
+	for _, want := range []string{"╭", "╮", "╰", "╯", "choose-window", "> pane", "0:main", "1:logs", "esc close"} {
+		if !strings.Contains(text, want) {
+			t.Errorf("chooser grid missing %q:\n%s", want, text)
 		}
-	}
-	if got := grid.Get(x+1, y+2).Char; got != string(lines[2][1]) {
-		t.Fatalf("grid cell at selected row = %q, want %q", got, string(lines[2][1]))
 	}
 
 	var buf strings.Builder
-	renderChooserOverlay(&buf, 32, 12, overlay)
+	renderChooserOverlay(&buf, 60, 16, overlay)
 	rendered := buf.String()
-	for row, line := range lines {
-		if !strings.Contains(rendered, line) {
-			t.Fatalf("rendered overlay missing line %q:\n%s", line, rendered)
-		}
-		if !strings.Contains(rendered, cursorPos(y+row+1, x+1)) {
-			t.Fatalf("rendered overlay missing cursor position for row %d", row)
-		}
+	if !strings.Contains(rendered, "choose-window") || !strings.Contains(rendered, "1:logs") {
+		t.Errorf("rendered chooser missing content:\n%s", rendered)
 	}
 }
 
@@ -381,8 +400,4 @@ func TestCompositorHelpersAndClipLine(t *testing.T) {
 			}
 		})
 	}
-}
-
-func cursorPos(row, col int) string {
-	return "\x1b[" + strconv.Itoa(row) + ";" + strconv.Itoa(col) + "H"
 }

--- a/internal/render/overlay_extra_test.go
+++ b/internal/render/overlay_extra_test.go
@@ -131,8 +131,8 @@ func TestChooserChromeFitsTallList(t *testing.T) {
 		t.Fatalf("box height %d exceeds the screen budget %d", rect.H, h-chooserModalMinMargin*2)
 	}
 	// The selected row must be within the windowed slice that was drawn.
-	if got := chooserRowLimit(h); got < 1 {
-		t.Fatalf("chooserRowLimit(%d) = %d, want >= 1", h, got)
+	if got := ChooserRowLimit(h); got < 1 {
+		t.Fatalf("ChooserRowLimit(%d) = %d, want >= 1", h, got)
 	}
 }
 

--- a/internal/render/overlay_status_test.go
+++ b/internal/render/overlay_status_test.go
@@ -294,37 +294,27 @@ func TestChooserOverlayLayoutAndRendering(t *testing.T) {
 		Selected: 2,
 	}
 
-	lines, styles, x, y := chooserOverlayLayout(24, 12, overlay)
-	if len(lines) == 0 || len(styles) != len(lines) {
-		t.Fatalf("chooserOverlayLayout returned lines=%v styles=%v", lines, styles)
-	}
-	if x < 0 || y < 0 {
-		t.Fatalf("chooser overlay origin = (%d,%d), want non-negative", x, y)
-	}
-
-	grid := NewScreenGrid(24, 12)
+	grid := NewScreenGrid(60, 16)
 	buildChooserOverlayCells(grid, overlay)
-	if got := grid.Get(x+1, y).Char; got == "" {
-		t.Fatal("chooser title row should populate grid cells")
-	}
-	selectedRow := -1
-	for i, style := range styles {
-		if style == chooserRowSelected {
-			selectedRow = i
-			break
+
+	// The selected row (index 2) must carry the Mauve accent background.
+	mauve := hexToColor(config.MauveHex)
+	found := false
+	for y := 0; y < grid.Height && !found; y++ {
+		for x := 0; x < grid.Width; x++ {
+			if grid.Get(x, y).Style.Bg == mauve {
+				found = true
+				break
+			}
 		}
 	}
-	if selectedRow < 0 {
-		t.Fatal("chooserOverlayLayout should mark one row as selected")
-	}
-	selected := grid.Get(x+1, y+selectedRow)
-	if selected.Style.Bg == nil {
-		t.Fatal("selected chooser row should have a background color")
+	if !found {
+		t.Fatal("selected chooser row should use the Mauve accent background")
 	}
 
 	buf := strings.Builder{}
-	renderChooserOverlay(&buf, 24, 12, overlay)
-	got := MaterializeGrid(buf.String(), 24, 12)
+	renderChooserOverlay(&buf, 60, 16, overlay)
+	got := MaterializeGrid(buf.String(), 60, 16)
 	for _, want := range []string{"choose-window", "> pane", "1:editor", "3:gpu"} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("chooser render missing %q in:\n%s", want, got)
@@ -426,34 +416,30 @@ func TestBuildChooserOverlayCellsSelectedRowUsesDistinctStyle(t *testing.T) {
 		},
 		Selected: 1,
 	}
-	grid := NewScreenGrid(20, 8)
+	grid := NewScreenGrid(30, 16)
 	buildChooserOverlayCells(grid, overlay)
-	lines, styles, x, y := chooserOverlayLayout(20, 8, overlay)
-	if len(lines) == 0 {
-		t.Fatal("chooserOverlayLayout should produce lines")
-	}
-	selectedRow := -1
-	baseRow := -1
-	for i, style := range styles {
-		switch style {
-		case chooserRowSelected:
-			selectedRow = i
-		case chooserRowNormal:
-			if baseRow < 0 {
-				baseRow = i
+
+	selBg := hexToColor(config.MauveHex)
+	normBg := hexToColor(config.Surface0Hex)
+	var sawSelected, sawNormal bool
+	for y := 0; y < grid.Height; y++ {
+		for x := 0; x < grid.Width; x++ {
+			switch grid.Get(x, y).Style.Bg {
+			case selBg:
+				sawSelected = true
+			case normBg:
+				sawNormal = true
 			}
 		}
 	}
-	if selectedRow < 0 || baseRow < 0 {
-		t.Fatalf("chooser styles = %v, want selected and normal rows", styles)
+	if !sawSelected {
+		t.Fatal("selected chooser row should use the Mauve accent background")
 	}
-	selectedCell := grid.Get(x+1, y+selectedRow)
-	baseCell := grid.Get(x+1, y+baseRow)
-	if selectedCell.Style.Bg == nil || baseCell.Style.Bg == nil {
-		t.Fatal("chooser overlay cells should include background colors")
+	if !sawNormal {
+		t.Fatal("expected normal rows on the Surface0 background")
 	}
-	if sameColor(selectedCell.Style.Bg, baseCell.Style.Bg) {
-		t.Fatal("selected chooser row should not use the same background as a normal row")
+	if sameColor(selBg, normBg) {
+		t.Fatal("selected and normal backgrounds must differ")
 	}
 }
 
@@ -1159,39 +1145,6 @@ func findRowLabel(grid *ScreenGrid, y, width int, label string) int {
 		}
 	}
 	return -1
-}
-
-func TestPadOrTrim(t *testing.T) {
-	t.Parallel()
-
-	if got := padOrTrim("abcdef", 4); got != "abcd" {
-		t.Fatalf("padOrTrim trim = %q, want %q", got, "abcd")
-	}
-	if got := padOrTrim("abc", 5); got != "abc  " {
-		t.Fatalf("padOrTrim pad = %q, want %q", got, "abc  ")
-	}
-	if got := padOrTrim("abc", 0); got != "" {
-		t.Fatalf("padOrTrim zero width = %q, want empty", got)
-	}
-}
-
-func TestChooserCellStyle(t *testing.T) {
-	t.Parallel()
-
-	border := uv.Style{Fg: hexToColor(config.TextColorHex)}
-	text := uv.Style{Fg: hexToColor(config.TextColorHex), Bg: hexToColor(config.Surface0Hex)}
-	dim := uv.Style{Fg: hexToColor(config.DimColorHex), Bg: hexToColor(config.Surface0Hex)}
-	selected := uv.Style{Fg: hexToColor(config.Surface0Hex), Bg: hexToColor(config.TextColorHex)}
-
-	if got := chooserCellStyle(chooserRowSelected, true, border, text, dim, selected); !sameColor(got.Fg, border.Fg) {
-		t.Fatal("border cells should always use the border style")
-	}
-	if got := chooserCellStyle(chooserRowDim, false, border, text, dim, selected); !sameColor(got.Fg, dim.Fg) {
-		t.Fatal("dim rows should use the dim style")
-	}
-	if got := chooserCellStyle(chooserRowSelected, false, border, text, dim, selected); !sameColor(got.Bg, selected.Bg) {
-		t.Fatal("selected rows should use the selected style")
-	}
 }
 
 func TestRenderPaneStatusLeadIndicator(t *testing.T) {

--- a/internal/render/text_input_overlay.go
+++ b/internal/render/text_input_overlay.go
@@ -3,31 +3,25 @@ package render
 import (
 	"strings"
 
-	uv "github.com/charmbracelet/ultraviolet"
 	"github.com/muesli/termenv"
-	"github.com/weill-labs/amux/internal/config"
 )
+
+// textInputChrome converts a TextInputOverlay into the shared dialogChrome.
+// The input is shown on a "> " line; the footer advertises the confirm/cancel keys.
+func textInputChrome(overlay *TextInputOverlay) dialogChrome {
+	return dialogChrome{
+		title:     overlay.Title,
+		showQuery: true,
+		query:     overlay.Input,
+		footer:    []footerHint{{key: "enter", label: "confirm"}, {key: "esc", label: "cancel"}},
+	}
+}
 
 func buildTextInputOverlayCells(g *ScreenGrid, overlay *TextInputOverlay) {
 	if overlay == nil {
 		return
 	}
-	lines, x, y := textInputOverlayLayout(g.Width, g.Height, overlay)
-	if len(lines) == 0 {
-		return
-	}
-	borderStyle := uv.Style{Fg: hexToColor(config.TextColorHex), Bg: hexToColor(config.Surface0Hex), Attrs: uv.AttrBold}
-	textStyle := uv.Style{Fg: hexToColor(config.TextColorHex), Bg: hexToColor(config.Surface0Hex)}
-
-	for row, line := range lines {
-		for col, r := range line {
-			style := textStyle
-			if col == 0 || col == len(line)-1 || row == 0 || row == len(lines)-1 {
-				style = borderStyle
-			}
-			g.Set(x+col, y+row, ScreenCell{Char: string(r), Width: 1, Style: style})
-		}
-	}
+	textInputChrome(overlay).place(g, defaultDialogStyles())
 }
 
 func renderTextInputOverlay(buf *strings.Builder, width, height int, overlay *TextInputOverlay) {
@@ -38,65 +32,5 @@ func renderTextInputOverlayWithProfile(buf *strings.Builder, width, height int, 
 	if overlay == nil {
 		return
 	}
-	lines, x, y := textInputOverlayLayout(width, height, overlay)
-	if len(lines) == 0 {
-		return
-	}
-	surface0Bg := bgHexSequence(config.Surface0Hex, profile)
-	textFg := fgHexSequence(config.TextColorHex, profile)
-	for row, line := range lines {
-		writeCursorTo(buf, y+row+1, x+1)
-		if row == 0 || row == len(lines)-1 {
-			buf.WriteString(surface0Bg + Bold + textFg)
-		} else {
-			buf.WriteString(surface0Bg + textFg)
-		}
-		buf.WriteString(line)
-		buf.WriteString(Reset)
-	}
-}
-
-func textInputOverlayLayout(screenW, screenH int, overlay *TextInputOverlay) ([]string, int, int) {
-	if overlay == nil || screenW <= 0 || screenH <= 0 {
-		return nil, 0, 0
-	}
-	title := " " + overlay.Title + " "
-	input := "> " + overlay.Input
-	if overlay.Input == "" {
-		input = "> "
-	}
-	width := len(title)
-	if len(input) > width {
-		width = len(input)
-	}
-	width += 2
-	maxWidth := screenW - chooserModalMinMargin*2
-	if maxWidth < 10 {
-		return nil, 0, 0
-	}
-	if width > chooserModalMaxWidth {
-		width = chooserModalMaxWidth
-	}
-	if width > maxWidth {
-		width = maxWidth
-	}
-
-	lines := []string{
-		"+" + padOrTrim(title, width-2) + "+",
-		"|" + padOrTrim(input, width-2) + "|",
-		"+" + strings.Repeat("-", width-2) + "+",
-	}
-	if len(lines) > screenH-chooserModalMinMargin*2 {
-		return nil, 0, 0
-	}
-
-	x := (screenW - width) / 2
-	y := (screenH - len(lines)) / 2
-	if x < 0 {
-		x = 0
-	}
-	if y < 0 {
-		y = 0
-	}
-	return lines, x, y
+	emitDialogChrome(buf, width, height, textInputChrome(overlay), profile)
 }

--- a/internal/render/text_input_overlay_test.go
+++ b/internal/render/text_input_overlay_test.go
@@ -5,45 +5,34 @@ import (
 	"testing"
 )
 
-func TestTextInputOverlayLayoutAndRendering(t *testing.T) {
+func TestTextInputOverlayRendersChrome(t *testing.T) {
 	t.Parallel()
 
-	overlay := &TextInputOverlay{
-		Title: "rename-window",
-		Input: "logs",
-	}
+	overlay := &TextInputOverlay{Title: "rename-window", Input: "logs"}
 
-	lines, x, y := textInputOverlayLayout(32, 12, overlay)
-	if len(lines) == 0 {
-		t.Fatal("textInputOverlayLayout returned no lines")
-	}
-	if x < 0 || y < 0 {
-		t.Fatalf("text input overlay origin = (%d,%d), want non-negative", x, y)
-	}
-
-	grid := NewScreenGrid(32, 12)
+	grid := NewScreenGrid(40, 12)
 	buildTextInputOverlayCells(grid, overlay)
 	text := gridToText(grid)
-	for _, line := range lines {
-		if !strings.Contains(text, line) {
-			t.Fatalf("grid text missing overlay line %q:\n%s", line, text)
+
+	for _, want := range []string{"╭", "╮", "╰", "╯", "rename-window", "> logs", "esc cancel"} {
+		if !strings.Contains(text, want) {
+			t.Errorf("grid text missing %q:\n%s", want, text)
 		}
 	}
 
 	var buf strings.Builder
-	renderTextInputOverlay(&buf, 32, 12, overlay)
+	renderTextInputOverlay(&buf, 40, 12, overlay)
 	rendered := buf.String()
-	for row, line := range lines {
-		if !strings.Contains(rendered, line) {
-			t.Fatalf("rendered overlay missing line %q:\n%s", line, rendered)
-		}
-		if !strings.Contains(rendered, cursorPos(y+row+1, x+1)) {
-			t.Fatalf("rendered overlay missing cursor position for row %d", row)
+	// The rendered footer interleaves SGR codes between the bold key and dim
+	// label, so check tokens individually rather than as one substring.
+	for _, want := range []string{"rename-window", "logs", "enter", "confirm", "esc", "cancel"} {
+		if !strings.Contains(rendered, want) {
+			t.Errorf("rendered overlay missing %q:\n%s", want, rendered)
 		}
 	}
 }
 
-func TestTextInputOverlayGuardsAndClamping(t *testing.T) {
+func TestTextInputOverlayGuards(t *testing.T) {
 	t.Parallel()
 
 	t.Run("nil overlay renders nothing", func(t *testing.T) {
@@ -51,6 +40,9 @@ func TestTextInputOverlayGuardsAndClamping(t *testing.T) {
 
 		grid := NewScreenGrid(20, 8)
 		buildTextInputOverlayCells(grid, nil)
+		if got := gridToText(grid); strings.TrimSpace(got) != "" {
+			t.Fatalf("buildTextInputOverlayCells(nil) drew %q, want empty", got)
+		}
 
 		var buf strings.Builder
 		renderTextInputOverlay(&buf, 20, 8, nil)
@@ -59,51 +51,28 @@ func TestTextInputOverlayGuardsAndClamping(t *testing.T) {
 		}
 	})
 
-	t.Run("layout guards", func(t *testing.T) {
+	t.Run("does not fit returns nothing", func(t *testing.T) {
 		t.Parallel()
 
-		tests := []struct {
-			name    string
-			width   int
-			height  int
-			overlay *TextInputOverlay
-		}{
-			{name: "nil overlay", width: 20, height: 8},
-			{name: "non-positive width", width: 0, height: 8, overlay: &TextInputOverlay{Title: "rename-window"}},
-			{name: "tiny width", width: 8, height: 8, overlay: &TextInputOverlay{Title: "rename-window"}},
-			{name: "tiny height", width: 20, height: 2, overlay: &TextInputOverlay{Title: "rename-window"}},
-		}
-
-		for _, tt := range tests {
-			tt := tt
-			t.Run(tt.name, func(t *testing.T) {
-				t.Parallel()
-
-				lines, x, y := textInputOverlayLayout(tt.width, tt.height, tt.overlay)
-				if lines != nil || x != 0 || y != 0 {
-					t.Fatalf("textInputOverlayLayout(%d, %d, %+v) = (%v, %d, %d), want nil layout", tt.width, tt.height, tt.overlay, lines, x, y)
-				}
-			})
+		overlay := &TextInputOverlay{Title: "rename-window", Input: "logs"}
+		var buf strings.Builder
+		renderTextInputOverlayWithProfile(&buf, 6, 8, overlay, defaultColorProfile)
+		if got := buf.String(); got != "" {
+			t.Fatalf("renderTextInputOverlay in tiny width = %q, want empty", got)
 		}
 	})
 
-	t.Run("input width can drive modal width", func(t *testing.T) {
+	t.Run("long input is clamped within screen", func(t *testing.T) {
 		t.Parallel()
 
-		overlay := &TextInputOverlay{
-			Title: "rename-window",
-			Input: "this-is-a-very-long-window-name",
-		}
-		lines, x, y := textInputOverlayLayout(18, 8, overlay)
-		if len(lines) != 3 {
-			t.Fatalf("len(lines) = %d, want 3", len(lines))
-		}
-		if x < 0 || y < 0 {
-			t.Fatalf("layout origin = (%d,%d), want non-negative", x, y)
-		}
-		for _, line := range lines {
-			if len(line) > 14 {
-				t.Fatalf("line %q exceeds clamped max width", line)
+		overlay := &TextInputOverlay{Title: "rename-window", Input: "this-is-a-very-long-window-name-that-overflows"}
+		grid := NewScreenGrid(24, 8)
+		buildTextInputOverlayCells(grid, overlay)
+		for y := 0; y < grid.Height; y++ {
+			for x := 0; x < grid.Width; x++ {
+				if grid.Get(x, y).Char == "╮" && x >= grid.Width {
+					t.Fatalf("top-right corner at x=%d exceeds screen width %d", x, grid.Width)
+				}
 			}
 		}
 	})

--- a/test/chooser_test.go
+++ b/test/chooser_test.go
@@ -17,7 +17,7 @@ func TestChooseWindowShowsModalAndSelectsWindow(t *testing.T) {
 	h.runCmd("select-window", "1")
 
 	h.sendClientKeys("C-a", "w")
-	if !h.waitFor("choose-window", 3*time.Second) || !h.waitFor("2:logs", 3*time.Second) {
+	if !h.waitFor("Choose", 3*time.Second) || !h.waitFor("2:logs", 3*time.Second) {
 		t.Fatalf("expected choose-window modal, got:\n%s", h.captureOuter())
 	}
 
@@ -51,7 +51,7 @@ func TestChooseTreeFocusesPaneAcrossWindows(t *testing.T) {
 	h.runCmd("select-window", "1")
 
 	h.sendClientKeys("C-a", "s")
-	if !h.waitFor("choose-tree", 3*time.Second) || !h.waitFor("2:logs", 3*time.Second) {
+	if !h.waitFor("Choose", 3*time.Second) || !h.waitFor("2:logs", 3*time.Second) {
 		t.Fatalf("expected choose-tree modal, got:\n%s", h.captureOuter())
 	}
 
@@ -76,12 +76,12 @@ func TestChooserDismissDoesNotLeakInput(t *testing.T) {
 	h.runCmd("select-window", "1")
 
 	h.sendClientKeys("C-a", "w")
-	if !h.waitFor("choose-window", 3*time.Second) {
+	if !h.waitFor("Choose", 3*time.Second) {
 		t.Fatalf("expected choose-window modal, got:\n%s", h.captureOuter())
 	}
 
 	h.sendClientKeys("l", "o", "g", "s", "Escape")
-	if !waitForOuterGone(h, "choose-window", 3*time.Second) {
+	if !waitForOuterGone(h, "Choose", 3*time.Second) {
 		t.Fatalf("expected chooser to dismiss\nScreen:\n%s", h.captureOuter())
 	}
 
@@ -97,7 +97,7 @@ func TestChooseTreeDismissesOnLayoutChange(t *testing.T) {
 
 	h := newAmuxHarness(t)
 	h.sendKeys("C-a", "s")
-	if !h.waitFor("choose-tree", 3*time.Second) {
+	if !h.waitFor("Choose", 3*time.Second) {
 		t.Fatalf("expected choose-tree modal, got:\n%s", h.captureOuter())
 	}
 
@@ -109,7 +109,7 @@ func TestChooseTreeDismissesOnLayoutChange(t *testing.T) {
 	if !strings.Contains(out, proto.UIEventChooseTreeHidden) {
 		t.Fatalf("wait-ui hidden output = %q", out)
 	}
-	if strings.Contains(h.captureOuter(), "choose-tree") {
+	if strings.Contains(h.captureOuter(), "Choose") {
 		t.Fatalf("chooser should clear on layout change, got:\n%s", h.captureOuter())
 	}
 }


### PR DESCRIPTION
## Motivation

amux's two native modal overlays — the chooser (`prefix+w` / `prefix+s`) and the text-input prompt (`prefix+,` / `prefix+.`) — rendered with ASCII `+ - |` borders, no padding, an inverted (near-white) selection bar, and no color, which looked crude next to crush's rounded, accented modals. This redesigns them for visual parity.

## Summary

- **Shared `dialogChrome` cell-builder** (`internal/render/dialog_chrome.go`): rounded Unicode borders (`╭─╮│╰╯`), interior padding, Mauve accent selection bar, a two-weight footer (bold keys in crush's `#858392`, dim labels, `•` separator), a scrollbar gutter, and section/header rows. The placement loop is **display-column-aware** (`ansi.StringWidth` + continuation cells), which fixes the byte-indexed loop that previously forced ASCII borders.
- **Both modals ported onto it.** The grid/diff path and the direct-ANSI full-render path share one placement via `computeLayout` / `emitDialogChrome`, so they can't diverge.
- **Richer choose-tree rows:** windows are bold section headers with a trailing rule; panes show a colored status glyph (`▶` lead, `●` active, `◇` idle, `○` busy), the pane name in its assigned color, and a dim git-branch/task suffix.
- **Tab toggle:** the chooser title bar shows `◉ Tree  ○ Window`; `Tab` / `Shift+Tab` switches the view in place, preserving the filter query. `prefix+w` / `prefix+s` still open their respective views.
- **Keyboard:** `j` / `k` now type into the filter; `Ctrl+J` / `Ctrl+K` move the selection (remapped to Down/Up at the decoded-event layer, before `Ctrl+J` folds to `0x0A` == Enter).
- **Mouse:** the chooser is an exclusive modal — wheel scrolls the selection, a left click on a row chooses it, a click outside dismisses it.
- `MauveHex` / `FooterKeyHex` added to `config`; `ToggleOn` / `ToggleOff` glyphs added to all three `IconSet` presets.

## Testing

```
env -u AMUX_SESSION -u TMUX go test ./internal/render/ ./internal/client/ ./internal/config/
env -u AMUX_SESSION -u TMUX go vet ./...
```

New unit tests cover the chrome (borders/padding/accent/footer/scrollbar/icons/rules/spacers), display-column placement, chooser hit-testing (`ChooserRowAtPoint`), Ctrl+J/K normalization, the row builders, the Tab toggle, and the mouse handler. Verified live via `make install`: rename prompt, choose-tree (icons/rules/branches), `j`/`k` filtering, and mouse click-to-choose.

The full `internal/render` and `internal/client` suites pass locally; the `test/` integration package is left to CI (local runs are contaminated by `.orca/pool` clone worktrees and machine load).

## Review focus

- `dialog_chrome.go` — the shared geometry (`computeLayout`) and the cell-placement loop; the per-row color suppression on the selected row.
- `internal/client/input_keys.go` `normalizeChooserInput` — the Ctrl+J→Down remap rationale (Enter collision).
- `internal/client/mouse.go` `handleChooserMouseEvent` — exclusive-modal consumption.
- Whether the `▶/●/◇/○` status-glyph mapping for panes matches your mental model.

Closes LAB-1970