### PR TITLE
LAB-1986: Add pane mailbox msg commands

### DIFF
--- a/internal/cli/cli_commands_msg.go
+++ b/internal/cli/cli_commands_msg.go
@@ -1,0 +1,111 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"os"
+)
+
+func msgCLICommands() map[string]commandHandler {
+	return map[string]commandHandler{
+		"msg": func(inv invocation, args []string) int {
+			if hasHelpFlag(args) {
+				fmt.Fprintln(inv.runtime.Stdout, msgUsage)
+				return 0
+			}
+			if len(args) == 0 {
+				fmt.Fprintln(inv.runtime.Stderr, msgUsage)
+				return 1
+			}
+			serverArgs, err := prepareMsgCLIArgs(inv.runtime.Stdin, args)
+			if err != nil {
+				fmt.Fprintf(inv.runtime.Stderr, "amux msg: %v\n", err)
+				return 1
+			}
+			return inv.runSessionCommand("msg", serverArgs)
+		},
+	}
+}
+
+func prepareMsgCLIArgs(stdin io.Reader, args []string) ([]string, error) {
+	if len(args) == 0 || args[0] != "send" {
+		return args, nil
+	}
+
+	out := make([]string, 0, len(args)+2)
+	out = append(out, args[0])
+	var bodySet bool
+	var bodyFileSet bool
+	var bodyFileData []byte
+
+	for i := 1; i < len(args); i++ {
+		switch args[i] {
+		case "--body":
+			value, next, err := msgCLIRequiredValue(args, i, "--body")
+			if err != nil {
+				return nil, err
+			}
+			if bodySet || bodyFileSet {
+				return nil, fmt.Errorf("--body, --body-file, and stdin are mutually exclusive")
+			}
+			bodySet = true
+			out = append(out, "--body", value)
+			i = next
+		case "--body-file":
+			value, next, err := msgCLIRequiredValue(args, i, "--body-file")
+			if err != nil {
+				return nil, err
+			}
+			if bodySet || bodyFileSet {
+				return nil, fmt.Errorf("--body, --body-file, and stdin are mutually exclusive")
+			}
+			data, err := os.ReadFile(value)
+			if err != nil {
+				return nil, fmt.Errorf("reading --body-file: %w", err)
+			}
+			bodyFileSet = true
+			bodyFileData = data
+			i = next
+		default:
+			out = append(out, args[i])
+		}
+	}
+
+	if shouldReadMsgStdin(stdin) {
+		if bodySet || bodyFileSet {
+			return nil, fmt.Errorf("--body, --body-file, and stdin are mutually exclusive")
+		}
+		data, err := io.ReadAll(stdin)
+		if err != nil {
+			return nil, fmt.Errorf("reading stdin: %w", err)
+		}
+		out = append(out, "--body", string(data))
+		return out, nil
+	}
+	if bodyFileSet {
+		out = append(out, "--body", string(bodyFileData))
+	}
+	return out, nil
+}
+
+func msgCLIRequiredValue(args []string, i int, name string) (string, int, error) {
+	if i+1 >= len(args) {
+		return "", i, fmt.Errorf("missing value for %s", name)
+	}
+	return args[i+1], i + 1, nil
+}
+
+func shouldReadMsgStdin(stdin io.Reader) bool {
+	if stdin == nil {
+		return false
+	}
+	f, ok := stdin.(*os.File)
+	if !ok {
+		return true
+	}
+	info, err := f.Stat()
+	if err != nil {
+		return false
+	}
+	return info.Mode()&os.ModeCharDevice == 0
+}

--- a/internal/cli/cli_commands_msg.go
+++ b/internal/cli/cli_commands_msg.go
@@ -9,7 +9,7 @@ import (
 func msgCLICommands() map[string]commandHandler {
 	return map[string]commandHandler{
 		"msg": func(inv invocation, args []string) int {
-			if hasHelpFlag(args) {
+			if wantsMsgHelp(args) {
 				fmt.Fprintln(inv.runtime.Stdout, msgUsage)
 				return 0
 			}
@@ -25,6 +25,11 @@ func msgCLICommands() map[string]commandHandler {
 			return inv.runSessionCommand("msg", serverArgs)
 		},
 	}
+}
+
+func wantsMsgHelp(args []string) bool {
+	return len(args) == 1 && isHelpFlag(args[0]) ||
+		len(args) == 2 && isHelpFlag(args[1])
 }
 
 func prepareMsgCLIArgs(stdin io.Reader, args []string) ([]string, error) {

--- a/internal/cli/cli_commands_msg_test.go
+++ b/internal/cli/cli_commands_msg_test.go
@@ -1,0 +1,209 @@
+package cli
+
+import (
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+type errReader struct{}
+
+func (errReader) Read([]byte) (int, error) {
+	return 0, errors.New("boom")
+}
+
+func TestPrepareMsgCLIArgs(t *testing.T) {
+	t.Parallel()
+
+	bodyPath := filepath.Join(t.TempDir(), "body.txt")
+	if err := os.WriteFile(bodyPath, []byte("file body\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile(body): %v", err)
+	}
+
+	tests := []struct {
+		name    string
+		stdin   io.Reader
+		args    []string
+		want    []string
+		wantErr string
+	}{
+		{
+			name: "non send command is unchanged",
+			args: []string{"inbox", "pane-1"},
+			want: []string{"inbox", "pane-1"},
+		},
+		{
+			name: "body flag is forwarded",
+			args: []string{"send", "--to", "pane-1", "--body", "hello"},
+			want: []string{"send", "--to", "pane-1", "--body", "hello"},
+		},
+		{
+			name: "body file becomes body flag",
+			args: []string{"send", "--to", "pane-1", "--body-file", bodyPath},
+			want: []string{"send", "--to", "pane-1", "--body", "file body\n"},
+		},
+		{
+			name:  "stdin becomes body flag",
+			stdin: strings.NewReader("stdin body"),
+			args:  []string{"send", "--to", "pane-1"},
+			want:  []string{"send", "--to", "pane-1", "--body", "stdin body"},
+		},
+		{
+			name:    "missing body value",
+			args:    []string{"send", "--body"},
+			wantErr: "missing value for --body",
+		},
+		{
+			name:    "missing body file value",
+			args:    []string{"send", "--body-file"},
+			wantErr: "missing value for --body-file",
+		},
+		{
+			name:    "body and body file conflict",
+			args:    []string{"send", "--body", "hello", "--body-file", bodyPath},
+			wantErr: "mutually exclusive",
+		},
+		{
+			name:    "body and stdin conflict",
+			stdin:   strings.NewReader("stdin body"),
+			args:    []string{"send", "--body", "hello"},
+			wantErr: "mutually exclusive",
+		},
+		{
+			name:    "body file and stdin conflict",
+			stdin:   strings.NewReader("stdin body"),
+			args:    []string{"send", "--body-file", bodyPath},
+			wantErr: "mutually exclusive",
+		},
+		{
+			name:    "body file read error",
+			args:    []string{"send", "--body-file", filepath.Join(t.TempDir(), "missing.txt")},
+			wantErr: "reading --body-file",
+		},
+		{
+			name:    "stdin read error",
+			stdin:   errReader{},
+			args:    []string{"send"},
+			wantErr: "reading stdin",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := prepareMsgCLIArgs(tt.stdin, tt.args)
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("prepareMsgCLIArgs() error = %v, want substring %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("prepareMsgCLIArgs(): %v", err)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("prepareMsgCLIArgs() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestShouldReadMsgStdin(t *testing.T) {
+	t.Parallel()
+
+	if shouldReadMsgStdin(nil) {
+		t.Fatal("nil stdin should not be read")
+	}
+	if !shouldReadMsgStdin(strings.NewReader("body")) {
+		t.Fatal("non-file stdin should be read")
+	}
+
+	f, err := os.CreateTemp(t.TempDir(), "stdin")
+	if err != nil {
+		t.Fatalf("CreateTemp: %v", err)
+	}
+	if !shouldReadMsgStdin(f) {
+		t.Fatal("regular file stdin should be read")
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if shouldReadMsgStdin(f) {
+		t.Fatal("stdin with stat error should not be read")
+	}
+}
+
+func TestMsgCLICommandHandler(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		args       []string
+		wantExit   int
+		wantStdout string
+		wantStderr string
+		wantCalls  []cliCall
+	}{
+		{
+			name:       "help",
+			args:       []string{"msg", "--help"},
+			wantStdout: msgUsage + "\n",
+		},
+		{
+			name:       "subcommand help",
+			args:       []string{"msg", "send", "--help"},
+			wantStdout: msgUsage + "\n",
+		},
+		{
+			name:       "missing subcommand",
+			args:       []string{"msg"},
+			wantExit:   1,
+			wantStderr: msgUsage + "\n",
+		},
+		{
+			name:       "prepare error",
+			args:       []string{"msg", "send", "--body"},
+			wantExit:   1,
+			wantStderr: "amux msg: missing value for --body\n",
+		},
+		{
+			name:     "dispatch",
+			args:     []string{"msg", "send", "--to", "pane-1", "--body", "hello"},
+			wantExit: 0,
+			wantCalls: []cliCall{{
+				kind:    "server-command",
+				session: resolvedSessionMarker,
+				cmd:     "msg",
+				args:    []string{"send", "--to", "pane-1", "--body", "hello"},
+			}},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newCLIRuntimeHarness()
+			gotExit := RunWithRuntime(tt.args, h.runtime())
+			if gotExit != tt.wantExit {
+				t.Fatalf("RunWithRuntime(%v) exit = %d, want %d", tt.args, gotExit, tt.wantExit)
+			}
+			if got := h.stdout.String(); got != tt.wantStdout {
+				t.Fatalf("stdout = %q, want %q", got, tt.wantStdout)
+			}
+			if got := h.stderr.String(); got != tt.wantStderr {
+				t.Fatalf("stderr = %q, want %q", got, tt.wantStderr)
+			}
+			if got, want := h.calls, resolveTestSessions(tt.wantCalls); !reflect.DeepEqual(got, want) {
+				t.Fatalf("calls = %#v, want %#v", got, want)
+			}
+		})
+	}
+}

--- a/internal/cli/cli_dispatch.go
+++ b/internal/cli/cli_dispatch.go
@@ -11,6 +11,7 @@ import (
 type Runtime struct {
 	Stdout             io.Writer
 	Stderr             io.Writer
+	Stdin              io.Reader
 	AttachSession      func(string) error
 	WriteVersionOutput func(io.Writer, []string) error
 	InstallTerminfo    func() error
@@ -44,6 +45,7 @@ func buildCLICommands() map[string]commandHandler {
 	addCLICommands(commands, layoutCLICommands())
 	addCLICommands(commands, windowCLICommands())
 	addCLICommands(commands, remoteCLICommands())
+	addCLICommands(commands, msgCLICommands())
 	addCLICommands(commands, doctorCLICommands())
 	commands["reload-server"] = func(inv invocation, args []string) int {
 		return inv.runSessionCommand("reload-server", PrependReloadExecPathArg(reload.ResolveExecutable, args))

--- a/internal/cli/cli_usage.go
+++ b/internal/cli/cli_usage.go
@@ -15,6 +15,7 @@ const (
 	diagUsage         = "usage: amux _diag [dump|goroutines|heap|info] [--output <path>]"
 	leadUsage         = "usage: amux lead [pane] | amux lead --clear"
 	metaUsage         = "usage: amux meta <set|get|rm> ..."
+	msgUsage          = "usage: amux msg <send|inbox|read|ack> ..."
 	moveUsage         = "usage: amux move <pane> up|down | amux move <pane> (--before <target>|--after <target>|--to-column <target>)"
 	remoteUsage       = "usage: amux remote <add|list|rm|panes|status|attach|detach|resize> ..."
 	spawnUsage        = "usage: amux spawn [--auto] [--at <pane>] [--window <name|id>] [--vertical|--horizontal] [--root] [--focus] [--attach <host>:<pane-name>] [--name NAME] [--task TASK] [--color COLOR]"
@@ -62,6 +63,7 @@ var commandUsageByName = map[string]string{
 	"list-windows":     listWindowsUsage,
 	"log":              logUsage,
 	"meta":             metaUsage,
+	"msg":              msgUsage,
 	"mouse":            mouseUsage,
 	"move":             moveUsage,
 	"new":              "usage: amux new [name]",
@@ -224,6 +226,11 @@ Usage:
   amux [-s session] meta get <pane> [key]
   amux [-s session] meta rm <pane> key [key...]
                                        Manage generic pane metadata
+  amux [-s session] msg send --from <pane> --to <pane[,pane...]> [--subject text] (--body text|--body-file path|stdin) [--format json]
+  amux [-s session] msg inbox [pane] [--unread] [--format json]
+  amux [-s session] msg read <msg-id> [--for pane] [--peek] [--format json]
+  amux [-s session] msg ack <msg-id> [--for pane] [--status ok|error|seen] [--note text] [--format json]
+                                       Manage pane mailbox messages
   amux [-s session] new-window         Create a new window
   amux [-s session] list-windows       List all windows
   amux [-s session] select-window <n>  Switch to window by index or name

--- a/internal/cli/runtime_entry.go
+++ b/internal/cli/runtime_entry.go
@@ -68,6 +68,7 @@ func defaultRuntime(buildCommit string) Runtime {
 	return Runtime{
 		Stdout: os.Stdout,
 		Stderr: os.Stderr,
+		Stdin:  os.Stdin,
 		AttachSession: func(sessionName string) error {
 			return client.RunSession(sessionName, term.GetSize)
 		},

--- a/internal/mailbox/store.go
+++ b/internal/mailbox/store.go
@@ -114,6 +114,10 @@ type ReadOptions struct {
 	Peek bool
 }
 
+type ListOptions struct {
+	UnreadOnly bool
+}
+
 type AckRequest struct {
 	Status string
 	Note   string
@@ -276,6 +280,10 @@ func (s *Store) Message(id MessageID) (Message, bool) {
 }
 
 func (s *Store) ListUnread(recipientID uint32) ([]DeliverySummary, error) {
+	return s.List(recipientID, ListOptions{UnreadOnly: true})
+}
+
+func (s *Store) List(recipientID uint32, opts ListOptions) ([]DeliverySummary, error) {
 	if s == nil {
 		return nil, fmt.Errorf("mailbox store is nil")
 	}
@@ -288,9 +296,10 @@ func (s *Store) ListUnread(recipientID uint32) ([]DeliverySummary, error) {
 	}
 	ids := make([]MessageID, 0, len(byMessage))
 	for id, delivery := range byMessage {
-		if delivery.ReadAt.IsZero() {
-			ids = append(ids, id)
+		if opts.UnreadOnly && (!delivery.ReadAt.IsZero() || !delivery.AckedAt.IsZero()) {
+			continue
 		}
+		ids = append(ids, id)
 	}
 	sort.Slice(ids, func(i, j int) bool {
 		return ids[i] < ids[j]

--- a/internal/mailbox/store_test.go
+++ b/internal/mailbox/store_test.go
@@ -182,6 +182,13 @@ func TestStoreAckBeforeReadAndIdempotentRepeat(t *testing.T) {
 	if !first.ReadAt.IsZero() {
 		t.Fatalf("ReadAt after ack-before-read = %s, want zero", first.ReadAt)
 	}
+	unread, err := store.ListUnread(2)
+	if err != nil {
+		t.Fatalf("ListUnread after ack-before-read: %v", err)
+	}
+	if len(unread) != 0 {
+		t.Fatalf("ListUnread after ack-before-read length = %d, want 0", len(unread))
+	}
 
 	now = now.Add(time.Minute)
 	repeated, err := store.Ack(msg.ID, 2, AckRequest{Status: "seen", Note: "queued"})

--- a/internal/server/commands.go
+++ b/internal/server/commands.go
@@ -223,6 +223,7 @@ var commandRegistry = map[string]CommandHandler{
 	"copy-mode":           cmdCopyMode,
 	"cursor":              cmdCursor,
 	"meta":                cmdMeta,
+	"msg":                 cmdMsg,
 	"wait":                cmdWait,
 	"_layout-json":        cmdLayoutJSON,
 	"events":              cmdEvents,

--- a/internal/server/commands_capture_test.go
+++ b/internal/server/commands_capture_test.go
@@ -241,15 +241,14 @@ func TestCaptureJSONMailboxMultiplePanesAndReadAckState(t *testing.T) {
 	assertJSONNumber(t, mailboxMap(t, capturePaneMap(t, capture, "pane-2")), "unread", 0)
 
 	pane3Mailbox := mailboxMap(t, capturePaneMap(t, capture, "pane-3"))
-	assertJSONNumber(t, pane3Mailbox, "unread", 2)
+	assertJSONNumber(t, pane3Mailbox, "unread", 1)
+	assertJSONMapLen(t, pane3Mailbox, "topics", 1)
 	assertTopicCount(t, pane3Mailbox, "review", 1)
-	assertTopicCount(t, pane3Mailbox, "status", 1)
 	latest := latestUnread(t, pane3Mailbox)
-	if len(latest) != 2 {
-		t.Fatalf("pane-3 latest_unread length = %d, want 2", len(latest))
+	if len(latest) != 1 {
+		t.Fatalf("pane-3 latest_unread length = %d, want 1", len(latest))
 	}
-	assertJSONString(t, latest[0], "id", string(msg2.ID))
-	assertJSONString(t, latest[1], "id", string(msg1.ID))
+	assertJSONString(t, latest[0], "id", string(msg1.ID))
 	for _, summary := range latest {
 		if _, ok := summary["acked_at"]; ok {
 			t.Fatalf("capture summary leaked ack state: %#v", summary)

--- a/internal/server/commands_msg.go
+++ b/internal/server/commands_msg.go
@@ -498,7 +498,7 @@ func mailboxActorAddress(mctx *MutationContext, actorPaneID uint32, role string)
 	if mctx.findWindowByPaneID(actorPaneID) == nil {
 		return mailbox.PaneAddress{}, fmt.Errorf("%s pane %d is not in any window", role, actorPaneID)
 	}
-	return mailboxAddressForPane(pane), nil
+	return mailboxCommandAddressForPane(pane), nil
 }
 
 func resolveMailboxPaneRef(mctx *MutationContext, actorPaneID uint32, ref, role string) (mailbox.PaneAddress, error) {
@@ -509,10 +509,10 @@ func resolveMailboxPaneRef(mctx *MutationContext, actorPaneID uint32, ref, role 
 	if window == nil {
 		return mailbox.PaneAddress{}, fmt.Errorf("%s pane %q is not in any window", role, ref)
 	}
-	return mailboxAddressForPane(pane), nil
+	return mailboxCommandAddressForPane(pane), nil
 }
 
-func mailboxAddressForPane(pane *mux.Pane) mailbox.PaneAddress {
+func mailboxCommandAddressForPane(pane *mux.Pane) mailbox.PaneAddress {
 	if pane == nil {
 		return mailbox.PaneAddress{}
 	}

--- a/internal/server/commands_msg.go
+++ b/internal/server/commands_msg.go
@@ -458,19 +458,6 @@ func runMsgAck(mctx *MutationContext, actorPaneID uint32, opts msgAckOptions) (s
 	return fmt.Sprintf("Acked %s for %s\n", opts.id, recipient.Name), nil
 }
 
-func (s *Session) ensureMailbox() *mailbox.Store {
-	if s.mailbox == nil {
-		s.mailbox = s.newMailboxStore()
-	}
-	return s.mailbox
-}
-
-func (s *Session) newMailboxStore() *mailbox.Store {
-	return mailbox.NewStore(mailbox.Options{Now: func() time.Time {
-		return s.clock().Now()
-	}})
-}
-
 func resolveMailboxSender(mctx *MutationContext, actorPaneID uint32, ref string) (mailbox.PaneAddress, error) {
 	if ref == "" {
 		return mailboxActorAddress(mctx, actorPaneID, "sender")

--- a/internal/server/commands_msg.go
+++ b/internal/server/commands_msg.go
@@ -1,0 +1,654 @@
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/weill-labs/amux/internal/mailbox"
+	"github.com/weill-labs/amux/internal/mux"
+)
+
+const msgUsage = "usage: msg <send|inbox|read|ack> ..."
+
+type msgFormat string
+
+const (
+	msgFormatText msgFormat = "text"
+	msgFormatJSON msgFormat = "json"
+)
+
+type msgSendOptions struct {
+	from     string
+	to       []string
+	subject  string
+	body     []byte
+	topics   []string
+	groups   []string
+	metadata map[string]json.RawMessage
+	replyTo  mailbox.MessageID
+	format   msgFormat
+}
+
+type msgInboxOptions struct {
+	target     string
+	unreadOnly bool
+	format     msgFormat
+}
+
+type msgReadOptions struct {
+	id     mailbox.MessageID
+	target string
+	peek   bool
+	format msgFormat
+}
+
+type msgAckOptions struct {
+	id     mailbox.MessageID
+	target string
+	status string
+	note   string
+	format msgFormat
+}
+
+type msgSendOutput struct {
+	ID         mailbox.MessageID     `json:"id"`
+	Sender     mailbox.PaneAddress   `json:"sender"`
+	Recipients []mailbox.PaneAddress `json:"recipients"`
+	Subject    string                `json:"subject"`
+	Topics     []string              `json:"topics,omitempty"`
+	Groups     []string              `json:"groups,omitempty"`
+	ThreadID   mailbox.ThreadID      `json:"thread_id"`
+	InReplyTo  mailbox.MessageID     `json:"in_reply_to,omitempty"`
+	CreatedAt  string                `json:"created_at"`
+	BodySize   int                   `json:"body_size"`
+	PartCount  int                   `json:"part_count"`
+}
+
+type msgSummaryOutput struct {
+	ID          mailbox.MessageID   `json:"id"`
+	Sender      mailbox.PaneAddress `json:"sender"`
+	Recipient   mailbox.PaneAddress `json:"recipient"`
+	Subject     string              `json:"subject"`
+	Topics      []string            `json:"topics,omitempty"`
+	Groups      []string            `json:"groups,omitempty"`
+	ThreadID    mailbox.ThreadID    `json:"thread_id"`
+	InReplyTo   mailbox.MessageID   `json:"in_reply_to,omitempty"`
+	CreatedAt   string              `json:"created_at"`
+	DeliveredAt string              `json:"delivered_at"`
+	ReadAt      string              `json:"read_at,omitempty"`
+	AckedAt     string              `json:"acked_at,omitempty"`
+	AckStatus   string              `json:"ack_status,omitempty"`
+	AckNote     string              `json:"ack_note,omitempty"`
+	BodySize    int                 `json:"body_size"`
+	PartCount   int                 `json:"part_count"`
+}
+
+type msgReadOutput struct {
+	ID         mailbox.MessageID          `json:"id"`
+	Sender     mailbox.PaneAddress        `json:"sender"`
+	Recipients []mailbox.PaneAddress      `json:"recipients"`
+	Subject    string                     `json:"subject"`
+	Topics     []string                   `json:"topics,omitempty"`
+	Groups     []string                   `json:"groups,omitempty"`
+	ThreadID   mailbox.ThreadID           `json:"thread_id"`
+	InReplyTo  mailbox.MessageID          `json:"in_reply_to,omitempty"`
+	CreatedAt  string                     `json:"created_at"`
+	ReadAt     string                     `json:"read_at,omitempty"`
+	Body       string                     `json:"body"`
+	BodySize   int                        `json:"body_size"`
+	PartCount  int                        `json:"part_count"`
+	Delivery   mailbox.DeliveryState      `json:"delivery"`
+	Metadata   map[string]json.RawMessage `json:"metadata,omitempty"`
+}
+
+type msgAckOutput struct {
+	MessageID mailbox.MessageID     `json:"id"`
+	Delivery  mailbox.DeliveryState `json:"delivery"`
+}
+
+func cmdMsg(ctx *CommandContext) {
+	if len(ctx.Args) == 0 {
+		ctx.replyErr(msgUsage)
+		return
+	}
+
+	switch ctx.Args[0] {
+	case "send":
+		opts, err := parseMsgSendOptions(ctx.Args[1:])
+		if err != nil {
+			ctx.replyErr(err.Error())
+			return
+		}
+		ctx.replyCommandMutation(ctx.Sess.enqueueCommandMutationContext(ctx.context(), func(mctx *MutationContext) commandMutationResult {
+			output, err := runMsgSend(mctx, ctx.ActorPaneID, opts)
+			return commandMutationResult{output: output, err: err}
+		}))
+	case "inbox":
+		opts, err := parseMsgInboxOptions(ctx.Args[1:])
+		if err != nil {
+			ctx.replyErr(err.Error())
+			return
+		}
+		ctx.replyCommandMutation(ctx.Sess.enqueueCommandMutationContext(ctx.context(), func(mctx *MutationContext) commandMutationResult {
+			output, err := runMsgInbox(mctx, ctx.ActorPaneID, opts)
+			return commandMutationResult{output: output, err: err}
+		}))
+	case "read":
+		opts, err := parseMsgReadOptions(ctx.Args[1:])
+		if err != nil {
+			ctx.replyErr(err.Error())
+			return
+		}
+		ctx.replyCommandMutation(ctx.Sess.enqueueCommandMutationContext(ctx.context(), func(mctx *MutationContext) commandMutationResult {
+			output, err := runMsgRead(mctx, ctx.ActorPaneID, opts)
+			return commandMutationResult{output: output, err: err}
+		}))
+	case "ack":
+		opts, err := parseMsgAckOptions(ctx.Args[1:])
+		if err != nil {
+			ctx.replyErr(err.Error())
+			return
+		}
+		ctx.replyCommandMutation(ctx.Sess.enqueueCommandMutationContext(ctx.context(), func(mctx *MutationContext) commandMutationResult {
+			output, err := runMsgAck(mctx, ctx.ActorPaneID, opts)
+			return commandMutationResult{output: output, err: err}
+		}))
+	default:
+		ctx.replyErr(msgUsage)
+	}
+}
+
+func parseMsgSendOptions(args []string) (msgSendOptions, error) {
+	opts := msgSendOptions{format: msgFormatText}
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--from":
+			value, next, err := requiredFlagValue(args, i, "--from")
+			if err != nil {
+				return opts, err
+			}
+			opts.from = value
+			i = next
+		case "--to":
+			value, next, err := requiredFlagValue(args, i, "--to")
+			if err != nil {
+				return opts, err
+			}
+			opts.to = appendCSVValues(opts.to, value)
+			i = next
+		case "--subject":
+			value, next, err := requiredFlagValue(args, i, "--subject")
+			if err != nil {
+				return opts, err
+			}
+			opts.subject = value
+			i = next
+		case "--body":
+			value, next, err := requiredFlagValue(args, i, "--body")
+			if err != nil {
+				return opts, err
+			}
+			opts.body = []byte(value)
+			i = next
+		case "--topic":
+			value, next, err := requiredFlagValue(args, i, "--topic")
+			if err != nil {
+				return opts, err
+			}
+			opts.topics = appendCSVValues(opts.topics, value)
+			i = next
+		case "--group":
+			value, next, err := requiredFlagValue(args, i, "--group")
+			if err != nil {
+				return opts, err
+			}
+			opts.groups = appendCSVValues(opts.groups, value)
+			i = next
+		case "--metadata":
+			value, next, err := requiredFlagValue(args, i, "--metadata")
+			if err != nil {
+				return opts, err
+			}
+			metadata, err := parseMsgMetadata(value)
+			if err != nil {
+				return opts, err
+			}
+			opts.metadata = metadata
+			i = next
+		case "--reply-to":
+			value, next, err := requiredFlagValue(args, i, "--reply-to")
+			if err != nil {
+				return opts, err
+			}
+			opts.replyTo = mailbox.MessageID(value)
+			i = next
+		case "--format":
+			format, next, err := parseMsgFormatFlag(args, i)
+			if err != nil {
+				return opts, err
+			}
+			opts.format = format
+			i = next
+		default:
+			return opts, fmt.Errorf("usage: msg send [--from pane] --to pane[,pane...] [--subject text] [--topic name] [--group name] [--metadata json] [--reply-to msg-id] --body text [--format json]")
+		}
+	}
+	return opts, nil
+}
+
+func parseMsgInboxOptions(args []string) (msgInboxOptions, error) {
+	opts := msgInboxOptions{format: msgFormatText}
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--unread":
+			opts.unreadOnly = true
+		case "--format":
+			format, next, err := parseMsgFormatFlag(args, i)
+			if err != nil {
+				return opts, err
+			}
+			opts.format = format
+			i = next
+		default:
+			if strings.HasPrefix(args[i], "-") {
+				return opts, fmt.Errorf("usage: msg inbox [pane] [--unread] [--format json]")
+			}
+			if opts.target != "" {
+				return opts, fmt.Errorf("usage: msg inbox [pane] [--unread] [--format json]")
+			}
+			opts.target = args[i]
+		}
+	}
+	return opts, nil
+}
+
+func parseMsgReadOptions(args []string) (msgReadOptions, error) {
+	opts := msgReadOptions{format: msgFormatText}
+	if len(args) == 0 {
+		return opts, fmt.Errorf("usage: msg read <msg-id> [--for pane] [--peek] [--format json]")
+	}
+	opts.id = mailbox.MessageID(args[0])
+	for i := 1; i < len(args); i++ {
+		switch args[i] {
+		case "--for":
+			value, next, err := requiredFlagValue(args, i, "--for")
+			if err != nil {
+				return opts, err
+			}
+			opts.target = value
+			i = next
+		case "--peek":
+			opts.peek = true
+		case "--format":
+			format, next, err := parseMsgFormatFlag(args, i)
+			if err != nil {
+				return opts, err
+			}
+			opts.format = format
+			i = next
+		default:
+			return opts, fmt.Errorf("usage: msg read <msg-id> [--for pane] [--peek] [--format json]")
+		}
+	}
+	return opts, nil
+}
+
+func parseMsgAckOptions(args []string) (msgAckOptions, error) {
+	opts := msgAckOptions{format: msgFormatText}
+	if len(args) == 0 {
+		return opts, fmt.Errorf("usage: msg ack <msg-id> [--for pane] [--status ok|error|seen] [--note text] [--format json]")
+	}
+	opts.id = mailbox.MessageID(args[0])
+	for i := 1; i < len(args); i++ {
+		switch args[i] {
+		case "--for":
+			value, next, err := requiredFlagValue(args, i, "--for")
+			if err != nil {
+				return opts, err
+			}
+			opts.target = value
+			i = next
+		case "--status":
+			value, next, err := requiredFlagValue(args, i, "--status")
+			if err != nil {
+				return opts, err
+			}
+			opts.status = value
+			i = next
+		case "--note":
+			value, next, err := requiredFlagValue(args, i, "--note")
+			if err != nil {
+				return opts, err
+			}
+			opts.note = value
+			i = next
+		case "--format":
+			format, next, err := parseMsgFormatFlag(args, i)
+			if err != nil {
+				return opts, err
+			}
+			opts.format = format
+			i = next
+		default:
+			return opts, fmt.Errorf("usage: msg ack <msg-id> [--for pane] [--status ok|error|seen] [--note text] [--format json]")
+		}
+	}
+	return opts, nil
+}
+
+func requiredFlagValue(args []string, i int, name string) (string, int, error) {
+	if i+1 >= len(args) {
+		return "", i, fmt.Errorf("missing value for %s", name)
+	}
+	return args[i+1], i + 1, nil
+}
+
+func parseMsgFormatFlag(args []string, i int) (msgFormat, int, error) {
+	value, next, err := requiredFlagValue(args, i, "--format")
+	if err != nil {
+		return "", i, err
+	}
+	switch value {
+	case "json":
+		return msgFormatJSON, next, nil
+	case "text":
+		return msgFormatText, next, nil
+	default:
+		return "", i, fmt.Errorf("unsupported msg format %q", value)
+	}
+}
+
+func appendCSVValues(out []string, raw string) []string {
+	for _, part := range strings.Split(raw, ",") {
+		part = strings.TrimSpace(part)
+		if part != "" {
+			out = append(out, part)
+		}
+	}
+	return out
+}
+
+func parseMsgMetadata(raw string) (map[string]json.RawMessage, error) {
+	var metadata map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(raw), &metadata); err != nil {
+		return nil, fmt.Errorf("invalid metadata JSON: %w", err)
+	}
+	if metadata == nil && strings.TrimSpace(raw) != "{}" {
+		return nil, fmt.Errorf("metadata must be a JSON object")
+	}
+	return metadata, nil
+}
+
+func runMsgSend(mctx *MutationContext, actorPaneID uint32, opts msgSendOptions) (string, error) {
+	sender, err := resolveMailboxSender(mctx, actorPaneID, opts.from)
+	if err != nil {
+		return "", err
+	}
+	recipients, err := resolveMailboxRecipients(mctx, actorPaneID, opts.to)
+	if err != nil {
+		return "", err
+	}
+	msg, err := mctx.sess.ensureMailbox().Send(mailbox.SendRequest{
+		Sender:     sender,
+		Recipients: recipients,
+		Topics:     opts.topics,
+		Groups:     opts.groups,
+		Subject:    opts.subject,
+		Body:       opts.body,
+		Metadata:   opts.metadata,
+		ReplyTo:    opts.replyTo,
+	})
+	if err != nil {
+		return "", err
+	}
+	if opts.format == msgFormatJSON {
+		return encodeMsgJSON(sendOutputForMessage(msg))
+	}
+	return fmt.Sprintf("Sent %s to %s\n", msg.ID, joinPaneNames(msg.Recipients)), nil
+}
+
+func runMsgInbox(mctx *MutationContext, actorPaneID uint32, opts msgInboxOptions) (string, error) {
+	recipient, err := resolveMailboxTarget(mctx, actorPaneID, opts.target, "inbox target")
+	if err != nil {
+		return "", err
+	}
+	summaries, err := mctx.sess.ensureMailbox().List(recipient.ID, mailbox.ListOptions{UnreadOnly: opts.unreadOnly})
+	if err != nil {
+		return "", err
+	}
+	if opts.format == msgFormatJSON {
+		return encodeMsgJSON(summariesOutput(summaries))
+	}
+	return formatMsgInboxText(summaries), nil
+}
+
+func runMsgRead(mctx *MutationContext, actorPaneID uint32, opts msgReadOptions) (string, error) {
+	recipient, err := resolveMailboxTarget(mctx, actorPaneID, opts.target, "read target")
+	if err != nil {
+		return "", err
+	}
+	msg, delivery, err := mctx.sess.ensureMailbox().Read(opts.id, recipient.ID, mailbox.ReadOptions{Peek: opts.peek})
+	if err != nil {
+		return "", err
+	}
+	body := msgBodyText(msg)
+	if opts.format == msgFormatJSON {
+		return encodeMsgJSON(readOutputForMessage(msg, delivery, body))
+	}
+	return ensureMsgTrailingNewline(body), nil
+}
+
+func runMsgAck(mctx *MutationContext, actorPaneID uint32, opts msgAckOptions) (string, error) {
+	recipient, err := resolveMailboxTarget(mctx, actorPaneID, opts.target, "ack target")
+	if err != nil {
+		return "", err
+	}
+	delivery, err := mctx.sess.ensureMailbox().Ack(opts.id, recipient.ID, mailbox.AckRequest{Status: opts.status, Note: opts.note})
+	if err != nil {
+		return "", err
+	}
+	if opts.format == msgFormatJSON {
+		return encodeMsgJSON(msgAckOutput{MessageID: opts.id, Delivery: delivery})
+	}
+	if opts.status != "" {
+		return fmt.Sprintf("Acked %s for %s status=%s\n", opts.id, recipient.Name, opts.status), nil
+	}
+	return fmt.Sprintf("Acked %s for %s\n", opts.id, recipient.Name), nil
+}
+
+func (s *Session) ensureMailbox() *mailbox.Store {
+	if s.mailbox == nil {
+		s.mailbox = mailbox.NewStore(mailbox.Options{Now: func() time.Time {
+			return s.clock().Now()
+		}})
+	}
+	return s.mailbox
+}
+
+func resolveMailboxSender(mctx *MutationContext, actorPaneID uint32, ref string) (mailbox.PaneAddress, error) {
+	if ref == "" {
+		return mailboxActorAddress(mctx, actorPaneID, "sender")
+	}
+	return resolveMailboxPaneRef(mctx, actorPaneID, ref, "sender")
+}
+
+func resolveMailboxTarget(mctx *MutationContext, actorPaneID uint32, ref, role string) (mailbox.PaneAddress, error) {
+	if ref == "" {
+		return mailboxActorAddress(mctx, actorPaneID, role)
+	}
+	return resolveMailboxPaneRef(mctx, actorPaneID, ref, role)
+}
+
+func resolveMailboxRecipients(mctx *MutationContext, actorPaneID uint32, refs []string) ([]mailbox.PaneAddress, error) {
+	if len(refs) == 0 {
+		return nil, fmt.Errorf("at least one recipient is required")
+	}
+	recipients := make([]mailbox.PaneAddress, 0, len(refs))
+	for _, ref := range refs {
+		recipient, err := resolveMailboxPaneRef(mctx, actorPaneID, ref, "recipient")
+		if err != nil {
+			return nil, err
+		}
+		recipients = append(recipients, recipient)
+	}
+	return recipients, nil
+}
+
+func mailboxActorAddress(mctx *MutationContext, actorPaneID uint32, role string) (mailbox.PaneAddress, error) {
+	if actorPaneID == 0 {
+		return mailbox.PaneAddress{}, fmt.Errorf("%s pane is required", role)
+	}
+	pane := mctx.findPaneByID(actorPaneID)
+	if pane == nil {
+		return mailbox.PaneAddress{}, fmt.Errorf("%s pane %d not found", role, actorPaneID)
+	}
+	if mctx.findWindowByPaneID(actorPaneID) == nil {
+		return mailbox.PaneAddress{}, fmt.Errorf("%s pane %d is not in any window", role, actorPaneID)
+	}
+	return mailboxAddressForPane(pane), nil
+}
+
+func resolveMailboxPaneRef(mctx *MutationContext, actorPaneID uint32, ref, role string) (mailbox.PaneAddress, error) {
+	pane, window, err := mctx.resolvePaneAcrossWindowsForActor(actorPaneID, ref)
+	if err != nil {
+		return mailbox.PaneAddress{}, err
+	}
+	if window == nil {
+		return mailbox.PaneAddress{}, fmt.Errorf("%s pane %q is not in any window", role, ref)
+	}
+	return mailboxAddressForPane(pane), nil
+}
+
+func mailboxAddressForPane(pane *mux.Pane) mailbox.PaneAddress {
+	if pane == nil {
+		return mailbox.PaneAddress{}
+	}
+	return mailbox.PaneAddress{ID: pane.ID, Name: pane.Meta.Name, Host: pane.Meta.Host}
+}
+
+func sendOutputForMessage(msg mailbox.Message) msgSendOutput {
+	return msgSendOutput{
+		ID:         msg.ID,
+		Sender:     msg.Sender,
+		Recipients: append([]mailbox.PaneAddress(nil), msg.Recipients...),
+		Subject:    msg.Subject,
+		Topics:     append([]string(nil), msg.Topics...),
+		Groups:     append([]string(nil), msg.Groups...),
+		ThreadID:   msg.ThreadID,
+		InReplyTo:  msg.InReplyTo,
+		CreatedAt:  msg.CreatedAt.Format(rfc3339NanoUTC),
+		BodySize:   messageOutputBodySize(msg),
+		PartCount:  len(msg.Parts),
+	}
+}
+
+func summariesOutput(summaries []mailbox.DeliverySummary) []msgSummaryOutput {
+	out := make([]msgSummaryOutput, 0, len(summaries))
+	for _, summary := range summaries {
+		out = append(out, summaryOutput(summary))
+	}
+	return out
+}
+
+func summaryOutput(summary mailbox.DeliverySummary) msgSummaryOutput {
+	out := msgSummaryOutput{
+		ID:          summary.MessageID,
+		Sender:      summary.Sender,
+		Recipient:   summary.Recipient,
+		Subject:     summary.Subject,
+		Topics:      append([]string(nil), summary.Topics...),
+		Groups:      append([]string(nil), summary.Groups...),
+		ThreadID:    summary.ThreadID,
+		InReplyTo:   summary.InReplyTo,
+		CreatedAt:   summary.CreatedAt.Format(rfc3339NanoUTC),
+		DeliveredAt: summary.DeliveredAt.Format(rfc3339NanoUTC),
+		AckStatus:   summary.AckStatus,
+		AckNote:     summary.AckNote,
+		BodySize:    summary.BodySize,
+		PartCount:   summary.PartCount,
+	}
+	if !summary.ReadAt.IsZero() {
+		out.ReadAt = summary.ReadAt.Format(rfc3339NanoUTC)
+	}
+	if !summary.AckedAt.IsZero() {
+		out.AckedAt = summary.AckedAt.Format(rfc3339NanoUTC)
+	}
+	return out
+}
+
+func readOutputForMessage(msg mailbox.Message, delivery mailbox.DeliveryState, body string) msgReadOutput {
+	out := msgReadOutput{
+		ID:         msg.ID,
+		Sender:     msg.Sender,
+		Recipients: append([]mailbox.PaneAddress(nil), msg.Recipients...),
+		Subject:    msg.Subject,
+		Topics:     append([]string(nil), msg.Topics...),
+		Groups:     append([]string(nil), msg.Groups...),
+		ThreadID:   msg.ThreadID,
+		InReplyTo:  msg.InReplyTo,
+		CreatedAt:  msg.CreatedAt.Format(rfc3339NanoUTC),
+		Body:       body,
+		BodySize:   messageOutputBodySize(msg),
+		PartCount:  len(msg.Parts),
+		Delivery:   delivery,
+		Metadata:   msg.Metadata,
+	}
+	if !delivery.ReadAt.IsZero() {
+		out.ReadAt = delivery.ReadAt.Format(rfc3339NanoUTC)
+	}
+	return out
+}
+
+const rfc3339NanoUTC = "2006-01-02T15:04:05.999999999Z07:00"
+
+func encodeMsgJSON(v any) (string, error) {
+	data, err := json.Marshal(v)
+	if err != nil {
+		return "", err
+	}
+	return string(data) + "\n", nil
+}
+
+func msgBodyText(msg mailbox.Message) string {
+	var b strings.Builder
+	for _, part := range msg.Parts {
+		b.Write(part.Bytes)
+	}
+	return b.String()
+}
+
+func messageOutputBodySize(msg mailbox.Message) int {
+	total := 0
+	for _, part := range msg.Parts {
+		total += part.Size
+	}
+	return total
+}
+
+func ensureMsgTrailingNewline(s string) string {
+	if strings.HasSuffix(s, "\n") {
+		return s
+	}
+	return s + "\n"
+}
+
+func joinPaneNames(addrs []mailbox.PaneAddress) string {
+	names := make([]string, 0, len(addrs))
+	for _, addr := range addrs {
+		names = append(names, addr.Name)
+	}
+	return strings.Join(names, ",")
+}
+
+func formatMsgInboxText(summaries []mailbox.DeliverySummary) string {
+	if len(summaries) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	for _, summary := range summaries {
+		fmt.Fprintf(&b, "%s from %s: %s (%d bytes)\n", summary.MessageID, summary.Sender.Name, summary.Subject, summary.BodySize)
+	}
+	return b.String()
+}

--- a/internal/server/commands_msg.go
+++ b/internal/server/commands_msg.go
@@ -460,11 +460,15 @@ func runMsgAck(mctx *MutationContext, actorPaneID uint32, opts msgAckOptions) (s
 
 func (s *Session) ensureMailbox() *mailbox.Store {
 	if s.mailbox == nil {
-		s.mailbox = mailbox.NewStore(mailbox.Options{Now: func() time.Time {
-			return s.clock().Now()
-		}})
+		s.mailbox = s.newMailboxStore()
 	}
 	return s.mailbox
+}
+
+func (s *Session) newMailboxStore() *mailbox.Store {
+	return mailbox.NewStore(mailbox.Options{Now: func() time.Time {
+		return s.clock().Now()
+	}})
 }
 
 func resolveMailboxSender(mctx *MutationContext, actorPaneID uint32, ref string) (mailbox.PaneAddress, error) {
@@ -538,7 +542,7 @@ func sendOutputForMessage(msg mailbox.Message) msgSendOutput {
 		Groups:     append([]string(nil), msg.Groups...),
 		ThreadID:   msg.ThreadID,
 		InReplyTo:  msg.InReplyTo,
-		CreatedAt:  msg.CreatedAt.Format(rfc3339NanoUTC),
+		CreatedAt:  msg.CreatedAt.Format(time.RFC3339Nano),
 		BodySize:   messageOutputBodySize(msg),
 		PartCount:  len(msg.Parts),
 	}
@@ -562,18 +566,18 @@ func summaryOutput(summary mailbox.DeliverySummary) msgSummaryOutput {
 		Groups:      append([]string(nil), summary.Groups...),
 		ThreadID:    summary.ThreadID,
 		InReplyTo:   summary.InReplyTo,
-		CreatedAt:   summary.CreatedAt.Format(rfc3339NanoUTC),
-		DeliveredAt: summary.DeliveredAt.Format(rfc3339NanoUTC),
+		CreatedAt:   summary.CreatedAt.Format(time.RFC3339Nano),
+		DeliveredAt: summary.DeliveredAt.Format(time.RFC3339Nano),
 		AckStatus:   summary.AckStatus,
 		AckNote:     summary.AckNote,
 		BodySize:    summary.BodySize,
 		PartCount:   summary.PartCount,
 	}
 	if !summary.ReadAt.IsZero() {
-		out.ReadAt = summary.ReadAt.Format(rfc3339NanoUTC)
+		out.ReadAt = summary.ReadAt.Format(time.RFC3339Nano)
 	}
 	if !summary.AckedAt.IsZero() {
-		out.AckedAt = summary.AckedAt.Format(rfc3339NanoUTC)
+		out.AckedAt = summary.AckedAt.Format(time.RFC3339Nano)
 	}
 	return out
 }
@@ -588,7 +592,7 @@ func readOutputForMessage(msg mailbox.Message, delivery mailbox.DeliveryState, b
 		Groups:     append([]string(nil), msg.Groups...),
 		ThreadID:   msg.ThreadID,
 		InReplyTo:  msg.InReplyTo,
-		CreatedAt:  msg.CreatedAt.Format(rfc3339NanoUTC),
+		CreatedAt:  msg.CreatedAt.Format(time.RFC3339Nano),
 		Body:       body,
 		BodySize:   messageOutputBodySize(msg),
 		PartCount:  len(msg.Parts),
@@ -596,12 +600,10 @@ func readOutputForMessage(msg mailbox.Message, delivery mailbox.DeliveryState, b
 		Metadata:   msg.Metadata,
 	}
 	if !delivery.ReadAt.IsZero() {
-		out.ReadAt = delivery.ReadAt.Format(rfc3339NanoUTC)
+		out.ReadAt = delivery.ReadAt.Format(time.RFC3339Nano)
 	}
 	return out
 }
-
-const rfc3339NanoUTC = "2006-01-02T15:04:05.999999999Z07:00"
 
 func encodeMsgJSON(v any) (string, error) {
 	data, err := json.Marshal(v)

--- a/internal/server/commands_msg_test.go
+++ b/internal/server/commands_msg_test.go
@@ -1,0 +1,201 @@
+package server
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/weill-labs/amux/internal/mux"
+)
+
+type msgCommandSendJSON struct {
+	ID         string `json:"id"`
+	Subject    string `json:"subject"`
+	Recipients []struct {
+		ID   uint32 `json:"id"`
+		Name string `json:"name"`
+	} `json:"recipients"`
+}
+
+type msgCommandInboxJSON []struct {
+	ID        string `json:"id"`
+	Subject   string `json:"subject"`
+	BodySize  int    `json:"body_size"`
+	PartCount int    `json:"part_count"`
+}
+
+func setupMsgCommandSession(t *testing.T) (*Server, *Session, func()) {
+	t.Helper()
+
+	srv, sess, cleanup := newCommandTestSession(t)
+	p1 := newTestPane(sess, 1, "pane-1")
+	p2 := newTestPane(sess, 2, "pane-2")
+	p3 := newTestPane(sess, 3, "shared")
+	p4 := newTestPane(sess, 4, "shared")
+	w := newTestWindowWithPanes(t, sess, 1, "main", p1, p2, p3, p4)
+	setSessionLayoutForTest(t, sess, w.ID, []*mux.Window{w}, p1, p2, p3, p4)
+	return srv, sess, cleanup
+}
+
+func parseMsgCommandSendJSON(t *testing.T, raw string) msgCommandSendJSON {
+	t.Helper()
+
+	var out msgCommandSendJSON
+	if err := json.Unmarshal([]byte(raw), &out); err != nil {
+		t.Fatalf("json.Unmarshal(send output): %v\nraw:\n%s", err, raw)
+	}
+	if out.ID == "" {
+		t.Fatalf("send JSON id is empty:\n%s", raw)
+	}
+	return out
+}
+
+func parseMsgCommandInboxJSON(t *testing.T, raw string) msgCommandInboxJSON {
+	t.Helper()
+
+	var out msgCommandInboxJSON
+	if err := json.Unmarshal([]byte(raw), &out); err != nil {
+		t.Fatalf("json.Unmarshal(inbox output): %v\nraw:\n%s", err, raw)
+	}
+	return out
+}
+
+func TestMsgCommandSendInboxReadAck(t *testing.T) {
+	t.Parallel()
+
+	srv, sess, cleanup := setupMsgCommandSession(t)
+	defer cleanup()
+
+	first := runTestCommand(t, srv, sess, "msg", "send", "--from", "pane-1", "--to", "pane-2", "--subject", "Review", "--body", "please review", "--format", "json")
+	if first.cmdErr != "" {
+		t.Fatalf("msg send by name error: %s", first.cmdErr)
+	}
+	firstMsg := parseMsgCommandSendJSON(t, first.output)
+	if firstMsg.Subject != "Review" || len(firstMsg.Recipients) != 1 || firstMsg.Recipients[0].Name != "pane-2" {
+		t.Fatalf("send by name JSON = %#v, want frozen pane-2 recipient", firstMsg)
+	}
+
+	second := runTestCommand(t, srv, sess, "msg", "send", "--from", "pane-1", "--to", "2", "--subject", "By ID", "--body", "body from id", "--format", "json")
+	if second.cmdErr != "" {
+		t.Fatalf("msg send by ID error: %s", second.cmdErr)
+	}
+	secondMsg := parseMsgCommandSendJSON(t, second.output)
+	if len(secondMsg.Recipients) != 1 || secondMsg.Recipients[0].ID != 2 {
+		t.Fatalf("send by ID JSON = %#v, want recipient ID 2", secondMsg)
+	}
+
+	inbox := runTestCommand(t, srv, sess, "msg", "inbox", "pane-2", "--unread", "--format", "json")
+	if inbox.cmdErr != "" {
+		t.Fatalf("msg inbox error: %s", inbox.cmdErr)
+	}
+	unread := parseMsgCommandInboxJSON(t, inbox.output)
+	if len(unread) != 2 {
+		t.Fatalf("unread inbox length = %d, want 2\n%s", len(unread), inbox.output)
+	}
+	if unread[0].ID != firstMsg.ID || unread[0].BodySize != len("please review") || unread[0].PartCount != 1 {
+		t.Fatalf("first unread summary = %#v, want first message summary", unread[0])
+	}
+
+	read := runTestCommand(t, srv, sess, "msg", "read", firstMsg.ID, "--for", "pane-2")
+	if read.cmdErr != "" {
+		t.Fatalf("msg read error: %s", read.cmdErr)
+	}
+	if !strings.Contains(read.output, "please review") {
+		t.Fatalf("msg read output = %q, want full body", read.output)
+	}
+
+	ack := runTestCommand(t, srv, sess, "msg", "ack", secondMsg.ID, "--for", "pane-2", "--status", "ok")
+	if ack.cmdErr != "" {
+		t.Fatalf("msg ack error: %s", ack.cmdErr)
+	}
+	afterAck := runTestCommand(t, srv, sess, "msg", "inbox", "pane-2", "--unread", "--format", "json")
+	if afterAck.cmdErr != "" {
+		t.Fatalf("msg inbox after ack error: %s", afterAck.cmdErr)
+	}
+	if got := parseMsgCommandInboxJSON(t, afterAck.output); len(got) != 0 {
+		t.Fatalf("unread inbox after read+ack = %#v, want empty", got)
+	}
+}
+
+func TestMsgCommandDefaultsToActorPane(t *testing.T) {
+	t.Parallel()
+
+	srv, sess, cleanup := setupMsgCommandSession(t)
+	defer cleanup()
+
+	sent := runTestCommandWithActor(t, srv, sess, 1, "msg", "send", "--to", "pane-2", "--subject", "Actor", "--body", "actor body", "--format", "json")
+	if sent.cmdErr != "" {
+		t.Fatalf("msg send from actor error: %s", sent.cmdErr)
+	}
+	msg := parseMsgCommandSendJSON(t, sent.output)
+
+	inbox := runTestCommandWithActor(t, srv, sess, 2, "msg", "inbox", "--unread", "--format", "json")
+	if inbox.cmdErr != "" {
+		t.Fatalf("msg inbox actor default error: %s", inbox.cmdErr)
+	}
+	if got := parseMsgCommandInboxJSON(t, inbox.output); len(got) != 1 || got[0].ID != msg.ID {
+		t.Fatalf("actor-default inbox = %#v, want message %s", got, msg.ID)
+	}
+
+	read := runTestCommandWithActor(t, srv, sess, 2, "msg", "read", msg.ID)
+	if read.cmdErr != "" {
+		t.Fatalf("msg read actor default error: %s", read.cmdErr)
+	}
+	if !strings.Contains(read.output, "actor body") {
+		t.Fatalf("actor-default read output = %q, want body", read.output)
+	}
+}
+
+func TestMsgCommandErrorsFailLoudly(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{
+			name: "missing recipient",
+			args: []string{"send", "--from", "pane-1", "--subject", "Nope", "--body", "body"},
+			want: "recipient",
+		},
+		{
+			name: "unknown recipient",
+			args: []string{"send", "--from", "pane-1", "--to", "missing", "--subject", "Nope", "--body", "body"},
+			want: "not found",
+		},
+		{
+			name: "ambiguous recipient",
+			args: []string{"send", "--from", "pane-1", "--to", "shared", "--subject", "Nope", "--body", "body"},
+			want: "ambiguous",
+		},
+		{
+			name: "empty body",
+			args: []string{"send", "--from", "pane-1", "--to", "pane-2", "--subject", "Nope", "--body", ""},
+			want: "body",
+		},
+		{
+			name: "invalid message ID",
+			args: []string{"read", "msg-999999", "--for", "pane-2"},
+			want: "not found",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv, sess, cleanup := setupMsgCommandSession(t)
+			defer cleanup()
+
+			res := runTestCommand(t, srv, sess, "msg", tt.args...)
+			if res.cmdErr == "" {
+				t.Fatalf("msg %s succeeded, want error containing %q", strings.Join(tt.args, " "), tt.want)
+			}
+			if !strings.Contains(res.cmdErr, tt.want) {
+				t.Fatalf("msg %s error = %q, want substring %q", strings.Join(tt.args, " "), res.cmdErr, tt.want)
+			}
+		})
+	}
+}

--- a/internal/server/commands_msg_test.go
+++ b/internal/server/commands_msg_test.go
@@ -9,8 +9,12 @@ import (
 )
 
 type msgCommandSendJSON struct {
-	ID         string `json:"id"`
-	Subject    string `json:"subject"`
+	ID         string   `json:"id"`
+	Subject    string   `json:"subject"`
+	Topics     []string `json:"topics"`
+	Groups     []string `json:"groups"`
+	ThreadID   string   `json:"thread_id"`
+	InReplyTo  string   `json:"in_reply_to"`
 	Recipients []struct {
 		ID   uint32 `json:"id"`
 		Name string `json:"name"`
@@ -20,8 +24,29 @@ type msgCommandSendJSON struct {
 type msgCommandInboxJSON []struct {
 	ID        string `json:"id"`
 	Subject   string `json:"subject"`
+	ReadAt    string `json:"read_at"`
+	AckedAt   string `json:"acked_at"`
 	BodySize  int    `json:"body_size"`
 	PartCount int    `json:"part_count"`
+}
+
+type msgCommandReadJSON struct {
+	ID       string                     `json:"id"`
+	Body     string                     `json:"body"`
+	ReadAt   string                     `json:"read_at"`
+	Metadata map[string]json.RawMessage `json:"metadata"`
+	Delivery struct {
+		AckStatus string `json:"ack_status"`
+		AckNote   string `json:"ack_note"`
+	} `json:"delivery"`
+}
+
+type msgCommandAckJSON struct {
+	ID       string `json:"id"`
+	Delivery struct {
+		AckStatus string `json:"ack_status"`
+		AckNote   string `json:"ack_note"`
+	} `json:"delivery"`
 }
 
 func setupMsgCommandSession(t *testing.T) (*Server, *Session, func()) {
@@ -56,6 +81,26 @@ func parseMsgCommandInboxJSON(t *testing.T, raw string) msgCommandInboxJSON {
 	var out msgCommandInboxJSON
 	if err := json.Unmarshal([]byte(raw), &out); err != nil {
 		t.Fatalf("json.Unmarshal(inbox output): %v\nraw:\n%s", err, raw)
+	}
+	return out
+}
+
+func parseMsgCommandReadJSON(t *testing.T, raw string) msgCommandReadJSON {
+	t.Helper()
+
+	var out msgCommandReadJSON
+	if err := json.Unmarshal([]byte(raw), &out); err != nil {
+		t.Fatalf("json.Unmarshal(read output): %v\nraw:\n%s", err, raw)
+	}
+	return out
+}
+
+func parseMsgCommandAckJSON(t *testing.T, raw string) msgCommandAckJSON {
+	t.Helper()
+
+	var out msgCommandAckJSON
+	if err := json.Unmarshal([]byte(raw), &out); err != nil {
+		t.Fatalf("json.Unmarshal(ack output): %v\nraw:\n%s", err, raw)
 	}
 	return out
 }
@@ -146,6 +191,98 @@ func TestMsgCommandDefaultsToActorPane(t *testing.T) {
 	}
 }
 
+func TestMsgCommandTextAndDetailedJSON(t *testing.T) {
+	t.Parallel()
+
+	srv, sess, cleanup := setupMsgCommandSession(t)
+	defer cleanup()
+
+	first := runTestCommand(t, srv, sess, "msg", "send",
+		"--from", "pane-1",
+		"--to", "pane-2,3",
+		"--subject", "Thread root",
+		"--topic", "build,review",
+		"--group", "agents",
+		"--metadata", `{"priority":"high"}`,
+		"--body", "root body",
+	)
+	if first.cmdErr != "" {
+		t.Fatalf("msg send text error: %s", first.cmdErr)
+	}
+	if !strings.Contains(first.output, "Sent msg-000001 to pane-2,shared") {
+		t.Fatalf("msg send text output = %q, want recipients", first.output)
+	}
+
+	inboxText := runTestCommand(t, srv, sess, "msg", "inbox", "pane-2")
+	if inboxText.cmdErr != "" {
+		t.Fatalf("msg inbox text error: %s", inboxText.cmdErr)
+	}
+	if !strings.Contains(inboxText.output, "msg-000001 from pane-1: Thread root (9 bytes)") {
+		t.Fatalf("msg inbox text output = %q, want summary", inboxText.output)
+	}
+
+	peek := runTestCommand(t, srv, sess, "msg", "read", "msg-000001", "--for", "pane-2", "--peek", "--format", "json")
+	if peek.cmdErr != "" {
+		t.Fatalf("msg read peek JSON error: %s", peek.cmdErr)
+	}
+	peekJSON := parseMsgCommandReadJSON(t, peek.output)
+	if peekJSON.Body != "root body" || peekJSON.ReadAt != "" {
+		t.Fatalf("peek JSON = %#v, want body without read_at", peekJSON)
+	}
+	if got := string(peekJSON.Metadata["priority"]); got != `"high"` {
+		t.Fatalf("metadata priority = %s, want high", got)
+	}
+
+	read := runTestCommand(t, srv, sess, "msg", "read", "msg-000001", "--for", "pane-2")
+	if read.cmdErr != "" {
+		t.Fatalf("msg read text error: %s", read.cmdErr)
+	}
+	if read.output != "root body\n" {
+		t.Fatalf("msg read text output = %q, want body with trailing newline", read.output)
+	}
+
+	ackText := runTestCommand(t, srv, sess, "msg", "ack", "msg-000001", "--for", "pane-2")
+	if ackText.cmdErr != "" {
+		t.Fatalf("msg ack text error: %s", ackText.cmdErr)
+	}
+	if ackText.output != "Acked msg-000001 for pane-2\n" {
+		t.Fatalf("msg ack text output = %q, want no-status ack", ackText.output)
+	}
+
+	allInbox := runTestCommand(t, srv, sess, "msg", "inbox", "pane-2", "--format", "json")
+	if allInbox.cmdErr != "" {
+		t.Fatalf("msg inbox all JSON error: %s", allInbox.cmdErr)
+	}
+	all := parseMsgCommandInboxJSON(t, allInbox.output)
+	if len(all) != 1 || all[0].ReadAt == "" || all[0].AckedAt == "" {
+		t.Fatalf("all inbox JSON = %#v, want read and ack timestamps", all)
+	}
+
+	reply := runTestCommand(t, srv, sess, "msg", "send",
+		"--from", "pane-2",
+		"--to", "pane-1",
+		"--reply-to", "msg-000001",
+		"--body", "reply body",
+		"--format", "json",
+	)
+	if reply.cmdErr != "" {
+		t.Fatalf("msg reply send error: %s", reply.cmdErr)
+	}
+	replyJSON := parseMsgCommandSendJSON(t, reply.output)
+	if replyJSON.InReplyTo != "msg-000001" || replyJSON.ThreadID != "msg-000001" {
+		t.Fatalf("reply JSON = %#v, want reply in root thread", replyJSON)
+	}
+
+	ackJSONRaw := runTestCommand(t, srv, sess, "msg", "ack", replyJSON.ID, "--for", "pane-1", "--status", "seen", "--note", "queued", "--format", "json")
+	if ackJSONRaw.cmdErr != "" {
+		t.Fatalf("msg ack JSON error: %s", ackJSONRaw.cmdErr)
+	}
+	ackJSON := parseMsgCommandAckJSON(t, ackJSONRaw.output)
+	if ackJSON.ID != replyJSON.ID || ackJSON.Delivery.AckStatus != "seen" || ackJSON.Delivery.AckNote != "queued" {
+		t.Fatalf("ack JSON = %#v, want seen note", ackJSON)
+	}
+}
+
 func TestMsgCommandErrorsFailLoudly(t *testing.T) {
 	t.Parallel()
 
@@ -178,6 +315,66 @@ func TestMsgCommandErrorsFailLoudly(t *testing.T) {
 			name: "invalid message ID",
 			args: []string{"read", "msg-999999", "--for", "pane-2"},
 			want: "not found",
+		},
+		{
+			name: "missing subcommand",
+			args: nil,
+			want: "usage: msg",
+		},
+		{
+			name: "unknown subcommand",
+			args: []string{"wait"},
+			want: "usage: msg",
+		},
+		{
+			name: "missing actor default",
+			args: []string{"inbox"},
+			want: "inbox target pane is required",
+		},
+		{
+			name: "unsupported format",
+			args: []string{"send", "--from", "pane-1", "--to", "pane-2", "--body", "body", "--format", "yaml"},
+			want: "unsupported msg format",
+		},
+		{
+			name: "invalid metadata",
+			args: []string{"send", "--from", "pane-1", "--to", "pane-2", "--body", "body", "--metadata", "null"},
+			want: "metadata must be a JSON object",
+		},
+		{
+			name: "unknown send flag",
+			args: []string{"send", "--unknown"},
+			want: "usage: msg send",
+		},
+		{
+			name: "unknown inbox flag",
+			args: []string{"inbox", "--bad"},
+			want: "usage: msg inbox",
+		},
+		{
+			name: "duplicate inbox target",
+			args: []string{"inbox", "pane-1", "pane-2"},
+			want: "usage: msg inbox",
+		},
+		{
+			name: "missing read id",
+			args: []string{"read"},
+			want: "usage: msg read",
+		},
+		{
+			name: "unknown read flag",
+			args: []string{"read", "msg-000001", "--bad"},
+			want: "usage: msg read",
+		},
+		{
+			name: "missing ack id",
+			args: []string{"ack"},
+			want: "usage: msg ack",
+		},
+		{
+			name: "unknown ack flag",
+			args: []string{"ack", "msg-000001", "--bad"},
+			want: "usage: msg ack",
 		},
 	}
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -110,10 +110,6 @@ type Session struct {
 	// panes are being reconstructed.
 	mirror *mirror.Manager
 
-	// Mailbox stores session-scoped pane messages. It is mutated only on the
-	// session event loop.
-	mailbox *mailbox.Store
-
 	// Crash checkpoint coordination owns debounce/periodic scheduling and disk writes.
 	checkpointCoordinator crashCheckpointCoordinator
 
@@ -524,7 +520,6 @@ func newSessionWithScrollbackConfigLogger(name string, scrollback ScrollbackConf
 	sess.input = newInputRouter()
 	sess.checkpointCoordinator = newSessionCheckpointCoordinator(sess)
 	sess.undo = newUndoManager(undoManagerConfig{})
-	sess.mailbox = sess.newMailboxStore()
 	sess.startEventLoop()
 	return sess
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -110,6 +110,10 @@ type Session struct {
 	// panes are being reconstructed.
 	mirror *mirror.Manager
 
+	// Mailbox stores session-scoped pane messages. It is mutated only on the
+	// session event loop.
+	mailbox *mailbox.Store
+
 	// Crash checkpoint coordination owns debounce/periodic scheduling and disk writes.
 	checkpointCoordinator crashCheckpointCoordinator
 
@@ -520,6 +524,9 @@ func newSessionWithScrollbackConfigLogger(name string, scrollback ScrollbackConf
 	sess.input = newInputRouter()
 	sess.checkpointCoordinator = newSessionCheckpointCoordinator(sess)
 	sess.undo = newUndoManager(undoManagerConfig{})
+	sess.mailbox = mailbox.NewStore(mailbox.Options{Now: func() time.Time {
+		return sess.clock().Now()
+	}})
 	sess.startEventLoop()
 	return sess
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -524,9 +524,7 @@ func newSessionWithScrollbackConfigLogger(name string, scrollback ScrollbackConf
 	sess.input = newInputRouter()
 	sess.checkpointCoordinator = newSessionCheckpointCoordinator(sess)
 	sess.undo = newUndoManager(undoManagerConfig{})
-	sess.mailbox = mailbox.NewStore(mailbox.Options{Now: func() time.Time {
-		return sess.clock().Now()
-	}})
+	sess.mailbox = sess.newMailboxStore()
 	sess.startEventLoop()
 	return sess
 }

--- a/test/msg_test.go
+++ b/test/msg_test.go
@@ -1,0 +1,73 @@
+package test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+type msgCLISendJSON struct {
+	ID string `json:"id"`
+}
+
+func runHarnessCLIWithInput(t *testing.T, h *ServerHarness, input string, args ...string) string {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), runCmdTimeout)
+	defer cancel()
+
+	cmd := h.commandWithContext(ctx, args...)
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	var exitErr *exec.ExitError
+	if err != nil && !errors.As(err, &exitErr) {
+		t.Fatalf("amux %s failed: %v\n%s", strings.Join(args, " "), err, out)
+	}
+	if exitErr != nil && exitErr.ExitCode() != 0 {
+		t.Fatalf("amux %s exit = %d, want 0\n%s", strings.Join(args, " "), exitErr.ExitCode(), out)
+	}
+	return string(out)
+}
+
+func parseMsgCLISendID(t *testing.T, raw string) string {
+	t.Helper()
+
+	var out msgCLISendJSON
+	if err := json.Unmarshal([]byte(raw), &out); err != nil {
+		t.Fatalf("json.Unmarshal(msg send output): %v\nraw:\n%s", err, raw)
+	}
+	if out.ID == "" {
+		t.Fatalf("msg send output missing id:\n%s", raw)
+	}
+	return out.ID
+}
+
+func TestMsgCLISendReadsStdinAndBodyFile(t *testing.T) {
+	t.Parallel()
+
+	h := newServerHarness(t)
+	h.runCmd("spawn", "--at", "pane-1")
+
+	stdinOut := runHarnessCLIWithInput(t, h, "stdin body\nsecond line\n", "msg", "send", "--from", "pane-1", "--to", "pane-2", "--subject", "stdin", "--format", "json")
+	stdinID := parseMsgCLISendID(t, stdinOut)
+	stdinRead := h.runCmd("msg", "read", stdinID, "--for", "pane-2")
+	if !strings.Contains(stdinRead, "stdin body\nsecond line") {
+		t.Fatalf("stdin message read output = %q, want stdin body", stdinRead)
+	}
+
+	bodyPath := filepath.Join(t.TempDir(), "message.txt")
+	if err := os.WriteFile(bodyPath, []byte("file body\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile(body): %v", err)
+	}
+	fileOut := h.runCmd("msg", "send", "--from", "pane-1", "--to", "pane-2", "--subject", "file", "--body-file", bodyPath, "--format", "json")
+	fileID := parseMsgCLISendID(t, fileOut)
+	fileRead := h.runCmd("msg", "read", fileID, "--for", "pane-2")
+	if !strings.Contains(fileRead, "file body") {
+		t.Fatalf("body-file message read output = %q, want file body", fileRead)
+	}
+}


### PR DESCRIPTION
**Motivation**

LAB-1991 added the server-owned mailbox store, but there was no CLI path for panes or agents to send, inspect, read, or acknowledge messages. This adds the narrow user-facing command surface needed to exercise that store without adding events, chrome, persistence, or orca-specific behavior.

**Summary**

- Add `amux msg send/inbox/read/ack` dispatch through the existing command protocol.
- Resolve senders and recipients through pane name/ID references, with actor-pane defaults for inbox/read/ack.
- Support JSON output plus text bodies from `--body`, `--body-file`, or piped stdin.
- Treat acked deliveries as no longer unread, including mailbox capture summaries.

**Testing**

- `go test ./internal/mailbox -run TestStoreAckBeforeReadAndIdempotentRepeat -count=100`
- `go test ./internal/server -run 'TestMsgCommand|TestCaptureJSONMailboxMultiplePanesAndReadAckState|TestMailboxEvents' -count=100`\n- `go test ./internal/cli -run 'TestPrepareMsgCLIArgs|TestShouldReadMsgStdin|TestMsgCLICommandHandler|TestMainAllCommandsSupportLongHelp|TestRunMainDispatchesCommands' -count=100`\n- `go test ./test -run TestMsgCLISendReadsStdinAndBodyFile -count=100`\n- `go test ./internal/server ./internal/cli -count=1`\n- `go test ./internal/mux -run ^TestCloseHandlesUnstartedProcessPane -count=100`
- `go test ./internal/server -run ^TestCheckpointCoordinatorTriggerDebouncesWrites -count=100`
- `scripts/check-diff-coverage.sh --no-fetch` (patch coverage 88.77%; local coverage run also reported unrelated clipboard integration failures)
- `go test ./... -timeout 120s` fails locally in `test`: `TestCopyModeClipboardUsesOSC52WhenInnerClientRunsOverSSH` and `TestCopyModeClipboardUsesTmuxPassthroughWhenInnerClientRunsOverSSHInTmux`; targeted reruns reproduced the same clipboard failures.
- Required GitHub `test` check passed on PR #845 after rerunning unrelated CI flakes.

**Review focus**

- Command output shapes for JSON send/inbox/read/ack.
- Actor-pane defaults versus explicit `--from`, `--to`, and `--for` resolution.
- Client-side body-source expansion before sending the command RPC.
- Error behavior for missing recipients, ambiguous panes, empty bodies, and invalid message IDs.

Closes LAB-1986