### PR TITLE
Improve mailbox CLI events and replies

### DIFF
--- a/.agents/skills/amux/SKILL.md
+++ b/.agents/skills/amux/SKILL.md
@@ -121,6 +121,41 @@ amux events --pane pane-1
 amux events --filter idle,busy,exited
 ```
 
+### Mailbox Messaging
+
+Use mailbox messages when panes need to coordinate without writing into another
+pane's PTY. Delivery is out-of-band: the recipient must check or wait on its
+mailbox; amux does not paste the body into the prompt.
+
+```bash
+# Send a message. Omit --from only when AMUX_PANE identifies the actor pane.
+amux msg send --from pane-1 --to pane-2 --subject "Logs ready" --body "See /tmp/run.log"
+printf 'multi-line body\n' | amux msg send --from pane-1 --to pane-2 --topic review
+
+# Check summaries. Bodies are not included in inbox output.
+amux msg inbox pane-2 --unread --format json
+
+# Read the body as the recipient. Omit --for only when AMUX_PANE identifies that pane.
+amux msg read msg-000001 --for pane-2 --format json
+
+# Reply to the original sender, inheriting the thread and topics.
+amux msg reply msg-000001 --from pane-2 --body "Ack, looking now." --format json
+
+# Reply and mark the original delivery handled for this recipient.
+amux msg reply msg-000001 --from pane-2 --body "Done" --ack ok --ack-note "handled"
+
+# Acknowledge without replying.
+amux msg ack msg-000001 --for pane-2 --status seen
+
+# Wait until a pane has an unread message matching a topic.
+amux wait msg pane-2 --topic review --timeout 5m --format json
+```
+
+For an agent handoff, send a mailbox message, then bootstrap or rely on a
+separate watcher to tell the target agent to run `amux msg inbox --unread`.
+Once the agent has read a message, prefer `amux msg reply <msg-id>` over
+manually rebuilding `--to`, `--reply-to`, and `--topic`.
+
 ### Pane Management
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -245,13 +245,15 @@ amux msg ack msg-000001 --for pane-2 --status seen
 amux msg ack msg-000001 --for pane-2 --status error --note "Need the full log."
 ```
 
-Reply by sending a new message with `--reply-to`; amux links it into the
-original thread but does not assign workflow meaning to the reply.
+Reply with `msg reply` when the current pane is responding to a message it
+received. It infers the original sender as the recipient, links the reply into
+the original thread, and inherits the original topics and groups unless you
+override them. Use `--ack` when the reply should also mark the original delivery
+handled for the replying pane.
 
 ```bash
-amux msg send --from pane-2 --to pane-1 \
-  --reply-to msg-000001 \
-  --body "Saw it; please include stderr too."
+amux msg reply msg-000001 --from pane-2 --body "Saw it; please include stderr too."
+amux msg reply msg-000001 --from pane-2 --body "Done" --ack ok --ack-note "handled"
 ```
 
 When a command is run from an attached pane context, amux can default omitted
@@ -379,6 +381,7 @@ Higher-level prompt delegation now lives at the script layer: compose `wait idle
 | `amux log clients` | Show recent client attach/detach history |
 | `amux log panes` | Show recent pane create/exit history with exit cwd, git branch, and reason |
 | `amux msg send [--from <pane>] --to <pane[,pane...]> [--subject text] [--topic name] [--group name] [--metadata json] [--reply-to msg-id] (--body text\|--body-file path\|stdin) [--format json]` | Send an out-of-band mailbox message to panes |
+| `amux msg reply <msg-id> [--from <pane>] [--to <pane[,pane...]>] [--subject text] [--topic name] [--group name] [--metadata json] [--ack ok\|error\|seen] [--ack-note text] (--body text\|--body-file path\|stdin) [--format json]` | Reply to a mailbox message, inferring the original sender when `--to` is omitted |
 | `amux msg inbox [pane] [--unread] [--format json]` | List mailbox summaries, optionally unread only |
 | `amux msg read <msg-id> [--for pane] [--peek] [--format json]` | Return a message body for a recipient and mark it read unless `--peek` is set |
 | `amux msg ack <msg-id> [--for pane] [--status ok\|error\|seen] [--note text] [--format json]` | Acknowledge a message for a recipient |

--- a/internal/cli/cli_commands_msg.go
+++ b/internal/cli/cli_commands_msg.go
@@ -10,7 +10,7 @@ func msgCLICommands() map[string]commandHandler {
 	return map[string]commandHandler{
 		"msg": func(inv invocation, args []string) int {
 			if wantsMsgHelp(args) {
-				fmt.Fprintln(inv.runtime.Stdout, msgUsage)
+				fmt.Fprintln(inv.runtime.Stdout, msgHelpUsage(args))
 				return 0
 			}
 			if len(args) == 0 {
@@ -32,8 +32,26 @@ func wantsMsgHelp(args []string) bool {
 		len(args) == 2 && isHelpFlag(args[1])
 }
 
+func msgHelpUsage(args []string) string {
+	if len(args) == 2 && isHelpFlag(args[1]) {
+		switch args[0] {
+		case "send":
+			return msgSendUsage
+		case "reply":
+			return msgReplyUsage
+		case "inbox":
+			return msgInboxUsage
+		case "read":
+			return msgReadUsage
+		case "ack":
+			return msgAckUsage
+		}
+	}
+	return msgUsage
+}
+
 func prepareMsgCLIArgs(stdin io.Reader, args []string) ([]string, error) {
-	if len(args) == 0 || args[0] != "send" {
+	if len(args) == 0 || (args[0] != "send" && args[0] != "reply") {
 		return args, nil
 	}
 

--- a/internal/cli/cli_commands_msg_test.go
+++ b/internal/cli/cli_commands_msg_test.go
@@ -182,6 +182,26 @@ func TestMsgCLICommandHandler(t *testing.T) {
 			wantStdout: "usage: amux msg reply <msg-id> [--from <pane>] [--to <pane[,pane...]>] [--subject text] [--topic name] [--group name] [--metadata json] [--ack ok|error|seen] [--ack-note text] (--body text|--body-file path|stdin) [--format json]\n",
 		},
 		{
+			name:       "inbox help",
+			args:       []string{"msg", "inbox", "--help"},
+			wantStdout: "usage: amux msg inbox [pane] [--unread] [--format json]\n",
+		},
+		{
+			name:       "read help",
+			args:       []string{"msg", "read", "--help"},
+			wantStdout: "usage: amux msg read <msg-id> [--for pane] [--peek] [--format json]\n",
+		},
+		{
+			name:       "ack help",
+			args:       []string{"msg", "ack", "--help"},
+			wantStdout: "usage: amux msg ack <msg-id> [--for pane] [--status ok|error|seen] [--note text] [--format json]\n",
+		},
+		{
+			name:       "unknown subcommand help falls back to msg help",
+			args:       []string{"msg", "unknown", "--help"},
+			wantStdout: msgUsage + "\n",
+		},
+		{
 			name:       "missing subcommand",
 			args:       []string{"msg"},
 			wantExit:   1,

--- a/internal/cli/cli_commands_msg_test.go
+++ b/internal/cli/cli_commands_msg_test.go
@@ -53,6 +53,22 @@ func TestPrepareMsgCLIArgs(t *testing.T) {
 			want:  []string{"send", "--to", "pane-1", "--body", "stdin body"},
 		},
 		{
+			name: "reply body flag is forwarded",
+			args: []string{"reply", "msg-000001", "--body", "hello"},
+			want: []string{"reply", "msg-000001", "--body", "hello"},
+		},
+		{
+			name: "reply body file becomes body flag",
+			args: []string{"reply", "msg-000001", "--body-file", bodyPath},
+			want: []string{"reply", "msg-000001", "--body", "file body\n"},
+		},
+		{
+			name:  "reply stdin becomes body flag",
+			stdin: strings.NewReader("stdin body"),
+			args:  []string{"reply", "msg-000001"},
+			want:  []string{"reply", "msg-000001", "--body", "stdin body"},
+		},
+		{
 			name:    "missing body value",
 			args:    []string{"send", "--body"},
 			wantErr: "missing value for --body",
@@ -158,7 +174,12 @@ func TestMsgCLICommandHandler(t *testing.T) {
 		{
 			name:       "subcommand help",
 			args:       []string{"msg", "send", "--help"},
-			wantStdout: msgUsage + "\n",
+			wantStdout: "usage: amux msg send [--from <pane>] --to <pane[,pane...]> [--subject text] [--topic name] [--group name] [--metadata json] [--reply-to msg-id] (--body text|--body-file path|stdin) [--format json]\n",
+		},
+		{
+			name:       "reply help",
+			args:       []string{"msg", "reply", "--help"},
+			wantStdout: "usage: amux msg reply <msg-id> [--from <pane>] [--to <pane[,pane...]>] [--subject text] [--topic name] [--group name] [--metadata json] [--ack ok|error|seen] [--ack-note text] (--body text|--body-file path|stdin) [--format json]\n",
 		},
 		{
 			name:       "missing subcommand",

--- a/internal/cli/cli_usage.go
+++ b/internal/cli/cli_usage.go
@@ -16,7 +16,12 @@ const (
 	leadUsage         = "usage: amux lead [pane] | amux lead --clear"
 	metaUsage         = "usage: amux meta <set|get|rm> ..."
 	mcpServerUsage    = "usage: amux mcp-server"
-	msgUsage          = "usage: amux msg <send|inbox|read|ack> ..."
+	msgUsage          = "usage: amux msg <send|reply|inbox|read|ack> ..."
+	msgSendUsage      = "usage: amux msg send [--from <pane>] --to <pane[,pane...]> [--subject text] [--topic name] [--group name] [--metadata json] [--reply-to msg-id] (--body text|--body-file path|stdin) [--format json]"
+	msgReplyUsage     = "usage: amux msg reply <msg-id> [--from <pane>] [--to <pane[,pane...]>] [--subject text] [--topic name] [--group name] [--metadata json] [--ack ok|error|seen] [--ack-note text] (--body text|--body-file path|stdin) [--format json]"
+	msgInboxUsage     = "usage: amux msg inbox [pane] [--unread] [--format json]"
+	msgReadUsage      = "usage: amux msg read <msg-id> [--for pane] [--peek] [--format json]"
+	msgAckUsage       = "usage: amux msg ack <msg-id> [--for pane] [--status ok|error|seen] [--note text] [--format json]"
 	moveUsage         = "usage: amux move <pane> up|down | amux move <pane> (--before <target>|--after <target>|--to-column <target>)"
 	remoteUsage       = "usage: amux remote <add|list|rm|panes|status|attach|detach|resize> ..."
 	spawnUsage        = "usage: amux spawn [--auto] [--at <pane>] [--window <name|id>] [--vertical|--horizontal] [--root] [--focus] [--attach <host>:<pane-name>] [--name NAME] [--task TASK] [--color COLOR]"
@@ -230,6 +235,7 @@ Usage:
                                        Manage generic pane metadata
   amux [-s session] mcp-server         Run the amux MCP server over stdio
   amux [-s session] msg send --from <pane> --to <pane[,pane...]> [--subject text] (--body text|--body-file path|stdin) [--format json]
+  amux [-s session] msg reply <msg-id> [--from <pane>] [--to <pane[,pane...]>] (--body text|--body-file path|stdin) [--ack ok|error|seen] [--format json]
   amux [-s session] msg inbox [pane] [--unread] [--format json]
   amux [-s session] msg read <msg-id> [--for pane] [--peek] [--format json]
   amux [-s session] msg ack <msg-id> [--for pane] [--status ok|error|seen] [--note text] [--format json]

--- a/internal/server/commands_msg.go
+++ b/internal/server/commands_msg.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -10,7 +11,14 @@ import (
 	"github.com/weill-labs/amux/internal/mux"
 )
 
-const msgUsage = "usage: msg <send|inbox|read|ack> ..."
+const (
+	msgUsage      = "usage: msg <send|reply|inbox|read|ack> ..."
+	msgSendUsage  = "usage: msg send [--from pane] --to pane[,pane...] [--subject text] [--topic name] [--group name] [--metadata json] [--reply-to msg-id] --body text [--format json]"
+	msgReplyUsage = "usage: msg reply <msg-id> [--from pane] [--to pane[,pane...]] [--subject text] [--topic name] [--group name] [--metadata json] [--ack status] [--ack-note text] --body text [--format json]"
+	msgInboxUsage = "usage: msg inbox [pane] [--unread] [--format json]"
+	msgReadUsage  = "usage: msg read <msg-id> [--for pane] [--peek] [--format json]"
+	msgAckUsage   = "usage: msg ack <msg-id> [--for pane] [--status ok|error|seen] [--note text] [--format json]"
+)
 
 type msgFormat string
 
@@ -35,6 +43,20 @@ type msgInboxOptions struct {
 	target     string
 	unreadOnly bool
 	format     msgFormat
+}
+
+type msgReplyOptions struct {
+	id        mailbox.MessageID
+	from      string
+	to        []string
+	subject   string
+	body      []byte
+	topics    []string
+	groups    []string
+	metadata  map[string]json.RawMessage
+	ackStatus string
+	ackNote   string
+	format    msgFormat
 }
 
 type msgReadOptions struct {
@@ -123,6 +145,16 @@ func cmdMsg(ctx *CommandContext) {
 		}
 		ctx.replyCommandMutation(ctx.Sess.enqueueCommandMutationContext(ctx.context(), func(mctx *MutationContext) commandMutationResult {
 			output, err := runMsgSend(mctx, ctx.ActorPaneID, opts)
+			return commandMutationResult{output: output, err: err}
+		}))
+	case "reply":
+		opts, err := parseMsgReplyOptions(ctx.Args[1:])
+		if err != nil {
+			ctx.replyErr(err.Error())
+			return
+		}
+		ctx.replyCommandMutation(ctx.Sess.enqueueCommandMutationContext(ctx.context(), func(mctx *MutationContext) commandMutationResult {
+			output, err := runMsgReply(mctx, ctx.ActorPaneID, opts)
 			return commandMutationResult{output: output, err: err}
 		}))
 	case "inbox":
@@ -232,7 +264,96 @@ func parseMsgSendOptions(args []string) (msgSendOptions, error) {
 			opts.format = format
 			i = next
 		default:
-			return opts, fmt.Errorf("usage: msg send [--from pane] --to pane[,pane...] [--subject text] [--topic name] [--group name] [--metadata json] [--reply-to msg-id] --body text [--format json]")
+			return opts, errors.New(msgSendUsage)
+		}
+	}
+	return opts, nil
+}
+
+func parseMsgReplyOptions(args []string) (msgReplyOptions, error) {
+	opts := msgReplyOptions{format: msgFormatText}
+	if len(args) == 0 {
+		return opts, errors.New(msgReplyUsage)
+	}
+	opts.id = mailbox.MessageID(args[0])
+	for i := 1; i < len(args); i++ {
+		switch args[i] {
+		case "--from":
+			value, next, err := requiredFlagValue(args, i, "--from")
+			if err != nil {
+				return opts, err
+			}
+			opts.from = value
+			i = next
+		case "--to":
+			value, next, err := requiredFlagValue(args, i, "--to")
+			if err != nil {
+				return opts, err
+			}
+			opts.to = appendCSVValues(opts.to, value)
+			i = next
+		case "--subject":
+			value, next, err := requiredFlagValue(args, i, "--subject")
+			if err != nil {
+				return opts, err
+			}
+			opts.subject = value
+			i = next
+		case "--body":
+			value, next, err := requiredFlagValue(args, i, "--body")
+			if err != nil {
+				return opts, err
+			}
+			opts.body = []byte(value)
+			i = next
+		case "--topic":
+			value, next, err := requiredFlagValue(args, i, "--topic")
+			if err != nil {
+				return opts, err
+			}
+			opts.topics = appendCSVValues(opts.topics, value)
+			i = next
+		case "--group":
+			value, next, err := requiredFlagValue(args, i, "--group")
+			if err != nil {
+				return opts, err
+			}
+			opts.groups = appendCSVValues(opts.groups, value)
+			i = next
+		case "--metadata":
+			value, next, err := requiredFlagValue(args, i, "--metadata")
+			if err != nil {
+				return opts, err
+			}
+			metadata, err := parseMsgMetadata(value)
+			if err != nil {
+				return opts, err
+			}
+			opts.metadata = metadata
+			i = next
+		case "--ack":
+			value, next, err := requiredFlagValue(args, i, "--ack")
+			if err != nil {
+				return opts, err
+			}
+			opts.ackStatus = value
+			i = next
+		case "--ack-note":
+			value, next, err := requiredFlagValue(args, i, "--ack-note")
+			if err != nil {
+				return opts, err
+			}
+			opts.ackNote = value
+			i = next
+		case "--format":
+			format, next, err := parseMsgFormatFlag(args, i)
+			if err != nil {
+				return opts, err
+			}
+			opts.format = format
+			i = next
+		default:
+			return opts, errors.New(msgReplyUsage)
 		}
 	}
 	return opts, nil
@@ -253,10 +374,10 @@ func parseMsgInboxOptions(args []string) (msgInboxOptions, error) {
 			i = next
 		default:
 			if strings.HasPrefix(args[i], "-") {
-				return opts, fmt.Errorf("usage: msg inbox [pane] [--unread] [--format json]")
+				return opts, errors.New(msgInboxUsage)
 			}
 			if opts.target != "" {
-				return opts, fmt.Errorf("usage: msg inbox [pane] [--unread] [--format json]")
+				return opts, errors.New(msgInboxUsage)
 			}
 			opts.target = args[i]
 		}
@@ -267,7 +388,7 @@ func parseMsgInboxOptions(args []string) (msgInboxOptions, error) {
 func parseMsgReadOptions(args []string) (msgReadOptions, error) {
 	opts := msgReadOptions{format: msgFormatText}
 	if len(args) == 0 {
-		return opts, fmt.Errorf("usage: msg read <msg-id> [--for pane] [--peek] [--format json]")
+		return opts, errors.New(msgReadUsage)
 	}
 	opts.id = mailbox.MessageID(args[0])
 	for i := 1; i < len(args); i++ {
@@ -289,7 +410,7 @@ func parseMsgReadOptions(args []string) (msgReadOptions, error) {
 			opts.format = format
 			i = next
 		default:
-			return opts, fmt.Errorf("usage: msg read <msg-id> [--for pane] [--peek] [--format json]")
+			return opts, errors.New(msgReadUsage)
 		}
 	}
 	return opts, nil
@@ -298,7 +419,7 @@ func parseMsgReadOptions(args []string) (msgReadOptions, error) {
 func parseMsgAckOptions(args []string) (msgAckOptions, error) {
 	opts := msgAckOptions{format: msgFormatText}
 	if len(args) == 0 {
-		return opts, fmt.Errorf("usage: msg ack <msg-id> [--for pane] [--status ok|error|seen] [--note text] [--format json]")
+		return opts, errors.New(msgAckUsage)
 	}
 	opts.id = mailbox.MessageID(args[0])
 	for i := 1; i < len(args); i++ {
@@ -332,7 +453,7 @@ func parseMsgAckOptions(args []string) (msgAckOptions, error) {
 			opts.format = format
 			i = next
 		default:
-			return opts, fmt.Errorf("usage: msg ack <msg-id> [--for pane] [--status ok|error|seen] [--note text] [--format json]")
+			return opts, errors.New(msgAckUsage)
 		}
 	}
 	return opts, nil
@@ -424,6 +545,56 @@ func runMsgInbox(mctx *MutationContext, actorPaneID uint32, opts msgInboxOptions
 	return formatMsgInboxText(summaries), nil
 }
 
+func runMsgReply(mctx *MutationContext, actorPaneID uint32, opts msgReplyOptions) (string, error) {
+	sender, err := resolveMailboxSender(mctx, actorPaneID, opts.from)
+	if err != nil {
+		return "", err
+	}
+	parent, ok := mctx.sess.ensureMailbox().Message(opts.id)
+	if !ok {
+		return "", fmt.Errorf("message %q not found", opts.id)
+	}
+	recipients, err := resolveMailboxReplyRecipients(mctx, actorPaneID, sender, parent, opts.to)
+	if err != nil {
+		return "", err
+	}
+	if opts.ackStatus != "" || opts.ackNote != "" {
+		if _, err := mctx.sess.ensureMailbox().DeliverySummary(parent.ID, sender.ID); err != nil {
+			return "", fmt.Errorf("cannot ack reply parent as %s: %w", sender.Name, err)
+		}
+	}
+	topics := opts.topics
+	if len(topics) == 0 {
+		topics = parent.Topics
+	}
+	groups := opts.groups
+	if len(groups) == 0 {
+		groups = parent.Groups
+	}
+	msg, err := mctx.sess.sendMailboxMessage(mailbox.SendRequest{
+		Sender:     sender,
+		Recipients: recipients,
+		Topics:     topics,
+		Groups:     groups,
+		Subject:    opts.subject,
+		Body:       opts.body,
+		Metadata:   opts.metadata,
+		ReplyTo:    parent.ID,
+	})
+	if err != nil {
+		return "", err
+	}
+	if opts.ackStatus != "" || opts.ackNote != "" {
+		if _, err := mctx.sess.ackMailboxMessage(parent.ID, sender.ID, mailbox.AckRequest{Status: opts.ackStatus, Note: opts.ackNote}); err != nil {
+			return "", err
+		}
+	}
+	if opts.format == msgFormatJSON {
+		return encodeMsgJSON(sendOutputForMessage(msg))
+	}
+	return fmt.Sprintf("Sent %s to %s\n", msg.ID, joinPaneNames(msg.Recipients)), nil
+}
+
 func runMsgRead(mctx *MutationContext, actorPaneID uint32, opts msgReadOptions) (string, error) {
 	recipient, err := resolveMailboxTarget(mctx, actorPaneID, opts.target, "read target")
 	if err != nil {
@@ -456,6 +627,37 @@ func runMsgAck(mctx *MutationContext, actorPaneID uint32, opts msgAckOptions) (s
 		return fmt.Sprintf("Acked %s for %s status=%s\n", opts.id, recipient.Name, opts.status), nil
 	}
 	return fmt.Sprintf("Acked %s for %s\n", opts.id, recipient.Name), nil
+}
+
+func resolveMailboxReplyRecipients(mctx *MutationContext, actorPaneID uint32, sender mailbox.PaneAddress, parent mailbox.Message, refs []string) ([]mailbox.PaneAddress, error) {
+	if len(refs) > 0 {
+		return resolveMailboxRecipients(mctx, actorPaneID, refs)
+	}
+	if sender.ID != parent.Sender.ID {
+		if !messageHasRecipient(parent, sender.ID) {
+			return nil, fmt.Errorf("reply recipient could not be inferred for %s; pass --to", sender.Name)
+		}
+		return []mailbox.PaneAddress{parent.Sender}, nil
+	}
+	recipients := make([]mailbox.PaneAddress, 0, len(parent.Recipients))
+	for _, recipient := range parent.Recipients {
+		if recipient.ID != sender.ID {
+			recipients = append(recipients, recipient)
+		}
+	}
+	if len(recipients) == 0 {
+		return nil, fmt.Errorf("reply recipient could not be inferred for %s; pass --to", sender.Name)
+	}
+	return recipients, nil
+}
+
+func messageHasRecipient(msg mailbox.Message, paneID uint32) bool {
+	for _, recipient := range msg.Recipients {
+		if recipient.ID == paneID {
+			return true
+		}
+	}
+	return false
 }
 
 func resolveMailboxSender(mctx *MutationContext, actorPaneID uint32, ref string) (mailbox.PaneAddress, error) {

--- a/internal/server/commands_msg.go
+++ b/internal/server/commands_msg.go
@@ -390,7 +390,7 @@ func runMsgSend(mctx *MutationContext, actorPaneID uint32, opts msgSendOptions) 
 	if err != nil {
 		return "", err
 	}
-	msg, err := mctx.sess.ensureMailbox().Send(mailbox.SendRequest{
+	msg, err := mctx.sess.sendMailboxMessage(mailbox.SendRequest{
 		Sender:     sender,
 		Recipients: recipients,
 		Topics:     opts.topics,
@@ -429,7 +429,7 @@ func runMsgRead(mctx *MutationContext, actorPaneID uint32, opts msgReadOptions) 
 	if err != nil {
 		return "", err
 	}
-	msg, delivery, err := mctx.sess.ensureMailbox().Read(opts.id, recipient.ID, mailbox.ReadOptions{Peek: opts.peek})
+	msg, delivery, err := mctx.sess.readMailboxMessage(opts.id, recipient.ID, mailbox.ReadOptions{Peek: opts.peek})
 	if err != nil {
 		return "", err
 	}
@@ -445,7 +445,7 @@ func runMsgAck(mctx *MutationContext, actorPaneID uint32, opts msgAckOptions) (s
 	if err != nil {
 		return "", err
 	}
-	delivery, err := mctx.sess.ensureMailbox().Ack(opts.id, recipient.ID, mailbox.AckRequest{Status: opts.status, Note: opts.note})
+	delivery, err := mctx.sess.ackMailboxMessage(opts.id, recipient.ID, mailbox.AckRequest{Status: opts.status, Note: opts.note})
 	if err != nil {
 		return "", err
 	}

--- a/internal/server/commands_msg_test.go
+++ b/internal/server/commands_msg_test.go
@@ -267,6 +267,117 @@ func TestMsgCommandReplyCanAckParent(t *testing.T) {
 	}
 }
 
+func TestParseMsgReplyOptions(t *testing.T) {
+	t.Parallel()
+
+	opts, err := parseMsgReplyOptions([]string{
+		"msg-000123",
+		"--from", "pane-2",
+		"--to", "pane-1,pane-3",
+		"--subject", "Subject",
+		"--topic", "review,build",
+		"--group", "agents",
+		"--metadata", `{"priority":"high"}`,
+		"--ack", "ok",
+		"--ack-note", "handled",
+		"--format", "json",
+	})
+	if err != nil {
+		t.Fatalf("parseMsgReplyOptions(): %v", err)
+	}
+	if opts.id != "msg-000123" || opts.from != "pane-2" || opts.subject != "Subject" {
+		t.Fatalf("parseMsgReplyOptions() = %#v, want id/from/subject populated", opts)
+	}
+	if got := strings.Join(opts.to, ","); got != "pane-1,pane-3" {
+		t.Fatalf("reply recipients = %q, want pane-1,pane-3", got)
+	}
+	if got := strings.Join(opts.topics, ","); got != "review,build" {
+		t.Fatalf("reply topics = %q, want review,build", got)
+	}
+	if got := strings.Join(opts.groups, ","); got != "agents" {
+		t.Fatalf("reply groups = %q, want agents", got)
+	}
+	if got := string(opts.metadata["priority"]); got != `"high"` {
+		t.Fatalf("reply metadata priority = %s, want high", got)
+	}
+	if opts.ackStatus != "ok" || opts.ackNote != "handled" || opts.format != msgFormatJSON {
+		t.Fatalf("reply ack/format = %#v, want ok handled JSON", opts)
+	}
+}
+
+func TestParseMsgReplyOptionsErrors(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{
+			name: "missing from",
+			args: []string{"msg-000001", "--from"},
+			want: "missing value for --from",
+		},
+		{
+			name: "missing to",
+			args: []string{"msg-000001", "--to"},
+			want: "missing value for --to",
+		},
+		{
+			name: "missing subject",
+			args: []string{"msg-000001", "--subject"},
+			want: "missing value for --subject",
+		},
+		{
+			name: "missing topic",
+			args: []string{"msg-000001", "--topic"},
+			want: "missing value for --topic",
+		},
+		{
+			name: "missing group",
+			args: []string{"msg-000001", "--group"},
+			want: "missing value for --group",
+		},
+		{
+			name: "missing metadata",
+			args: []string{"msg-000001", "--metadata"},
+			want: "missing value for --metadata",
+		},
+		{
+			name: "invalid metadata",
+			args: []string{"msg-000001", "--metadata", "[]"},
+			want: "invalid metadata JSON",
+		},
+		{
+			name: "missing ack",
+			args: []string{"msg-000001", "--ack"},
+			want: "missing value for --ack",
+		},
+		{
+			name: "missing ack note",
+			args: []string{"msg-000001", "--ack-note"},
+			want: "missing value for --ack-note",
+		},
+		{
+			name: "unsupported format",
+			args: []string{"msg-000001", "--format", "yaml"},
+			want: "unsupported msg format",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := parseMsgReplyOptions(tt.args)
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("parseMsgReplyOptions(%v) error = %v, want substring %q", tt.args, err, tt.want)
+			}
+		})
+	}
+}
+
 func TestMsgCommandReplyRecipientInferenceEdges(t *testing.T) {
 	t.Parallel()
 
@@ -329,6 +440,52 @@ func TestMsgCommandReplyRecipientInferenceEdges(t *testing.T) {
 	selfReply := runTestCommandWithActor(t, srv, sess, 1, "msg", "reply", selfJSON.ID, "--body", "cannot infer")
 	if selfReply.cmdErr == "" || !strings.Contains(selfReply.cmdErr, "pass --to") {
 		t.Fatalf("self reply error = %q, want pass --to", selfReply.cmdErr)
+	}
+
+	textReply := runTestCommand(t, srv, sess, "msg", "reply", rootJSON.ID, "--from", "pane-2", "--body", "text reply")
+	if textReply.cmdErr != "" {
+		t.Fatalf("msg reply text error: %s", textReply.cmdErr)
+	}
+	if !strings.Contains(textReply.output, "Sent msg-") || !strings.Contains(textReply.output, "to pane-1") {
+		t.Fatalf("msg reply text output = %q, want recipient pane-1", textReply.output)
+	}
+}
+
+func TestMsgCommandReplyErrors(t *testing.T) {
+	t.Parallel()
+
+	srv, sess, cleanup := setupMsgCommandSession(t)
+	defer cleanup()
+
+	root := runTestCommand(t, srv, sess, "msg", "send", "--from", "pane-1", "--to", "pane-2", "--body", "root", "--format", "json")
+	if root.cmdErr != "" {
+		t.Fatalf("msg send root error: %s", root.cmdErr)
+	}
+	rootJSON := parseMsgCommandSendJSON(t, root.output)
+
+	missingSender := runTestCommand(t, srv, sess, "msg", "reply", rootJSON.ID, "--from", "missing", "--body", "reply")
+	if missingSender.cmdErr == "" || !strings.Contains(missingSender.cmdErr, "not found") {
+		t.Fatalf("missing sender error = %q, want not found", missingSender.cmdErr)
+	}
+
+	missingParent := runTestCommand(t, srv, sess, "msg", "reply", "msg-999999", "--from", "pane-2", "--body", "reply")
+	if missingParent.cmdErr == "" || !strings.Contains(missingParent.cmdErr, "not found") {
+		t.Fatalf("missing parent error = %q, want not found", missingParent.cmdErr)
+	}
+
+	ackByObserver := runTestCommandWithActor(t, srv, sess, 3, "msg", "reply", rootJSON.ID, "--to", "pane-1", "--ack", "ok", "--body", "reply")
+	if ackByObserver.cmdErr == "" || !strings.Contains(ackByObserver.cmdErr, "cannot ack reply parent") {
+		t.Fatalf("observer ack error = %q, want cannot ack reply parent", ackByObserver.cmdErr)
+	}
+
+	emptyBody := runTestCommand(t, srv, sess, "msg", "reply", rootJSON.ID, "--from", "pane-2", "--body", "")
+	if emptyBody.cmdErr == "" || !strings.Contains(emptyBody.cmdErr, "body") {
+		t.Fatalf("empty reply body error = %q, want body", emptyBody.cmdErr)
+	}
+
+	oversizedAckNote := runTestCommand(t, srv, sess, "msg", "reply", rootJSON.ID, "--from", "pane-2", "--body", "reply", "--ack-note", strings.Repeat("x", 4097))
+	if oversizedAckNote.cmdErr == "" || !strings.Contains(oversizedAckNote.cmdErr, "ack note") {
+		t.Fatalf("oversized ack note error = %q, want ack note", oversizedAckNote.cmdErr)
 	}
 }
 

--- a/internal/server/commands_msg_test.go
+++ b/internal/server/commands_msg_test.go
@@ -26,6 +26,8 @@ type msgCommandInboxJSON []struct {
 	Subject   string `json:"subject"`
 	ReadAt    string `json:"read_at"`
 	AckedAt   string `json:"acked_at"`
+	AckStatus string `json:"ack_status"`
+	AckNote   string `json:"ack_note"`
 	BodySize  int    `json:"body_size"`
 	PartCount int    `json:"part_count"`
 }
@@ -188,6 +190,80 @@ func TestMsgCommandDefaultsToActorPane(t *testing.T) {
 	}
 	if !strings.Contains(read.output, "actor body") {
 		t.Fatalf("actor-default read output = %q, want body", read.output)
+	}
+}
+
+func TestMsgCommandReplyInfersRecipientAndThread(t *testing.T) {
+	t.Parallel()
+
+	srv, sess, cleanup := setupMsgCommandSession(t)
+	defer cleanup()
+
+	root := runTestCommand(t, srv, sess, "msg", "send",
+		"--from", "pane-1",
+		"--to", "pane-2",
+		"--subject", "Proof",
+		"--topic", "handoff",
+		"--group", "agents",
+		"--body", "root body",
+		"--format", "json",
+	)
+	if root.cmdErr != "" {
+		t.Fatalf("msg send root error: %s", root.cmdErr)
+	}
+	rootJSON := parseMsgCommandSendJSON(t, root.output)
+
+	reply := runTestCommandWithActor(t, srv, sess, 2, "msg", "reply", rootJSON.ID, "--body", "reply body", "--format", "json")
+	if reply.cmdErr != "" {
+		t.Fatalf("msg reply error: %s", reply.cmdErr)
+	}
+	replyJSON := parseMsgCommandSendJSON(t, reply.output)
+	if replyJSON.InReplyTo != rootJSON.ID || replyJSON.ThreadID != rootJSON.ID {
+		t.Fatalf("reply JSON = %#v, want reply in root thread", replyJSON)
+	}
+	if len(replyJSON.Recipients) != 1 || replyJSON.Recipients[0].Name != "pane-1" {
+		t.Fatalf("reply recipients = %#v, want original sender pane-1", replyJSON.Recipients)
+	}
+	if got := strings.Join(replyJSON.Topics, ","); got != "handoff" {
+		t.Fatalf("reply topics = %q, want inherited handoff", got)
+	}
+	if got := strings.Join(replyJSON.Groups, ","); got != "agents" {
+		t.Fatalf("reply groups = %q, want inherited agents", got)
+	}
+
+	read := runTestCommand(t, srv, sess, "msg", "read", replyJSON.ID, "--for", "pane-1")
+	if read.cmdErr != "" {
+		t.Fatalf("msg read reply error: %s", read.cmdErr)
+	}
+	if read.output != "reply body\n" {
+		t.Fatalf("reply body = %q, want reply body", read.output)
+	}
+}
+
+func TestMsgCommandReplyCanAckParent(t *testing.T) {
+	t.Parallel()
+
+	srv, sess, cleanup := setupMsgCommandSession(t)
+	defer cleanup()
+
+	root := runTestCommand(t, srv, sess, "msg", "send", "--from", "pane-1", "--to", "pane-2", "--body", "please ack", "--format", "json")
+	if root.cmdErr != "" {
+		t.Fatalf("msg send root error: %s", root.cmdErr)
+	}
+	rootJSON := parseMsgCommandSendJSON(t, root.output)
+
+	reply := runTestCommandWithActor(t, srv, sess, 2, "msg", "reply", rootJSON.ID, "--body", "acked", "--ack", "ok", "--ack-note", "handled", "--format", "json")
+	if reply.cmdErr != "" {
+		t.Fatalf("msg reply --ack error: %s", reply.cmdErr)
+	}
+
+	inbox := runTestCommand(t, srv, sess, "msg", "inbox", "pane-2", "--format", "json")
+	if inbox.cmdErr != "" {
+		t.Fatalf("msg inbox error: %s", inbox.cmdErr)
+	}
+	all := parseMsgCommandInboxJSON(t, inbox.output)
+	if len(all) != 1 || all[0].AckStatus != "ok" || all[0].AckNote != "handled" {
+		t.Fatalf("pane-2 inbox = %#v, want parent acked ok with note", all)
 	}
 }
 
@@ -360,6 +436,16 @@ func TestMsgCommandErrorsFailLoudly(t *testing.T) {
 			name: "missing read id",
 			args: []string{"read"},
 			want: "usage: msg read",
+		},
+		{
+			name: "missing reply id",
+			args: []string{"reply"},
+			want: "usage: msg reply",
+		},
+		{
+			name: "unknown reply flag",
+			args: []string{"reply", "msg-000001", "--bad"},
+			want: "usage: msg reply",
 		},
 		{
 			name: "unknown read flag",

--- a/internal/server/commands_msg_test.go
+++ b/internal/server/commands_msg_test.go
@@ -267,6 +267,71 @@ func TestMsgCommandReplyCanAckParent(t *testing.T) {
 	}
 }
 
+func TestMsgCommandReplyRecipientInferenceEdges(t *testing.T) {
+	t.Parallel()
+
+	srv, sess, cleanup := setupMsgCommandSession(t)
+	defer cleanup()
+
+	root := runTestCommand(t, srv, sess, "msg", "send",
+		"--from", "pane-1",
+		"--to", "pane-2",
+		"--topic", "root-topic",
+		"--group", "root-group",
+		"--body", "root",
+		"--format", "json",
+	)
+	if root.cmdErr != "" {
+		t.Fatalf("msg send root error: %s", root.cmdErr)
+	}
+	rootJSON := parseMsgCommandSendJSON(t, root.output)
+
+	fromOriginalSender := runTestCommandWithActor(t, srv, sess, 1, "msg", "reply", rootJSON.ID, "--body", "sender follow-up", "--format", "json")
+	if fromOriginalSender.cmdErr != "" {
+		t.Fatalf("msg reply from original sender error: %s", fromOriginalSender.cmdErr)
+	}
+	fromOriginalSenderJSON := parseMsgCommandSendJSON(t, fromOriginalSender.output)
+	if len(fromOriginalSenderJSON.Recipients) != 1 || fromOriginalSenderJSON.Recipients[0].Name != "pane-2" {
+		t.Fatalf("original sender reply recipients = %#v, want original recipient pane-2", fromOriginalSenderJSON.Recipients)
+	}
+
+	explicitTo := runTestCommandWithActor(t, srv, sess, 3, "msg", "reply", rootJSON.ID,
+		"--to", "pane-1",
+		"--topic", "override-topic",
+		"--group", "override-group",
+		"--body", "observer reply",
+		"--format", "json",
+	)
+	if explicitTo.cmdErr != "" {
+		t.Fatalf("msg reply with explicit recipient error: %s", explicitTo.cmdErr)
+	}
+	explicitToJSON := parseMsgCommandSendJSON(t, explicitTo.output)
+	if len(explicitToJSON.Recipients) != 1 || explicitToJSON.Recipients[0].Name != "pane-1" {
+		t.Fatalf("explicit reply recipients = %#v, want pane-1", explicitToJSON.Recipients)
+	}
+	if got := strings.Join(explicitToJSON.Topics, ","); got != "override-topic" {
+		t.Fatalf("explicit reply topics = %q, want override-topic", got)
+	}
+	if got := strings.Join(explicitToJSON.Groups, ","); got != "override-group" {
+		t.Fatalf("explicit reply groups = %q, want override-group", got)
+	}
+
+	observer := runTestCommandWithActor(t, srv, sess, 3, "msg", "reply", rootJSON.ID, "--body", "cannot infer")
+	if observer.cmdErr == "" || !strings.Contains(observer.cmdErr, "pass --to") {
+		t.Fatalf("observer reply error = %q, want pass --to", observer.cmdErr)
+	}
+
+	self := runTestCommand(t, srv, sess, "msg", "send", "--from", "pane-1", "--to", "pane-1", "--body", "self", "--format", "json")
+	if self.cmdErr != "" {
+		t.Fatalf("msg send self error: %s", self.cmdErr)
+	}
+	selfJSON := parseMsgCommandSendJSON(t, self.output)
+	selfReply := runTestCommandWithActor(t, srv, sess, 1, "msg", "reply", selfJSON.ID, "--body", "cannot infer")
+	if selfReply.cmdErr == "" || !strings.Contains(selfReply.cmdErr, "pass --to") {
+		t.Fatalf("self reply error = %q, want pass --to", selfReply.cmdErr)
+	}
+}
+
 func TestMsgCommandTextAndDetailedJSON(t *testing.T) {
 	t.Parallel()
 
@@ -446,6 +511,11 @@ func TestMsgCommandErrorsFailLoudly(t *testing.T) {
 			name: "unknown reply flag",
 			args: []string{"reply", "msg-000001", "--bad"},
 			want: "usage: msg reply",
+		},
+		{
+			name: "missing reply body value",
+			args: []string{"reply", "msg-000001", "--body"},
+			want: "missing value for --body",
 		},
 		{
 			name: "unknown read flag",

--- a/internal/server/mailbox_events_test.go
+++ b/internal/server/mailbox_events_test.go
@@ -193,6 +193,94 @@ func TestWaitMessageReturnsUnreadDelivery(t *testing.T) {
 	}
 }
 
+func TestMsgCommandSendWakesWaitMessage(t *testing.T) {
+	t.Parallel()
+
+	srv, sess, p1, p2, cleanup := newMailboxTestSession(t)
+	defer cleanup()
+
+	resultCh := make(chan struct {
+		output string
+		cmdErr string
+	}, 1)
+	go func() {
+		resultCh <- runTestCommand(t, srv, sess, "wait", "msg", p2.Meta.Name, "--format", "json", "--timeout", "500ms")
+	}()
+	waitForMailboxWaitSubscription(t, sess)
+
+	sent := runTestCommand(t, srv, sess, "msg", "send",
+		"--from", p1.Meta.Name,
+		"--to", p2.Meta.Name,
+		"--subject", "CLI incoming",
+		"--body", "body hidden from wait",
+		"--format", "json")
+	if sent.cmdErr != "" {
+		t.Fatalf("msg send error = %q", sent.cmdErr)
+	}
+	var sentSummary struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal([]byte(sent.output), &sentSummary); err != nil {
+		t.Fatalf("unmarshal msg send output %q: %v", sent.output, err)
+	}
+
+	res := readWaitMessageResult(t, resultCh)
+	if res.cmdErr != "" {
+		t.Fatalf("wait msg error = %q", res.cmdErr)
+	}
+	if strings.Contains(res.output, "body hidden from wait") {
+		t.Fatalf("wait msg leaked body: %s", res.output)
+	}
+	var waitSummary struct {
+		ID      string `json:"id"`
+		Subject string `json:"subject"`
+	}
+	if err := json.Unmarshal([]byte(res.output), &waitSummary); err != nil {
+		t.Fatalf("unmarshal wait msg output %q: %v", res.output, err)
+	}
+	if waitSummary.ID != sentSummary.ID || waitSummary.Subject != "CLI incoming" {
+		t.Fatalf("wait msg summary = %+v, want CLI sent message %q", waitSummary, sentSummary.ID)
+	}
+}
+
+func TestMsgCommandReadAndAckEmitEvents(t *testing.T) {
+	t.Parallel()
+
+	srv, sess, p1, p2, cleanup := newMailboxTestSession(t)
+	defer cleanup()
+
+	msg := mustSendMailboxMessage(t, sess, p1, p2, "CLI read", "body")
+	res := sess.enqueueEventSubscribe(sess.context(), eventFilter{
+		Types:  []string{EventMessageRead, EventMessageAck},
+		PaneID: p2.ID,
+	}, false)
+	defer sess.enqueueEventUnsubscribe(res.sub)
+
+	read := runTestCommand(t, srv, sess, "msg", "read", string(msg.ID), "--for", p2.Meta.Name)
+	if read.cmdErr != "" {
+		t.Fatalf("msg read error = %q", read.cmdErr)
+	}
+	readEvent := readMailboxEvent(t, res.sub, time.Second)
+	if readEvent.Type != EventMessageRead {
+		t.Fatalf("read event type = %q, want %q", readEvent.Type, EventMessageRead)
+	}
+	if readEvent.Message == nil || readEvent.Message.ID != string(msg.ID) || readEvent.Message.ReadAt == "" {
+		t.Fatalf("read event message = %+v, want read timestamp", readEvent.Message)
+	}
+
+	ack := runTestCommand(t, srv, sess, "msg", "ack", string(msg.ID), "--for", p2.Meta.Name, "--status", "seen", "--note", "cli ack")
+	if ack.cmdErr != "" {
+		t.Fatalf("msg ack error = %q", ack.cmdErr)
+	}
+	ackEvent := readMailboxEvent(t, res.sub, time.Second)
+	if ackEvent.Type != EventMessageAck {
+		t.Fatalf("ack event type = %q, want %q", ackEvent.Type, EventMessageAck)
+	}
+	if ackEvent.Message == nil || ackEvent.Message.ID != string(msg.ID) || ackEvent.Message.AckStatus != "seen" || ackEvent.Message.AckedAt == "" {
+		t.Fatalf("ack event message = %+v, want ack status and timestamp", ackEvent.Message)
+	}
+}
+
 func TestWaitMessageTimeout(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Motivation

Live dogfooding showed two mailbox UX gaps: `amux wait msg` did not wake for messages sent through the CLI path, and an agent replying from another pane had to reverse-engineer verbose `msg send --reply-to` syntax from source. Pane 186 also showed that the amux skill did not document mailbox flows well enough for an agent to use them without extra lookup.

## Summary

- Route `msg send`, `msg read`, and `msg ack` through the session mailbox helpers so CLI operations emit lifecycle events.
- Add `amux msg reply <msg-id>` to infer the original sender, preserve thread/topic/group context, and optionally ack the parent delivery.
- Add subcommand-specific `amux msg <subcommand> --help` output.
- Document mailbox send/read/reply/ack flows in README and the amux agent skill.
- Cover the mailbox reply parser/help/error branches so Codecov patch coverage tracks the CLI behavior directly.

## Testing

- `go test ./internal/server -run 'TestMsgCommandSendWakesWaitMessage|TestMsgCommandReadAndAckEmitEvents' -count=100`
- `go test ./internal/server -run 'TestMsgCommandReply|TestMsgCommandErrorsFailLoudly|TestMsgCommandTextAndDetailedJSON' -count=100`
- `go test ./internal/server -run 'TestParseMsgReplyOptions|TestMsgCommandReplyRecipientInferenceEdges|TestMsgCommandReplyErrors' -count=100`
- `go test ./internal/cli -run 'TestPrepareMsgCLIArgs|TestMsgCLICommandHandler|TestMaybePrintCommandHelp' -count=100`
- `go test ./internal/server ./internal/cli -run 'Mailbox|WaitMessage|MsgCommand|ParseWaitMessage|CallToolDispatchesMailboxCommands' -count=1`
- `go test ./... -timeout 120s`
- `scripts/check-diff-coverage.sh` (100.00% diff coverage locally after the CI fix)
- `scripts/push-and-watch-ci.sh` (GitHub `test` passed; `codecov/patch` passed)
- `make install`
- Live dogfood with pane 186:
  - Verified mailbox round trip `172 -> 186 -> 172` without pasting the message body into pane 186.
  - Verified pane 186 used `amux msg reply msg-000016 --from 186 --body ... --ack ok --format json` and the reply arrived as `msg-000017` with the inherited topic.
  - Verified pane 186's parent delivery was acked and both pane 172 and pane 186 unread inboxes were empty.

## Review focus

Check that the CLI path now matches the MCP/internal mailbox path without changing store semantics. For `msg reply`, focus on recipient inference, inherited topics/groups, and the optional ack behavior when the replying pane received the parent message.
