### PR TITLE
LAB-1987: Emit mailbox events and wait for messages

### DIFF
--- a/internal/cli/cli_commands_layout.go
+++ b/internal/cli/cli_commands_layout.go
@@ -167,7 +167,7 @@ func layoutCLICommands() map[string]commandHandler {
 		},
 		"wait": func(inv invocation, args []string) int {
 			if len(args) < 1 {
-				fmt.Fprintln(inv.runtime.Stderr, "usage: amux wait <idle|busy|exited|ready|content|layout|clipboard|checkpoint|ui> ...")
+				fmt.Fprintln(inv.runtime.Stderr, waitUsage)
 				return 1
 			}
 			return inv.runSessionCommand("wait", args)

--- a/internal/cli/cli_usage.go
+++ b/internal/cli/cli_usage.go
@@ -33,7 +33,7 @@ const (
 	selectWindowUsage = "usage: amux select-window <index|name>"
 	statusUsage       = "usage: amux status"
 	undoUsage         = "usage: amux undo"
-	waitUsage         = "usage: amux wait <idle|busy|exited|ready|content|layout|clipboard|checkpoint|ui> ..."
+	waitUsage         = "usage: amux wait <idle|busy|exited|ready|content|layout|clipboard|checkpoint|ui|msg> ..."
 	newWindowUsage    = "usage: amux new-window [--name NAME]"
 	nextWindowUsage   = "usage: amux next-window"
 	prevWindowUsage   = "usage: amux prev-window"

--- a/internal/cli/main_test.go
+++ b/internal/cli/main_test.go
@@ -289,7 +289,7 @@ func TestResolveCanonicalSessionCommand(t *testing.T) {
 			name:        "wait needs a kind",
 			args:        []string{"wait"},
 			wantHandled: true,
-			wantErrText: "usage: amux wait <idle|busy|exited|ready|content|layout|clipboard|checkpoint|ui> ...",
+			wantErrText: "usage: amux wait <idle|busy|exited|ready|content|layout|clipboard|checkpoint|ui|msg> ...",
 		},
 		{
 			name:        "rename needs pane and new name",
@@ -611,7 +611,7 @@ func TestMaybePrintCommandHelp(t *testing.T) {
 			name:        "wait long help reflects idle rename",
 			args:        []string{"wait", "--help"},
 			wantHandled: true,
-			wantStdout:  "usage: amux wait <idle|busy|exited|ready|content|layout|clipboard|checkpoint|ui> ...\n",
+			wantStdout:  "usage: amux wait <idle|busy|exited|ready|content|layout|clipboard|checkpoint|ui|msg> ...\n",
 		},
 		{
 			name:        "last-window help",

--- a/internal/cli/main_usage_test.go
+++ b/internal/cli/main_usage_test.go
@@ -100,7 +100,7 @@ func TestMainWaitUsage(t *testing.T) {
 	if code != 1 {
 		t.Fatalf("exit code = %d, want 1\n%s", code, out)
 	}
-	if !strings.Contains(out, "usage: amux wait <idle|busy|exited|ready|content|layout|clipboard|checkpoint|ui> ...") {
+	if !strings.Contains(out, "usage: amux wait <idle|busy|exited|ready|content|layout|clipboard|checkpoint|ui|msg> ...") {
 		t.Fatalf("wait usage output = %q", out)
 	}
 }

--- a/internal/eventloop/event.go
+++ b/internal/eventloop/event.go
@@ -19,6 +19,9 @@ const (
 	EventClientConnect    = "client-connect"
 	EventClientDisconnect = "client-disconnect"
 	EventPaneExit         = "pane-exit"
+	EventMessageDelivered = "message-delivered"
+	EventMessageRead      = "message-read"
+	EventMessageAck       = "message-ack"
 )
 
 const (
@@ -33,17 +36,18 @@ const DefaultEventThrottle = 50 * time.Millisecond
 
 // Event is a single event in the NDJSON event stream.
 type Event struct {
-	Type       string                 `json:"type"`
-	Timestamp  string                 `json:"ts"`
-	Generation uint64                 `json:"generation,omitempty"`
-	PaneID     uint32                 `json:"pane_id,omitempty"`
-	PaneName   string                 `json:"pane_name,omitempty"`
-	Host       string                 `json:"host,omitempty"`
-	ActivePane string                 `json:"active_pane,omitempty"`
-	ClientID   string                 `json:"client_id,omitempty"`
-	Reason     string                 `json:"reason,omitempty"`
-	Cursor     *proto.CaptureCursor   `json:"cursor,omitempty"`
-	Terminal   *proto.CaptureTerminal `json:"terminal,omitempty"`
+	Type       string                       `json:"type"`
+	Timestamp  string                       `json:"ts"`
+	Generation uint64                       `json:"generation,omitempty"`
+	PaneID     uint32                       `json:"pane_id,omitempty"`
+	PaneName   string                       `json:"pane_name,omitempty"`
+	Host       string                       `json:"host,omitempty"`
+	ActivePane string                       `json:"active_pane,omitempty"`
+	ClientID   string                       `json:"client_id,omitempty"`
+	Reason     string                       `json:"reason,omitempty"`
+	Cursor     *proto.CaptureCursor         `json:"cursor,omitempty"`
+	Terminal   *proto.CaptureTerminal       `json:"terminal,omitempty"`
+	Message    *proto.MailboxMessageSummary `json:"message,omitempty"`
 }
 
 // Subscriber is a subscriber to the event stream.

--- a/internal/mailbox/store.go
+++ b/internal/mailbox/store.go
@@ -77,22 +77,23 @@ type DeliveryState struct {
 }
 
 type DeliverySummary struct {
-	MessageID   MessageID   `json:"message_id"`
-	Sender      PaneAddress `json:"sender"`
-	Recipient   PaneAddress `json:"recipient"`
-	Subject     string      `json:"subject"`
-	Topics      []string    `json:"topics,omitempty"`
-	Groups      []string    `json:"groups,omitempty"`
-	ThreadID    ThreadID    `json:"thread_id"`
-	InReplyTo   MessageID   `json:"in_reply_to,omitempty"`
-	CreatedAt   time.Time   `json:"created_at"`
-	DeliveredAt time.Time   `json:"delivered_at"`
-	ReadAt      time.Time   `json:"read_at,omitempty"`
-	AckedAt     time.Time   `json:"acked_at,omitempty"`
-	AckStatus   string      `json:"ack_status,omitempty"`
-	AckNote     string      `json:"ack_note,omitempty"`
-	BodySize    int         `json:"body_size"`
-	PartCount   int         `json:"part_count"`
+	MessageID    MessageID   `json:"message_id"`
+	Sender       PaneAddress `json:"sender"`
+	Recipient    PaneAddress `json:"recipient"`
+	Subject      string      `json:"subject"`
+	Topics       []string    `json:"topics,omitempty"`
+	Groups       []string    `json:"groups,omitempty"`
+	ThreadID     ThreadID    `json:"thread_id"`
+	InReplyTo    MessageID   `json:"in_reply_to,omitempty"`
+	CreatedAt    time.Time   `json:"created_at"`
+	DeliveredAt  time.Time   `json:"delivered_at"`
+	ReadAt       time.Time   `json:"read_at,omitempty"`
+	AckedAt      time.Time   `json:"acked_at,omitempty"`
+	AckStatus    string      `json:"ack_status,omitempty"`
+	AckNote      string      `json:"ack_note,omitempty"`
+	LastEventSeq uint64      `json:"last_event_seq,omitempty"`
+	BodySize     int         `json:"body_size"`
+	PartCount    int         `json:"part_count"`
 }
 
 type SendRequest struct {
@@ -299,6 +300,29 @@ func (s *Store) ListUnread(recipientID uint32) ([]DeliverySummary, error) {
 		summaries = append(summaries, summaryFor(s.messages[id], byMessage[id]))
 	}
 	return summaries, nil
+}
+
+func (s *Store) DeliverySummary(id MessageID, recipientID uint32) (DeliverySummary, error) {
+	if s == nil {
+		return DeliverySummary{}, fmt.Errorf("mailbox store is nil")
+	}
+	msg, delivery, err := s.messageDelivery(id, recipientID)
+	if err != nil {
+		return DeliverySummary{}, err
+	}
+	return summaryFor(msg, delivery), nil
+}
+
+func (s *Store) SetLastEventSeq(id MessageID, recipientID uint32, seq uint64) (DeliverySummary, error) {
+	if s == nil {
+		return DeliverySummary{}, fmt.Errorf("mailbox store is nil")
+	}
+	msg, delivery, err := s.messageDelivery(id, recipientID)
+	if err != nil {
+		return DeliverySummary{}, err
+	}
+	delivery.LastEventSeq = seq
+	return summaryFor(msg, delivery), nil
 }
 
 func (s *Store) Read(id MessageID, recipientID uint32, opts ReadOptions) (Message, DeliveryState, error) {
@@ -568,22 +592,23 @@ func metadataByteSize(metadata map[string]json.RawMessage) int {
 
 func summaryFor(msg *Message, delivery *DeliveryState) DeliverySummary {
 	return DeliverySummary{
-		MessageID:   msg.ID,
-		Sender:      msg.Sender,
-		Recipient:   delivery.Recipient,
-		Subject:     msg.Subject,
-		Topics:      append([]string(nil), msg.Topics...),
-		Groups:      append([]string(nil), msg.Groups...),
-		ThreadID:    msg.ThreadID,
-		InReplyTo:   msg.InReplyTo,
-		CreatedAt:   msg.CreatedAt,
-		DeliveredAt: delivery.DeliveredAt,
-		ReadAt:      delivery.ReadAt,
-		AckedAt:     delivery.AckedAt,
-		AckStatus:   delivery.AckStatus,
-		AckNote:     delivery.AckNote,
-		BodySize:    messageBodySize(msg),
-		PartCount:   len(msg.Parts),
+		MessageID:    msg.ID,
+		Sender:       msg.Sender,
+		Recipient:    delivery.Recipient,
+		Subject:      msg.Subject,
+		Topics:       append([]string(nil), msg.Topics...),
+		Groups:       append([]string(nil), msg.Groups...),
+		ThreadID:     msg.ThreadID,
+		InReplyTo:    msg.InReplyTo,
+		CreatedAt:    msg.CreatedAt,
+		DeliveredAt:  delivery.DeliveredAt,
+		ReadAt:       delivery.ReadAt,
+		AckedAt:      delivery.AckedAt,
+		AckStatus:    delivery.AckStatus,
+		AckNote:      delivery.AckNote,
+		LastEventSeq: delivery.LastEventSeq,
+		BodySize:     messageBodySize(msg),
+		PartCount:    len(msg.Parts),
 	}
 }
 

--- a/internal/mailbox/store_test.go
+++ b/internal/mailbox/store_test.go
@@ -69,6 +69,25 @@ func TestStoreSendCreatesMessageAndUnreadDelivery(t *testing.T) {
 	if summary.DeliveredAt != now || !summary.ReadAt.IsZero() || !summary.AckedAt.IsZero() {
 		t.Fatalf("delivery timestamps = %#v, want delivered only", summary)
 	}
+	if summary.LastEventSeq != 0 {
+		t.Fatalf("LastEventSeq = %d, want 0 before event emission", summary.LastEventSeq)
+	}
+
+	updated, err := store.SetLastEventSeq(msg.ID, 2, 42)
+	if err != nil {
+		t.Fatalf("SetLastEventSeq: %v", err)
+	}
+	if updated.LastEventSeq != 42 {
+		t.Fatalf("updated LastEventSeq = %d, want 42", updated.LastEventSeq)
+	}
+
+	delivery, err := store.DeliverySummary(msg.ID, 2)
+	if err != nil {
+		t.Fatalf("DeliverySummary: %v", err)
+	}
+	if delivery.LastEventSeq != 42 {
+		t.Fatalf("DeliverySummary LastEventSeq = %d, want 42", delivery.LastEventSeq)
+	}
 }
 
 func TestStoreListUnreadReadAndAckTransitions(t *testing.T) {
@@ -592,6 +611,12 @@ func TestStoreRejectsReadAndAckNoOps(t *testing.T) {
 	if _, err := store.ListUnread(0); err == nil || !strings.Contains(err.Error(), "recipient") {
 		t.Fatalf("ListUnread invalid pane error = %v, want recipient error", err)
 	}
+	if _, err := store.DeliverySummary("msg-999999", 2); err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("DeliverySummary unknown error = %v, want not found", err)
+	}
+	if _, err := store.SetLastEventSeq(msg.ID, 3, 99); err == nil || !strings.Contains(err.Error(), "not delivered") {
+		t.Fatalf("SetLastEventSeq non-recipient error = %v, want not delivered", err)
+	}
 }
 
 func TestStoreNilReceiverErrors(t *testing.T) {
@@ -609,6 +634,12 @@ func TestStoreNilReceiverErrors(t *testing.T) {
 	}
 	if _, err := store.ListUnread(2); err == nil || !strings.Contains(err.Error(), "nil") {
 		t.Fatalf("nil ListUnread error = %v, want nil store error", err)
+	}
+	if _, err := store.DeliverySummary("msg-000001", 2); err == nil || !strings.Contains(err.Error(), "nil") {
+		t.Fatalf("nil DeliverySummary error = %v, want nil store error", err)
+	}
+	if _, err := store.SetLastEventSeq("msg-000001", 2, 1); err == nil || !strings.Contains(err.Error(), "nil") {
+		t.Fatalf("nil SetLastEventSeq error = %v, want nil store error", err)
 	}
 	if _, _, err := store.Read("msg-000001", 2, ReadOptions{}); err == nil || !strings.Contains(err.Error(), "nil") {
 		t.Fatalf("nil Read error = %v, want nil store error", err)

--- a/internal/proto/mailbox.go
+++ b/internal/proto/mailbox.go
@@ -1,28 +1,21 @@
 package proto
 
-// MailboxPaneSummary identifies a pane in mailbox event summaries.
-type MailboxPaneSummary struct {
-	ID   uint32 `json:"id"`
-	Name string `json:"name"`
-	Host string `json:"host,omitempty"`
-}
-
 // MailboxMessageSummary is the summary-only mailbox payload used by events and waits.
 // It intentionally omits message bodies and arbitrary metadata values.
 type MailboxMessageSummary struct {
-	ID           string             `json:"id"`
-	From         MailboxPaneSummary `json:"from"`
-	Subject      string             `json:"subject,omitempty"`
-	Topics       []string           `json:"topics,omitempty"`
-	Groups       []string           `json:"groups,omitempty"`
-	ThreadID     string             `json:"thread_id,omitempty"`
-	InReplyTo    string             `json:"in_reply_to,omitempty"`
-	BodySize     int                `json:"body_size"`
-	PartCount    int                `json:"part_count"`
-	CreatedAt    string             `json:"created_at,omitempty"`
-	DeliveredAt  string             `json:"delivered_at,omitempty"`
-	ReadAt       string             `json:"read_at,omitempty"`
-	AckedAt      string             `json:"acked_at,omitempty"`
-	AckStatus    string             `json:"ack_status,omitempty"`
-	LastEventSeq uint64             `json:"last_event_seq,omitempty"`
+	ID           string         `json:"id"`
+	From         MailboxAddress `json:"from"`
+	Subject      string         `json:"subject,omitempty"`
+	Topics       []string       `json:"topics,omitempty"`
+	Groups       []string       `json:"groups,omitempty"`
+	ThreadID     string         `json:"thread_id,omitempty"`
+	InReplyTo    string         `json:"in_reply_to,omitempty"`
+	BodySize     int            `json:"body_size"`
+	PartCount    int            `json:"part_count"`
+	CreatedAt    string         `json:"created_at,omitempty"`
+	DeliveredAt  string         `json:"delivered_at,omitempty"`
+	ReadAt       string         `json:"read_at,omitempty"`
+	AckedAt      string         `json:"acked_at,omitempty"`
+	AckStatus    string         `json:"ack_status,omitempty"`
+	LastEventSeq uint64         `json:"last_event_seq,omitempty"`
 }

--- a/internal/proto/mailbox.go
+++ b/internal/proto/mailbox.go
@@ -1,0 +1,28 @@
+package proto
+
+// MailboxPaneSummary identifies a pane in mailbox event summaries.
+type MailboxPaneSummary struct {
+	ID   uint32 `json:"id"`
+	Name string `json:"name"`
+	Host string `json:"host,omitempty"`
+}
+
+// MailboxMessageSummary is the summary-only mailbox payload used by events and waits.
+// It intentionally omits message bodies and arbitrary metadata values.
+type MailboxMessageSummary struct {
+	ID           string             `json:"id"`
+	From         MailboxPaneSummary `json:"from"`
+	Subject      string             `json:"subject,omitempty"`
+	Topics       []string           `json:"topics,omitempty"`
+	Groups       []string           `json:"groups,omitempty"`
+	ThreadID     string             `json:"thread_id,omitempty"`
+	InReplyTo    string             `json:"in_reply_to,omitempty"`
+	BodySize     int                `json:"body_size"`
+	PartCount    int                `json:"part_count"`
+	CreatedAt    string             `json:"created_at,omitempty"`
+	DeliveredAt  string             `json:"delivered_at,omitempty"`
+	ReadAt       string             `json:"read_at,omitempty"`
+	AckedAt      string             `json:"acked_at,omitempty"`
+	AckStatus    string             `json:"ack_status,omitempty"`
+	LastEventSeq uint64             `json:"last_event_seq,omitempty"`
+}

--- a/internal/server/commands/wait/commands.go
+++ b/internal/server/commands/wait/commands.go
@@ -1,21 +1,32 @@
 package wait
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"time"
 
+	"github.com/weill-labs/amux/internal/proto"
 	commandpkg "github.com/weill-labs/amux/internal/server/commands"
 )
 
 const (
-	waitCommandUsage   = "usage: wait <idle|busy|exited|ready|content|layout|clipboard|checkpoint|ui> ..."
+	waitCommandUsage   = "usage: wait <idle|busy|exited|ready|content|layout|clipboard|checkpoint|ui|msg> ..."
 	cursorCommandUsage = "usage: cursor <layout|clipboard|ui> [--client <id>]"
 )
 
 type CheckpointRecord struct {
 	Generation uint64
 	Path       string
+}
+
+type MessageWaitOptions struct {
+	PaneRef        string
+	Topic          string
+	AfterMessageID string
+	AfterEventSeq  uint64
+	Timeout        time.Duration
+	FormatJSON     bool
 }
 
 type Context interface {
@@ -32,6 +43,7 @@ type Context interface {
 	WaitUI(eventName, requestedClientID string, afterGen uint64, afterSet bool, timeout time.Duration) error
 	WaitReady(actorPaneID uint32, args []string) error
 	WaitIdle(actorPaneID uint32, args []string) error
+	WaitMessage(actorPaneID uint32, opts MessageWaitOptions) (proto.MailboxMessageSummary, error)
 }
 
 func Cursor(ctx Context, args []string) commandpkg.Result {
@@ -75,6 +87,8 @@ func Wait(ctx Context, actorPaneID uint32, args []string) commandpkg.Result {
 		return WaitBusy(ctx, actorPaneID, args[1:])
 	case "ui":
 		return WaitUI(ctx, args[1:])
+	case "msg":
+		return WaitMessage(ctx, actorPaneID, args[1:])
 	default:
 		return commandpkg.Result{Err: fmt.Errorf("unknown wait kind: %s", args[0])}
 	}
@@ -213,4 +227,23 @@ func WaitUI(ctx Context, args []string) commandpkg.Result {
 		return commandpkg.Result{Err: err}
 	}
 	return commandpkg.Result{Output: eventName + "\n"}
+}
+
+func WaitMessage(ctx Context, actorPaneID uint32, args []string) commandpkg.Result {
+	opts, err := ParseWaitMessageArgs(args)
+	if err != nil {
+		return commandpkg.Result{Err: err}
+	}
+	summary, err := ctx.WaitMessage(actorPaneID, opts)
+	if err != nil {
+		return commandpkg.Result{Err: err}
+	}
+	if opts.FormatJSON {
+		data, err := json.Marshal(summary)
+		if err != nil {
+			return commandpkg.Result{Err: err}
+		}
+		return commandpkg.Result{Output: string(data) + "\n"}
+	}
+	return commandpkg.Result{Output: summary.ID + "\n"}
 }

--- a/internal/server/commands/wait/commands_test.go
+++ b/internal/server/commands/wait/commands_test.go
@@ -1,6 +1,8 @@
 package wait
 
 import (
+	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -41,12 +43,59 @@ func (stubWaitContext) WaitMessage(uint32, MessageWaitOptions) (proto.MailboxMes
 	return proto.MailboxMessageSummary{}, nil
 }
 
+type messageWaitContext struct {
+	stubWaitContext
+	summary proto.MailboxMessageSummary
+	err     error
+}
+
+func (ctx messageWaitContext) WaitMessage(uint32, MessageWaitOptions) (proto.MailboxMessageSummary, error) {
+	return ctx.summary, ctx.err
+}
+
 func TestCursorUsage(t *testing.T) {
 	t.Parallel()
 
 	got := Cursor(stubWaitContext{}, nil)
 	if got.Err == nil || got.Err.Error() != cursorCommandUsage {
 		t.Fatalf("Cursor(nil) error = %v, want %q", got.Err, cursorCommandUsage)
+	}
+}
+
+func TestWaitMessageResultFormatting(t *testing.T) {
+	t.Parallel()
+
+	ctx := messageWaitContext{summary: proto.MailboxMessageSummary{
+		ID:      "msg-000001",
+		Subject: "Review ready",
+	}}
+
+	text := Wait(ctx, 0, []string{"msg", "pane-2"})
+	if text.Err != nil || text.Output != "msg-000001\n" {
+		t.Fatalf("Wait msg text = (%q, %v), want message ID output", text.Output, text.Err)
+	}
+
+	jsonResult := Wait(ctx, 0, []string{"msg", "pane-2", "--format", "json"})
+	if jsonResult.Err != nil {
+		t.Fatalf("Wait msg json error = %v", jsonResult.Err)
+	}
+	if !strings.Contains(jsonResult.Output, `"id":"msg-000001"`) || !strings.Contains(jsonResult.Output, `"subject":"Review ready"`) {
+		t.Fatalf("Wait msg json output = %q, want summary", jsonResult.Output)
+	}
+}
+
+func TestWaitMessageErrors(t *testing.T) {
+	t.Parallel()
+
+	usage := Wait(stubWaitContext{}, 0, []string{"msg"})
+	if usage.Err == nil || !strings.Contains(usage.Err.Error(), "usage: wait msg <pane>") {
+		t.Fatalf("Wait msg usage error = %v, want usage", usage.Err)
+	}
+
+	boom := errors.New("boom")
+	failed := Wait(messageWaitContext{err: boom}, 0, []string{"msg", "pane-2"})
+	if failed.Err != boom {
+		t.Fatalf("Wait msg context error = %v, want boom", failed.Err)
 	}
 }
 

--- a/internal/server/commands/wait/commands_test.go
+++ b/internal/server/commands/wait/commands_test.go
@@ -3,6 +3,8 @@ package wait
 import (
 	"testing"
 	"time"
+
+	"github.com/weill-labs/amux/internal/proto"
 )
 
 type stubWaitContext struct{}
@@ -34,6 +36,10 @@ func (stubWaitContext) WaitUI(string, string, uint64, bool, time.Duration) error
 func (stubWaitContext) WaitReady(uint32, []string) error { return nil }
 
 func (stubWaitContext) WaitIdle(uint32, []string) error { return nil }
+
+func (stubWaitContext) WaitMessage(uint32, MessageWaitOptions) (proto.MailboxMessageSummary, error) {
+	return proto.MailboxMessageSummary{}, nil
+}
 
 func TestCursorUsage(t *testing.T) {
 	t.Parallel()

--- a/internal/server/commands/wait/commands_test.go
+++ b/internal/server/commands/wait/commands_test.go
@@ -94,7 +94,7 @@ func TestWaitMessageErrors(t *testing.T) {
 
 	boom := errors.New("boom")
 	failed := Wait(messageWaitContext{err: boom}, 0, []string{"msg", "pane-2"})
-	if failed.Err != boom {
+	if !errors.Is(failed.Err, boom) {
 		t.Fatalf("Wait msg context error = %v, want boom", failed.Err)
 	}
 }

--- a/internal/server/commands/wait/wait.go
+++ b/internal/server/commands/wait/wait.go
@@ -2,6 +2,8 @@ package wait
 
 import (
 	"fmt"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/weill-labs/amux/internal/mux"
@@ -92,6 +94,49 @@ func ParseWaitUIArgs(args []string) (eventName, clientID string, afterGen uint64
 	}
 	timeout = parsed.Duration("--timeout")
 	return eventName, clientID, afterGen, afterSet, timeout, nil
+}
+
+func ParseWaitMessageArgs(args []string) (MessageWaitOptions, error) {
+	if len(args) < 1 {
+		return MessageWaitOptions{}, fmt.Errorf("usage: wait msg <pane> [--topic <topic>] [--after <msg-id|seq>] [--timeout <duration>] [--format json]")
+	}
+	opts := MessageWaitOptions{PaneRef: args[0]}
+	parsed, err := cmdflags.ParseCommandFlags(args[1:], []cmdflags.FlagSpec{
+		{Name: "--topic", Type: cmdflags.FlagTypeString},
+		{Name: "--after", Type: cmdflags.FlagTypeString},
+		{Name: "--timeout", Type: cmdflags.FlagTypeDuration, Default: 5 * time.Second},
+		{Name: "--format", Type: cmdflags.FlagTypeString},
+	})
+	if err != nil {
+		return MessageWaitOptions{}, err
+	}
+	positionals := parsed.Positionals()
+	if len(positionals) > 0 {
+		return MessageWaitOptions{}, fmt.Errorf("unknown flag: %s", positionals[0])
+	}
+	opts.Topic = parsed.String("--topic")
+	format := parsed.String("--format")
+	switch format {
+	case "", "text":
+	case "json":
+		opts.FormatJSON = true
+	default:
+		return MessageWaitOptions{}, fmt.Errorf("unsupported format: %s", format)
+	}
+	after := parsed.String("--after")
+	if after != "" {
+		if strings.HasPrefix(after, "msg-") {
+			opts.AfterMessageID = after
+		} else {
+			seq, err := strconv.ParseUint(after, 10, 64)
+			if err != nil {
+				return MessageWaitOptions{}, fmt.Errorf("invalid --after: %s", after)
+			}
+			opts.AfterEventSeq = seq
+		}
+	}
+	opts.Timeout = parsed.Duration("--timeout")
+	return opts, nil
 }
 
 func WaitBusyForegroundProcessGroup(status mux.ForegroundJobState) int {

--- a/internal/server/commands/wait/wait_parse_test.go
+++ b/internal/server/commands/wait/wait_parse_test.go
@@ -244,6 +244,86 @@ func TestParseWaitUIArgs(t *testing.T) {
 	}
 }
 
+func TestParseWaitMessageArgs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		args      []string
+		want      MessageWaitOptions
+		wantError string
+	}{
+		{
+			name:      "missing pane",
+			wantError: "usage: wait msg <pane>",
+		},
+		{
+			name: "defaults",
+			args: []string{"pane-2"},
+			want: MessageWaitOptions{
+				PaneRef: "pane-2",
+				Timeout: 5 * time.Second,
+			},
+		},
+		{
+			name: "json topic and message cursor",
+			args: []string{"pane-2", "--topic", "review", "--after", "msg-000123", "--timeout", "250ms", "--format", "json"},
+			want: MessageWaitOptions{
+				PaneRef:        "pane-2",
+				Topic:          "review",
+				AfterMessageID: "msg-000123",
+				Timeout:        250 * time.Millisecond,
+				FormatJSON:     true,
+			},
+		},
+		{
+			name: "event sequence cursor",
+			args: []string{"pane-2", "--after", "42"},
+			want: MessageWaitOptions{
+				PaneRef:       "pane-2",
+				AfterEventSeq: 42,
+				Timeout:       5 * time.Second,
+			},
+		},
+		{
+			name:      "invalid cursor",
+			args:      []string{"pane-2", "--after", "later"},
+			wantError: "invalid --after: later",
+		},
+		{
+			name:      "unsupported format",
+			args:      []string{"pane-2", "--format", "yaml"},
+			wantError: "unsupported format: yaml",
+		},
+		{
+			name:      "unknown positional",
+			args:      []string{"pane-2", "extra"},
+			wantError: "unknown flag: extra",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := ParseWaitMessageArgs(tt.args)
+			if tt.wantError != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantError) {
+					t.Fatalf("ParseWaitMessageArgs(%v) error = %v, want substring %q", tt.args, err, tt.wantError)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParseWaitMessageArgs(%v): %v", tt.args, err)
+			}
+			if got != tt.want {
+				t.Fatalf("ParseWaitMessageArgs(%v) = %+v, want %+v", tt.args, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestWaitBusyForegroundProcessGroup(t *testing.T) {
 	t.Parallel()
 

--- a/internal/server/commands_wait.go
+++ b/internal/server/commands_wait.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	waitCommandUsage   = "usage: wait <idle|busy|exited|ready|content|layout|clipboard|checkpoint|ui> ..."
+	waitCommandUsage   = "usage: wait <idle|busy|exited|ready|content|layout|clipboard|checkpoint|ui|msg> ..."
 	cursorCommandUsage = "usage: cursor <layout|clipboard|ui> [--client <id>]"
 )
 
@@ -213,6 +213,56 @@ func (ctx waitCommandContext) WaitIdle(actorPaneID uint32, args []string) error 
 		return err
 	}
 	return waitForPaneIdle(ctx.context(), ctx.Sess, paneRef, pane.paneID, opts)
+}
+
+func (ctx waitCommandContext) WaitMessage(actorPaneID uint32, opts waitcmd.MessageWaitOptions) (proto.MailboxMessageSummary, error) {
+	pane, err := ctx.Sess.queryResolvedPaneForActorContext(ctx.context(), actorPaneID, opts.PaneRef)
+	if err != nil {
+		return proto.MailboxMessageSummary{}, err
+	}
+
+	sub := ctx.Sess.enqueueMailboxWaitSubscribe(ctx.context(), pane.paneID)
+	if sub.sub == nil {
+		return proto.MailboxMessageSummary{}, fmt.Errorf("session shutting down")
+	}
+	defer ctx.Sess.enqueueEventUnsubscribe(sub.sub)
+
+	matchOpts := mailboxWaitOptions{
+		topic:          opts.Topic,
+		afterMessageID: opts.AfterMessageID,
+		afterEventSeq:  opts.AfterEventSeq,
+	}
+	for _, data := range sub.initialState {
+		ev, ok := mailboxEventSummaryFromJSON(data)
+		if ok && mailboxEventMatchesWait(ev, matchOpts) {
+			return *ev.Message, nil
+		}
+	}
+	if !sub.targetExists {
+		return proto.MailboxMessageSummary{}, fmt.Errorf("pane %q disappeared while waiting for message", opts.PaneRef)
+	}
+
+	timer := time.NewTimer(opts.Timeout)
+	defer timer.Stop()
+	for {
+		select {
+		case data := <-sub.sub.Ch:
+			ev, ok := mailboxEventSummaryFromJSON(data)
+			if !ok {
+				continue
+			}
+			if ev.Type == EventPaneExit {
+				return proto.MailboxMessageSummary{}, fmt.Errorf("pane %q disappeared while waiting for message", opts.PaneRef)
+			}
+			if mailboxEventMatchesWait(ev, matchOpts) {
+				return *ev.Message, nil
+			}
+		case <-timer.C:
+			return proto.MailboxMessageSummary{}, fmt.Errorf("timeout waiting for message for %s", opts.PaneRef)
+		case <-ctx.context().Done():
+			return proto.MailboxMessageSummary{}, ctx.context().Err()
+		}
+	}
 }
 
 func cmdCursor(ctx *CommandContext) {

--- a/internal/server/commands_wait.go
+++ b/internal/server/commands_wait.go
@@ -233,9 +233,8 @@ func (ctx waitCommandContext) WaitMessage(actorPaneID uint32, opts waitcmd.Messa
 		afterEventSeq:  opts.AfterEventSeq,
 	}
 	for _, data := range sub.initialState {
-		ev, ok := mailboxEventSummaryFromJSON(data)
-		if ok && mailboxEventMatchesWait(ev, matchOpts) {
-			return *ev.Message, nil
+		if summary, matched, _ := mailboxWaitEventFromJSON(data, matchOpts); matched {
+			return summary, nil
 		}
 	}
 	if !sub.targetExists {
@@ -247,15 +246,12 @@ func (ctx waitCommandContext) WaitMessage(actorPaneID uint32, opts waitcmd.Messa
 	for {
 		select {
 		case data := <-sub.sub.Ch:
-			ev, ok := mailboxEventSummaryFromJSON(data)
-			if !ok {
-				continue
-			}
-			if ev.Type == EventPaneExit {
+			summary, matched, paneExited := mailboxWaitEventFromJSON(data, matchOpts)
+			if paneExited {
 				return proto.MailboxMessageSummary{}, fmt.Errorf("pane %q disappeared while waiting for message", opts.PaneRef)
 			}
-			if mailboxEventMatchesWait(ev, matchOpts) {
-				return *ev.Message, nil
+			if matched {
+				return summary, nil
 			}
 		case <-timer.C:
 			return proto.MailboxMessageSummary{}, fmt.Errorf("timeout waiting for message for %s", opts.PaneRef)

--- a/internal/server/event.go
+++ b/internal/server/event.go
@@ -20,6 +20,9 @@ const (
 	EventClientConnect    = eventloop.EventClientConnect
 	EventClientDisconnect = eventloop.EventClientDisconnect
 	EventPaneExit         = eventloop.EventPaneExit
+	EventMessageDelivered = eventloop.EventMessageDelivered
+	EventMessageRead      = eventloop.EventMessageRead
+	EventMessageAck       = eventloop.EventMessageAck
 )
 
 const (
@@ -87,6 +90,8 @@ func (s *Session) currentStateEvents() []Event {
 			})
 		}
 	}
+
+	events = append(events, s.currentMailboxStateEvents(now)...)
 
 	for _, cc := range s.ensureClientManager().snapshotClients() {
 		events = append(events, Event{

--- a/internal/server/mailbox.go
+++ b/internal/server/mailbox.go
@@ -1,0 +1,255 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"slices"
+	"time"
+
+	"github.com/weill-labs/amux/internal/eventloop"
+	"github.com/weill-labs/amux/internal/mailbox"
+	"github.com/weill-labs/amux/internal/proto"
+)
+
+func (s *Session) ensureMailbox() *mailbox.Store {
+	if s.mailbox == nil {
+		s.mailbox = mailbox.NewStore(mailbox.Options{Now: func() time.Time { return s.clock().Now() }})
+	}
+	return s.mailbox
+}
+
+func (s *Session) enqueueMailboxSend(ctx context.Context, req mailbox.SendRequest) (mailbox.Message, error) {
+	var msg mailbox.Message
+	res := s.enqueueCommandMutationContext(ctx, func(mctx *MutationContext) commandMutationResult {
+		var err error
+		msg, err = mctx.sess.sendMailboxMessage(req)
+		return commandMutationResult{err: err}
+	})
+	return msg, res.err
+}
+
+func (s *Session) enqueueMailboxRead(ctx context.Context, id mailbox.MessageID, recipientID uint32, opts mailbox.ReadOptions) (mailbox.Message, mailbox.DeliveryState, error) {
+	var msg mailbox.Message
+	var state mailbox.DeliveryState
+	res := s.enqueueCommandMutationContext(ctx, func(mctx *MutationContext) commandMutationResult {
+		var err error
+		msg, state, err = mctx.sess.readMailboxMessage(id, recipientID, opts)
+		return commandMutationResult{err: err}
+	})
+	return msg, state, res.err
+}
+
+func (s *Session) enqueueMailboxAck(ctx context.Context, id mailbox.MessageID, recipientID uint32, req mailbox.AckRequest) (mailbox.DeliveryState, error) {
+	var state mailbox.DeliveryState
+	res := s.enqueueCommandMutationContext(ctx, func(mctx *MutationContext) commandMutationResult {
+		var err error
+		state, err = mctx.sess.ackMailboxMessage(id, recipientID, req)
+		return commandMutationResult{err: err}
+	})
+	return state, res.err
+}
+
+func (s *Session) sendMailboxMessage(req mailbox.SendRequest) (mailbox.Message, error) {
+	msg, err := s.ensureMailbox().Send(req)
+	if err != nil {
+		return mailbox.Message{}, err
+	}
+	for _, recipient := range msg.Recipients {
+		summary, err := s.mailbox.DeliverySummary(msg.ID, recipient.ID)
+		if err != nil {
+			return mailbox.Message{}, err
+		}
+		s.emitMailboxEvent(EventMessageDelivered, summary)
+	}
+	return msg, nil
+}
+
+func (s *Session) readMailboxMessage(id mailbox.MessageID, recipientID uint32, opts mailbox.ReadOptions) (mailbox.Message, mailbox.DeliveryState, error) {
+	before, err := s.ensureMailbox().DeliverySummary(id, recipientID)
+	if err != nil {
+		return mailbox.Message{}, mailbox.DeliveryState{}, err
+	}
+	msg, state, err := s.mailbox.Read(id, recipientID, opts)
+	if err != nil {
+		return mailbox.Message{}, mailbox.DeliveryState{}, err
+	}
+	if !opts.Peek && before.ReadAt.IsZero() && !state.ReadAt.IsZero() {
+		summary, err := s.mailbox.DeliverySummary(id, recipientID)
+		if err != nil {
+			return mailbox.Message{}, mailbox.DeliveryState{}, err
+		}
+		s.emitMailboxEvent(EventMessageRead, summary)
+	}
+	return msg, state, nil
+}
+
+func (s *Session) ackMailboxMessage(id mailbox.MessageID, recipientID uint32, req mailbox.AckRequest) (mailbox.DeliveryState, error) {
+	before, err := s.ensureMailbox().DeliverySummary(id, recipientID)
+	if err != nil {
+		return mailbox.DeliveryState{}, err
+	}
+	state, err := s.mailbox.Ack(id, recipientID, req)
+	if err != nil {
+		return mailbox.DeliveryState{}, err
+	}
+	if before.AckedAt.IsZero() || before.AckStatus != req.Status || before.AckNote != req.Note {
+		summary, err := s.mailbox.DeliverySummary(id, recipientID)
+		if err != nil {
+			return mailbox.DeliveryState{}, err
+		}
+		s.emitMailboxEvent(EventMessageAck, summary)
+	}
+	return state, nil
+}
+
+func (s *Session) emitMailboxEvent(eventType string, summary mailbox.DeliverySummary) {
+	seq := s.nextMailboxEventSeq()
+	if updated, err := s.ensureMailbox().SetLastEventSeq(summary.MessageID, summary.Recipient.ID, seq); err == nil {
+		summary = updated
+	}
+	s.emitEvent(mailboxEvent(eventType, seq, summary))
+}
+
+func (s *Session) nextMailboxEventSeq() uint64 {
+	s.mailboxEventSeq++
+	return s.mailboxEventSeq
+}
+
+func (s *Session) currentMailboxStateEvents(now string) []Event {
+	if s.mailbox == nil {
+		return nil
+	}
+	var events []Event
+	for _, pane := range s.Panes {
+		summaries, err := s.mailbox.ListUnread(pane.ID)
+		if err != nil {
+			continue
+		}
+		for _, summary := range summaries {
+			ev := mailboxEvent(EventMessageDelivered, summary.LastEventSeq, summary)
+			ev.Timestamp = now
+			events = append(events, ev)
+		}
+	}
+	return events
+}
+
+func mailboxEvent(eventType string, seq uint64, summary mailbox.DeliverySummary) Event {
+	return Event{
+		Type:       eventType,
+		Generation: seq,
+		PaneID:     summary.Recipient.ID,
+		PaneName:   summary.Recipient.Name,
+		Host:       summary.Recipient.Host,
+		Message:    mailboxSummaryToProto(summary),
+	}
+}
+
+func mailboxSummaryToProto(summary mailbox.DeliverySummary) *proto.MailboxMessageSummary {
+	return &proto.MailboxMessageSummary{
+		ID:           string(summary.MessageID),
+		From:         mailboxAddressToProto(summary.Sender),
+		Subject:      summary.Subject,
+		Topics:       append([]string(nil), summary.Topics...),
+		Groups:       append([]string(nil), summary.Groups...),
+		ThreadID:     string(summary.ThreadID),
+		InReplyTo:    string(summary.InReplyTo),
+		BodySize:     summary.BodySize,
+		PartCount:    summary.PartCount,
+		CreatedAt:    formatMailboxTime(summary.CreatedAt),
+		DeliveredAt:  formatMailboxTime(summary.DeliveredAt),
+		ReadAt:       formatMailboxTime(summary.ReadAt),
+		AckedAt:      formatMailboxTime(summary.AckedAt),
+		AckStatus:    summary.AckStatus,
+		LastEventSeq: summary.LastEventSeq,
+	}
+}
+
+func mailboxAddressToProto(addr mailbox.PaneAddress) proto.MailboxPaneSummary {
+	return proto.MailboxPaneSummary{
+		ID:   addr.ID,
+		Name: addr.Name,
+		Host: addr.Host,
+	}
+}
+
+func formatMailboxTime(t time.Time) string {
+	if t.IsZero() {
+		return ""
+	}
+	return t.UTC().Format(time.RFC3339Nano)
+}
+
+type mailboxWaitSubscribeResult struct {
+	sub          *eventSub
+	initialState [][]byte
+	targetExists bool
+}
+
+type mailboxWaitOptions struct {
+	topic          string
+	afterMessageID string
+	afterEventSeq  uint64
+}
+
+type mailboxWaitSubscribeCmd struct {
+	paneID uint32
+	reply  chan mailboxWaitSubscribeResult
+}
+
+func (e mailboxWaitSubscribeCmd) handle(ctx context.Context, s *Session) {
+	filter := eventFilter{
+		Types:  []string{EventMessageDelivered, EventPaneExit},
+		PaneID: e.paneID,
+	}
+	sub := eventloop.Subscribe(&s.eventSubs, filter)
+	result := mailboxWaitSubscribeResult{
+		sub:          sub,
+		initialState: eventloop.MarshalMatching(s.currentStateEvents(), filter),
+		targetExists: s.findPaneByID(e.paneID) != nil && s.findWindowByPaneID(e.paneID) != nil,
+	}
+	select {
+	case e.reply <- result:
+	case <-ctx.Done():
+		eventloop.Unsubscribe(&s.eventSubs, sub)
+	}
+}
+
+func (s *Session) enqueueMailboxWaitSubscribe(ctx context.Context, paneID uint32) mailboxWaitSubscribeResult {
+	reply := make(chan mailboxWaitSubscribeResult)
+	if !s.enqueueEvent(ctx, mailboxWaitSubscribeCmd{paneID: paneID, reply: reply}) {
+		return mailboxWaitSubscribeResult{}
+	}
+	select {
+	case res := <-reply:
+		return res
+	case <-ctx.Done():
+		return mailboxWaitSubscribeResult{}
+	case <-s.sessionEventDone:
+		return mailboxWaitSubscribeResult{}
+	}
+}
+
+func mailboxEventSummaryFromJSON(data []byte) (Event, bool) {
+	var ev Event
+	if err := json.Unmarshal(data, &ev); err != nil {
+		return Event{}, false
+	}
+	return ev, true
+}
+
+func mailboxEventMatchesWait(ev Event, opts mailboxWaitOptions) bool {
+	if ev.Type != EventMessageDelivered || ev.Message == nil {
+		return false
+	}
+	if opts.topic != "" && !slices.Contains(ev.Message.Topics, opts.topic) {
+		return false
+	}
+	if opts.afterMessageID != "" && ev.Message.ID <= opts.afterMessageID {
+		return false
+	}
+	if opts.afterEventSeq != 0 && ev.Generation <= opts.afterEventSeq {
+		return false
+	}
+	return true
+}

--- a/internal/server/mailbox.go
+++ b/internal/server/mailbox.go
@@ -4,19 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"slices"
-	"time"
 
 	"github.com/weill-labs/amux/internal/eventloop"
 	"github.com/weill-labs/amux/internal/mailbox"
 	"github.com/weill-labs/amux/internal/proto"
 )
-
-func (s *Session) ensureMailbox() *mailbox.Store {
-	if s.mailbox == nil {
-		s.mailbox = mailbox.NewStore(mailbox.Options{Now: func() time.Time { return s.clock().Now() }})
-	}
-	return s.mailbox
-}
 
 func (s *Session) enqueueMailboxSend(ctx context.Context, req mailbox.SendRequest) (mailbox.Message, error) {
 	var msg mailbox.Message
@@ -165,19 +157,12 @@ func mailboxSummaryToProto(summary mailbox.DeliverySummary) *proto.MailboxMessag
 	}
 }
 
-func mailboxAddressToProto(addr mailbox.PaneAddress) proto.MailboxPaneSummary {
-	return proto.MailboxPaneSummary{
+func mailboxAddressToProto(addr mailbox.PaneAddress) proto.MailboxAddress {
+	return proto.MailboxAddress{
 		ID:   addr.ID,
 		Name: addr.Name,
 		Host: addr.Host,
 	}
-}
-
-func formatMailboxTime(t time.Time) string {
-	if t.IsZero() {
-		return ""
-	}
-	return t.UTC().Format(time.RFC3339Nano)
 }
 
 type mailboxWaitSubscribeResult struct {

--- a/internal/server/mailbox.go
+++ b/internal/server/mailbox.go
@@ -238,6 +238,20 @@ func mailboxEventSummaryFromJSON(data []byte) (Event, bool) {
 	return ev, true
 }
 
+func mailboxWaitEventFromJSON(data []byte, opts mailboxWaitOptions) (summary proto.MailboxMessageSummary, matched bool, paneExited bool) {
+	ev, ok := mailboxEventSummaryFromJSON(data)
+	if !ok {
+		return proto.MailboxMessageSummary{}, false, false
+	}
+	if ev.Type == EventPaneExit {
+		return proto.MailboxMessageSummary{}, false, true
+	}
+	if !mailboxEventMatchesWait(ev, opts) {
+		return proto.MailboxMessageSummary{}, false, false
+	}
+	return *ev.Message, true, false
+}
+
 func mailboxEventMatchesWait(ev Event, opts mailboxWaitOptions) bool {
 	if ev.Type != EventMessageDelivered || ev.Message == nil {
 		return false

--- a/internal/server/mailbox_events_test.go
+++ b/internal/server/mailbox_events_test.go
@@ -1,0 +1,319 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/weill-labs/amux/internal/mailbox"
+	"github.com/weill-labs/amux/internal/mux"
+)
+
+func TestMailboxDeliveredEventIsSummaryOnly(t *testing.T) {
+	t.Parallel()
+
+	_, sess, p1, p2, cleanup := newMailboxTestSession(t)
+	defer cleanup()
+
+	res := sess.enqueueEventSubscribe(sess.context(), eventFilter{
+		Types:  []string{EventMessageDelivered},
+		PaneID: p2.ID,
+	}, false)
+	defer sess.enqueueEventUnsubscribe(res.sub)
+
+	msg := mustSendMailboxMessage(t, sess, p1, p2, "Review ready", "please review the full body")
+
+	data := readMailboxEventData(t, res.sub, time.Second)
+	if strings.Contains(string(data), "please review the full body") {
+		t.Fatalf("delivered event leaked body: %s", string(data))
+	}
+
+	var ev Event
+	mustUnmarshalJSON(t, data, &ev)
+	if ev.Type != EventMessageDelivered {
+		t.Fatalf("event type = %q, want %q", ev.Type, EventMessageDelivered)
+	}
+	if ev.PaneID != p2.ID || ev.PaneName != p2.Meta.Name {
+		t.Fatalf("recipient fields = (%d, %q), want pane 2", ev.PaneID, ev.PaneName)
+	}
+	if ev.Message == nil {
+		t.Fatal("event message summary is nil")
+	}
+	if ev.Message.ID != string(msg.ID) || ev.Message.Subject != "Review ready" {
+		t.Fatalf("message summary = %+v, want sent message", ev.Message)
+	}
+	if ev.Message.From.ID != p1.ID || ev.Message.From.Name != p1.Meta.Name {
+		t.Fatalf("message from = %+v, want pane 1", ev.Message.From)
+	}
+	if ev.Message.BodySize != len("please review the full body") || ev.Message.PartCount != 1 {
+		t.Fatalf("message body summary = (%d, %d), want size and part count", ev.Message.BodySize, ev.Message.PartCount)
+	}
+}
+
+func TestMailboxReadAndAckEvents(t *testing.T) {
+	t.Parallel()
+
+	_, sess, p1, p2, cleanup := newMailboxTestSession(t)
+	defer cleanup()
+
+	msg := mustSendMailboxMessage(t, sess, p1, p2, "Read me", "body")
+	res := sess.enqueueEventSubscribe(sess.context(), eventFilter{
+		Types:  []string{EventMessageRead, EventMessageAck},
+		PaneID: p2.ID,
+	}, false)
+	defer sess.enqueueEventUnsubscribe(res.sub)
+
+	if _, _, err := sess.enqueueMailboxRead(context.Background(), msg.ID, p2.ID, mailbox.ReadOptions{}); err != nil {
+		t.Fatalf("enqueueMailboxRead: %v", err)
+	}
+	readEvent := readMailboxEvent(t, res.sub, time.Second)
+	if readEvent.Type != EventMessageRead {
+		t.Fatalf("read event type = %q, want %q", readEvent.Type, EventMessageRead)
+	}
+	if readEvent.Message == nil || readEvent.Message.ID != string(msg.ID) || readEvent.Message.ReadAt == "" {
+		t.Fatalf("read event message = %+v, want read timestamp", readEvent.Message)
+	}
+
+	if _, err := sess.enqueueMailboxAck(context.Background(), msg.ID, p2.ID, mailbox.AckRequest{Status: "ok", Note: "done"}); err != nil {
+		t.Fatalf("enqueueMailboxAck: %v", err)
+	}
+	ackEvent := readMailboxEvent(t, res.sub, time.Second)
+	if ackEvent.Type != EventMessageAck {
+		t.Fatalf("ack event type = %q, want %q", ackEvent.Type, EventMessageAck)
+	}
+	if ackEvent.Message == nil || ackEvent.Message.ID != string(msg.ID) || ackEvent.Message.AckStatus != "ok" || ackEvent.Message.AckedAt == "" {
+		t.Fatalf("ack event message = %+v, want ack status and timestamp", ackEvent.Message)
+	}
+}
+
+func TestMailboxEventsFilterByRecipientPane(t *testing.T) {
+	t.Parallel()
+
+	_, sess, p1, p2, cleanup := newMailboxTestSession(t)
+	defer cleanup()
+	p3 := newTestPane(sess, 3, "pane-3")
+	mustSessionMutation(t, sess, func(sess *Session) {
+		w := sess.activeWindow()
+		if _, err := w.Split(mux.SplitHorizontal, p3); err != nil {
+			t.Fatalf("Split: %v", err)
+		}
+		sess.Panes = w.Panes()
+	})
+
+	res := sess.enqueueEventSubscribe(sess.context(), eventFilter{
+		Types:  []string{EventMessageDelivered},
+		PaneID: p2.ID,
+	}, false)
+	defer sess.enqueueEventUnsubscribe(res.sub)
+
+	mustSendMailboxMessage(t, sess, p1, p3, "Other pane", "body")
+	mustSendMailboxMessage(t, sess, p1, p2, "Target pane", "body")
+
+	ev := readMailboxEvent(t, res.sub, time.Second)
+	if ev.PaneID != p2.ID || ev.Message == nil || ev.Message.Subject != "Target pane" {
+		t.Fatalf("filtered event = %+v, want only pane-2 delivery", ev)
+	}
+	select {
+	case data := <-res.sub.Ch:
+		t.Fatalf("unexpected extra event: %s", string(data))
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+func TestMailboxDeliveredReplayIncludesOnlyUnreadMessages(t *testing.T) {
+	t.Parallel()
+
+	_, sess, p1, p2, cleanup := newMailboxTestSession(t)
+	defer cleanup()
+
+	msg := mustSendMailboxMessage(t, sess, p1, p2, "Unread", "body")
+	replay := sess.enqueueEventSubscribe(sess.context(), eventFilter{
+		Types:  []string{EventMessageDelivered},
+		PaneID: p2.ID,
+	}, true)
+	defer sess.enqueueEventUnsubscribe(replay.sub)
+
+	if len(replay.initialState) != 1 {
+		t.Fatalf("initial state length = %d, want 1", len(replay.initialState))
+	}
+	var ev Event
+	mustUnmarshalJSON(t, replay.initialState[0], &ev)
+	if ev.Type != EventMessageDelivered || ev.Message == nil || ev.Message.ID != string(msg.ID) {
+		t.Fatalf("initial event = %+v, want unread delivery", ev)
+	}
+
+	if _, _, err := sess.enqueueMailboxRead(context.Background(), msg.ID, p2.ID, mailbox.ReadOptions{}); err != nil {
+		t.Fatalf("enqueueMailboxRead: %v", err)
+	}
+	afterRead := sess.enqueueEventSubscribe(sess.context(), eventFilter{
+		Types:  []string{EventMessageDelivered},
+		PaneID: p2.ID,
+	}, true)
+	defer sess.enqueueEventUnsubscribe(afterRead.sub)
+	if len(afterRead.initialState) != 0 {
+		t.Fatalf("initial state after read length = %d, want 0", len(afterRead.initialState))
+	}
+}
+
+func TestWaitMessageReturnsUnreadDelivery(t *testing.T) {
+	t.Parallel()
+
+	srv, sess, p1, p2, cleanup := newMailboxTestSession(t)
+	defer cleanup()
+
+	resultCh := make(chan struct {
+		output string
+		cmdErr string
+	}, 1)
+	go func() {
+		resultCh <- runTestCommand(t, srv, sess, "wait", "msg", p2.Meta.Name, "--format", "json", "--timeout", "5s")
+	}()
+	waitForMailboxWaitSubscription(t, sess)
+
+	msg := mustSendMailboxMessage(t, sess, p1, p2, "Incoming", "body hidden from wait")
+
+	res := readWaitMessageResult(t, resultCh)
+	if res.cmdErr != "" {
+		t.Fatalf("wait msg error = %q", res.cmdErr)
+	}
+	if strings.Contains(res.output, "body hidden from wait") {
+		t.Fatalf("wait msg leaked body: %s", res.output)
+	}
+	var summary struct {
+		ID      string `json:"id"`
+		Subject string `json:"subject"`
+	}
+	if err := json.Unmarshal([]byte(res.output), &summary); err != nil {
+		t.Fatalf("unmarshal wait msg output %q: %v", res.output, err)
+	}
+	if summary.ID != string(msg.ID) || summary.Subject != "Incoming" {
+		t.Fatalf("wait msg summary = %+v, want sent message", summary)
+	}
+}
+
+func TestWaitMessageTimeout(t *testing.T) {
+	t.Parallel()
+
+	srv, sess, _, p2, cleanup := newMailboxTestSession(t)
+	defer cleanup()
+
+	res := runTestCommand(t, srv, sess, "wait", "msg", p2.Meta.Name, "--timeout", "1ms")
+	if !strings.Contains(res.cmdErr, "timeout waiting for message for pane-2") {
+		t.Fatalf("wait msg timeout error = %q", res.cmdErr)
+	}
+}
+
+func TestWaitMessagePaneDisappearance(t *testing.T) {
+	t.Parallel()
+
+	srv, sess, _, p2, cleanup := newMailboxTestSession(t)
+	defer cleanup()
+
+	resultCh := make(chan struct {
+		output string
+		cmdErr string
+	}, 1)
+	go func() {
+		resultCh <- runTestCommand(t, srv, sess, "wait", "msg", p2.Meta.Name, "--timeout", "5s")
+	}()
+	waitForMailboxWaitSubscription(t, sess)
+
+	sess.enqueuePaneExit(p2.ID, "test")
+
+	res := readWaitMessageResult(t, resultCh)
+	if !strings.Contains(res.cmdErr, "pane \"pane-2\" disappeared while waiting for message") {
+		t.Fatalf("wait msg pane disappearance error = %q", res.cmdErr)
+	}
+}
+
+func newMailboxTestSession(t *testing.T) (*Server, *Session, *mux.Pane, *mux.Pane, func()) {
+	t.Helper()
+
+	srv, sess, cleanup := newCommandTestSession(t)
+	p1 := newTestPane(sess, 1, "pane-1")
+	p2 := newTestPane(sess, 2, "pane-2")
+	w := newTestWindowWithPanes(t, sess, 1, "main", p1, p2)
+	setSessionLayoutForTest(t, sess, w.ID, []*mux.Window{w}, p1, p2)
+	return srv, sess, p1, p2, cleanup
+}
+
+func mustSendMailboxMessage(t *testing.T, sess *Session, sender, recipient *mux.Pane, subject, body string) mailbox.Message {
+	t.Helper()
+
+	msg, err := sess.enqueueMailboxSend(context.Background(), mailbox.SendRequest{
+		Sender:     mailboxAddressForPane(sender),
+		Recipients: []mailbox.PaneAddress{mailboxAddressForPane(recipient)},
+		Subject:    subject,
+		Body:       []byte(body),
+	})
+	if err != nil {
+		t.Fatalf("enqueueMailboxSend: %v", err)
+	}
+	return msg
+}
+
+func mailboxAddressForPane(pane *mux.Pane) mailbox.PaneAddress {
+	return mailbox.PaneAddress{
+		ID:   pane.ID,
+		Name: pane.Meta.Name,
+		Host: pane.Meta.Host,
+	}
+}
+
+func readMailboxEvent(t *testing.T, sub *eventSub, timeout time.Duration) Event {
+	t.Helper()
+
+	var ev Event
+	mustUnmarshalJSON(t, readMailboxEventData(t, sub, timeout), &ev)
+	return ev
+}
+
+func readMailboxEventData(t *testing.T, sub *eventSub, timeout time.Duration) []byte {
+	t.Helper()
+
+	select {
+	case data := <-sub.Ch:
+		return data
+	case <-time.After(timeout):
+		t.Fatal("timeout waiting for mailbox event")
+		return nil
+	}
+}
+
+func waitForMailboxWaitSubscription(t *testing.T, sess *Session) {
+	t.Helper()
+	waitUntil(t, func() bool {
+		return mustSessionQuery(t, sess, func(sess *Session) int {
+			count := 0
+			for _, sub := range sess.eventSubs {
+				if sub.Filter.PaneName == "pane-2" || sub.Filter.PaneID == 2 {
+					count++
+				}
+			}
+			return count
+		}) > 0
+	})
+}
+
+func readWaitMessageResult(t *testing.T, resultCh <-chan struct {
+	output string
+	cmdErr string
+}) struct {
+	output string
+	cmdErr string
+} {
+	t.Helper()
+
+	select {
+	case res := <-resultCh:
+		return res
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for wait msg result")
+		return struct {
+			output string
+			cmdErr string
+		}{}
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -73,6 +73,10 @@ type Session struct {
 	// duplicate terminal events.
 	terminalEventState map[uint32]paneTerminalEventState
 
+	// Mailbox state is session-scoped and mutated on the session event loop.
+	mailbox         *mailbox.Store
+	mailboxEventSeq uint64
+
 	undo *UndoManager
 
 	// Mailbox is server-owned and mutated only on the session event loop.
@@ -511,6 +515,7 @@ func newSessionWithScrollbackConfigLogger(name string, scrollback ScrollbackConf
 		paneLog:            newPaneLog(defaultPaneLogSize),
 	}
 	sess.idle = NewIdleTracker(sess.clock)
+	sess.mailbox = mailbox.NewStore(mailbox.Options{Now: func() time.Time { return sess.clock().Now() }})
 	sess.terminalEventState = make(map[uint32]paneTerminalEventState)
 	sess.waiters = newWaiterManager()
 	sess.capture = newCaptureForwarder()

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -73,14 +73,11 @@ type Session struct {
 	// duplicate terminal events.
 	terminalEventState map[uint32]paneTerminalEventState
 
-	// Mailbox state is session-scoped and mutated on the session event loop.
+	// Mailbox is server-owned and mutated only on the session event loop.
 	mailbox         *mailbox.Store
 	mailboxEventSeq uint64
 
 	undo *UndoManager
-
-	// Mailbox is server-owned and mutated only on the session event loop.
-	mailbox *mailbox.Store
 
 	// Configurable timing — zero values use defaults. Tests inject short durations.
 	VTIdleSettle time.Duration // default: 2s


### PR DESCRIPTION
## Motivation

LAB-1991 landed the in-memory mailbox store, but amux still had no reactive path for mailbox lifecycle changes. This adds the event/wait seam needed for agents and tools to observe unread deliveries without adding agent-specific policy or the broader `amux msg` CLI surface.

## Summary

- Add summary-only mailbox event payloads for `message-delivered`, `message-read`, and `message-ack`.
- Wire a session-owned mailbox store to emit lifecycle events and replay unread deliveries through the existing event stream semantics.
- Add `amux wait msg` with pane targeting, topic and cursor filters, JSON/text output, timeout errors, and pane-disappearance errors.
- Add focused store, event, parser, and wait-command coverage.

## Testing

- `go test ./internal/server -run 'TestMailbox|TestWaitMessage' -count=100`
- `go test ./internal/server/commands/wait -count=100`
- `go test ./internal/mailbox -count=100`
- `scripts/check-diff-coverage.sh` (diff coverage 78.08%; integration phase still reports the pre-existing SSH clipboard harness failures listed below)
- `go test ./... -timeout 120s` (fails locally in `./test` on `TestCopyModeClipboardUsesOSC52WhenInnerClientRunsOverSSH` and `TestCopyModeClipboardUsesTmuxPassthroughWhenInnerClientRunsOverSSHInTmux`; exact rerun fails the same way, with clipboard/OSC52 timeouts unrelated to mailbox changes)

## Review focus

- Confirm mailbox events remain summary-only and never expose message bodies or arbitrary metadata.
- Check that `wait msg` closes the inbox/wait race by subscribing and replaying initial unread state on the session event loop.
- Check that pane filtering uses the existing event `pane_id`/`pane_name` path without introducing orca, agent CLI, or A2A policy.

Closes LAB-1987
