### PR TITLE
LAB-1971: Exclude .orca from repo-tree audit walks

### DIFF
--- a/test/hermetic_subprocess_test.go
+++ b/test/hermetic_subprocess_test.go
@@ -22,8 +22,7 @@ func TestAmuxSubprocessesUseHermeticHelper(t *testing.T) {
 			return err
 		}
 		if d.IsDir() {
-			switch d.Name() {
-			case ".git", "testdata":
+			if skipAuditDir(d.Name()) {
 				return filepath.SkipDir
 			}
 			return nil

--- a/test/parallel_audit_test.go
+++ b/test/parallel_audit_test.go
@@ -57,8 +57,7 @@ func findMissingParallelCalls(root string) ([]parallelFinding, error) {
 			return err
 		}
 		if info.IsDir() {
-			switch path {
-			case ".git", "vendor":
+			if skipAuditDir(info.Name()) {
 				return filepath.SkipDir
 			}
 			return nil

--- a/test/script_helpers_test.go
+++ b/test/script_helpers_test.go
@@ -51,6 +51,35 @@ func repoPath(tb testing.TB, rel string) string {
 	return filepath.Join(repoRoot(tb), filepath.FromSlash(rel))
 }
 
+func TestSkipAuditDir(t *testing.T) {
+	t.Parallel()
+
+	skip := []string{".git", ".orca", "vendor", "testdata", "node_modules"}
+	for _, name := range skip {
+		if !skipAuditDir(name) {
+			t.Errorf("skipAuditDir(%q) = false, want true", name)
+		}
+	}
+	for _, name := range []string{"internal", "test", "render", "client", ".orcas", "orca"} {
+		if skipAuditDir(name) {
+			t.Errorf("skipAuditDir(%q) = true, want false", name)
+		}
+	}
+}
+
+// skipAuditDir reports whether a directory (by base name) should be skipped by
+// repo-tree audit walks. It excludes VCS metadata, vendored deps, test
+// fixtures, and orca clone-pool worktrees (.orca) whose duplicated *_test.go
+// copies would otherwise trip the audits with phantom findings. See LAB-1971.
+func skipAuditDir(name string) bool {
+	switch name {
+	case ".git", ".orca", "vendor", "testdata", "node_modules":
+		return true
+	default:
+		return false
+	}
+}
+
 func testLogDir(home string) string {
 	return filepath.Join(home, ".local", "state", "amux", "logs")
 }


### PR DESCRIPTION
## Motivation

`go test ./test/` fails locally whenever an orca clone pool exists at `.orca/pool/clone-*`. The repo-tree audit tests walk the entire working tree and scan every `*_test.go`, so they trip on the duplicated test files inside the clone-pool worktrees and report phantom findings:

```
amux subprocess tests must go through the hermetic subprocess helper:
  .orca/pool/clone-04/test/server_harness_test.go:172
  .orca/pool/clone-05/...
```

This made the local integration suite unrunnable on any machine running orca with a populated clone pool — during LAB-1970 (#833) it meant integration failures only surfaced in CI.

## Summary

- Add a shared `skipAuditDir(name)` helper (`test/script_helpers_test.go`) that excludes `.git`, `.orca`, `vendor`, `testdata`, and `node_modules`, and route both tree-walking audits through it:
  - `TestAmuxSubprocessesUseHermeticHelper` (`hermetic_subprocess_test.go`)
  - `TestParallelAudit` (`parallel_audit_test.go`)
- Fix a latent bug in `parallel_audit`: it switched on the full `path` instead of the directory base name, so its `.git`/`vendor` skip never actually matched.

## Testing

```
go test ./test/ -run '^(TestSkipAuditDir|TestAmuxSubprocessesUseHermeticHelper|TestParallelAudit)$' -count=1
```

All three pass **with a populated `.orca/pool/` present locally** — they failed before this change. Added `TestSkipAuditDir` for the helper itself.

## Review focus

- The `skipAuditDir` exclusion list — is anything else worth excluding (e.g. nested git worktrees)?
- The `path` → `info.Name()` fix in `parallel_audit` changes which dirs are actually skipped (previously none were); confirms no real findings are now missed (`TestParallelAudit` still passes with 0 findings).

Closes LAB-1971