### PR TITLE
LAB-1981: Route default spawn from the lead pane to the logical root

### DIFF
--- a/internal/server/commands_layout.go
+++ b/internal/server/commands_layout.go
@@ -219,12 +219,13 @@ func queryCreatePaneSnapshot(sess *Session, actorPaneID uint32, command string, 
 			return createPaneSnapshot{}, fmt.Errorf("no active pane")
 		}
 		return createPaneSnapshot{
-			inheritPane:  w.ActivePane,
-			windowWidth:  w.Width,
-			windowHeight: w.Height,
-			inheritHost:  w.ActivePane.Meta.Host,
-			inheritProxy: w.ActivePane.IsProxy(),
-			targetPaneID: w.ActivePane.ID,
+			inheritPane:              w.ActivePane,
+			windowWidth:              w.Width,
+			windowHeight:             w.Height,
+			inheritHost:              w.ActivePane.Meta.Host,
+			inheritProxy:             w.ActivePane.IsProxy(),
+			targetPaneID:             w.ActivePane.ID,
+			treatLeadPaneAsWindowRef: command == "spawn",
 		}, nil
 	})
 }

--- a/test/window_test.go
+++ b/test/window_test.go
@@ -127,6 +127,39 @@ func TestSpawnAtLeadPaneUsesWindowPlacement(t *testing.T) {
 	assertWorkersStackedInSameColumn(t, "targeted spawn", worker1, worker2)
 }
 
+func TestSpawnFromActiveLeadPaneRoutesToLogicalRoot(t *testing.T) {
+	t.Parallel()
+
+	h := newServerHarness(t)
+	setLead(t, h, "pane-1")
+
+	// Materialize the pending lead into an anchored multi-pane layout.
+	out := h.runCmd("spawn", "--name", "worker-1")
+	if strings.Contains(out, "cannot operate on lead pane") {
+		t.Fatalf("spawn should not reject the pending lead pane, got: %s", out)
+	}
+
+	// Re-focus the lead pane so the next default spawn (no --at) targets it.
+	h.runCmd("focus", "pane-1")
+
+	// A default spawn from the active lead pane must route the new pane into
+	// the logical root, exactly like `spawn --at <lead>`, instead of erroring
+	// as though the caller were mutating the anchored lead column.
+	out = h.runCmd("spawn", "--name", "worker-2")
+	if strings.Contains(out, "cannot operate on lead pane") {
+		t.Fatalf("default spawn from the active lead pane should route to the logical root, got: %s", out)
+	}
+
+	capture := h.captureJSON()
+	lead := h.jsonPane(capture, "pane-1")
+	worker1 := h.jsonPane(capture, "worker-1")
+	worker2 := h.jsonPane(capture, "worker-2")
+	if !lead.Lead {
+		t.Fatal("pane-1 should remain the lead pane after default spawn")
+	}
+	assertLeadPaneLeftOfWorkers(t, lead, worker1, worker2)
+}
+
 func TestSpawnAutoAtLeadPaneUsesWindowPlacement(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Motivation

`amux spawn` (default placement, no `--at`) errored with `cannot operate on lead pane` whenever the active pane was the designated lead pane in an anchored multi-pane layout. Creating a sibling pane shouldn't be blocked by the lead-pane anchor guard — that guard exists to reject *mutations* of the anchored lead column (split/resize/move/swap), not the creation of a new pane. Surfaced during federation verification (`spawn --attach <host>:<pane>` failed when the lead pane was active); reproduces with plain `amux spawn`.

## Summary

- `queryCreatePaneSnapshot`'s default-placement branch (active pane, no `--at`) now sets `treatLeadPaneAsWindowRef: command == "spawn"`, matching the explicit `--at` branch directly above it. A default `spawn` whose active pane is the lead now routes the new pane into the logical root instead of hitting the lead-pane mutation guard.
- Placement uses the normal default-spawn direction, so the new pane opens a new column in the logical root (it does **not** stack like `spawn --at <lead>`). The lead stays anchored on the left.
- Added regression test `TestSpawnFromActiveLeadPaneRoutesToLogicalRoot` covering default spawn from an active lead pane in an anchored 2+ pane layout, asserting the lead stays left and the new pane lands in its own column.

## Testing

- `go test ./test/ -run TestSpawnFromActiveLeadPaneRoutesToLogicalRoot -count=100` — green (red before the fix; the failure was `cannot operate on lead pane`).
- `go test ./test/ -run 'TestSpawn|TestNewWindowLeadPane|Lead'` — no regressions (`--at` stacking test unaffected).
- `go vet ./internal/server/... ./test/` — clean.

## Review focus

- The behavioral change is one line in `commands_layout.go` (default branch of `queryCreatePaneSnapshot`). Confirm `command == "spawn"` is the right scope — it intentionally limits logical-root routing to `spawn`, mirroring the existing `--at` branch, rather than applying it to every create-pane command.
- The new pane opens a new column rather than stacking; this matches default-spawn behavior elsewhere (default spawn adds a column), so the fix keeps lead and non-lead spawn placement consistent.

Closes LAB-1981
