### PR TITLE
LAB-1980: Add version flags and tmux hints

### DIFF
--- a/internal/cli/cli_dispatch.go
+++ b/internal/cli/cli_dispatch.go
@@ -77,6 +77,9 @@ func runCLI(runtime Runtime, rawArgs []string) int {
 	if MaybePrintCommandHelp(runtime.Stdout, args) {
 		return 0
 	}
+	if isVersionFlag(args[0]) {
+		return commands["version"](invocation, nil)
+	}
 	if args[0] == "help" || isHelpFlag(args[0]) {
 		runtime.PrintUsage()
 		return 0
@@ -85,10 +88,26 @@ func runCLI(runtime Runtime, rawArgs []string) int {
 	handler, ok := commands[args[0]]
 	if !ok {
 		fmt.Fprintf(runtime.Stderr, "amux: unknown command %q\n", args[0])
+		if hint, ok := tmuxCompatCommandHint(args[0]); ok {
+			fmt.Fprintf(runtime.Stderr, "did you mean `%s`?\n", hint)
+		}
 		runtime.PrintUsage()
 		return 1
 	}
 	return handler(invocation, args[1:])
+}
+
+func isVersionFlag(arg string) bool {
+	return arg == "--version" || arg == "-V"
+}
+
+func tmuxCompatCommandHint(command string) (string, bool) {
+	switch command {
+	case "capture-pane", "pipe-pane", "pane":
+		return "amux capture", true
+	default:
+		return "", false
+	}
 }
 
 func (inv invocation) runDefaultSession() int {

--- a/internal/cli/main_test.go
+++ b/internal/cli/main_test.go
@@ -736,6 +736,24 @@ func TestRunMainDispatchesCommands(t *testing.T) {
 			},
 		},
 		{
+			name:       "version long flag dispatch",
+			args:       []string{"--version"},
+			wantExit:   0,
+			wantStdout: "version\n",
+			wantCalls: []cliCall{
+				{kind: "version"},
+			},
+		},
+		{
+			name:       "version short flag dispatch",
+			args:       []string{"-V"},
+			wantExit:   0,
+			wantStdout: "version\n",
+			wantCalls: []cliCall{
+				{kind: "version"},
+			},
+		},
+		{
 			name:     "spawn focus dispatches parsed command",
 			args:     []string{"spawn", "--focus"},
 			wantExit: 0,
@@ -876,6 +894,27 @@ func TestRunMainHelpAndUsageErrors(t *testing.T) {
 			wantExit:       1,
 			wantUsageCalls: 1,
 			wantStderr:     "amux: unknown command \"dashboard\"\n",
+		},
+		{
+			name:           "capture-pane suggests capture",
+			args:           []string{"capture-pane"},
+			wantExit:       1,
+			wantUsageCalls: 1,
+			wantStderr:     "amux: unknown command \"capture-pane\"\ndid you mean `amux capture`?\n",
+		},
+		{
+			name:           "pipe-pane suggests capture",
+			args:           []string{"pipe-pane"},
+			wantExit:       1,
+			wantUsageCalls: 1,
+			wantStderr:     "amux: unknown command \"pipe-pane\"\ndid you mean `amux capture`?\n",
+		},
+		{
+			name:           "pane suggests capture",
+			args:           []string{"pane"},
+			wantExit:       1,
+			wantUsageCalls: 1,
+			wantStderr:     "amux: unknown command \"pane\"\ndid you mean `amux capture`?\n",
 		},
 		{
 			name:       "send-keys usage error stays in dispatch layer",

--- a/test/version_test.go
+++ b/test/version_test.go
@@ -23,6 +23,51 @@ func TestVersionCommand(t *testing.T) {
 	}
 }
 
+func TestVersionFlagAliases(t *testing.T) {
+	want, err := newHermeticAmuxCommand(t, "version").CombinedOutput()
+	if err != nil {
+		t.Fatalf("amux version failed: %v\n%s", err, want)
+	}
+
+	for _, flag := range []string{"--version", "-V"} {
+		flag := flag
+		t.Run(flag, func(t *testing.T) {
+			t.Parallel()
+
+			out, err := newHermeticAmuxCommand(t, flag).CombinedOutput()
+			if err != nil {
+				t.Fatalf("amux %s failed: %v\n%s", flag, err, out)
+			}
+			if string(out) != string(want) {
+				t.Fatalf("amux %s output = %q, want %q", flag, out, want)
+			}
+		})
+	}
+}
+
+func TestTmuxStyleUnknownCommandHints(t *testing.T) {
+	t.Parallel()
+
+	for _, command := range []string{"capture-pane", "pipe-pane", "pane"} {
+		command := command
+		t.Run(command, func(t *testing.T) {
+			t.Parallel()
+
+			out, err := newHermeticAmuxCommand(t, command).CombinedOutput()
+			if err == nil {
+				t.Fatalf("amux %s succeeded, want non-zero exit\n%s", command, out)
+			}
+			output := string(out)
+			if !strings.Contains(output, "amux: unknown command \""+command+"\"") {
+				t.Fatalf("amux %s output missing unknown command error:\n%s", command, output)
+			}
+			if !strings.Contains(output, "did you mean `amux capture`?") {
+				t.Fatalf("amux %s output missing capture hint:\n%s", command, output)
+			}
+		})
+	}
+}
+
 func TestStatusIncludesBuild(t *testing.T) {
 	t.Parallel()
 	h := newServerHarness(t)


### PR DESCRIPTION
## Motivation

Agents sometimes use conventional version flags or tmux-style pane commands when operating amux. Those invocations currently fail with bare unknown-command errors, which costs an avoidable recovery round trip.

## Summary

- Route `amux --version` and `amux -V` through the existing `amux version` output path.
- Add unknown-command hints for `capture-pane`, `pipe-pane`, and bare `pane` to point users at `amux capture`.
- Cover the dispatch behavior directly and through hermetic CLI subprocess tests.

## Testing

- `go test ./internal/cli -run 'TestRunMainDispatchesCommands|TestRunMainHelpAndUsageErrors'`
- `go test ./test -run 'TestVersionFlagAliases|TestTmuxStyleUnknownCommandHints'`
- `go test ./internal/cli -run 'TestRunMainDispatchesCommands|TestRunMainHelpAndUsageErrors' -count=100`
- `go test ./test -run 'TestVersionFlagAliases|TestTmuxStyleUnknownCommandHints' -count=100`
- `go test ./... -timeout 120s`

## Review focus

Check the CLI dispatch ordering: version flags should bypass session attach, while normal help handling and unknown-command usage output should retain existing behavior.

Closes LAB-1980
