### PR TITLE
LAB-1975: Stabilize respawn pane replacement

### DIFF
--- a/internal/mux/pane.go
+++ b/internal/mux/pane.go
@@ -59,6 +59,7 @@ func paneExecCommand(shell string, id uint32, sessionName, dir, colorProfile str
 	cmd.Env = paneCommandEnvWithProfile(os.Environ(), id, sessionName, colorProfile)
 	if dir != "" {
 		cmd.Dir = dir
+		cmd.Env = envWithValue(cmd.Env, "PWD", dir)
 	}
 	return cmd
 }
@@ -266,6 +267,26 @@ func paneCommandEnvWithProfile(base []string, paneID uint32, sessionName, colorP
 		env = append(env, fmt.Sprintf("%s=%s", termprofile.EnvKey, colorProfile))
 	}
 	return env
+}
+
+func envWithValue(env []string, key, value string) []string {
+	prefix := key + "="
+	next := make([]string, 0, len(env)+1)
+	replaced := false
+	for _, entry := range env {
+		if strings.HasPrefix(entry, prefix) {
+			if !replaced {
+				next = append(next, prefix+value)
+				replaced = true
+			}
+			continue
+		}
+		next = append(next, entry)
+	}
+	if !replaced {
+		next = append(next, prefix+value)
+	}
+	return next
 }
 
 type paneEnv []string

--- a/internal/mux/pane_env_test.go
+++ b/internal/mux/pane_env_test.go
@@ -59,3 +59,45 @@ func TestPaneCommandEnvStripsOuterTerminalVars(t *testing.T) {
 		}
 	}
 }
+
+func TestPaneExecCommandSetsPWDForWorkingDir(t *testing.T) {
+	t.Parallel()
+
+	cmd := paneExecCommand("/bin/sh", 7, "inner", "/tmp/amux-pane-dir", "")
+
+	if cmd.Dir != "/tmp/amux-pane-dir" {
+		t.Fatalf("cmd.Dir = %q, want /tmp/amux-pane-dir", cmd.Dir)
+	}
+	assertEnvValue(t, cmd.Env, "PWD", "/tmp/amux-pane-dir")
+}
+
+func TestEnvWithValueReplacesDuplicateEntries(t *testing.T) {
+	t.Parallel()
+
+	env := envWithValue([]string{
+		"PATH=/bin",
+		"PWD=/old",
+		"PWD=/older",
+	}, "PWD", "/new")
+
+	assertEnvValue(t, env, "PWD", "/new")
+}
+
+func assertEnvValue(t *testing.T, env []string, key, want string) {
+	t.Helper()
+
+	prefix := key + "="
+	count := 0
+	for _, entry := range env {
+		if !strings.HasPrefix(entry, prefix) {
+			continue
+		}
+		count++
+		if got := strings.TrimPrefix(entry, prefix); got != want {
+			t.Fatalf("%s = %q, want %q in %v", key, got, want, env)
+		}
+	}
+	if count != 1 {
+		t.Fatalf("%s count = %d, want 1 in %v", key, count, env)
+	}
+}

--- a/internal/server/commands_layout.go
+++ b/internal/server/commands_layout.go
@@ -104,6 +104,8 @@ func resolveInheritedPaneDir(sess *Session, pane *mux.Pane) string {
 type respawnTarget struct {
 	pane         *mux.Pane
 	colorProfile string
+	startDir     string
+	metaDir      string
 }
 
 func runCreatePane(ctx *CommandContext, actorPaneID uint32, command string, placement createPanePlacement, req createPaneRequest, keepFocus bool) commandpkg.Result {
@@ -635,11 +637,21 @@ func cmdRespawn(ctx *CommandContext) {
 		return
 	}
 
+	startDir := target.startDir
+	if startDir == "" {
+		cwd, _ := target.pane.DetectCwdBranch()
+		if cwd != "" {
+			startDir = cwd
+		}
+	}
+	if startDir == "" {
+		startDir = target.metaDir
+	}
 	newPane, err := ctx.Sess.buildConfiguredLocalPane(ctx.Srv, localPaneBuildRequest{
 		sourcePane:   target.pane,
 		sessionName:  ctx.Sess.Name,
 		colorProfile: target.colorProfile,
-		startDir:     effectiveRespawnDir(target.pane),
+		startDir:     startDir,
 		onOutput:     ctx.Sess.paneOutputCallback(),
 		onExit:       ctx.Sess.paneExitCallback(),
 	})
@@ -694,6 +706,8 @@ func queryRespawnTarget(sess *Session, actorPaneID uint32, args []string) (respa
 		return respawnTarget{
 			pane:         pane,
 			colorProfile: sess.paneLaunchColorProfile(nil),
+			startDir:     pane.LiveCwd(),
+			metaDir:      pane.Meta.Dir,
 		}, nil
 	})
 }

--- a/internal/server/respawn_command_test.go
+++ b/internal/server/respawn_command_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"bytes"
+	"context"
 	"net"
 	"os"
 	"path/filepath"
@@ -21,6 +22,7 @@ func TestRespawnCommandRestartsLocalPaneInPlace(t *testing.T) {
 
 	srv, sess, cleanup := newCommandTestSession(t)
 	defer cleanup()
+	sess.DisablePaneMetaAutoRefresh = true
 
 	startDir := t.TempDir()
 	nextDir := t.TempDir()
@@ -63,7 +65,9 @@ func TestRespawnCommandRestartsLocalPaneInPlace(t *testing.T) {
 
 	pane.SetRetainedHistory([]string{"base-1", "base-2"})
 	pane.FeedOutput([]byte("stale-screen"))
-	pane.ApplyCwdBranch(nextDir, "feat/respawn")
+	mustSessionMutation(t, sess, func(sess *Session) {
+		sess.findPaneByID(pane.ID).ApplyCwdBranch(nextDir, "feat/respawn")
+	})
 
 	oldPID := pane.ProcessPid()
 	if oldPID == 0 {
@@ -201,6 +205,7 @@ func TestRespawnCommandRestartsLocalPaneInPlace(t *testing.T) {
 	}
 
 	waitForFileString(t, cwdFile, nextDirResolved)
+	waitForPaneClosed(t, pane)
 	waitForProcessExit(t, oldPID)
 }
 
@@ -253,6 +258,65 @@ func TestQueryRespawnTargetCapturesColorProfile(t *testing.T) {
 	}
 }
 
+func TestQueryRespawnTargetCapturesStartDir(t *testing.T) {
+	t.Parallel()
+
+	sess := newSession("test-respawn-target-start-dir")
+	stopCrashCheckpointLoop(t, sess)
+	t.Cleanup(func() {
+		stopSessionBackgroundLoops(t, sess)
+	})
+
+	liveDir := t.TempDir()
+	pane := newTestPane(sess, 1, "pane-1")
+	window := newTestWindowWithPanes(t, sess, 1, "main", pane)
+	mustSessionMutation(t, sess, func(sess *Session) {
+		sess.Windows = []*mux.Window{window}
+		sess.ActiveWindowID = window.ID
+		sess.Panes = []*mux.Pane{pane}
+		pane.ApplyCwdBranch(liveDir, "feat/respawn")
+	})
+
+	target, err := queryRespawnTarget(sess, 0, []string{"pane-1"})
+	if err != nil {
+		t.Fatalf("queryRespawnTarget: %v", err)
+	}
+	if target.startDir != liveDir {
+		t.Fatalf("respawn target start dir = %q, want %q", target.startDir, liveDir)
+	}
+}
+
+func TestQueryRespawnTargetCapturesMetaDir(t *testing.T) {
+	t.Parallel()
+
+	metaDir := t.TempDir()
+	sess := newSession("test-respawn-target-meta-dir")
+	stopCrashCheckpointLoop(t, sess)
+	t.Cleanup(func() {
+		stopSessionBackgroundLoops(t, sess)
+	})
+
+	pane := newTestPane(sess, 1, "pane-1")
+	pane.Meta.Dir = metaDir
+	window := newTestWindowWithPanes(t, sess, 1, "main", pane)
+	mustSessionMutation(t, sess, func(sess *Session) {
+		sess.Windows = []*mux.Window{window}
+		sess.ActiveWindowID = window.ID
+		sess.Panes = []*mux.Pane{pane}
+	})
+
+	target, err := queryRespawnTarget(sess, 0, []string{"pane-1"})
+	if err != nil {
+		t.Fatalf("queryRespawnTarget: %v", err)
+	}
+	if target.startDir != "" {
+		t.Fatalf("respawn target start dir = %q, want empty live cwd", target.startDir)
+	}
+	if target.metaDir != metaDir {
+		t.Fatalf("respawn target meta dir = %q, want %q", target.metaDir, metaDir)
+	}
+}
+
 func mustCreatePaneWithMeta(t *testing.T, sess *Session, srv *Server, meta mux.PaneMeta, cols, rows int) *mux.Pane {
 	t.Helper()
 
@@ -271,8 +335,8 @@ func writeRespawnTestShell(t *testing.T, markerFile, cwdFile string) string {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "respawn-test-shell.sh")
 	script := "#!/bin/sh\n" +
+		"/bin/pwd -P > " + strconv.Quote(cwdFile) + "\n" +
 		"printf x >> " + strconv.Quote(markerFile) + "\n" +
-		"pwd > " + strconv.Quote(cwdFile) + "\n" +
 		"while [ \"$1\" = \"-l\" ]; do\n\tshift\n" +
 		"done\n" +
 		"while IFS= read -r line; do\n\teval \"$line\"\n" +
@@ -333,6 +397,17 @@ func waitForProcessExit(t *testing.T, pid int) {
 	waitUntilRespawn(t, respawnWaitTimeout, func() bool {
 		return syscall.Kill(pid, 0) != nil
 	})
+}
+
+func waitForPaneClosed(t *testing.T, pane *mux.Pane) {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), respawnWaitTimeout)
+	defer cancel()
+
+	if err := pane.WaitClosed(ctx); err != nil {
+		t.Fatalf("timed out waiting for pane close: %v", err)
+	}
 }
 
 func waitUntilRespawn(t *testing.T, timeout time.Duration, cond func() bool, detailFns ...func() string) {

--- a/internal/server/session_pane.go
+++ b/internal/server/session_pane.go
@@ -45,13 +45,17 @@ func (s *Session) closePaneAsync(pane *mux.Pane) {
 	if pane == nil {
 		return
 	}
-	closePane := s.paneCloser
-	if closePane == nil {
-		closePane = func(pane *mux.Pane) {
-			_ = pane.Close()
-		}
+	if s.paneCloser != nil {
+		go s.paneCloser(pane)
+		return
 	}
-	go closePane(pane)
+
+	closeRequested := make(chan struct{})
+	go func() {
+		_ = pane.Close()
+		close(closeRequested)
+	}()
+	<-closeRequested
 }
 
 func cleanupFailedPaneMutation(sess *Session, pane *mux.Pane, err error) commandMutationResult {
@@ -426,19 +430,6 @@ func (s *Session) undoClosePane() (pane *mux.Pane, err error) {
 		return nil, err
 	}
 	return pane, nil
-}
-
-func effectiveRespawnDir(pane *mux.Pane) string {
-	if pane == nil {
-		return ""
-	}
-	if cwd := pane.LiveCwd(); cwd != "" {
-		return cwd
-	}
-	if cwd, _ := pane.DetectCwdBranch(); cwd != "" {
-		return cwd
-	}
-	return pane.Meta.Dir
 }
 
 func clonePaneMetaForReplacement(meta mux.PaneMeta) mux.PaneMeta {


### PR DESCRIPTION
## Motivation

`TestRespawnCommandRestartsLocalPaneInPlace` could time out or observe stale respawn state under package load because the fixture used early marker writes as startup signals while respawn read replacement launch data after leaving the session actor. The replacement shell could also inherit a stale `PWD` while being launched with a different `cmd.Dir`.

## Summary

- Capture the actor-owned live cwd and metadata cwd in `queryRespawnTarget`, then build the respawn launch directory off-actor with the original precedence: live cwd, detected process cwd, metadata cwd.
- Request default pane closes before command mutations reply, while keeping blocking close teardown off the session actor.
- Keep pane launch `PWD` aligned with `cmd.Dir` so shell scripts observe the same cwd that amux requested.
- Tighten the respawn test fixture so marker files mean cwd has already been recorded, live cwd is updated through the actor, auto-refresh is disabled for the manual cwd fixture, and the old pane close is awaited through `WaitClosed` before checking the old PID.

## Testing

```bash
golangci-lint run
go test ./internal/mux -run 'TestPaneExecCommandSetsPWDForWorkingDir|TestEnvWithValueReplacesDuplicateEntries' -count=100
go test -race ./internal/server -run 'TestRespawnCommandRestartsLocalPaneInPlace|TestQueryRespawnTargetCaptures(ColorProfile|StartDir|MetaDir)' -count=100 -parallel=4 -timeout 120s
go test -race ./internal/server -run 'TestSessionEventLoopStaysResponsiveWhilePaneCloseBlocks|TestReplyCommandMutationSendsErrorWhilePaneCloseBlocks|TestEnqueueCommandMutationSchedulesPaneCloseOffLoop|TestRespawnCommandFailureUsesSessionCloser|TestClosePaneAsyncIgnoresNilPane' -count=100 -parallel=4 -timeout 120s
go test ./test -run TestRespawnPreservesPaneMetadataAndCwdWhileResettingState -count=10 -timeout 120s
go test -race ./internal/mux -count=1 -timeout 120s
go test -race -count=1 -timeout 60s ./internal/server/
scripts/push-and-watch-ci.sh --force-with-lease
gh pr checks 839
```

A broader local `go test -race -count=1 -timeout 60s ./internal/...` attempt failed outside this diff in `internal/client` (`TestReadAttachBootstrapKeepsPeakHeapUnderBound` timed out at 60s); `internal/server` passed in that run. GitHub required checks passed on the latest head.

## Review focus

- The respawn target snapshot boundary: actor-owned live cwd and metadata cwd are captured on the actor, while process cwd detection remains off-actor.
- The pane close initiation change: default close requests are synchronized only until `Pane.Close` has scheduled teardown, not until blocking teardown completes.
- The `PWD` environment update for panes launched with an explicit working directory.

Closes LAB-1975
