### PR TITLE
LAB-1962: Add remote pane chooser source

### DIFF
--- a/internal/client/attach.go
+++ b/internal/client/attach.go
@@ -415,6 +415,18 @@ func showChooserOnRenderLoop(cr *ClientRenderer, msgCh chan<- *RenderMsg, mode c
 	})
 }
 
+func showRemoteChooserOnRenderLoop(cr *ClientRenderer, msgCh chan<- *RenderMsg, req *proto.ChooserRequest) bool {
+	return callLocalRenderAction[bool](cr, msgCh, func(cr *ClientRenderer) localRenderResult {
+		if req == nil || req.Kind != proto.ChooserKindRemotePanes || !cr.ShowRemoteChooser(req.Host, req.Layout) {
+			return localRenderResult{value: false}
+		}
+		return localRenderResult{
+			effects: overlayRenderNowResult().effects,
+			value:   true,
+		}
+	})
+}
+
 func showWindowRenamePromptOnRenderLoop(cr *ClientRenderer, msgCh chan<- *RenderMsg) bool {
 	return callLocalRenderAction[bool](cr, msgCh, func(cr *ClientRenderer) localRenderResult {
 		if !cr.ShowWindowRenamePrompt() {
@@ -763,6 +775,12 @@ func runSessionWithDeps(sessionName string, getTermSize func(int) (int, int, err
 				select {
 				case injectCh <- injectedInput{data: msg.Input, paneID: msg.PaneID}:
 				default:
+				}
+			case proto.MsgTypeChooser:
+				if !showRemoteChooserOnRenderLoop(cr, msgCh, msg.Chooser) {
+					if !queueRender(&RenderMsg{Typ: RenderMsgBell}) {
+						return
+					}
 				}
 			case proto.MsgTypeServerReload:
 				// Server is reloading — re-exec ourselves to reconnect.

--- a/internal/client/chooser.go
+++ b/internal/client/chooser.go
@@ -18,7 +18,16 @@ type chooserMode string
 const (
 	chooserModeTree   chooserMode = "tree"
 	chooserModeWindow chooserMode = "window"
+	chooserModeRemote chooserMode = "remote"
 )
+
+// Source builds chooser rows from a backing pane/window collection.
+type Source interface {
+	title() string
+	buildItems(mode chooserMode, icons render.IconSet) []chooserItem
+	toggle(mode chooserMode) *render.ChooserToggle
+	toggleMode(mode chooserMode) chooserMode
+}
 
 type chooserItem struct {
 	text        string
@@ -35,13 +44,22 @@ type chooserItem struct {
 }
 
 type chooserState struct {
-	mode        chooserMode
-	query       bubblesutil.TextInputState
+	mode     chooserMode
+	query    bubblesutil.TextInputState
+	source   Source
+	icons    render.IconSet
+	items    []chooserItem
+	selected int
+}
+
+type localChooserSource struct {
 	windows     []proto.WindowSnapshot
 	activeWinID uint32
-	icons       render.IconSet
-	items       []chooserItem
-	selected    int
+}
+
+type remoteChooserSource struct {
+	host   string
+	layout *proto.LayoutSnapshot
 }
 
 type chooserCommand struct {
@@ -71,6 +89,8 @@ func (m chooserMode) title() string {
 		return "choose-tree"
 	case chooserModeWindow:
 		return "choose-window"
+	case chooserModeRemote:
+		return "remote-attach"
 	default:
 		return "chooser"
 	}
@@ -109,12 +129,31 @@ func (cr *ClientRenderer) ShowChooser(mode chooserMode) bool {
 	}
 
 	state := &chooserState{
-		mode:        mode,
-		windows:     windows,
-		activeWinID: activeWinID,
-		icons:       cr.IconSet(),
+		mode:   mode,
+		source: localChooserSource{windows: windows, activeWinID: activeWinID},
+		icons:  cr.IconSet(),
 	}
 	state.rebuild()
+
+	result := cr.reduceUI(uiActionShowChooser{chooser: state})
+	cr.emitUIEvents(result.uiEvents)
+	return true
+}
+
+func (cr *ClientRenderer) ShowRemoteChooser(host string, layout *proto.LayoutSnapshot) bool {
+	if strings.TrimSpace(host) == "" || layout == nil {
+		return false
+	}
+
+	state := &chooserState{
+		mode:   chooserModeRemote,
+		source: remoteChooserSource{host: host, layout: layout},
+		icons:  cr.IconSet(),
+	}
+	state.rebuild()
+	if len(state.items) == 0 {
+		return false
+	}
 
 	result := cr.reduceUI(uiActionShowChooser{chooser: state})
 	cr.emitUIEvents(result.uiEvents)
@@ -208,16 +247,18 @@ func (cr *ClientRenderer) chooserOverlayFromSnapshot(state *clientSnapshot) *ren
 	}
 	screenW, screenH := cr.chooserScreenSize()
 	rows, selected := state.ui.chooser.overlayRows(screenW, screenH)
-	toggleSelected := 0
-	if state.ui.chooser.mode == chooserModeWindow {
-		toggleSelected = 1
+	title := "Choose"
+	var toggle *render.ChooserToggle
+	if state.ui.chooser.source != nil {
+		title = state.ui.chooser.source.title()
+		toggle = state.ui.chooser.source.toggle(state.ui.chooser.mode)
 	}
 	return &render.ChooserOverlay{
-		Title:    "Choose",
+		Title:    title,
 		Query:    state.ui.chooser.query.Value,
 		Rows:     rows,
 		Selected: selected,
-		Toggle:   &render.ChooserToggle{Options: []string{"Tree", "Window"}, Selected: toggleSelected},
+		Toggle:   toggle,
 	}
 }
 
@@ -228,12 +269,15 @@ func (cr *ClientRenderer) toggleChooserMode() {
 		if next.ui.chooser == nil {
 			return clientUIResult{}
 		}
-		next.ui.chooser = cloneChooserState(next.ui.chooser)
-		if next.ui.chooser.mode == chooserModeWindow {
-			next.ui.chooser.mode = chooserModeTree
-		} else {
-			next.ui.chooser.mode = chooserModeWindow
+		if next.ui.chooser.source == nil {
+			return clientUIResult{}
 		}
+		next.ui.chooser = cloneChooserState(next.ui.chooser)
+		nextMode := next.ui.chooser.source.toggleMode(next.ui.chooser.mode)
+		if nextMode == next.ui.chooser.mode {
+			return clientUIResult{}
+		}
+		next.ui.chooser.mode = nextMode
 		next.ui.chooser.rebuild()
 		next.ui.dirty = true
 		return clientUIResult{}
@@ -370,18 +414,12 @@ func (cr *ClientRenderer) selectChooser() chooserCommand {
 }
 
 func (st *chooserState) rebuild() {
-	items := make([]chooserItem, 0, len(st.windows)*2)
-	treeMode := st.mode == chooserModeTree
-	for _, ws := range st.windows {
-		items = append(items, chooserWindowItem(ws, ws.ID == st.activeWinID, treeMode, st.icons))
-		if !treeMode {
-			continue
-		}
-		for _, ps := range ws.Panes {
-			items = append(items, chooserPaneItem(ps, ps.ID == ws.ActivePaneID, st.icons))
-		}
+	if st.source == nil {
+		st.items = nil
+		st.selected = 0
+		return
 	}
-	st.items = items
+	st.items = st.source.buildItems(st.mode, st.icons)
 	st.selected = 0
 }
 
@@ -411,6 +449,7 @@ func (st *chooserState) model(screenW, screenH int) list.Model {
 		if selected >= visible {
 			selected = visible - 1
 		}
+		selected = chooserSelectableIndex(model.VisibleItems(), selected)
 		model.Select(selected)
 	}
 	return model
@@ -471,6 +510,125 @@ func chooserListHeight(screenH int) int {
 	return render.ChooserRowLimit(screenH)
 }
 
+func (s localChooserSource) title() string {
+	return "Choose"
+}
+
+func (s localChooserSource) buildItems(mode chooserMode, icons render.IconSet) []chooserItem {
+	items := make([]chooserItem, 0, len(s.windows)*2)
+	treeMode := mode == chooserModeTree
+	for _, ws := range s.windows {
+		items = append(items, chooserWindowItem(ws, ws.ID == s.activeWinID, treeMode, icons))
+		if !treeMode {
+			continue
+		}
+		for _, ps := range ws.Panes {
+			items = append(items, chooserPaneItem(ps, ps.ID == ws.ActivePaneID, icons))
+		}
+	}
+	return items
+}
+
+func (s localChooserSource) toggle(mode chooserMode) *render.ChooserToggle {
+	selected := 0
+	if mode == chooserModeWindow {
+		selected = 1
+	}
+	return &render.ChooserToggle{Options: []string{"Tree", "Window"}, Selected: selected}
+}
+
+func (s localChooserSource) toggleMode(mode chooserMode) chooserMode {
+	if mode == chooserModeWindow {
+		return chooserModeTree
+	}
+	return chooserModeWindow
+}
+
+func (s remoteChooserSource) title() string {
+	return "Remote panes: " + s.host
+}
+
+func (s remoteChooserSource) buildItems(_ chooserMode, icons render.IconSet) []chooserItem {
+	if s.layout == nil {
+		return nil
+	}
+	if len(s.layout.Windows) == 0 {
+		panes := chooserLeafPanes(s.layout.Root, s.layout.Panes)
+		items := make([]chooserItem, 0, len(panes))
+		for _, ps := range panes {
+			items = append(items, remoteChooserPaneItem(ps, ps.ID == s.layout.ActivePaneID, s.host, "", icons))
+		}
+		return items
+	}
+
+	var items []chooserItem
+	for _, ws := range s.layout.Windows {
+		panes := chooserLeafPanes(ws.Root, ws.Panes)
+		if len(panes) == 0 {
+			continue
+		}
+		items = append(items, remoteChooserWindowHeaderItem(ws, panes))
+		for _, ps := range panes {
+			items = append(items, remoteChooserPaneItem(ps, ps.ID == ws.ActivePaneID, s.host, ws.Name, icons))
+		}
+	}
+	return items
+}
+
+func (s remoteChooserSource) toggle(chooserMode) *render.ChooserToggle {
+	return nil
+}
+
+func (s remoteChooserSource) toggleMode(mode chooserMode) chooserMode {
+	return mode
+}
+
+func remoteChooserWindowHeaderItem(ws proto.WindowSnapshot, panes []proto.PaneSnapshot) chooserItem {
+	return chooserItem{
+		text:        strconv.Itoa(ws.Index) + ":" + chooserWindowName(ws) + " (" + chooserPaneCount(len(panes)) + ")",
+		filterValue: strings.ToLower(strings.Join([]string{strconv.Itoa(ws.Index), chooserWindowName(ws)}, " ")),
+		header:      true,
+		rule:        true,
+	}
+}
+
+func remoteChooserPaneItem(ps proto.PaneSnapshot, active bool, host, windowName string, icons render.IconSet) chooserItem {
+	item := chooserPaneItemWithCommand(ps, active, icons, "remote", []string{"attach", host + ":" + ps.Name})
+	filterTerms := append(chooserPaneFilterTerms(ps), host, windowName)
+	item.filterValue = strings.ToLower(strings.Join(filterTerms, " "))
+	if item.desc == "" {
+		item.desc = windowName
+	}
+	return item
+}
+
+func chooserLeafPanes(root proto.CellSnapshot, panes []proto.PaneSnapshot) []proto.PaneSnapshot {
+	byID := make(map[uint32]proto.PaneSnapshot, len(panes))
+	for _, pane := range panes {
+		byID[pane.ID] = pane
+	}
+	var out []proto.PaneSnapshot
+	seen := make(map[uint32]bool, len(panes))
+	var walk func(proto.CellSnapshot)
+	walk = func(cell proto.CellSnapshot) {
+		if cell.IsLeaf {
+			if cell.PaneID == 0 || seen[cell.PaneID] {
+				return
+			}
+			seen[cell.PaneID] = true
+			if pane, ok := byID[cell.PaneID]; ok {
+				out = append(out, pane)
+			}
+			return
+		}
+		for _, child := range cell.Children {
+			walk(child)
+		}
+	}
+	walk(root)
+	return out
+}
+
 func chooserWindowFilterValue(ws proto.WindowSnapshot, includePanes bool) string {
 	parts := []string{strconv.Itoa(ws.Index), chooserWindowName(ws)}
 	if includePanes {
@@ -499,6 +657,28 @@ func chooserHasSelectableItems(items []list.Item) bool {
 	return false
 }
 
+func chooserSelectableIndex(items []list.Item, preferred int) int {
+	if len(items) == 0 {
+		return 0
+	}
+	if preferred < 0 {
+		preferred = 0
+	}
+	if preferred >= len(items) {
+		preferred = len(items) - 1
+	}
+	if row, ok := items[preferred].(chooserListItem); ok && row.selectable {
+		return preferred
+	}
+	for i, item := range items {
+		row, ok := item.(chooserListItem)
+		if ok && row.selectable {
+			return i
+		}
+	}
+	return preferred
+}
+
 // chooserWindowItem builds the row for a window. In tree mode it is a bold
 // section header with a trailing rule; in window mode it is a plain selectable
 // row, marked with a status dot when it is the active window.
@@ -524,6 +704,10 @@ func chooserWindowItem(ws proto.WindowSnapshot, active, treeMode bool, icons ren
 // chooserPaneItem builds the row for a pane: a colored status icon, the pane
 // name in its assigned color, and a dim branch/task suffix.
 func chooserPaneItem(ps proto.PaneSnapshot, active bool, icons render.IconSet) chooserItem {
+	return chooserPaneItemWithCommand(ps, active, icons, "focus", []string{ps.Name})
+}
+
+func chooserPaneItemWithCommand(ps proto.PaneSnapshot, active bool, icons render.IconSet, command string, args []string) chooserItem {
 	icon := icons.PaneBusy
 	switch {
 	case ps.Lead:
@@ -549,8 +733,8 @@ func chooserPaneItem(ps proto.PaneSnapshot, active bool, icons render.IconSet) c
 		iconColor:   iconColor,
 		textColor:   ps.Color,
 		desc:        desc,
-		command:     "focus",
-		args:        []string{ps.Name},
+		command:     command,
+		args:        append([]string(nil), args...),
 	}
 }
 

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -143,6 +143,9 @@ func (cr *ClientRenderer) emitUIEvent(name string) {
 
 func (cr *ClientRenderer) emitUIEvents(names []string) {
 	for _, name := range names {
+		if name == "" {
+			continue
+		}
 		cr.emitUIEvent(name)
 	}
 }

--- a/internal/client/client_state.go
+++ b/internal/client/client_state.go
@@ -62,9 +62,6 @@ func cloneChooserState(src *chooserState) *chooserState {
 		return nil
 	}
 	dst := *src
-	if src.windows != nil {
-		dst.windows = append([]proto.WindowSnapshot(nil), src.windows...)
-	}
 	if src.items != nil {
 		dst.items = append([]chooserItem(nil), src.items...)
 	}

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"image/color"
 	"reflect"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -2421,6 +2422,66 @@ func TestChooserTabTogglesTreeWindow(t *testing.T) {
 	cr.HandleChooserInput([]byte{'\t'})
 	if ov := cr.chooserOverlay(); ov.Toggle.Selected != 1 {
 		t.Fatalf("second tab should return to Window view, toggle = %+v", ov.Toggle)
+	}
+}
+
+func TestLocalChooserSourceKeepsTreeSelectionCommand(t *testing.T) {
+	t.Parallel()
+
+	cr := buildMultiWindowRenderer(t)
+	if !cr.ShowChooser(chooserModeTree) {
+		t.Fatal("ShowChooser tree should succeed")
+	}
+
+	cr.HandleChooserInput([]byte("pane-3"))
+	cmd := cr.selectChooser()
+	if cmd.command != "select-window" || len(cmd.args) != 1 || cmd.args[0] != "2" {
+		t.Fatalf("local chooser selection = %+v, want select-window 2", cmd)
+	}
+}
+
+func TestRemoteChooserSourcePopulatesLeafPaneRows(t *testing.T) {
+	t.Parallel()
+
+	cr := NewClientRenderer(80, 24)
+	cr.HandleLayout(twoPane80x23())
+	remoteLayout := multiWindow80x23()
+	remoteLayout.Windows[0].Panes[1].Name = "remote-side"
+	remoteLayout.Windows[0].Panes[1].Task = ""
+	remoteLayout.Windows[0].Panes[1].GitBranch = "main"
+	remoteLayout.Windows[1].Panes[0].Name = "remote-logs"
+
+	if !cr.ShowRemoteChooser("hetzner-1", remoteLayout) {
+		t.Fatal("ShowRemoteChooser should succeed")
+	}
+	overlay := cr.chooserOverlay()
+	if overlay == nil {
+		t.Fatal("missing chooser overlay")
+	}
+	if overlay.Title != "Remote panes: hetzner-1" {
+		t.Fatalf("remote chooser title = %q", overlay.Title)
+	}
+	if overlay.Toggle != nil {
+		t.Fatalf("remote chooser toggle = %+v, want nil", overlay.Toggle)
+	}
+	if overlay.Selected == 0 {
+		t.Fatalf("remote chooser selected header row, rows=%+v", overlay.Rows)
+	}
+
+	var texts []string
+	for _, row := range overlay.Rows {
+		texts = append(texts, row.Text)
+	}
+	for _, want := range []string{"1:editor (2 panes)", "remote-side", "2:logs (1 pane)", "remote-logs"} {
+		if !slices.Contains(texts, want) {
+			t.Fatalf("remote chooser rows missing %q in %v", want, texts)
+		}
+	}
+
+	cr.HandleChooserInput([]byte("remote-side"))
+	cmd := cr.selectChooser()
+	if cmd.command != "remote" || !reflect.DeepEqual(cmd.args, []string{"attach", "hetzner-1:remote-side"}) {
+		t.Fatalf("remote chooser selection = %+v, want remote attach hetzner-1:remote-side", cmd)
 	}
 }
 

--- a/internal/proto/types.go
+++ b/internal/proto/types.go
@@ -35,6 +35,18 @@ type WindowSnapshot struct {
 	Panes        []PaneSnapshot `json:"panes"`
 }
 
+const (
+	ChooserKindRemotePanes = "remote-panes"
+)
+
+// ChooserRequest asks an attached client to open a client-local chooser using
+// a server-populated source.
+type ChooserRequest struct {
+	Kind   string          `json:"kind"`
+	Host   string          `json:"host,omitempty"`
+	Layout *LayoutSnapshot `json:"layout,omitempty"`
+}
+
 // CellSnapshot is a serializable layout tree node.
 type CellSnapshot struct {
 	X        int            `json:"x"`

--- a/internal/proto/wire.go
+++ b/internal/proto/wire.go
@@ -128,6 +128,9 @@ const (
 
 	// Server → Client — work metadata/status for a restricted pane subscription.
 	MsgTypePaneMetaUpdate MsgType = 28
+
+	// Server → Client — open a client-local chooser populated by server data.
+	MsgTypeChooser MsgType = 29
 )
 
 // Message is the wire protocol envelope. Only the fields relevant to
@@ -202,6 +205,9 @@ type Message struct {
 
 	// MsgTypeUIEvent
 	UIEvent string
+
+	// MsgTypeChooser
+	Chooser *ChooserRequest
 }
 
 const maxMessageSize = 16 * 1024 * 1024 // 16 MB

--- a/internal/proto/wire_low_coverage_test.go
+++ b/internal/proto/wire_low_coverage_test.go
@@ -167,6 +167,17 @@ func TestWriteReadMsgAllMessageTypes(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "chooser",
+			msg: Message{
+				Type: MsgTypeChooser,
+				Chooser: &ChooserRequest{
+					Kind:   ChooserKindRemotePanes,
+					Host:   "hetzner-1",
+					Layout: sampleLayoutSnapshot(),
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/server/client_conn.go
+++ b/internal/server/client_conn.go
@@ -293,6 +293,10 @@ func cloneMessage(msg *Message) *Message {
 	cp.PaneData = append([]byte(nil), msg.PaneData...)
 	cp.History = append([]string(nil), msg.History...)
 	cp.StyledHistory = proto.CloneStyledLines(msg.StyledHistory)
+	if msg.Chooser != nil {
+		chooser := *msg.Chooser
+		cp.Chooser = &chooser
+	}
 	return &cp
 }
 

--- a/internal/server/commands_remote.go
+++ b/internal/server/commands_remote.go
@@ -27,7 +27,7 @@ const (
 	remoteStatusUsage    = "usage: remote status"
 	remoteRmUsage        = "usage: remote rm <name>"
 	remotePanesUsage     = "usage: remote panes <name>"
-	remoteAttachUsage    = "usage: remote attach <name>:<pane-name>"
+	remoteAttachUsage    = "usage: remote attach (<name>|<name>:<pane-name>)"
 	remoteDetachUsage    = "usage: remote detach <local-pane>"
 	remoteResizeUsage    = "usage: remote resize <local-pane>"
 	remoteCommandTimeout = 10 * time.Second
@@ -251,7 +251,10 @@ func runRemoteAttach(ctx *CommandContext) commandpkg.Result {
 		return commandpkg.Result{Err: errors.New(remoteAttachUsage)}
 	}
 	hostName, paneName, ok := strings.Cut(ctx.Args[1], ":")
-	if !ok || hostName == "" || paneName == "" {
+	if !ok {
+		return runRemoteAttachChooser(ctx, ctx.Args[1])
+	}
+	if hostName == "" || paneName == "" {
 		return commandpkg.Result{Err: errors.New(remoteAttachUsage)}
 	}
 	host, err := lookupRemoteHost(hostName)
@@ -290,6 +293,39 @@ func runRemoteAttach(ctx *CommandContext) commandpkg.Result {
 			broadcastLayout: true,
 		}
 	}))
+}
+
+func runRemoteAttachChooser(ctx *CommandContext, hostName string) commandpkg.Result {
+	if strings.TrimSpace(hostName) == "" || strings.HasPrefix(hostName, "-") {
+		return commandpkg.Result{Err: errors.New(remoteAttachUsage)}
+	}
+	if ctx == nil || ctx.Sess == nil {
+		return commandpkg.Result{Err: fmt.Errorf("no client attached")}
+	}
+	client, err := ctx.Sess.queryUIClientContext(ctx.context(), "", "")
+	if err != nil {
+		return commandpkg.Result{Err: err}
+	}
+	host, err := lookupRemoteHost(hostName)
+	if err != nil {
+		return commandpkg.Result{Err: err}
+	}
+	layout, err := listRemotePanes(ctx.context(), host)
+	if err != nil {
+		return commandpkg.Result{Err: err}
+	}
+	if err := client.client.Send(&Message{
+		Type: MsgTypeChooser,
+		Chooser: &proto.ChooserRequest{
+			Kind:   proto.ChooserKindRemotePanes,
+			Host:   hostName,
+			Layout: layout,
+		},
+	}); err != nil {
+		return commandpkg.Result{Err: err}
+	}
+	_ = client.client.Flush()
+	return commandpkg.Result{Output: fmt.Sprintf("Opened remote pane chooser for %s\n", hostName)}
 }
 
 func runRemoteDetach(ctx *CommandContext) commandpkg.Result {

--- a/internal/server/commands_remote_test.go
+++ b/internal/server/commands_remote_test.go
@@ -88,7 +88,8 @@ func TestRunRemoteCommandUsageErrors(t *testing.T) {
 		{name: "rm usage", args: []string{"rm"}, want: remoteRmUsage},
 		{name: "panes usage", args: []string{"panes"}, want: remotePanesUsage},
 		{name: "attach usage", args: []string{"attach"}, want: remoteAttachUsage},
-		{name: "attach malformed target", args: []string{"attach", "remote"}, want: remoteAttachUsage},
+		{name: "attach malformed target", args: []string{"attach", "remote:"}, want: remoteAttachUsage},
+		{name: "attach flag-like chooser host", args: []string{"attach", "--bad"}, want: remoteAttachUsage},
 		{name: "detach usage", args: []string{"detach"}, want: remoteDetachUsage},
 		{name: "resize usage", args: []string{"resize"}, want: remoteResizeUsage},
 	}
@@ -102,6 +103,15 @@ func TestRunRemoteCommandUsageErrors(t *testing.T) {
 				t.Fatalf("runRemoteCommand(%v) error = %v, want %q", tt.args, got.Err, tt.want)
 			}
 		})
+	}
+}
+
+func TestRunRemoteAttachChooserRequiresAttachedClient(t *testing.T) {
+	t.Parallel()
+
+	got := runRemoteCommand(&CommandContext{Args: []string{"attach", "remote"}})
+	if got.Err == nil || got.Err.Error() != "no client attached" {
+		t.Fatalf("runRemoteCommand attach chooser error = %v, want no client attached", got.Err)
 	}
 }
 

--- a/internal/server/protocol.go
+++ b/internal/server/protocol.go
@@ -51,6 +51,9 @@ const (
 
 	// Server → Client — work metadata/status for a restricted pane subscription.
 	MsgTypePaneMetaUpdate = proto.MsgTypePaneMetaUpdate
+
+	// Server → Client — open a client-local chooser populated by server data.
+	MsgTypeChooser = proto.MsgTypeChooser
 )
 
 // WriteMsg encodes and writes a message to w.

--- a/test/remote_chooser_test.go
+++ b/test/remote_chooser_test.go
@@ -1,0 +1,83 @@
+package test
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/weill-labs/amux/internal/server"
+)
+
+func TestRemoteAttachChooserSelectsMirror(t *testing.T) {
+	t.Parallel()
+
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Skip("python3 not available for fake ssh transport")
+	}
+
+	remote := newServerHarnessForSession(t, newServerHarnessPairSession(t, "remote"), "", 80, 24, "", false, false)
+	remote.runCmd("rename", "pane-1", "remote-agent")
+	remote.runCmd("spawn", "--name", "remote-side", "--vertical")
+
+	fakeDir, sshLog := writeFakeSSH(t)
+	configPath := writeRemoteChooserConfig(t, remote)
+	local := newAmuxHarness(t,
+		"AMUX_CONFIG="+configPath,
+		"PATH="+fakeDir+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"AMUX_FAKE_SSH_LOG="+sshLog,
+	)
+
+	out := local.runCmd("remote", "attach", remoteCLITestHost)
+	if !strings.Contains(out, "Opened remote pane chooser for "+remoteCLITestHost) {
+		t.Fatalf("remote attach chooser output = %q", out)
+	}
+	waitForFakeSSHCalls(t, sshLog, 1)
+	if !local.waitFor("Remote panes: "+remoteCLITestHost, 5*time.Second) || !local.waitFor("remote-side", 5*time.Second) {
+		t.Fatalf("remote chooser did not render remote panes\nouter:\n%s", local.captureOuter())
+	}
+
+	gen := local.generation()
+	local.sendClientKeys("r", "e", "m", "o", "t", "e", "-", "s", "i", "d", "e", "Enter")
+	local.waitLayout(gen)
+	mirrorName := waitForInnerMirrorName(t, local, remoteCLITestHost)
+	waitForFakeSSHCalls(t, sshLog, 3)
+
+	remote.runCmd("send-keys", "remote-side", "printf REMOTE_CHOOSER_ATTACH", "Enter")
+	if !local.waitFor("REMOTE_CHOOSER_ATTACH", 5*time.Second) {
+		t.Fatalf("selected mirror %s did not receive remote output\nouter:\n%s", mirrorName, local.captureOuter())
+	}
+}
+
+func writeRemoteChooserConfig(t *testing.T, remote *ServerHarness) string {
+	t.Helper()
+
+	configPath := filepath.Join(t.TempDir(), "config.toml")
+	configContent := fmt.Sprintf(`
+[remote.hosts.%s]
+ssh = "fake-target"
+session = %q
+socket_path = %q
+`, remoteCLITestHost, remote.session, server.SocketPath(remote.session))
+	if err := os.WriteFile(configPath, []byte(configContent), 0o644); err != nil {
+		t.Fatalf("writing remote chooser config: %v", err)
+	}
+	return configPath
+}
+
+func waitForInnerMirrorName(t *testing.T, h *AmuxHarness, host string) string {
+	t.Helper()
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if name := localMirrorName(h.runCmd("list", "--no-cwd"), host); name != "" {
+			return name
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	t.Fatalf("local mirror for host %q did not appear", host)
+	return ""
+}


### PR DESCRIPTION
## Motivation

`amux remote attach <host>` needed the final federation picker path: show remote leaf panes with the existing chooser UI and attach the selected pane through the mirror flow.

## Summary

- Extracted the client chooser behind a `Source` interface while preserving local tree/window behavior.
- Added a remote pane chooser source and a server-to-client chooser message populated from `MsgTypeListPanes`.
- Wired `remote attach <host>` to open the picker; selected rows run the existing `remote attach <host>:<pane>` mirror path.

## Testing

- `go test ./internal/client -run 'Test(LocalChooserSourceKeepsTreeSelectionCommand|RemoteChooserSourcePopulatesLeafPaneRows)' -count=100`
- `go test ./internal/server -run TestRunRemoteAttachChooserRequiresAttachedClient -count=100`
- `go test ./test -run TestRemoteAttachChooserSelectsMirror -count=100 -timeout 25m`
- `go test -race ./internal/client ./internal/server ./internal/proto -run 'Test(LocalChooserSourceKeepsTreeSelectionCommand|RemoteChooserSourcePopulatesLeafPaneRows|RunRemoteAttachChooserRequiresAttachedClient|WriteReadMsgAllMessageTypes)'`
- `go test -race ./test -run TestRemoteAttachChooserSelectsMirror -count=1 -timeout 120s`
- `go test ./test -run 'TestRemoteCLI|TestRemoteAttachChooserSelectsMirror' -count=1`
- `go test ./... -timeout 120s` failed in the pre-existing clipboard SSH/tmux tests: `TestCopyModeClipboardUsesOSC52WhenInnerClientRunsOverSSH` and `TestCopyModeClipboardUsesTmuxPassthroughWhenInnerClientRunsOverSSHInTmux`; rerunning those exact tests reproduced the same OSC52/clipboard timeout failure without exercising remote chooser code.

## Review focus

- The new `MsgTypeChooser` server-to-client path and whether using a server-populated remote layout is the right boundary.
- Remote chooser filtering: window headers are context only, so pane-name filtering selects the pane row directly.
- `remote attach <host>` currently requires one attached UI client; non-interactive attach remains unchanged.

Closes LAB-1962