### PR TITLE
LAB-1974: Fix federation wave-3 retro-review findings

### DIFF
--- a/internal/cli/cli_usage.go
+++ b/internal/cli/cli_usage.go
@@ -16,7 +16,7 @@ const (
 	leadUsage         = "usage: amux lead [pane] | amux lead --clear"
 	metaUsage         = "usage: amux meta <set|get|rm> ..."
 	moveUsage         = "usage: amux move <pane> up|down | amux move <pane> (--before <target>|--after <target>|--to-column <target>)"
-	remoteUsage       = "usage: amux remote <add|list|rm|panes|attach|detach|resize> ..."
+	remoteUsage       = "usage: amux remote <add|list|rm|panes|status|attach|detach|resize> ..."
 	spawnUsage        = "usage: amux spawn [--auto] [--at <pane>] [--window <name|id>] [--vertical|--horizontal] [--root] [--focus] [--attach <host>:<pane-name>] [--name NAME] [--task TASK] [--color COLOR]"
 	swapUsage         = "usage: amux swap <pane1> <pane2> [--tree] | amux swap forward | amux swap backward"
 	cursorUsage       = "usage: amux cursor <layout|clipboard|ui> [--client <id>]"
@@ -207,7 +207,7 @@ Usage:
   amux [-s session] respawn <pane>     Restart a pane shell in place
   amux [-s session] resize-pane <pane> <dir> [n]
                                        Resize pane (dir: left/right/up/down)
-  amux [-s session] remote <add|list|rm|panes|attach|detach|resize> ...
+  amux [-s session] remote <add|list|rm|panes|status|attach|detach|resize> ...
                                        Manage remote amux hosts and mirror panes
   amux [-s session] equalize [--vertical|--all]
                                        Rebalance root columns, column rows, or both

--- a/internal/server/commands/layout/args.go
+++ b/internal/server/commands/layout/args.go
@@ -145,6 +145,9 @@ func parseCreatePaneArgs(mode createPaneMode, args []string) (createPaneArgs, er
 	if parsed.Auto && (parsed.RootLevel || hasExplicitDir) {
 		return createPaneArgs{}, fmt.Errorf("spawn --auto cannot be combined with explicit placement")
 	}
+	if parsed.Auto && parsed.Attach != nil {
+		return createPaneArgs{}, fmt.Errorf("spawn --auto cannot be combined with --attach")
+	}
 	if (((parsed.PaneRef != "" || parsed.WindowRef != "") && !parsed.Auto) || parsed.RootLevel) && !hasExplicitDir {
 		parsed.Dir = mux.SplitHorizontal
 	}

--- a/internal/server/commands/layout/args_test.go
+++ b/internal/server/commands/layout/args_test.go
@@ -66,6 +66,12 @@ func TestParseCreatePaneArgs(t *testing.T) {
 			args:    []string{"pane-1"},
 			wantErr: `unknown spawn arg "pane-1"`,
 		},
+		{
+			name:    "spawn rejects --auto with --attach",
+			mode:    createPaneModeSpawn,
+			args:    []string{"--auto", "--attach", "hetzner-1:pane-1786"},
+			wantErr: "spawn --auto cannot be combined with --attach",
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/server/commands_layout.go
+++ b/internal/server/commands_layout.go
@@ -144,6 +144,12 @@ func runCreatePane(ctx *CommandContext, actorPaneID uint32, command string, plac
 
 func runCreateMirrorPane(ctx *CommandContext, actorPaneID uint32, command string, placement createPanePlacement, req createPaneRequest, keepFocus bool, snapshot createPaneSnapshot) commandpkg.Result {
 	ref := *req.attach
+	// Validate the remote host up-front, mirroring `remote attach`. Without
+	// this, an unknown host would create a mirror pane that can never connect
+	// while the command reports success (silent failure).
+	if _, err := lookupRemoteHost(ref.Host); err != nil {
+		return commandpkg.Result{Err: err}
+	}
 	meta := mux.PaneMeta{
 		Name:  req.name,
 		Host:  ref.Host,

--- a/internal/server/commands_remote.go
+++ b/internal/server/commands_remote.go
@@ -21,9 +21,10 @@ import (
 )
 
 const (
-	remoteCommandUsage   = "usage: remote <add|list|rm|panes|attach|detach|resize> ..."
+	remoteCommandUsage   = "usage: remote <add|list|rm|panes|status|attach|detach|resize> ..."
 	remoteAddUsage       = "usage: remote add <name> --ssh <target> --socket <path> [--session <name>]"
 	remoteListUsage      = "usage: remote list"
+	remoteStatusUsage    = "usage: remote status"
 	remoteRmUsage        = "usage: remote rm <name>"
 	remotePanesUsage     = "usage: remote panes <name>"
 	remoteAttachUsage    = "usage: remote attach <name>:<pane-name>"
@@ -82,6 +83,8 @@ func runRemoteCommand(ctx *CommandContext) commandpkg.Result {
 		return runRemoteAdd(ctx)
 	case "list":
 		return runRemoteList(ctx)
+	case "status":
+		return runRemoteStatus(ctx)
 	case "rm":
 		return runRemoteRm(ctx)
 	case "panes":
@@ -141,6 +144,71 @@ func runRemoteList(ctx *CommandContext) commandpkg.Result {
 			name, host.SSH, remoteCommandSession(host), host.SocketPath, remoteHostHealth(name, snaps))
 	}
 	return commandpkg.Result{Output: b.String()}
+}
+
+func runRemoteStatus(ctx *CommandContext) commandpkg.Result {
+	if len(ctx.Args) != 1 {
+		return commandpkg.Result{Err: errors.New(remoteStatusUsage)}
+	}
+	cfg, err := loadRemoteConfig()
+	if err != nil {
+		return commandpkg.Result{Err: err}
+	}
+	if len(cfg.Remote.Hosts) == 0 {
+		return commandpkg.Result{Output: "No remotes.\n"}
+	}
+
+	return commandpkg.Result{Output: formatRemoteStatus(cfg.Remote.Hosts, remoteMirrorSnapshots(ctx))}
+}
+
+// formatRemoteStatus renders the `remote status` table: one block per
+// configured host with its overall health plus a row per active mirror
+// (remote pane name, remote pane ID, connection state). Pure function so the
+// rendering is unit-testable without touching disk config or a live session.
+func formatRemoteStatus(hosts map[string]config.Host, snaps []mirrorpkg.Snapshot) string {
+	byHost := make(map[string][]mirrorpkg.Snapshot)
+	for _, snap := range snaps {
+		byHost[snap.RemoteRef.Host] = append(byHost[snap.RemoteRef.Host], snap)
+	}
+
+	b := strings.Builder{} // local accumulator (not a package-level var)
+	fmt.Fprintf(&b, "%-20s %-14s %-20s %-8s %s\n", "HOST", "HEALTH", "PANE", "REMOTE", "STATE")
+	for _, name := range sortedRemoteHostNames(hosts) {
+		health := remoteHostHealth(name, snaps)
+		mirrors := byHost[name]
+		if len(mirrors) == 0 {
+			fmt.Fprintf(&b, "%-20s %-14s %-20s %-8s %s\n", name, health, "-", "-", "-")
+			continue
+		}
+		sortMirrorSnapshots(mirrors)
+		for i, snap := range mirrors {
+			hostCol, healthCol := name, health
+			if i > 0 {
+				// Repeat host/health only on the first row for readability.
+				hostCol, healthCol = "", ""
+			}
+			state := string(snap.State)
+			if snap.LastError != "" {
+				state = fmt.Sprintf("%s (%s)", state, snap.LastError)
+			}
+			fmt.Fprintf(&b, "%-20s %-14s %-20s %-8s %s\n",
+				hostCol, healthCol, snap.RemoteRef.PaneName, remotePaneIDLabel(snap.RemotePaneID), state)
+		}
+	}
+	return b.String()
+}
+
+func sortMirrorSnapshots(snaps []mirrorpkg.Snapshot) {
+	sort.Slice(snaps, func(i, j int) bool {
+		return snaps[i].RemoteRef.PaneName < snaps[j].RemoteRef.PaneName
+	})
+}
+
+func remotePaneIDLabel(id uint32) string {
+	if id == 0 {
+		return "-"
+	}
+	return fmt.Sprintf("%d", id)
 }
 
 func runRemoteRm(ctx *CommandContext) commandpkg.Result {

--- a/internal/server/commands_remote.go
+++ b/internal/server/commands_remote.go
@@ -172,12 +172,12 @@ func formatRemoteStatus(hosts map[string]config.Host, snaps []mirrorpkg.Snapshot
 	}
 
 	b := strings.Builder{} // local accumulator (not a package-level var)
-	fmt.Fprintf(&b, "%-20s %-14s %-20s %-8s %s\n", "HOST", "HEALTH", "PANE", "REMOTE", "STATE")
+	fmt.Fprintf(&b, "%-20s %-14s %-20s %-10s %s\n", "HOST", "HEALTH", "PANE", "ID", "STATE")
 	for _, name := range sortedRemoteHostNames(hosts) {
 		health := remoteHostHealth(name, snaps)
 		mirrors := byHost[name]
 		if len(mirrors) == 0 {
-			fmt.Fprintf(&b, "%-20s %-14s %-20s %-8s %s\n", name, health, "-", "-", "-")
+			fmt.Fprintf(&b, "%-20s %-14s %-20s %-10s %s\n", name, health, "-", "-", "-")
 			continue
 		}
 		sortMirrorSnapshots(mirrors)
@@ -191,7 +191,7 @@ func formatRemoteStatus(hosts map[string]config.Host, snaps []mirrorpkg.Snapshot
 			if snap.LastError != "" {
 				state = fmt.Sprintf("%s (%s)", state, snap.LastError)
 			}
-			fmt.Fprintf(&b, "%-20s %-14s %-20s %-8s %s\n",
+			fmt.Fprintf(&b, "%-20s %-14s %-20s %-10s %s\n",
 				hostCol, healthCol, snap.RemoteRef.PaneName, remotePaneIDLabel(snap.RemotePaneID), state)
 		}
 	}

--- a/internal/server/commands_remote_test.go
+++ b/internal/server/commands_remote_test.go
@@ -84,6 +84,7 @@ func TestRunRemoteCommandUsageErrors(t *testing.T) {
 		{name: "unknown subcommand", args: []string{"bogus"}, want: remoteCommandUsage},
 		{name: "add usage", args: []string{"add"}, want: remoteAddUsage},
 		{name: "list usage", args: []string{"list", "extra"}, want: remoteListUsage},
+		{name: "status usage", args: []string{"status", "extra"}, want: remoteStatusUsage},
 		{name: "rm usage", args: []string{"rm"}, want: remoteRmUsage},
 		{name: "panes usage", args: []string{"panes"}, want: remotePanesUsage},
 		{name: "attach usage", args: []string{"attach"}, want: remoteAttachUsage},
@@ -428,6 +429,52 @@ func TestRemoteHostHealth(t *testing.T) {
 	}
 	if got := remoteHostHealth("one", snaps); got != "connected,dead(2)" {
 		t.Fatalf("remoteHostHealth(one) = %q, want connected,dead(2)", got)
+	}
+}
+
+func TestFormatRemoteStatus(t *testing.T) {
+	t.Parallel()
+
+	hosts := map[string]config.Host{
+		"hetzner-1": {SSH: "host1", SocketPath: "/tmp/a/main"},
+		"hetzner-2": {SSH: "host2", SocketPath: "/tmp/b/main"},
+	}
+	snaps := []mirrorpkg.Snapshot{
+		{RemoteRef: checkpoint.RemoteRef{Host: "hetzner-1", PaneName: "pane-1786"}, RemotePaneID: 1786, State: mirrorpkg.StateConnected},
+		{RemoteRef: checkpoint.RemoteRef{Host: "hetzner-1", PaneName: "L0-meta"}, State: mirrorpkg.StateReconnecting, LastError: "dial timeout"},
+	}
+
+	got := formatRemoteStatus(hosts, snaps)
+
+	// Header present.
+	if !strings.Contains(got, "HOST") || !strings.Contains(got, "STATE") {
+		t.Fatalf("missing header:\n%s", got)
+	}
+	// Mirror rows sorted by remote pane name (L0-meta before pane-1786) with
+	// the remote pane ID and last-error annotation rendered.
+	if idx1, idx2 := strings.Index(got, "L0-meta"), strings.Index(got, "pane-1786"); idx1 < 0 || idx2 < 0 || idx1 > idx2 {
+		t.Fatalf("mirror rows missing or unsorted:\n%s", got)
+	}
+	if !strings.Contains(got, "1786") {
+		t.Fatalf("remote pane id not rendered:\n%s", got)
+	}
+	if !strings.Contains(got, "reconnecting (dial timeout)") {
+		t.Fatalf("state+error not rendered:\n%s", got)
+	}
+	// A host with no active mirrors renders an idle placeholder row.
+	if !strings.Contains(got, "hetzner-2") {
+		t.Fatalf("idle host missing:\n%s", got)
+	}
+}
+
+func TestRemotePaneIDLabel(t *testing.T) {
+	t.Parallel()
+
+	if got := remotePaneIDLabel(0); got != "-" {
+		t.Fatalf("remotePaneIDLabel(0) = %q, want -", got)
+	}
+	if got := remotePaneIDLabel(1786); got != "1786" {
+		t.Fatalf("remotePaneIDLabel(1786) = %q, want 1786", got)
 	}
 }
 

--- a/internal/server/mirror/manager.go
+++ b/internal/server/mirror/manager.go
@@ -92,7 +92,13 @@ func (m *Manager) Configure(cfg Config) {
 	}
 	m.mu.Lock()
 	m.hosts = cloneHosts(cfg.Hosts)
-	m.dialer = cfg.Dialer
+	// Only replace the dialer when one is supplied. A nil dialer means "no
+	// change" so that config-only reconfigures (e.g. remote add/rm passing
+	// ConfigureMirrors(hosts, nil)) do not wipe an injected dialer; a nil
+	// dialer field still falls back to SSHDialer{} via currentDialer().
+	if cfg.Dialer != nil {
+		m.dialer = cfg.Dialer
+	}
 	m.retryPolicy = normalizeRetryPolicy(cfg.RetryPolicy)
 	m.attachTimeout = cfg.AttachTimeout
 	if m.attachTimeout <= 0 {
@@ -163,6 +169,11 @@ func (m *Manager) Track(pane *mux.Pane, ref checkpoint.RemoteRef) error {
 	if _, ok := m.hostForRefLocked(ref); ok {
 		m.startLocked(ms)
 	} else {
+		// Host not configured yet: keep the mirror pending so a later
+		// Configure (e.g. checkpoint restore racing config load) can start
+		// it. User-facing create paths (spawn --attach, remote attach)
+		// validate the host up-front and never reach here with an unknown
+		// host, so this stays a tolerant restore/deferred path.
 		ms.lastErr = fmt.Sprintf("remote host %q is not configured", ref.Host)
 	}
 	return nil

--- a/internal/server/mirror/manager_test.go
+++ b/internal/server/mirror/manager_test.go
@@ -331,6 +331,33 @@ func TestManagerConfigureStartsDeferredMirror(t *testing.T) {
 	waitForMirrorState(t, mgr, pane.ID, StateDead)
 }
 
+func TestManagerConfigurePreservesDialerWhenNil(t *testing.T) {
+	t.Parallel()
+
+	injected := failingDialer{err: errors.New("dial failed")}
+	mgr := NewManager(Config{Dialer: injected})
+	t.Cleanup(mgr.Close)
+
+	// A config-only reconfigure (as `remote add`/`rm` does via
+	// ConfigureMirrors(hosts, nil)) passes a nil dialer and must NOT wipe the
+	// injected dialer.
+	mgr.Configure(Config{
+		Hosts: map[string]config.Host{
+			"remote": {SSH: "ignored", Session: "main", SocketPath: "/tmp/amux-test"},
+		},
+	})
+
+	mgr.mu.Lock()
+	got := mgr.dialer
+	mgr.mu.Unlock()
+	if got == nil {
+		t.Fatal("Configure with nil dialer wiped the injected dialer")
+	}
+	if _, ok := got.(failingDialer); !ok {
+		t.Fatalf("dialer = %T, want the injected failingDialer", got)
+	}
+}
+
 func TestManagerCloseClosesTrackedLinks(t *testing.T) {
 	t.Parallel()
 

--- a/test/spawn_attach_test.go
+++ b/test/spawn_attach_test.go
@@ -3,6 +3,7 @@ package test
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"strings"
 	"testing"
 
@@ -11,6 +12,7 @@ import (
 
 func TestSpawnAttachCreatesMirrorAndForwardsInput(t *testing.T) {
 	t.Parallel()
+	skipIfNoNetcat(t)
 
 	fakeSSHDir := writeSpawnAttachFakeSSH(t)
 	remoteHost := "hetzner-1"
@@ -43,6 +45,34 @@ func TestSpawnAttachCreatesMirrorAndForwardsInput(t *testing.T) {
 	local.runCmd("send-keys", "mirror-agent", "printf FROM_MIRROR", "Enter")
 	if out := remote.runCmd("wait", "content", "pane-1786", "FROM_MIRROR", "--timeout", "5s"); strings.Contains(out, "timed out") {
 		t.Fatalf("remote pane did not receive mirror input:\n%s", out)
+	}
+}
+
+func TestSpawnAttachUnknownHostFails(t *testing.T) {
+	t.Parallel()
+
+	// No fake ssh / nc needed: the unknown host is rejected before any
+	// connection is attempted.
+	local, _ := newServerHarnessPairWithLocalRemote(t, "hetzner-1")
+
+	out := local.runCmd("spawn", "--at", "pane-1", "--horizontal", "--attach", "nonexistent:pane-1786", "--name", "mirror-agent")
+	if !strings.Contains(out, `remote "nonexistent" not found`) {
+		t.Fatalf("spawn --attach unknown host output = %q, want a not-found error", out)
+	}
+
+	// The failure must be surfaced before any mirror pane is created — the
+	// local session still has only its original pane (this is the silent
+	// unknown-host regression guard).
+	capture := local.captureJSON()
+	if len(capture.Panes) != 1 {
+		t.Fatalf("local pane count = %d, want 1 (no mirror created on error)", len(capture.Panes))
+	}
+}
+
+func skipIfNoNetcat(tb testing.TB) {
+	tb.Helper()
+	if _, err := exec.LookPath("nc"); err != nil {
+		tb.Skip("skipping: `nc` not on PATH (required by the fake-ssh mirror transport)")
 	}
 }
 


### PR DESCRIPTION
## Motivation

The wave-3 federation tickets (LAB-1960/1961/1963/1964) direct-landed to `main` without a PR/CI/bot review. A retroactive 4-agent review (one per ticket) found the code sound — 2 clean, 2 minor-fixes, **zero P1s, all security invariants hold** — but surfaced a small set of real fixes. This PR addresses them through the proper PR + CI + review path the direct-landing race skipped.

## Summary

- **[P2] `spawn --attach` silent unknown-host (LAB-1961)** — `spawn --attach badhost:pane` reported success but created a dead mirror, because the spawn path skipped the host validation `remote attach` already does. Added the same `lookupRemoteHost` check up-front in `runCreateMirrorPane`. The mirror manager's `Track` keeps its tolerant deferred-start contract for checkpoint restore (verified by the existing `TestManagerConfigureStartsDeferredMirror`).
- **[P2] `remote status` command (LAB-1960)** — spec listed it but only add/list/rm/panes/attach/detach/resize existed. Implemented it (per-host health + active-mirror rows); rendering extracted into a pure `formatRemoteStatus` for unit testing.
- **[P3] reject `--auto --attach`** — the spawn parser allowed this undefined combo; now rejected like the existing `--auto`+placement guard.
- **[P3] dialer-reset guard (LAB-1960)** — `mirror.Configure` only replaces the dialer when one is supplied, so a config-only reconfigure (`remote add`/`rm` passing a nil dialer) no longer wipes an injected dialer; nil still falls back to `SSHDialer`.
- Converted the file's no-arg `fmt.Errorf(usageConst)` calls to `errors.New` (staticcheck SA1006, flagged once the file is touched).

## Testing

```
go build ./... && go vet ./internal/server/...
go test ./internal/server/mirror/ -run 'ConfigurePreservesDialer|ConfigureStartsDeferred|NilReceiversAndTrack' -count=100
go test ./internal/server/ -run 'FormatRemoteStatus|RemotePaneIDLabel|RunRemoteCommandUsageErrors' -count=100
go test ./internal/server/commands/layout/ -run TestParseCreatePaneArgs -count=100
go test ./test/ -run TestSpawnAttach -count=20
```

All green. `TestRespawnCommandRestartsLocalPaneInPlace` is an environment-flaky timeout under parallel load (passes in isolation; touches no code in this diff; previously documented on LAB-1953).

## Review focus

- The silent-failure fix: `spawn --attach` to an unknown host now errors with **no pane created**, and `Track`'s deferred-start path (checkpoint restore) is unchanged.
- `formatRemoteStatus` output format.
- The dialer guard: only-overwrite-when-non-nil is correct because `currentDialer()` falls back to `SSHDialer`.

Follows up the retro-review of the direct-landed wave-3 tickets. Closes LAB-1974.