### PR TITLE
LAB-1984: Add remote window mirroring (attach-window)

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,6 +399,31 @@ Higher-level prompt delegation now lives at the script layer: compose `wait idle
 | `amux rename-window <name>` | Rename the active window |
 | `amux resize-window <cols> <rows>` | Resize window to given dimensions |
 
+### Remote (federation)
+
+Mirror panes and windows from another amux server over SSH. The local server
+dials `ssh <target>` and connects to the remote's Unix socket; mirrored panes
+stream the remote PTY output and forward input back.
+
+| Command | Description |
+|---------|-------------|
+| `amux remote add <name> --ssh <target> --socket <path> [--session <name>]` | Register a remote host |
+| `amux remote list` | List registered remotes and health |
+| `amux remote rm <name>` | Remove a remote |
+| `amux remote status` | Show active mirrors per host |
+| `amux remote panes <name>` | List a remote host's panes |
+| `amux remote windows <name>` | List a remote host's windows |
+| `amux remote attach <name>:<pane>` | Mirror a single remote pane locally |
+| `amux remote attach-window <name>:<window>` | Mirror a whole remote window into a new local window |
+| `amux remote detach <local-pane>` | Stop mirroring a pane |
+| `amux remote detach-window <local-window>` | Tear down a mirrored window |
+| `amux remote resize <local-pane>` | Resize the remote pane to match the local mirror |
+
+A window mirror reconstructs the remote window's split layout, tracks structural
+changes live (panes added/removed/re-split), and pushes the local window's size
+to the remote so it re-renders to match — most effective for headless remote
+windows. Mirrors survive server reloads.
+
 ## Keybindings
 
 Default prefix: `Ctrl-a`.

--- a/docs/plans/LAB-1984-findings.md
+++ b/docs/plans/LAB-1984-findings.md
@@ -1,0 +1,58 @@
+# LAB-1984 — Research findings: window-level remote mirroring
+
+## Goal
+Add the ability to mirror an entire remote *window* (all its panes, in their
+split layout) into a new local window, parallel to today's single-pane
+`amux remote attach <host>:<pane>`.
+
+## How single-pane mirroring works today (verified file:line)
+
+- **CLI dispatch** — `internal/server/commands_remote.go:73-101` (`cmdRemote` →
+  `runRemoteCommand` switch). Subcommands: add/list/rm/panes/status/attach/detach/resize.
+- **`remote attach <host>:<pane>`** — `commands_remote.go:249-296`. Splits on `:`,
+  builds `checkpoint.RemoteRef{Host,Session,PaneName}`, then in a mutation:
+  1. `prepareMirrorPane(meta, ref, w.Width, contentHeight)` — constructs a proxy
+     pane, registers it in `s.Panes`, does **not** insert it into a window
+     (`session_pane.go:173-192`).
+  2. `w.SplitPaneWithOptions(...)` — inserts the leaf into the active window.
+  3. `trackMirrorPane(pane, ref)` → `mirror.Manager.Track` — starts the mirror.
+- **Mirror lifecycle** — `internal/server/mirror/manager.go`. `mirrors map[uint32]*mirrorState`
+  keyed by **local pane ID**. Per mirror: one SSH `Link`, resolves remote pane ID
+  by name, sends `MsgTypeAttachPane`, then `readLoop` feeds `MsgTypePaneOutput`
+  bytes into the local emulator via `pane.FeedOutput`. Input goes back out via
+  `Manager.Write` → `MsgTypeInputPane` (manager.go:202-228).
+  Handled inbound msgs: PaneHistory, PaneOutput, PaneMetaUpdate, Exit, CmdResult —
+  **no layout updates** (manager.go:537-563).
+- **Transport** — `internal/remote/link.go` (SSHDialer spawns `ssh <target> -- nc -U <socket>`),
+  `internal/remote/resolve.go` (`ListPanes` → `MsgTypeListPanes`/`MsgTypeLayout`,
+  `ResolvePaneID`). `remote.ListPanes` already returns the FULL multi-window layout
+  (`proto.LayoutSnapshot.Windows []WindowSnapshot`).
+- **Persistence** — `checkpoint.RemoteRef{Host,Session,PaneName}` per proxy pane.
+  Local layout (windows + splits) is checkpointed separately. On reload each proxy
+  pane re-tracks independently (`internal/server/checkpoint.go`).
+
+## Linchpin for reuse
+- **`mux.RebuildWindowFromSnapshot(ws proto.WindowSnapshot, width, height int, paneMap map[uint32]*Pane) *Window`**
+  (`internal/mux/snapshot.go:164`) builds a local `Window` matching a remote
+  `WindowSnapshot`'s split tree, wiring in proxy panes keyed by remote pane ID.
+  This means window mirroring is mostly: make N proxy panes → build paneMap →
+  RebuildWindowFromSnapshot → append window → Track each pane.
+- **`runNewWindow`** (`commands_layout.go:884-919`) is the canonical "append a new
+  local window + activate" path: `nextWindowID()`, set ID/Name, append to
+  `sess.Windows`, `activateWindow`.
+
+## Key consequence: MVP can reuse per-pane machinery wholesale
+Because each remote window pane becomes an ordinary independent proxy pane:
+- Input routing already works (active local pane's write override → its remote ID).
+- `remote detach <pane>` / `remote resize <pane>` already work per pane.
+- **Checkpoint/restore survives reload for free**: each pane re-tracks via its
+  own RemoteRef, and the local window shape is restored from the local layout
+  checkpoint. No new checkpoint code needed for the MVP.
+
+## Limitations to defer (Phase 2+)
+1. **Static snapshot** — the per-pane subscription receives no layout broadcasts,
+   so remote split add/remove after attach is NOT reflected. Re-attach to refresh.
+2. **Dimension matching** — local window may differ from the remote's geometry;
+   per-pane `remote resize` still applies. Window-level resize is future work.
+3. **Whole-window detach** — MVP relies on closing the local window or detaching
+   panes individually; a single `remote detach --window` is a nice-to-have.

--- a/docs/plans/LAB-1984-plan.md
+++ b/docs/plans/LAB-1984-plan.md
@@ -1,16 +1,31 @@
 # LAB-1984 — Implementation plan: window-level remote mirroring
 
-## Scope (MVP / tracer bullet)
-Mirror a remote window's panes + split layout into a new local window, reusing the
-existing per-pane mirror machinery. Static snapshot at attach time. Defer dynamic
-resync, window-level dimension matching, and whole-window detach to follow-ups.
+## Locked decisions (user-confirmed)
+- **Delivery:** single big PR with structured TDD commits on one branch.
+- **CLI:** separate verbs — `remote windows`, `remote attach-window`, `remote detach-window`.
+- **Dimension matching:** resize the REMOTE to match the LOCAL window geometry
+  (extend `planRemoteResize` per pane). Fallbacks required for lead panes and
+  single-axis windows (skip + log; cannot resize those).
+- **Architecture:** reuse the existing per-pane output/input mirror path untouched
+  (one Link per pane). Add only a separate per-window LAYOUT-subscription link
+  (`MsgTypeAttachWindow`) for dynamic resync. Server change is minimal: one accept
+  case + relax `allowsServerMessage` to pass `MsgTypeLayout` for a window-scoped conn.
 
-## CLI surface
+## Scope (FULL feature, single PR) — confirmed with user
+Mirror a remote window's panes + split layout into a new local window. Includes:
+1. Static window mirror (reuse per-pane machinery + RebuildWindowFromSnapshot).
+2. **Dynamic resync** — remote window layout changes (pane add/remove/resize)
+   propagate to the local mirror via a new layout-subscription channel.
+3. **Dimension matching** — the local mirror window tracks the remote window's
+   geometry (and/or reconciles size like the per-pane `remote resize`).
+4. **Whole-window detach** — `remote detach-window <local-window>` one-shot teardown.
+
+## CLI surface — confirmed: separate verbs
 - `amux remote windows <name>` — list the remote host's windows
   (index, name, pane count, dimensions, active marker). Parallels `remote panes`.
-- `amux remote attach --window <name>:<window>` — mirror a whole remote window.
-  `--window` disambiguates from the pane form (matches the existing
-  `send-keys --window <index|name>` convention). Accepts window name or index.
+- `amux remote attach-window <name>:<window>` — mirror a whole remote window
+  (window name or index). Distinct verb from pane `attach`.
+- `amux remote detach-window <local-window>` — tear down a mirrored window.
 
 ## Build sequence (TDD, separate commits per red/green/refactor)
 
@@ -62,7 +77,24 @@ make coverage
 - **RebuildWindowFromSnapshot pane sizing** — confirm it sizes proxy panes from the
   local width/height + snapshot proportions (not the remote's absolute dims).
 
-## Out of scope (follow-up tickets)
-- Dynamic remote-split resync (needs a layout-subscription channel on the mirror link).
-- Window-level dimension matching / `remote resize --window`.
-- `remote detach --window` single-command teardown.
+## Dynamic resync — design (the hard part)
+The per-pane mirror link carries pane output only. For window mirroring we need the
+remote to tell us when the window's split structure changes. Approach:
+- Add `MsgTypeAttachWindow{Session, WindowName}` on the remote: subscribes the
+  connection to (a) layout snapshots for that window on every change, and (b) the
+  output streams of all panes in it. Server reuses its existing per-client layout
+  broadcast path, scoped to one window.
+- Local mirror manager gains a window-mirror state: on each inbound layout snapshot,
+  reconcile — add proxy panes for new remote pane IDs, soft-close removed ones,
+  re-run RebuildWindowFromSnapshot to update the split tree, rebroadcast locally.
+- Falls back to a single multiplexed link per window (not N) so add/remove of remote
+  panes does not require opening/closing sockets mid-stream.
+- TO VERIFY before coding: server-side handling of MsgTypeAttachPane (is there a
+  scoped subscriber model to extend?), the layout broadcast path, and whether output
+  for multiple panes can share one connection. See LAB-1984-findings.md "resync".
+
+## Dimension matching — design
+- On attach and on local-window resize, send the remote a window-level resize
+  (reuse planRemoteResize per pane, or a new window-resize remote command) so the
+  remote window geometry tracks the local mirror window. Confirm RebuildWindowFromSnapshot
+  scales cell proportions to the local width/height.

--- a/docs/plans/LAB-1984-plan.md
+++ b/docs/plans/LAB-1984-plan.md
@@ -1,0 +1,68 @@
+# LAB-1984 — Implementation plan: window-level remote mirroring
+
+## Scope (MVP / tracer bullet)
+Mirror a remote window's panes + split layout into a new local window, reusing the
+existing per-pane mirror machinery. Static snapshot at attach time. Defer dynamic
+resync, window-level dimension matching, and whole-window detach to follow-ups.
+
+## CLI surface
+- `amux remote windows <name>` — list the remote host's windows
+  (index, name, pane count, dimensions, active marker). Parallels `remote panes`.
+- `amux remote attach --window <name>:<window>` — mirror a whole remote window.
+  `--window` disambiguates from the pane form (matches the existing
+  `send-keys --window <index|name>` convention). Accepts window name or index.
+
+## Build sequence (TDD, separate commits per red/green/refactor)
+
+### Step 1 — `remote windows` listing
+- Add `windows` case to `runRemoteCommand` dispatch + usage string.
+- `runRemoteWindows`: `listRemotePanes(host)` → iterate `layout.Windows` →
+  format a table (reuse/extend listing helpers).
+- Tests: unit test the formatter from a synthetic `LayoutSnapshot`;
+  hermetic CLI test for arg validation/usage.
+
+### Step 2 — resolve a remote window ref
+- Add `WindowName` (or a `RemoteWindowRef`) + a resolver:
+  `resolveRemoteWindow(layout, ref) -> WindowSnapshot` (by name, then index).
+- Pure function, table-driven tests (found / not-found / ambiguous / by-index).
+
+### Step 3 — `remote attach --window` (the core)
+- Parse `--window` flag in attach; split `<name>:<window>`.
+- Mutation:
+  1. Fetch remote layout, resolve target `WindowSnapshot`.
+  2. For each remote **leaf** pane: `prepareMirrorPane(meta, RemoteRef{Host,Session,PaneName}, cols, rows)`;
+     record `paneMap[remotePaneID] = pane`.
+  3. `win := mux.RebuildWindowFromSnapshot(ws, w.Width, w.Height, paneMap)`.
+  4. Assign `win.ID = nextWindowID()`, name it (e.g. `<host>:<window>`),
+     append to `sess.Windows`, `activateWindow(win)`.
+  5. `trackMirrorPane(pane, ref)` for each proxy pane.
+  6. Broadcast layout.
+- Integration test via the server harness: drive a second in-process amux as the
+  "remote", attach its multi-pane window, assert the local session gains a window
+  with matching pane count/structure and that output flows.
+
+### Step 4 — docs + polish
+- Update `amux --help` usage block and README CLI reference.
+- Update `docs/capture-architecture.md` / remote docs if they enumerate subcommands.
+- Note the static-snapshot limitation in help text or docs.
+
+## Test commands
+```
+go test ./internal/server/... ./internal/mux/... ./test/... -timeout 120s
+cd test && go test -run TestRemote -count=100   # repeat new tests for flakes
+make coverage
+```
+
+## Risks / open questions
+- **Disambiguation choice** (flag vs separate verb vs auto-detect) — see Decision A.
+- **Partial connect** — panes connect independently; the window appears immediately
+  with panes filling in as each subscription bootstraps. Acceptable for MVP; note it.
+- **Window naming collisions** — local window name `<host>:<window>` must not clash
+  with `nextWindowID`/name uniqueness rules; verify in `runNewWindow` path.
+- **RebuildWindowFromSnapshot pane sizing** — confirm it sizes proxy panes from the
+  local width/height + snapshot proportions (not the remote's absolute dims).
+
+## Out of scope (follow-up tickets)
+- Dynamic remote-split resync (needs a layout-subscription channel on the mirror link).
+- Window-level dimension matching / `remote resize --window`.
+- `remote detach --window` single-command teardown.

--- a/docs/plans/LAB-1984-progress.md
+++ b/docs/plans/LAB-1984-progress.md
@@ -1,0 +1,22 @@
+# LAB-1984 — Progress
+
+## Status: PLANNING (awaiting user sign-off on scope + CLI shape)
+
+## Done
+- [x] Research: mapped single-pane mirror end-to-end (findings.md).
+- [x] Confirmed `mux.RebuildWindowFromSnapshot` enables window reconstruction.
+- [x] Confirmed per-pane checkpoint/restore covers reload for free in MVP.
+- [x] Drafted phased plan (plan.md).
+
+## Next (pending approval)
+- [ ] Decision A: CLI disambiguation (`--window` flag vs `attach-window` verb).
+- [ ] Decision B: confirm MVP scope (static snapshot, defer dynamic resync).
+- [ ] Step 1: `remote windows` listing (TDD).
+- [ ] Step 2: remote window resolver (TDD).
+- [ ] Step 3: `remote attach --window` core (TDD).
+- [ ] Step 4: docs + help.
+
+## Notes / breadcrumbs
+- Branch: `LAB-1984-remote-window-mirror` off `origin/main@bcfab03`.
+- Each remote window pane → independent proxy pane; window is a creation-time
+  arrangement via RebuildWindowFromSnapshot. Reuses all per-pane lifecycle.

--- a/docs/plans/LAB-1984-progress.md
+++ b/docs/plans/LAB-1984-progress.md
@@ -8,15 +8,31 @@
 - [x] Confirmed per-pane checkpoint/restore covers reload for free in MVP.
 - [x] Drafted phased plan (plan.md).
 
-## Next (pending approval)
-- [ ] Decision A: CLI disambiguation (`--window` flag vs `attach-window` verb).
-- [ ] Decision B: confirm MVP scope (static snapshot, defer dynamic resync).
-- [ ] Step 1: `remote windows` listing (TDD).
-- [ ] Step 2: remote window resolver (TDD).
-- [ ] Step 3: `remote attach --window` core (TDD).
-- [ ] Step 4: docs + help.
+## Decisions (locked)
+- CLI: separate verbs `remote windows` / `attach-window` / `detach-window`.
+- Scope: FULL feature in one PR (static + dynamic resync + dimension matching).
+- Dimension matching: resize REMOTE to match LOCAL (extend planRemoteResize).
+- Architecture: reuse per-pane output/input links untouched; add one per-window
+  layout-subscription link (MsgTypeAttachWindow) for dynamic resync.
+
+## Done
+- [x] Step 1a: `ResolveWindowFromLayout` resolver (remote pkg) + tests.
+- [x] Step 1b: `remote windows` listing (formatRemoteWindows + dispatch) + tests.
+
+## Next
+- [ ] Step 2: `remote attach-window` core — build N proxy panes, RebuildWindowFromSnapshot,
+      new local window, track each pane (static mirror).
+- [ ] Step 3: `MsgTypeAttachWindow` server handler + allowsServerMessage relax.
+- [ ] Step 4: window-mirror coordinator in mirror.Manager + reconcile loop.
+- [ ] Step 5: dimension matching (resize remote to local on attach + local resize).
+- [ ] Step 6: `remote detach-window` teardown.
+- [ ] Step 7: checkpoint/restore for window mirrors (resume layout subscription).
+- [ ] Step 8: docs + `amux --help` + README CLI reference.
 
 ## Notes / breadcrumbs
 - Branch: `LAB-1984-remote-window-mirror` off `origin/main@bcfab03`.
 - Each remote window pane → independent proxy pane; window is a creation-time
   arrangement via RebuildWindowFromSnapshot. Reuses all per-pane lifecycle.
+- GOTCHA: never name a Go file `*_windows*.go` / `*_linux*.go` etc — Go's filename
+  GOOS/GOARCH constraint silently excludes it. Window-listing test lives in
+  `commands_remote_winlist_test.go` for this reason.

--- a/docs/plans/LAB-1984-progress.md
+++ b/docs/plans/LAB-1984-progress.md
@@ -22,8 +22,8 @@
       RebuildWindowFromSnapshot, uniqueLocalWindowName, e2e test. [7d816d1]
 
 ## Next (protocol-heavy, higher risk)
-- [ ] Step 3: `MsgTypeAttachWindow` (=30) server handler + `scopedWindowID` on
-      clientConn + relax `allowsServerMessage` to pass MsgTypeLayout for it.
+- [x] Step 3: `MsgTypeAttachWindow` (=30) server handler + `scopedWindowID` on
+      clientConn + relax `allowsServerMessage` to pass MsgTypeLayout. [6630270]
 - [ ] Step 4: window-mirror coordinator in mirror.Manager — open the layout link,
       reconcile on each remote layout snapshot (add/remove/restructure panes).
 - [ ] Step 5: dimension matching — resize REMOTE to match LOCAL on attach + on
@@ -31,6 +31,15 @@
 - [ ] Step 6: `remote detach-window <local-window>` teardown.
 - [ ] Step 7: checkpoint/restore for window mirrors (resume layout subscription).
 - [ ] Step 8: docs + `amux --help` + README CLI reference.
+
+## Live validation (hetzner-1, 2026-05-30)
+- `remote windows hetzner-1` listed all 11 real windows.
+- `remote attach-window hetzner-1:orca` rebuilt the 3-pane window locally; all 3
+  mirrors connected and streamed real orca output; split structure + per-pane
+  `@hetzner-1` headers correct; appeared in session bar as `hetzner-1:orca`.
+- Local width (~265) ≈ remote orca (265) → near-zero wrapping, confirming the
+  Step-5 thesis (wrapping is purely a width-delta problem).
+- Cleanup (detach x3 + rm) left remote orca workers alive → detach non-destructive.
 
 ## Verified working now
 - `amux remote windows <host>` lists remote windows.

--- a/docs/plans/LAB-1984-progress.md
+++ b/docs/plans/LAB-1984-progress.md
@@ -1,6 +1,6 @@
 # LAB-1984 — Progress
 
-## Status: PLANNING (awaiting user sign-off on scope + CLI shape)
+## Status: COMPLETE — all steps implemented and tested
 
 ## Done
 - [x] Research: mapped single-pane mirror end-to-end (findings.md).
@@ -30,11 +30,11 @@
       diffs the remote window snapshot vs the local mirror window (match panes by
       remote name), create/soft-close proxies, rebuild the split tree; register
       the window mirror in `attach-window`. (NEXT — largest/riskiest sub-step.)
-- [ ] Step 5: dimension matching — resize REMOTE to match LOCAL on attach + on
-      local window resize (extend planRemoteResize; skip lead/single-axis panes).
-- [ ] Step 6: `remote detach-window <local-window>` teardown.
-- [ ] Step 7: checkpoint/restore for window mirrors (resume layout subscription).
-- [ ] Step 8: docs + `amux --help` + README CLI reference.
+- [x] Step 5: dimension matching — push local window size to remote (attach +
+      MsgTypeResize on local resize); remote re-renders the window. [cd40a8a]
+- [x] Step 6: `remote detach-window <local-window>` teardown. [cd37bb2]
+- [x] Step 7: checkpoint/restore for window mirrors. [6d24b9d]
+- [x] Step 8: docs + `amux --help` + README CLI reference.
 
 ## Live validation (hetzner-1, 2026-05-30)
 - `remote windows hetzner-1` listed all 11 real windows.

--- a/docs/plans/LAB-1984-progress.md
+++ b/docs/plans/LAB-1984-progress.md
@@ -16,18 +16,27 @@
   layout-subscription link (MsgTypeAttachWindow) for dynamic resync.
 
 ## Done
-- [x] Step 1a: `ResolveWindowFromLayout` resolver (remote pkg) + tests.
-- [x] Step 1b: `remote windows` listing (formatRemoteWindows + dispatch) + tests.
+- [x] Step 1a: `ResolveWindowFromLayout` resolver (remote pkg) + tests. [9354311]
+- [x] Step 1b: `remote windows` listing (formatRemoteWindows + dispatch) + tests. [9354311]
+- [x] Step 2: `remote attach-window` static mirror — planRemoteWindowLeaves,
+      RebuildWindowFromSnapshot, uniqueLocalWindowName, e2e test. [7d816d1]
 
-## Next
-- [ ] Step 2: `remote attach-window` core — build N proxy panes, RebuildWindowFromSnapshot,
-      new local window, track each pane (static mirror).
-- [ ] Step 3: `MsgTypeAttachWindow` server handler + allowsServerMessage relax.
-- [ ] Step 4: window-mirror coordinator in mirror.Manager + reconcile loop.
-- [ ] Step 5: dimension matching (resize remote to local on attach + local resize).
-- [ ] Step 6: `remote detach-window` teardown.
+## Next (protocol-heavy, higher risk)
+- [ ] Step 3: `MsgTypeAttachWindow` (=30) server handler + `scopedWindowID` on
+      clientConn + relax `allowsServerMessage` to pass MsgTypeLayout for it.
+- [ ] Step 4: window-mirror coordinator in mirror.Manager — open the layout link,
+      reconcile on each remote layout snapshot (add/remove/restructure panes).
+- [ ] Step 5: dimension matching — resize REMOTE to match LOCAL on attach + on
+      local window resize (extend planRemoteResize; skip lead/single-axis panes).
+- [ ] Step 6: `remote detach-window <local-window>` teardown.
 - [ ] Step 7: checkpoint/restore for window mirrors (resume layout subscription).
 - [ ] Step 8: docs + `amux --help` + README CLI reference.
+
+## Verified working now
+- `amux remote windows <host>` lists remote windows.
+- `amux remote attach-window <host>:<window>` mirrors a remote window into a new
+  local window; each pane streams independently. Static snapshot (no live resync
+  yet); content wraps if local/remote geometry differ until Step 5.
 
 ## Notes / breadcrumbs
 - Branch: `LAB-1984-remote-window-mirror` off `origin/main@bcfab03`.

--- a/docs/plans/LAB-1984-progress.md
+++ b/docs/plans/LAB-1984-progress.md
@@ -24,8 +24,12 @@
 ## Next (protocol-heavy, higher risk)
 - [x] Step 3: `MsgTypeAttachWindow` (=30) server handler + `scopedWindowID` on
       clientConn + relax `allowsServerMessage` to pass MsgTypeLayout. [6630270]
-- [ ] Step 4: window-mirror coordinator in mirror.Manager — open the layout link,
-      reconcile on each remote layout snapshot (add/remove/restructure panes).
+- [x] Step 4a: mirror.Manager window-layout subscription (TrackWindow/DetachWindow,
+      OnWindowLayout callback, WindowRef) + tests. [8ab1888]
+- [ ] Step 4b: session-side reconcile — wire OnWindowLayout to a mutation that
+      diffs the remote window snapshot vs the local mirror window (match panes by
+      remote name), create/soft-close proxies, rebuild the split tree; register
+      the window mirror in `attach-window`. (NEXT — largest/riskiest sub-step.)
 - [ ] Step 5: dimension matching — resize REMOTE to match LOCAL on attach + on
       local window resize (extend planRemoteResize; skip lead/single-axis panes).
 - [ ] Step 6: `remote detach-window <local-window>` teardown.

--- a/internal/checkpoint/checkpoint.go
+++ b/internal/checkpoint/checkpoint.go
@@ -49,6 +49,19 @@ type RemoteRef struct {
 	PaneName string
 }
 
+// RemoteWindowRef captures a mirrored remote window so its layout subscription
+// can be re-established after a reload. Keyed by local window ID in the
+// checkpoint. Signature is the last applied structural signature, so the first
+// post-reload layout broadcast is a no-op when nothing changed.
+type RemoteWindowRef struct {
+	Host       string
+	Session    string
+	WindowName string
+	Cols       int
+	Rows       int
+	Signature  string
+}
+
 // ServerCheckpoint captures the full server state for reload.
 type ServerCheckpoint struct {
 	Version       int
@@ -63,6 +76,9 @@ type ServerCheckpoint struct {
 	Panes         []PaneCheckpoint
 	Mailbox       *mailbox.Snapshot
 	MailboxSeq    uint64
+	// WindowMirrors maps local window ID -> mirrored remote window, so window
+	// layout subscriptions resume after reload.
+	WindowMirrors map[uint32]RemoteWindowRef
 }
 
 // Write gob-encodes the checkpoint to a temp file and returns the path.

--- a/internal/checkpoint/checkpoint_test.go
+++ b/internal/checkpoint/checkpoint_test.go
@@ -72,6 +72,9 @@ func TestRoundTrip(t *testing.T) {
 				Screen: "$ echo test\ntest",
 			},
 		},
+		WindowMirrors: map[uint32]RemoteWindowRef{
+			7: {Host: "remote", Session: "main", WindowName: "amux", Cols: 200, Rows: 50, Signature: "(0[a][b])"},
+		},
 	}
 	setMetaCollections(t, &cp.Panes[0].Meta, []int{42, 73}, []string{"LAB-338", "LAB-412"})
 	setMetaCollections(t, &cp.Panes[1].Meta, []int{99}, []string{"LAB-777"})
@@ -100,6 +103,9 @@ func TestRoundTrip(t *testing.T) {
 	}
 	if got.ListenerFd != cp.ListenerFd {
 		t.Errorf("ListenerFd = %d, want %d", got.ListenerFd, cp.ListenerFd)
+	}
+	if want := cp.WindowMirrors[7]; got.WindowMirrors[7] != want {
+		t.Errorf("WindowMirrors[7] = %+v, want %+v", got.WindowMirrors[7], want)
 	}
 	if got.SessionLockFd != cp.SessionLockFd {
 		t.Errorf("SessionLockFd = %d, want %d", got.SessionLockFd, cp.SessionLockFd)

--- a/internal/cli/cli_usage.go
+++ b/internal/cli/cli_usage.go
@@ -23,7 +23,7 @@ const (
 	msgReadUsage      = "usage: amux msg read <msg-id> [--for pane] [--peek] [--format json]"
 	msgAckUsage       = "usage: amux msg ack <msg-id> [--for pane] [--status ok|error|seen] [--note text] [--format json]"
 	moveUsage         = "usage: amux move <pane> up|down | amux move <pane> (--before <target>|--after <target>|--to-column <target>)"
-	remoteUsage       = "usage: amux remote <add|list|rm|panes|status|attach|detach|resize> ..."
+	remoteUsage       = "usage: amux remote <add|list|rm|panes|windows|status|attach|attach-window|detach|detach-window|resize> ..."
 	spawnUsage        = "usage: amux spawn [--auto] [--at <pane>] [--window <name|id>] [--vertical|--horizontal] [--root] [--focus] [--attach <host>:<pane-name>] [--name NAME] [--task TASK] [--color COLOR]"
 	swapUsage         = "usage: amux swap <pane1> <pane2> [--tree] | amux swap forward | amux swap backward"
 	cursorUsage       = "usage: amux cursor <layout|clipboard|ui> [--client <id>]"
@@ -216,8 +216,14 @@ Usage:
   amux [-s session] respawn <pane>     Restart a pane shell in place
   amux [-s session] resize-pane <pane> <dir> [n]
                                        Resize pane (dir: left/right/up/down)
-  amux [-s session] remote <add|list|rm|panes|status|attach|detach|resize> ...
-                                       Manage remote amux hosts and mirror panes
+  amux [-s session] remote <add|list|rm|panes|windows|status|attach|attach-window|detach|detach-window|resize> ...
+                                       Manage remote amux hosts; mirror remote panes and windows
+  amux [-s session] remote windows <name>
+                                       List a remote host's windows
+  amux [-s session] remote attach-window <name>:<window>
+                                       Mirror a whole remote window into a new local window
+  amux [-s session] remote detach-window <local-window>
+                                       Tear down a mirrored remote window
   amux [-s session] equalize [--vertical|--all]
                                        Rebalance root columns, column rows, or both
   amux [-s session] kill <pane>        Kill a pane

--- a/internal/proto/wire.go
+++ b/internal/proto/wire.go
@@ -131,6 +131,13 @@ const (
 
 	// Server → Client — open a client-local chooser populated by server data.
 	MsgTypeChooser MsgType = 29
+
+	// Client → Server — subscribe to a window's layout snapshots. The server
+	// streams MsgTypeLayout for the session on every layout change, scoped so
+	// the subscriber receives layout updates (used by remote window mirroring to
+	// track a remote window's structure). Pane output is not delivered on this
+	// connection; it flows over separate per-pane subscriptions.
+	MsgTypeAttachWindow MsgType = 30
 )
 
 // Message is the wire protocol envelope. Only the fields relevant to
@@ -208,6 +215,9 @@ type Message struct {
 
 	// MsgTypeChooser
 	Chooser *ChooserRequest
+
+	// MsgTypeAttachWindow — the remote window to subscribe to, by name.
+	WindowName string
 }
 
 const maxMessageSize = 16 * 1024 * 1024 // 16 MB

--- a/internal/remote/resolve_window.go
+++ b/internal/remote/resolve_window.go
@@ -1,0 +1,70 @@
+package remote
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/weill-labs/amux/internal/proto"
+)
+
+// ResolveWindowErrorKind identifies window-resolution failures that callers can
+// handle without string matching.
+type ResolveWindowErrorKind string
+
+const (
+	ResolveWindowNotFound  ResolveWindowErrorKind = "not_found"
+	ResolveWindowAmbiguous ResolveWindowErrorKind = "ambiguous"
+)
+
+// ResolveWindowError reports a typed failure to resolve a window reference.
+type ResolveWindowError struct {
+	Ref     string
+	Kind    ResolveWindowErrorKind
+	Matches []string // window names that matched, for the ambiguous case
+}
+
+func (e *ResolveWindowError) Error() string {
+	if e.Kind == ResolveWindowAmbiguous {
+		return fmt.Sprintf("window %q is ambiguous (matches: %s)", e.Ref, strings.Join(e.Matches, ", "))
+	}
+	return fmt.Sprintf("window %q not found", e.Ref)
+}
+
+// ResolveWindowFromLayout resolves a window reference against a LayoutSnapshot's
+// windows. A purely numeric ref is treated as a 1-based window index; any other
+// ref is matched against window names (ambiguous when several share the name).
+func ResolveWindowFromLayout(layout *proto.LayoutSnapshot, ref string) (proto.WindowSnapshot, error) {
+	notFound := &ResolveWindowError{Ref: ref, Kind: ResolveWindowNotFound}
+	if layout == nil || len(layout.Windows) == 0 {
+		return proto.WindowSnapshot{}, notFound
+	}
+
+	if idx, err := strconv.Atoi(strings.TrimSpace(ref)); err == nil && idx > 0 {
+		for _, w := range layout.Windows {
+			if w.Index == idx {
+				return w, nil
+			}
+		}
+		return proto.WindowSnapshot{}, notFound
+	}
+
+	matches := make([]proto.WindowSnapshot, 0) // local accumulator (not a package-level var)
+	for _, w := range layout.Windows {
+		if w.Name == ref {
+			matches = append(matches, w)
+		}
+	}
+	switch len(matches) {
+	case 1:
+		return matches[0], nil
+	case 0:
+		return proto.WindowSnapshot{}, notFound
+	default:
+		names := make([]string, 0, len(matches))
+		for _, w := range matches {
+			names = append(names, fmt.Sprintf("%s#%d", w.Name, w.ID))
+		}
+		return proto.WindowSnapshot{}, &ResolveWindowError{Ref: ref, Kind: ResolveWindowAmbiguous, Matches: names}
+	}
+}

--- a/internal/remote/resolve_window_test.go
+++ b/internal/remote/resolve_window_test.go
@@ -1,0 +1,66 @@
+package remote
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/weill-labs/amux/internal/proto"
+)
+
+func windowLayout(windows ...proto.WindowSnapshot) *proto.LayoutSnapshot {
+	return &proto.LayoutSnapshot{Windows: windows}
+}
+
+func win(id uint32, name string, index int) proto.WindowSnapshot {
+	return proto.WindowSnapshot{ID: id, Name: name, Index: index}
+}
+
+func TestResolveWindowFromLayout(t *testing.T) {
+	t.Parallel()
+
+	layout := windowLayout(
+		win(10, "amux", 1),
+		win(20, "orca", 2),
+		win(30, "orca", 3), // duplicate name → ambiguous by name
+	)
+
+	tests := []struct {
+		name     string
+		layout   *proto.LayoutSnapshot
+		ref      string
+		wantID   uint32
+		wantKind ResolveWindowErrorKind
+	}{
+		{name: "by unique name", layout: layout, ref: "amux", wantID: 10},
+		{name: "by index", layout: layout, ref: "2", wantID: 20},
+		{name: "by index last", layout: layout, ref: "3", wantID: 30},
+		{name: "ambiguous name", layout: layout, ref: "orca", wantKind: ResolveWindowAmbiguous},
+		{name: "missing name", layout: layout, ref: "ghost", wantKind: ResolveWindowNotFound},
+		{name: "index out of range", layout: layout, ref: "9", wantKind: ResolveWindowNotFound},
+		{name: "nil layout", layout: nil, ref: "amux", wantKind: ResolveWindowNotFound},
+		{name: "no windows", layout: &proto.LayoutSnapshot{}, ref: "amux", wantKind: ResolveWindowNotFound},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := ResolveWindowFromLayout(tt.layout, tt.ref)
+			if tt.wantKind != "" {
+				var rwErr *ResolveWindowError
+				if !errors.As(err, &rwErr) {
+					t.Fatalf("expected ResolveWindowError, got %v", err)
+				}
+				if rwErr.Kind != tt.wantKind {
+					t.Fatalf("kind = %q, want %q", rwErr.Kind, tt.wantKind)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got.ID != tt.wantID {
+				t.Fatalf("window ID = %d, want %d", got.ID, tt.wantID)
+			}
+		})
+	}
+}

--- a/internal/server/checkpoint.go
+++ b/internal/server/checkpoint.go
@@ -165,6 +165,7 @@ func (s *Session) buildReloadCheckpointWithSnapshot(snapshot paneHistoryScreenSn
 			Layout:        *snap,
 			MailboxSeq:    sess.mailboxEventSeq,
 		}
+		cp.WindowMirrors = windowMirrorCheckpoints(sess)
 
 		return reloadCheckpointWork{
 			cp:      cp,
@@ -366,6 +367,10 @@ func NewServerFromCheckpointWithScrollbackConfigLogger(cp *checkpoint.ServerChec
 		sess.ActiveWindowID = winID
 	}
 	sess.refreshInputTarget()
+
+	// Resume window-layout subscriptions (deferred start if hosts are not yet
+	// configured; ConfigureMirrors will start them once they are).
+	sess.restoreWindowMirrors(cp.WindowMirrors)
 
 	// Start PTY read loops for all restored panes (skip proxy panes)
 	for _, p := range sess.Panes {

--- a/internal/server/client_conn.go
+++ b/internal/server/client_conn.go
@@ -45,6 +45,7 @@ type clientConn struct {
 	capabilities       proto.ClientCapabilities
 	colorProfile       string
 	scopedPaneID       uint32
+	scopedWindowID     uint32
 	predictions        map[uint32][]pendingPredictionEpoch
 	logger             *charmlog.Logger
 	bootstrapping      atomic.Bool
@@ -119,12 +120,37 @@ func (cc *clientConn) isPaneScoped() bool {
 	return cc != nil && cc.scopedPaneID != 0
 }
 
+// restrictToWindow scopes a connection to a single window's layout updates. The
+// connection is non-interactive and receives MsgTypeLayout broadcasts only;
+// pane output is delivered over separate per-pane subscriptions.
+func (cc *clientConn) restrictToWindow(windowID uint32) {
+	cc.scopedWindowID = windowID
+	cc.nonInteractive = true
+}
+
+func (cc *clientConn) isWindowScoped() bool {
+	return cc != nil && cc.scopedWindowID != 0
+}
+
 func (cc *clientConn) isScopedToPane(paneID uint32) bool {
 	return cc != nil && cc.scopedPaneID == paneID
 }
 
 func (cc *clientConn) allowsServerMessage(msg *Message) bool {
-	if cc == nil || cc.scopedPaneID == 0 || msg == nil {
+	if cc == nil || msg == nil {
+		return true
+	}
+	// Window-scoped subscribers receive only layout snapshots (plus terminal
+	// results). Pane output reaches a window mirror over separate per-pane links.
+	if cc.scopedWindowID != 0 {
+		switch msg.Type {
+		case MsgTypeLayout, MsgTypeCmdResult, MsgTypeExit:
+			return true
+		default:
+			return false
+		}
+	}
+	if cc.scopedPaneID == 0 {
 		return true
 	}
 	switch msg.Type {
@@ -406,6 +432,12 @@ func (cc *clientConn) readLoop(srv *Server, sess *Session) {
 			if !cc.handlePaneScopedMessage(sess, msg) {
 				return
 			}
+			continue
+		}
+
+		if cc.isWindowScoped() {
+			// Layout-only subscription: ignore any inbound client messages and
+			// keep the connection alive to receive MsgTypeLayout broadcasts.
 			continue
 		}
 

--- a/internal/server/client_conn.go
+++ b/internal/server/client_conn.go
@@ -436,8 +436,12 @@ func (cc *clientConn) readLoop(srv *Server, sess *Session) {
 		}
 
 		if cc.isWindowScoped() {
-			// Layout-only subscription: ignore any inbound client messages and
-			// keep the connection alive to receive MsgTypeLayout broadcasts.
+			// Layout subscription. The only inbound message it sends is a resize
+			// declaring the size to render the subscribed window at; everything
+			// else is ignored. The connection stays alive for MsgTypeLayout pushes.
+			if msg.Type == MsgTypeResize {
+				sess.enqueueResizeMirrorWindow(cc.scopedWindowID, msg.Cols, msg.Rows)
+			}
 			continue
 		}
 

--- a/internal/server/commands_remote.go
+++ b/internal/server/commands_remote.go
@@ -314,6 +314,35 @@ func planRemoteWindowLeaves(ws proto.WindowSnapshot) ([]remoteWindowLeaf, error)
 	return leaves, nil
 }
 
+// remoteWindowSignature encodes a remote window's structure: split directions
+// and leaf pane names, in tree order, excluding cell sizes. Two snapshots with
+// the same signature differ only in geometry/metadata, so a window mirror can
+// skip reconciliation. Add/remove/re-split all change the signature.
+func remoteWindowSignature(ws proto.WindowSnapshot) string {
+	names := paneSnapshotsByID(ws.Panes)
+	b := strings.Builder{} // local accumulator (not a package-level var)
+	writeRemoteWindowSignature(&b, ws.Root, names)
+	return b.String()
+}
+
+func writeRemoteWindowSignature(b *strings.Builder, cell proto.CellSnapshot, names map[uint32]proto.PaneSnapshot) {
+	if cell.IsLeaf {
+		b.WriteByte('[')
+		if pane, ok := names[cell.PaneID]; ok && pane.Name != "" {
+			b.WriteString(pane.Name)
+		} else {
+			fmt.Fprintf(b, "#%d", cell.PaneID)
+		}
+		b.WriteByte(']')
+		return
+	}
+	fmt.Fprintf(b, "(%d", cell.Dir)
+	for _, child := range cell.Children {
+		writeRemoteWindowSignature(b, child, names)
+	}
+	b.WriteByte(')')
+}
+
 // collectRemoteWindowLeaves appends one remoteWindowLeaf per leaf cell, in
 // left-to-right tree order, resolving each leaf's pane name from snapshots.
 func collectRemoteWindowLeaves(cell proto.CellSnapshot, snapshots map[uint32]proto.PaneSnapshot, windowName string, out *[]remoteWindowLeaf) error {
@@ -463,6 +492,19 @@ func runRemoteAttachWindow(ctx *CommandContext) commandpkg.Result {
 
 		mctx.Windows = append(mctx.Windows, win)
 		mctx.activateWindow(win)
+
+		// Activate dynamic resync: subscribe to the remote window's layout and
+		// seed the structural signature so the first (matching) broadcast is a
+		// no-op rather than an immediate rebuild.
+		if mctx.sess.windowMirrorSigs == nil {
+			mctx.sess.windowMirrorSigs = make(map[uint32]string)
+		}
+		mctx.sess.windowMirrorSigs[win.ID] = remoteWindowSignature(ws)
+		_ = mctx.sess.mirror.TrackWindow(win.ID, mirrorpkg.WindowRef{
+			Host:       hostName,
+			Session:    session,
+			WindowName: ws.Name,
+		})
 
 		return commandMutationResult{
 			output:          fmt.Sprintf("Attached %s:%s as window %s (%d panes)\n", hostName, ws.Name, win.Name, len(created)),

--- a/internal/server/commands_remote.go
+++ b/internal/server/commands_remote.go
@@ -31,6 +31,7 @@ const (
 	remoteAttachUsage       = "usage: remote attach (<name>|<name>:<pane-name>)"
 	remoteAttachWindowUsage = "usage: remote attach-window <name>:<window>"
 	remoteDetachUsage       = "usage: remote detach <local-pane>"
+	remoteDetachWindowUsage = "usage: remote detach-window <local-window>"
 	remoteResizeUsage       = "usage: remote resize <local-pane>"
 	remoteCommandTimeout    = 10 * time.Second
 )
@@ -99,6 +100,8 @@ func runRemoteCommand(ctx *CommandContext) commandpkg.Result {
 		return runRemoteAttachWindow(ctx)
 	case "detach":
 		return runRemoteDetach(ctx)
+	case "detach-window":
+		return runRemoteDetachWindow(ctx)
 	case "resize":
 		return runRemoteResize(ctx)
 	default:
@@ -535,6 +538,51 @@ func uniqueLocalWindowName(mctx *MutationContext, host, remoteName string) strin
 		}
 	}
 	return base
+}
+
+func runRemoteDetachWindow(ctx *CommandContext) commandpkg.Result {
+	if len(ctx.Args) != 2 {
+		return commandpkg.Result{Err: errors.New(remoteDetachWindowUsage)}
+	}
+	ref := ctx.Args[1]
+	return toCommandResult(ctx.Sess.enqueueCommandMutationContext(ctx.context(), func(mctx *MutationContext) commandMutationResult {
+		w := mctx.resolveWindow(ref)
+		if w == nil {
+			return commandMutationResult{err: fmt.Errorf("window %q not found", ref)}
+		}
+		if _, ok := mctx.sess.windowMirrorSigs[w.ID]; !ok {
+			return commandMutationResult{err: fmt.Errorf("window %q is not a remote mirror", w.Name)}
+		}
+		name := w.Name
+		paneIDs := windowPaneIDs(w)
+
+		// Stop the layout subscription first, then soft-close each pane (which
+		// also detaches the per-pane mirror); closing the last pane removes the
+		// window.
+		mctx.sess.mirror.DetachWindow(w.ID)
+		delete(mctx.sess.windowMirrorSigs, w.ID)
+		for _, id := range paneIDs {
+			mctx.softClosePane(id)
+		}
+		return commandMutationResult{
+			output:          fmt.Sprintf("Detached mirror window %s (%d panes)\n", name, len(paneIDs)),
+			broadcastLayout: true,
+		}
+	}))
+}
+
+// windowPaneIDs returns the IDs of every leaf pane in a window, in tree order.
+func windowPaneIDs(w *mux.Window) []uint32 {
+	ids := make([]uint32, 0)
+	if w == nil || w.Root == nil {
+		return ids
+	}
+	w.Root.Walk(func(c *mux.LayoutCell) {
+		if c.Pane != nil {
+			ids = append(ids, c.Pane.ID)
+		}
+	})
+	return ids
 }
 
 func runRemoteAttachChooser(ctx *CommandContext, hostName string) commandpkg.Result {

--- a/internal/server/commands_remote.go
+++ b/internal/server/commands_remote.go
@@ -27,6 +27,7 @@ const (
 	remoteStatusUsage    = "usage: remote status"
 	remoteRmUsage        = "usage: remote rm <name>"
 	remotePanesUsage     = "usage: remote panes <name>"
+	remoteWindowsUsage   = "usage: remote windows <name>"
 	remoteAttachUsage    = "usage: remote attach (<name>|<name>:<pane-name>)"
 	remoteDetachUsage    = "usage: remote detach <local-pane>"
 	remoteResizeUsage    = "usage: remote resize <local-pane>"
@@ -89,6 +90,8 @@ func runRemoteCommand(ctx *CommandContext) commandpkg.Result {
 		return runRemoteRm(ctx)
 	case "panes":
 		return runRemotePanes(ctx)
+	case "windows":
+		return runRemoteWindows(ctx)
 	case "attach":
 		return runRemoteAttach(ctx)
 	case "detach":
@@ -244,6 +247,42 @@ func runRemotePanes(ctx *CommandContext) commandpkg.Result {
 	}
 	home, _ := os.UserHomeDir()
 	return commandpkg.Result{Output: listingcmd.FormatPaneList(remoteLayoutPaneEntries(layout), home, true)}
+}
+
+func runRemoteWindows(ctx *CommandContext) commandpkg.Result {
+	if len(ctx.Args) != 2 {
+		return commandpkg.Result{Err: errors.New(remoteWindowsUsage)}
+	}
+	host, err := lookupRemoteHost(ctx.Args[1])
+	if err != nil {
+		return commandpkg.Result{Err: err}
+	}
+	layout, err := listRemotePanes(ctx.context(), host)
+	if err != nil {
+		return commandpkg.Result{Err: err}
+	}
+	return commandpkg.Result{Output: formatRemoteWindows(layout)}
+}
+
+// formatRemoteWindows renders the `remote windows` table: one row per remote
+// window with its index, name, leaf-pane count, root dimensions, and an active
+// marker. Pure function so it is unit-testable without a live remote.
+func formatRemoteWindows(layout *proto.LayoutSnapshot) string {
+	if layout == nil || len(layout.Windows) == 0 {
+		return "No windows.\n"
+	}
+	b := strings.Builder{} // local accumulator (not a package-level var)
+	fmt.Fprintf(&b, "%-3s %-20s %-6s %-12s %s\n", "", "NAME", "PANES", "DIMENSIONS", "INDEX")
+	for _, w := range layout.Windows {
+		marker := " "
+		if layout.ActiveWindowID == w.ID {
+			marker = "*"
+		}
+		paneCount := len(leafCellIDs(w.Root))
+		dims := fmt.Sprintf("%dx%d", w.Root.W, w.Root.H)
+		fmt.Fprintf(&b, "%-3s %-20s %-6d %-12s %d\n", marker, w.Name, paneCount, dims, w.Index)
+	}
+	return b.String()
 }
 
 func runRemoteAttach(ctx *CommandContext) commandpkg.Result {

--- a/internal/server/commands_remote.go
+++ b/internal/server/commands_remote.go
@@ -21,17 +21,18 @@ import (
 )
 
 const (
-	remoteCommandUsage   = "usage: remote <add|list|rm|panes|status|attach|detach|resize> ..."
-	remoteAddUsage       = "usage: remote add <name> --ssh <target> --socket <path> [--session <name>]"
-	remoteListUsage      = "usage: remote list"
-	remoteStatusUsage    = "usage: remote status"
-	remoteRmUsage        = "usage: remote rm <name>"
-	remotePanesUsage     = "usage: remote panes <name>"
-	remoteWindowsUsage   = "usage: remote windows <name>"
-	remoteAttachUsage    = "usage: remote attach (<name>|<name>:<pane-name>)"
-	remoteDetachUsage    = "usage: remote detach <local-pane>"
-	remoteResizeUsage    = "usage: remote resize <local-pane>"
-	remoteCommandTimeout = 10 * time.Second
+	remoteCommandUsage      = "usage: remote <add|list|rm|panes|windows|status|attach|attach-window|detach|detach-window|resize> ..."
+	remoteAddUsage          = "usage: remote add <name> --ssh <target> --socket <path> [--session <name>]"
+	remoteListUsage         = "usage: remote list"
+	remoteStatusUsage       = "usage: remote status"
+	remoteRmUsage           = "usage: remote rm <name>"
+	remotePanesUsage        = "usage: remote panes <name>"
+	remoteWindowsUsage      = "usage: remote windows <name>"
+	remoteAttachUsage       = "usage: remote attach (<name>|<name>:<pane-name>)"
+	remoteAttachWindowUsage = "usage: remote attach-window <name>:<window>"
+	remoteDetachUsage       = "usage: remote detach <local-pane>"
+	remoteResizeUsage       = "usage: remote resize <local-pane>"
+	remoteCommandTimeout    = 10 * time.Second
 )
 
 type remoteAddArgs struct {
@@ -94,6 +95,8 @@ func runRemoteCommand(ctx *CommandContext) commandpkg.Result {
 		return runRemoteWindows(ctx)
 	case "attach":
 		return runRemoteAttach(ctx)
+	case "attach-window":
+		return runRemoteAttachWindow(ctx)
 	case "detach":
 		return runRemoteDetach(ctx)
 	case "resize":
@@ -285,6 +288,62 @@ func formatRemoteWindows(layout *proto.LayoutSnapshot) string {
 	return b.String()
 }
 
+// remoteWindowLeaf pairs one remote leaf pane with the data needed to build a
+// local proxy pane for it: the remote pane ID, its name (for the RemoteRef), and
+// its cell content dimensions.
+type remoteWindowLeaf struct {
+	remoteID uint32
+	name     string
+	cols     int
+	rows     int
+}
+
+// planRemoteWindowLeaves walks a remote window snapshot's layout tree in leaf
+// order and pairs each leaf with its pane name and content dimensions. Pure and
+// unit-testable so the attach mutation stays thin. Returns an error when a leaf
+// lacks a usable pane snapshot or the window has no panes.
+func planRemoteWindowLeaves(ws proto.WindowSnapshot) ([]remoteWindowLeaf, error) {
+	snapshots := paneSnapshotsByID(ws.Panes)
+	leaves := make([]remoteWindowLeaf, 0)
+	if err := collectRemoteWindowLeaves(ws.Root, snapshots, ws.Name, &leaves); err != nil {
+		return nil, err
+	}
+	if len(leaves) == 0 {
+		return nil, fmt.Errorf("remote window %q has no panes", ws.Name)
+	}
+	return leaves, nil
+}
+
+// collectRemoteWindowLeaves appends one remoteWindowLeaf per leaf cell, in
+// left-to-right tree order, resolving each leaf's pane name from snapshots.
+func collectRemoteWindowLeaves(cell proto.CellSnapshot, snapshots map[uint32]proto.PaneSnapshot, windowName string, out *[]remoteWindowLeaf) error {
+	if cell.IsLeaf {
+		if cell.PaneID == 0 {
+			return nil
+		}
+		pane, ok := snapshots[cell.PaneID]
+		if !ok {
+			return fmt.Errorf("remote window %q: no pane snapshot for leaf %d", windowName, cell.PaneID)
+		}
+		if pane.Name == "" {
+			return fmt.Errorf("remote window %q: pane %d has no name", windowName, cell.PaneID)
+		}
+		*out = append(*out, remoteWindowLeaf{
+			remoteID: cell.PaneID,
+			name:     pane.Name,
+			cols:     cell.W,
+			rows:     mux.PaneContentHeight(cell.H),
+		})
+		return nil
+	}
+	for _, child := range cell.Children {
+		if err := collectRemoteWindowLeaves(child, snapshots, windowName, out); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func runRemoteAttach(ctx *CommandContext) commandpkg.Result {
 	if len(ctx.Args) != 2 {
 		return commandpkg.Result{Err: errors.New(remoteAttachUsage)}
@@ -332,6 +391,108 @@ func runRemoteAttach(ctx *CommandContext) commandpkg.Result {
 			broadcastLayout: true,
 		}
 	}))
+}
+
+func runRemoteAttachWindow(ctx *CommandContext) commandpkg.Result {
+	if len(ctx.Args) != 2 {
+		return commandpkg.Result{Err: errors.New(remoteAttachWindowUsage)}
+	}
+	hostName, windowRef, ok := strings.Cut(ctx.Args[1], ":")
+	if !ok || hostName == "" || windowRef == "" {
+		return commandpkg.Result{Err: errors.New(remoteAttachWindowUsage)}
+	}
+	host, err := lookupRemoteHost(hostName)
+	if err != nil {
+		return commandpkg.Result{Err: err}
+	}
+	layout, err := listRemotePanes(ctx.context(), host)
+	if err != nil {
+		return commandpkg.Result{Err: err}
+	}
+	ws, err := remote.ResolveWindowFromLayout(layout, windowRef)
+	if err != nil {
+		return commandpkg.Result{Err: err}
+	}
+	leaves, err := planRemoteWindowLeaves(ws)
+	if err != nil {
+		return commandpkg.Result{Err: err}
+	}
+	session := remoteCommandSession(host)
+
+	return toCommandResult(ctx.Sess.enqueueCommandMutationContext(ctx.context(), func(mctx *MutationContext) commandMutationResult {
+		base := mctx.activeWindow()
+		if base == nil {
+			return commandMutationResult{err: fmt.Errorf("no active window")}
+		}
+		paneMap := make(map[uint32]*mux.Pane, len(leaves))
+		refs := make(map[uint32]checkpoint.RemoteRef, len(leaves))
+		created := make([]*mux.Pane, 0, len(leaves))
+		cleanup := func() {
+			for _, p := range created {
+				mctx.removePane(p.ID)
+				mctx.ScheduleClose(p)
+			}
+		}
+		for _, leaf := range leaves {
+			ref := checkpoint.RemoteRef{Host: hostName, Session: session, PaneName: leaf.name}
+			pane, err := mctx.prepareMirrorPane(mux.PaneMeta{}, ref, leaf.cols, leaf.rows)
+			if err != nil {
+				cleanup()
+				return commandMutationResult{err: err}
+			}
+			paneMap[leaf.remoteID] = pane
+			refs[leaf.remoteID] = ref
+			created = append(created, pane)
+		}
+
+		win := mux.RebuildWindowFromSnapshot(ws, base.Width, base.Height, paneMap)
+		win.ID = mctx.nextWindowID()
+		win.Name = uniqueLocalWindowName(mctx, hostName, ws.Name)
+		// Mirror panes are independent local proxies: clear remote-scoped lead and
+		// zoom IDs so they do not dangle (a lead pane would also block the
+		// dimension-matching resize).
+		win.LeadPaneID = 0
+		win.ZoomedPaneID = 0
+
+		for _, leaf := range leaves {
+			if err := mctx.trackMirrorPane(paneMap[leaf.remoteID], refs[leaf.remoteID]); err != nil {
+				cleanup()
+				return commandMutationResult{err: err}
+			}
+		}
+
+		mctx.Windows = append(mctx.Windows, win)
+		mctx.activateWindow(win)
+
+		return commandMutationResult{
+			output:          fmt.Sprintf("Attached %s:%s as window %s (%d panes)\n", hostName, ws.Name, win.Name, len(created)),
+			broadcastLayout: true,
+		}
+	}))
+}
+
+// uniqueLocalWindowName builds a collision-free local window name for a mirrored
+// remote window, preferring "<host>:<remote-window>" and suffixing -N on clash.
+func uniqueLocalWindowName(mctx *MutationContext, host, remoteName string) string {
+	base := fmt.Sprintf("%s:%s", host, remoteName)
+	taken := func(name string) bool {
+		for _, w := range mctx.Windows {
+			if w != nil && w.Name == name {
+				return true
+			}
+		}
+		return false
+	}
+	if !taken(base) {
+		return base
+	}
+	for i := 2; i < 100; i++ {
+		cand := fmt.Sprintf("%s-%d", base, i)
+		if !taken(cand) {
+			return cand
+		}
+	}
+	return base
 }
 
 func runRemoteAttachChooser(ctx *CommandContext, hostName string) commandpkg.Result {

--- a/internal/server/commands_remote.go
+++ b/internal/server/commands_remote.go
@@ -504,7 +504,7 @@ func runRemoteAttachWindow(ctx *CommandContext) commandpkg.Result {
 			Host:       hostName,
 			Session:    session,
 			WindowName: ws.Name,
-		})
+		}, win.Width, win.Height)
 
 		return commandMutationResult{
 			output:          fmt.Sprintf("Attached %s:%s as window %s (%d panes)\n", hostName, ws.Name, win.Name, len(created)),

--- a/internal/server/commands_remote.go
+++ b/internal/server/commands_remote.go
@@ -351,7 +351,7 @@ func writeRemoteWindowSignature(b *strings.Builder, cell proto.CellSnapshot, nam
 func collectRemoteWindowLeaves(cell proto.CellSnapshot, snapshots map[uint32]proto.PaneSnapshot, windowName string, out *[]remoteWindowLeaf) error {
 	if cell.IsLeaf {
 		if cell.PaneID == 0 {
-			return nil
+			return fmt.Errorf("remote window %q: leaf has no pane id", windowName)
 		}
 		pane, ok := snapshots[cell.PaneID]
 		if !ok {
@@ -493,6 +493,8 @@ func runRemoteAttachWindow(ctx *CommandContext) commandpkg.Result {
 			}
 		}
 
+		prevActiveWindowID := mctx.ActiveWindowID
+		prevPreviousWindowID := mctx.PreviousWindowID
 		mctx.Windows = append(mctx.Windows, win)
 		mctx.activateWindow(win)
 
@@ -503,17 +505,31 @@ func runRemoteAttachWindow(ctx *CommandContext) commandpkg.Result {
 			mctx.sess.windowMirrorSigs = make(map[uint32]string)
 		}
 		mctx.sess.windowMirrorSigs[win.ID] = remoteWindowSignature(ws)
-		_ = mctx.sess.mirror.TrackWindow(win.ID, mirrorpkg.WindowRef{
+		if err := trackRemoteWindowMirror(mctx.sess, win.ID, mirrorpkg.WindowRef{
 			Host:       hostName,
 			Session:    session,
 			WindowName: ws.Name,
-		}, win.Width, win.Height)
+		}, win.Width, win.Height); err != nil {
+			cleanup()
+			mctx.Windows = removeWindowByID(mctx.Windows, win.ID)
+			mctx.ActiveWindowID = prevActiveWindowID
+			mctx.PreviousWindowID = prevPreviousWindowID
+			delete(mctx.sess.windowMirrorSigs, win.ID)
+			return commandMutationResult{err: err}
+		}
 
 		return commandMutationResult{
 			output:          fmt.Sprintf("Attached %s:%s as window %s (%d panes)\n", hostName, ws.Name, win.Name, len(created)),
 			broadcastLayout: true,
 		}
 	}))
+}
+
+func trackRemoteWindowMirror(s *Session, localWindowID uint32, ref mirrorpkg.WindowRef, cols, rows int) error {
+	if s == nil || s.mirror == nil {
+		return fmt.Errorf("mirror manager is not configured")
+	}
+	return s.mirror.TrackWindow(localWindowID, ref, cols, rows)
 }
 
 // uniqueLocalWindowName builds a collision-free local window name for a mirrored
@@ -531,13 +547,22 @@ func uniqueLocalWindowName(mctx *MutationContext, host, remoteName string) strin
 	if !taken(base) {
 		return base
 	}
-	for i := 2; i < 100; i++ {
+	for i := 2; ; i++ {
 		cand := fmt.Sprintf("%s-%d", base, i)
 		if !taken(cand) {
 			return cand
 		}
 	}
-	return base
+}
+
+func removeWindowByID(windows []*mux.Window, id uint32) []*mux.Window {
+	out := windows[:0]
+	for _, w := range windows {
+		if w == nil || w.ID != id {
+			out = append(out, w)
+		}
+	}
+	return out
 }
 
 func runRemoteDetachWindow(ctx *CommandContext) commandpkg.Result {

--- a/internal/server/commands_remote_winattach_test.go
+++ b/internal/server/commands_remote_winattach_test.go
@@ -1,9 +1,12 @@
 package server
 
 import (
+	"fmt"
 	"testing"
 
+	"github.com/weill-labs/amux/internal/mux"
 	"github.com/weill-labs/amux/internal/proto"
+	mirrorpkg "github.com/weill-labs/amux/internal/server/mirror"
 )
 
 func TestPlanRemoteWindowLeaves(t *testing.T) {
@@ -67,6 +70,18 @@ func TestPlanRemoteWindowLeavesErrors(t *testing.T) {
 				Panes: []proto.PaneSnapshot{{ID: 5, Name: ""}},
 			},
 		},
+		{
+			name: "mixed tree with zero pane id",
+			ws: proto.WindowSnapshot{
+				ID:   1,
+				Name: "amux",
+				Root: proto.CellSnapshot{Dir: 0, Children: []proto.CellSnapshot{
+					{IsLeaf: true, PaneID: 5, W: 40, H: 24},
+					{IsLeaf: true, PaneID: 0, W: 40, H: 24},
+				}},
+				Panes: []proto.PaneSnapshot{{ID: 5, Name: "pane-5"}},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -75,5 +90,27 @@ func TestPlanRemoteWindowLeavesErrors(t *testing.T) {
 				t.Fatalf("expected error for %s", tt.name)
 			}
 		})
+	}
+}
+
+func TestUniqueLocalWindowNameExhaustsSuffixes(t *testing.T) {
+	t.Parallel()
+
+	mctx := &MutationContext{}
+	mctx.Windows = append(mctx.Windows, &mux.Window{Name: "remote:amux"})
+	for i := 2; i <= 100; i++ {
+		mctx.Windows = append(mctx.Windows, &mux.Window{Name: fmt.Sprintf("remote:amux-%d", i)})
+	}
+
+	if got := uniqueLocalWindowName(mctx, "remote", "amux"); got != "remote:amux-101" {
+		t.Fatalf("name = %q, want remote:amux-101", got)
+	}
+}
+
+func TestTrackRemoteWindowMirrorRequiresManager(t *testing.T) {
+	t.Parallel()
+
+	if err := trackRemoteWindowMirror(&Session{}, 1, mirrorpkg.WindowRef{Host: "remote", WindowName: "amux"}, 80, 24); err == nil {
+		t.Fatal("expected error without mirror manager")
 	}
 }

--- a/internal/server/commands_remote_winattach_test.go
+++ b/internal/server/commands_remote_winattach_test.go
@@ -1,0 +1,79 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/weill-labs/amux/internal/proto"
+)
+
+func TestPlanRemoteWindowLeaves(t *testing.T) {
+	t.Parallel()
+
+	// A vertical split: two leaves side by side, each 100x50.
+	ws := proto.WindowSnapshot{
+		ID:   7,
+		Name: "amux",
+		Root: proto.CellSnapshot{
+			W: 200, H: 50, Dir: 0,
+			Children: []proto.CellSnapshot{
+				{IsLeaf: true, PaneID: 11, W: 100, H: 50},
+				{IsLeaf: true, PaneID: 12, W: 100, H: 50},
+			},
+		},
+		Panes: []proto.PaneSnapshot{
+			{ID: 11, Name: "pane-11"},
+			{ID: 12, Name: "pane-12"},
+		},
+	}
+
+	leaves, err := planRemoteWindowLeaves(ws)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(leaves) != 2 {
+		t.Fatalf("got %d leaves, want 2", len(leaves))
+	}
+	if leaves[0].remoteID != 11 || leaves[0].name != "pane-11" || leaves[0].cols != 100 {
+		t.Fatalf("leaf[0] = %+v", leaves[0])
+	}
+	if leaves[1].remoteID != 12 || leaves[1].name != "pane-12" {
+		t.Fatalf("leaf[1] = %+v", leaves[1])
+	}
+}
+
+func TestPlanRemoteWindowLeavesErrors(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		ws   proto.WindowSnapshot
+	}{
+		{
+			name: "no leaves",
+			ws:   proto.WindowSnapshot{ID: 1, Root: proto.CellSnapshot{W: 80, H: 24}},
+		},
+		{
+			name: "leaf without pane snapshot",
+			ws: proto.WindowSnapshot{
+				ID:   1,
+				Root: proto.CellSnapshot{IsLeaf: true, PaneID: 99, W: 80, H: 24},
+			},
+		},
+		{
+			name: "leaf with empty name",
+			ws: proto.WindowSnapshot{
+				ID:    1,
+				Root:  proto.CellSnapshot{IsLeaf: true, PaneID: 5, W: 80, H: 24},
+				Panes: []proto.PaneSnapshot{{ID: 5, Name: ""}},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if _, err := planRemoteWindowLeaves(tt.ws); err == nil {
+				t.Fatalf("expected error for %s", tt.name)
+			}
+		})
+	}
+}

--- a/internal/server/commands_remote_winlist_test.go
+++ b/internal/server/commands_remote_winlist_test.go
@@ -1,0 +1,68 @@
+package server
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/weill-labs/amux/internal/proto"
+)
+
+func TestFormatRemoteWindows(t *testing.T) {
+	t.Parallel()
+
+	layout := &proto.LayoutSnapshot{
+		ActiveWindowID: 20,
+		Windows: []proto.WindowSnapshot{
+			{
+				ID:    10,
+				Name:  "amux",
+				Index: 1,
+				Root:  proto.CellSnapshot{W: 200, H: 50, Children: []proto.CellSnapshot{leafCell(1, 100, 50), leafCell(2, 100, 50)}},
+				Panes: []proto.PaneSnapshot{{ID: 1}, {ID: 2}},
+			},
+			{
+				ID:    20,
+				Name:  "orca",
+				Index: 2,
+				Root:  leafCell(3, 200, 50),
+				Panes: []proto.PaneSnapshot{{ID: 3}},
+			},
+		},
+	}
+
+	out := formatRemoteWindows(layout)
+
+	for _, want := range []string{"INDEX", "NAME", "PANES", "amux", "orca", "200x50"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("output missing %q:\n%s", want, out)
+		}
+	}
+	// The active window (orca, ID 20) is marked.
+	orcaLine := lineContaining(t, out, "orca")
+	if !strings.Contains(orcaLine, "*") {
+		t.Fatalf("expected active marker on orca line, got %q", orcaLine)
+	}
+	// amux has 2 panes.
+	amuxLine := lineContaining(t, out, "amux")
+	if !strings.Contains(amuxLine, "2") {
+		t.Fatalf("expected pane count 2 on amux line, got %q", amuxLine)
+	}
+}
+
+func TestFormatRemoteWindowsEmpty(t *testing.T) {
+	t.Parallel()
+	if got := formatRemoteWindows(&proto.LayoutSnapshot{}); !strings.Contains(got, "No windows") {
+		t.Fatalf("expected empty notice, got %q", got)
+	}
+}
+
+func lineContaining(t *testing.T, text, sub string) string {
+	t.Helper()
+	for _, line := range strings.Split(text, "\n") {
+		if strings.Contains(line, sub) {
+			return line
+		}
+	}
+	t.Fatalf("no line containing %q in:\n%s", sub, text)
+	return ""
+}

--- a/internal/server/commands_remote_winsig_test.go
+++ b/internal/server/commands_remote_winsig_test.go
@@ -1,0 +1,89 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/weill-labs/amux/internal/proto"
+)
+
+func TestRemoteWindowSignatureIgnoresNonStructuralChanges(t *testing.T) {
+	t.Parallel()
+
+	base := proto.WindowSnapshot{
+		Name: "amux",
+		Root: proto.CellSnapshot{
+			W: 200, H: 50, Dir: 0,
+			Children: []proto.CellSnapshot{
+				{IsLeaf: true, PaneID: 1, W: 100, H: 50},
+				{IsLeaf: true, PaneID: 2, W: 100, H: 50},
+			},
+		},
+		Panes: []proto.PaneSnapshot{{ID: 1, Name: "a"}, {ID: 2, Name: "b"}},
+	}
+
+	// Same structure, different cell sizes / IDs but same names+shape -> same sig.
+	resized := base
+	resized.Root.Children = []proto.CellSnapshot{
+		{IsLeaf: true, PaneID: 1, W: 150, H: 50},
+		{IsLeaf: true, PaneID: 2, W: 50, H: 50},
+	}
+
+	if remoteWindowSignature(base) != remoteWindowSignature(resized) {
+		t.Fatal("resize-only change should not alter the structural signature")
+	}
+}
+
+func TestRemoteWindowSignatureDetectsStructuralChanges(t *testing.T) {
+	t.Parallel()
+
+	twoPanes := proto.WindowSnapshot{
+		Name: "amux",
+		Root: proto.CellSnapshot{
+			Dir: 0,
+			Children: []proto.CellSnapshot{
+				{IsLeaf: true, PaneID: 1, W: 100, H: 50},
+				{IsLeaf: true, PaneID: 2, W: 100, H: 50},
+			},
+		},
+		Panes: []proto.PaneSnapshot{{ID: 1, Name: "a"}, {ID: 2, Name: "b"}},
+	}
+
+	tests := []struct {
+		name  string
+		other proto.WindowSnapshot
+	}{
+		{
+			name: "added pane",
+			other: proto.WindowSnapshot{
+				Root: proto.CellSnapshot{Dir: 0, Children: []proto.CellSnapshot{
+					{IsLeaf: true, PaneID: 1}, {IsLeaf: true, PaneID: 2}, {IsLeaf: true, PaneID: 3},
+				}},
+				Panes: []proto.PaneSnapshot{{ID: 1, Name: "a"}, {ID: 2, Name: "b"}, {ID: 3, Name: "c"}},
+			},
+		},
+		{
+			name: "removed pane",
+			other: proto.WindowSnapshot{
+				Root:  proto.CellSnapshot{IsLeaf: true, PaneID: 1},
+				Panes: []proto.PaneSnapshot{{ID: 1, Name: "a"}},
+			},
+		},
+		{
+			name: "different split direction",
+			other: proto.WindowSnapshot{
+				Root: proto.CellSnapshot{Dir: 1, Children: []proto.CellSnapshot{
+					{IsLeaf: true, PaneID: 1}, {IsLeaf: true, PaneID: 2},
+				}},
+				Panes: []proto.PaneSnapshot{{ID: 1, Name: "a"}, {ID: 2, Name: "b"}},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if remoteWindowSignature(twoPanes) == remoteWindowSignature(tt.other) {
+				t.Fatalf("%s should change the structural signature", tt.name)
+			}
+		})
+	}
+}

--- a/internal/server/mirror/manager.go
+++ b/internal/server/mirror/manager.go
@@ -36,6 +36,9 @@ type Config struct {
 	RetryPolicy   remote.RetryPolicy
 	AttachTimeout time.Duration
 	OnMetaUpdate  func(paneID uint32, update proto.PaneMetaUpdate)
+	// OnWindowLayout is invoked with each layout snapshot a mirrored remote
+	// window pushes, so the owner can reconcile the local mirror window.
+	OnWindowLayout func(localWindowID uint32, ref WindowRef, layout *proto.LayoutSnapshot)
 }
 
 type Snapshot struct {
@@ -49,6 +52,11 @@ type Snapshot struct {
 type Manager struct {
 	ctx    context.Context
 	cancel context.CancelFunc
+
+	// Window-layout mirrors (guarded by mu below). Kept in their own alignment
+	// group so adding these long field names does not re-tab the block below.
+	windowMirrors  map[uint32]*windowMirrorState
+	onWindowLayout func(localWindowID uint32, ref WindowRef, layout *proto.LayoutSnapshot)
 
 	mu            sync.Mutex
 	hosts         map[string]config.Host
@@ -78,9 +86,10 @@ type mirrorState struct {
 func NewManager(cfg Config) *Manager {
 	ctx, cancel := context.WithCancel(context.Background())
 	m := &Manager{
-		ctx:     ctx,
-		cancel:  cancel,
-		mirrors: make(map[uint32]*mirrorState),
+		ctx:           ctx,
+		cancel:        cancel,
+		mirrors:       make(map[uint32]*mirrorState),
+		windowMirrors: make(map[uint32]*windowMirrorState),
 	}
 	m.Configure(cfg)
 	return m
@@ -107,6 +116,9 @@ func (m *Manager) Configure(cfg Config) {
 	if cfg.OnMetaUpdate != nil {
 		m.onMetaUpdate = cfg.OnMetaUpdate
 	}
+	if cfg.OnWindowLayout != nil {
+		m.onWindowLayout = cfg.OnWindowLayout
+	}
 	var start []*mirrorState
 	for _, ms := range m.mirrors {
 		if ms.running || ms.state == StateDetached || ms.state == StateDead {
@@ -119,6 +131,16 @@ func (m *Manager) Configure(cfg Config) {
 	for _, ms := range start {
 		m.startLocked(ms)
 	}
+	// startWindowLocked only sets running + launches a goroutine; it does not
+	// mutate windowMirrors, so starting during the range is safe.
+	for _, ws := range m.windowMirrors {
+		if ws.running || ws.state == StateDetached || ws.state == StateDead {
+			continue
+		}
+		if _, ok := m.hosts[ws.ref.Host]; ok {
+			m.startWindowLocked(ws)
+		}
+	}
 	m.mu.Unlock()
 }
 
@@ -129,10 +151,15 @@ func (m *Manager) Close() {
 	m.cancel()
 
 	m.mu.Lock()
-	links := make([]*remote.Link, 0, len(m.mirrors))
+	links := make([]*remote.Link, 0, len(m.mirrors)+len(m.windowMirrors))
 	for _, ms := range m.mirrors {
 		if ms.link != nil {
 			links = append(links, ms.link)
+		}
+	}
+	for _, ws := range m.windowMirrors {
+		if ws.link != nil {
+			links = append(links, ws.link)
 		}
 	}
 	m.mu.Unlock()

--- a/internal/server/mirror/window.go
+++ b/internal/server/mirror/window.go
@@ -1,0 +1,312 @@
+package mirror
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/weill-labs/amux/internal/config"
+	"github.com/weill-labs/amux/internal/proto"
+	"github.com/weill-labs/amux/internal/remote"
+)
+
+// WindowRef identifies a remote window to mirror: a configured host name, the
+// remote session, and the remote window name. Unlike a pane RemoteRef, windows
+// are resolved by name on the remote (no numeric ID is carried), so the
+// subscription survives the remote reassigning window IDs.
+type WindowRef struct {
+	Host       string
+	Session    string
+	WindowName string
+}
+
+// windowMirrorState tracks one live window-layout subscription, keyed by the
+// local mirror window ID. It carries a single link that streams MsgTypeLayout;
+// pane output for the window's panes flows over separate per-pane mirrors.
+type windowMirrorState struct {
+	localWindowID uint32
+	ref           WindowRef
+	state         State
+	generation    uint64
+	link          *remote.Link
+	running       bool
+	lastErr       string
+}
+
+// TrackWindow opens a layout subscription to a remote window. The Manager
+// invokes its OnWindowLayout callback with every layout snapshot the remote
+// pushes, so the owner can reconcile the local mirror window's structure.
+func (m *Manager) TrackWindow(localWindowID uint32, ref WindowRef) error {
+	if m == nil {
+		return fmt.Errorf("mirror manager is nil")
+	}
+	if localWindowID == 0 {
+		return fmt.Errorf("local window id is required")
+	}
+	if ref.Host == "" {
+		return fmt.Errorf("remote host is required")
+	}
+	if ref.WindowName == "" {
+		return fmt.Errorf("remote window name is required")
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.windowMirrors == nil {
+		m.windowMirrors = make(map[uint32]*windowMirrorState)
+	}
+	ws := &windowMirrorState{
+		localWindowID: localWindowID,
+		ref:           ref,
+		state:         StateConnecting,
+	}
+	m.windowMirrors[localWindowID] = ws
+	if _, ok := m.hosts[ref.Host]; ok {
+		m.startWindowLocked(ws)
+	} else {
+		// Host not configured yet: stay pending so a later Configure can start
+		// it (mirrors the per-pane deferred-start path).
+		ws.lastErr = fmt.Sprintf("remote host %q is not configured", ref.Host)
+	}
+	return nil
+}
+
+// DetachWindow tears down a window-layout subscription. It does not touch the
+// per-pane mirrors of the window's panes; the caller detaches those separately.
+func (m *Manager) DetachWindow(localWindowID uint32) {
+	if m == nil || localWindowID == 0 {
+		return
+	}
+	m.mu.Lock()
+	ws := m.windowMirrors[localWindowID]
+	if ws == nil {
+		m.mu.Unlock()
+		return
+	}
+	ws.state = StateDetached
+	link := ws.link
+	ws.link = nil
+	delete(m.windowMirrors, localWindowID)
+	m.mu.Unlock()
+	if link != nil {
+		_ = link.Close()
+	}
+}
+
+// WindowSnapshot reports the current state of a window-layout subscription.
+func (m *Manager) WindowSnapshot(localWindowID uint32) (Snapshot, bool) {
+	if m == nil {
+		return Snapshot{}, false
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	ws := m.windowMirrors[localWindowID]
+	if ws == nil {
+		return Snapshot{}, false
+	}
+	return Snapshot{State: ws.state, Generation: ws.generation, LastError: ws.lastErr}, true
+}
+
+func (m *Manager) startWindowLocked(ws *windowMirrorState) {
+	if ws == nil || ws.running || ws.state == StateDetached || ws.state == StateDead {
+		return
+	}
+	ws.running = true
+	id := ws.localWindowID
+	m.wg.Add(1)
+	go m.runWindow(id, ws)
+}
+
+func (m *Manager) runWindow(localWindowID uint32, owner *windowMirrorState) {
+	defer m.wg.Done()
+	defer m.markWindowStopped(localWindowID, owner)
+
+	attempt := 0
+	first := true
+	for {
+		if err := m.ctx.Err(); err != nil {
+			return
+		}
+		if !m.isCurrentWindow(localWindowID, owner) {
+			return
+		}
+		if !first {
+			attempt++
+			if attempt > m.retryPolicy.MaxAttempts {
+				m.markWindowDead(localWindowID, owner, "remote window connection retry budget exhausted")
+				return
+			}
+			if !m.sleepBeforeRetry(attempt) {
+				return
+			}
+			if !m.isCurrentWindow(localWindowID, owner) {
+				return
+			}
+		}
+		first = false
+
+		connected, terminal := m.attachAndReadWindow(localWindowID, owner)
+		if terminal {
+			return
+		}
+		if connected {
+			attempt = 0
+		}
+	}
+}
+
+func (m *Manager) attachAndReadWindow(localWindowID uint32, owner *windowMirrorState) (connected, terminal bool) {
+	host, ref, ok := m.prepareWindowAttempt(localWindowID, owner)
+	if !ok {
+		return false, true
+	}
+
+	attachCtx, cancel := context.WithTimeout(m.ctx, m.attachTimeout)
+	defer cancel()
+
+	link := remote.NewLink(host, m.currentDialer())
+	if err := link.Connect(attachCtx); err != nil {
+		m.recordWindowError(localWindowID, owner, err)
+		return false, false
+	}
+	if err := link.WriteMsg(&proto.Message{
+		Type:       proto.MsgTypeAttachWindow,
+		Session:    windowSession(host, ref),
+		WindowName: ref.WindowName,
+	}); err != nil {
+		_ = link.Close()
+		m.recordWindowError(localWindowID, owner, err)
+		return false, false
+	}
+
+	generation, ok := m.markWindowConnected(localWindowID, owner, link)
+	if !ok {
+		_ = link.Close()
+		return true, true
+	}
+
+	err := m.readLoopWindow(localWindowID, owner, generation, link)
+	_ = link.Close()
+	if err != nil {
+		m.recordWindowError(localWindowID, owner, err)
+		if m.isWindowTerminal(localWindowID, owner) {
+			return true, true
+		}
+	}
+	return true, false
+}
+
+func (m *Manager) readLoopWindow(localWindowID uint32, owner *windowMirrorState, generation uint64, link *remote.Link) error {
+	for {
+		msg, err := link.ReadMsg()
+		if err != nil {
+			return err
+		}
+		if msg == nil || msg.Type != proto.MsgTypeLayout || msg.Layout == nil {
+			continue
+		}
+		cb, ref, ok := m.windowLayoutCallback(localWindowID, owner, generation)
+		if !ok {
+			return nil
+		}
+		if cb != nil {
+			cb(localWindowID, ref, msg.Layout)
+		}
+	}
+}
+
+func (m *Manager) prepareWindowAttempt(localWindowID uint32, owner *windowMirrorState) (config.Host, WindowRef, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	ws := m.windowMirrors[localWindowID]
+	if ws == nil || ws != owner || ws.state == StateDetached || ws.state == StateDead {
+		return config.Host{}, WindowRef{}, false
+	}
+	ws.state = StateConnecting
+	host, ok := m.hosts[ws.ref.Host]
+	if !ok {
+		ws.lastErr = fmt.Sprintf("remote host %q is not configured", ws.ref.Host)
+		return config.Host{}, ws.ref, false
+	}
+	if host.Session == "" {
+		host.Session = ws.ref.Session
+	}
+	return host, ws.ref, true
+}
+
+func (m *Manager) markWindowConnected(localWindowID uint32, owner *windowMirrorState, link *remote.Link) (uint64, bool) {
+	m.mu.Lock()
+	ws := m.windowMirrors[localWindowID]
+	if ws == nil || ws != owner || ws.state == StateDetached || ws.state == StateDead {
+		m.mu.Unlock()
+		return 0, false
+	}
+	oldLink := ws.link
+	ws.generation++
+	gen := ws.generation
+	ws.link = link
+	ws.state = StateConnected
+	ws.lastErr = ""
+	m.mu.Unlock()
+
+	if oldLink != nil && oldLink != link {
+		_ = oldLink.Close()
+	}
+	return gen, true
+}
+
+func (m *Manager) windowLayoutCallback(localWindowID uint32, owner *windowMirrorState, generation uint64) (func(uint32, WindowRef, *proto.LayoutSnapshot), WindowRef, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	ws := m.windowMirrors[localWindowID]
+	if ws == nil || ws != owner || ws.generation != generation || ws.state == StateDetached || ws.state == StateDead {
+		return nil, WindowRef{}, false
+	}
+	return m.onWindowLayout, ws.ref, true
+}
+
+func (m *Manager) markWindowStopped(localWindowID uint32, owner *windowMirrorState) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if ws := m.windowMirrors[localWindowID]; ws != nil && ws == owner {
+		ws.running = false
+	}
+}
+
+func (m *Manager) isCurrentWindow(localWindowID uint32, owner *windowMirrorState) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.windowMirrors[localWindowID] == owner
+}
+
+func (m *Manager) markWindowDead(localWindowID uint32, owner *windowMirrorState, message string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if ws := m.windowMirrors[localWindowID]; ws != nil && ws == owner {
+		ws.state = StateDead
+		ws.lastErr = message
+	}
+}
+
+func (m *Manager) recordWindowError(localWindowID uint32, owner *windowMirrorState, err error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	ws := m.windowMirrors[localWindowID]
+	if ws != nil && ws == owner && ws.state != StateDead && ws.state != StateDetached {
+		ws.state = StateReconnecting
+		ws.lastErr = err.Error()
+	}
+}
+
+func (m *Manager) isWindowTerminal(localWindowID uint32, owner *windowMirrorState) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	ws := m.windowMirrors[localWindowID]
+	return ws == nil || ws != owner || ws.state == StateDead || ws.state == StateDetached
+}
+
+func windowSession(host config.Host, ref WindowRef) string {
+	if ref.Session != "" {
+		return ref.Session
+	}
+	return host.Session
+}

--- a/internal/server/mirror/window.go
+++ b/internal/server/mirror/window.go
@@ -96,6 +96,31 @@ func (m *Manager) DetachWindow(localWindowID uint32) {
 	}
 }
 
+// WindowMirrorInfo describes a tracked window mirror for checkpointing.
+type WindowMirrorInfo struct {
+	Ref  WindowRef
+	Cols int
+	Rows int
+}
+
+// WindowMirrorInfos returns the live window mirrors keyed by local window ID, so
+// the owner can persist them for restore after a reload.
+func (m *Manager) WindowMirrorInfos() map[uint32]WindowMirrorInfo {
+	if m == nil {
+		return nil
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make(map[uint32]WindowMirrorInfo, len(m.windowMirrors))
+	for id, ws := range m.windowMirrors {
+		if ws == nil || ws.state == StateDetached || ws.state == StateDead {
+			continue
+		}
+		out[id] = WindowMirrorInfo{Ref: ws.ref, Cols: ws.cols, Rows: ws.rows}
+	}
+	return out
+}
+
 // WindowSnapshot reports the current state of a window-layout subscription.
 func (m *Manager) WindowSnapshot(localWindowID uint32) (Snapshot, bool) {
 	if m == nil {

--- a/internal/server/mirror/window.go
+++ b/internal/server/mirror/window.go
@@ -25,6 +25,8 @@ type WindowRef struct {
 type windowMirrorState struct {
 	localWindowID uint32
 	ref           WindowRef
+	cols          int
+	rows          int
 	state         State
 	generation    uint64
 	link          *remote.Link
@@ -35,7 +37,7 @@ type windowMirrorState struct {
 // TrackWindow opens a layout subscription to a remote window. The Manager
 // invokes its OnWindowLayout callback with every layout snapshot the remote
 // pushes, so the owner can reconcile the local mirror window's structure.
-func (m *Manager) TrackWindow(localWindowID uint32, ref WindowRef) error {
+func (m *Manager) TrackWindow(localWindowID uint32, ref WindowRef, cols, rows int) error {
 	if m == nil {
 		return fmt.Errorf("mirror manager is nil")
 	}
@@ -57,6 +59,8 @@ func (m *Manager) TrackWindow(localWindowID uint32, ref WindowRef) error {
 	ws := &windowMirrorState{
 		localWindowID: localWindowID,
 		ref:           ref,
+		cols:          cols,
+		rows:          rows,
 		state:         StateConnecting,
 	}
 	m.windowMirrors[localWindowID] = ws
@@ -168,10 +172,13 @@ func (m *Manager) attachAndReadWindow(localWindowID uint32, owner *windowMirrorS
 		m.recordWindowError(localWindowID, owner, err)
 		return false, false
 	}
+	cols, rows := m.windowSize(localWindowID, owner)
 	if err := link.WriteMsg(&proto.Message{
 		Type:       proto.MsgTypeAttachWindow,
 		Session:    windowSession(host, ref),
 		WindowName: ref.WindowName,
+		Cols:       cols,
+		Rows:       rows,
 	}); err != nil {
 		_ = link.Close()
 		m.recordWindowError(localWindowID, owner, err)
@@ -212,6 +219,41 @@ func (m *Manager) readLoopWindow(localWindowID uint32, owner *windowMirrorState,
 			cb(localWindowID, ref, msg.Layout)
 		}
 	}
+}
+
+// ResizeWindow updates the desired size for a mirrored window and pushes it to
+// the remote so the remote re-renders the window at the local dimensions. A
+// no-op when the size is unchanged or the link is not connected yet (the size
+// is also carried on the next attach).
+func (m *Manager) ResizeWindow(localWindowID uint32, cols, rows int) {
+	if m == nil || localWindowID == 0 || cols <= 0 || rows <= 0 {
+		return
+	}
+	m.mu.Lock()
+	ws := m.windowMirrors[localWindowID]
+	if ws == nil || (ws.cols == cols && ws.rows == rows) {
+		m.mu.Unlock()
+		return
+	}
+	ws.cols = cols
+	ws.rows = rows
+	link := ws.link
+	connected := ws.state == StateConnected
+	m.mu.Unlock()
+
+	if connected && link != nil {
+		_ = link.WriteMsg(&proto.Message{Type: proto.MsgTypeResize, Cols: cols, Rows: rows})
+	}
+}
+
+func (m *Manager) windowSize(localWindowID uint32, owner *windowMirrorState) (int, int) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	ws := m.windowMirrors[localWindowID]
+	if ws == nil || ws != owner {
+		return 0, 0
+	}
+	return ws.cols, ws.rows
 }
 
 func (m *Manager) prepareWindowAttempt(localWindowID uint32, owner *windowMirrorState) (config.Host, WindowRef, bool) {

--- a/internal/server/mirror/window.go
+++ b/internal/server/mirror/window.go
@@ -32,6 +32,10 @@ type windowMirrorState struct {
 	link          *remote.Link
 	running       bool
 	lastErr       string
+	// resizePending/resizing coalesce size pushes so the write happens off the
+	// caller's goroutine (the session event loop) with at most one writer.
+	resizePending bool
+	resizing      bool
 }
 
 // TrackWindow opens a layout subscription to a remote window. The Manager
@@ -247,9 +251,10 @@ func (m *Manager) readLoopWindow(localWindowID uint32, owner *windowMirrorState,
 }
 
 // ResizeWindow updates the desired size for a mirrored window and pushes it to
-// the remote so the remote re-renders the window at the local dimensions. A
-// no-op when the size is unchanged or the link is not connected yet (the size
-// is also carried on the next attach).
+// the remote so the remote re-renders the window at the local dimensions. The
+// actual link write happens on a dedicated goroutine so a slow remote link can
+// never block the caller (the session event loop). The size is also carried on
+// the next attach, so a push that lands before the link connects is not lost.
 func (m *Manager) ResizeWindow(localWindowID uint32, cols, rows int) {
 	if m == nil || localWindowID == 0 || cols <= 0 || rows <= 0 {
 		return
@@ -262,11 +267,37 @@ func (m *Manager) ResizeWindow(localWindowID uint32, cols, rows int) {
 	}
 	ws.cols = cols
 	ws.rows = rows
-	link := ws.link
-	connected := ws.state == StateConnected
+	ws.resizePending = true
+	if ws.resizing {
+		// A drainer goroutine is already running; it will pick up the new size.
+		m.mu.Unlock()
+		return
+	}
+	ws.resizing = true
+	m.wg.Add(1)
 	m.mu.Unlock()
+	go m.drainWindowResizes(localWindowID, ws)
+}
 
-	if connected && link != nil {
+// drainWindowResizes writes pending size pushes to the remote link until none
+// remain, off the event loop. At most one drainer runs per window mirror, and
+// it always sends the latest requested size.
+func (m *Manager) drainWindowResizes(localWindowID uint32, owner *windowMirrorState) {
+	defer m.wg.Done()
+	for {
+		m.mu.Lock()
+		ws := m.windowMirrors[localWindowID]
+		if ws != owner || !ws.resizePending || ws.state != StateConnected || ws.link == nil {
+			if ws == owner {
+				ws.resizing = false
+			}
+			m.mu.Unlock()
+			return
+		}
+		ws.resizePending = false
+		cols, rows, link := ws.cols, ws.rows, ws.link
+		m.mu.Unlock()
+
 		_ = link.WriteMsg(&proto.Message{Type: proto.MsgTypeResize, Cols: cols, Rows: rows})
 	}
 }

--- a/internal/server/mirror/window_test.go
+++ b/internal/server/mirror/window_test.go
@@ -99,9 +99,9 @@ func TestManagerResizeWindowPushesSize(t *testing.T) {
 	}
 	<-connected
 
-	// net.Pipe is synchronous, so drive the write concurrently with the read
-	// (a real socket buffers and would not block here).
-	go mgr.ResizeWindow(7, 120, 30)
+	// ResizeWindow is non-blocking (the write happens on a drainer goroutine),
+	// so the read below drains the synchronous net.Pipe.
+	mgr.ResizeWindow(7, 120, 30)
 
 	resize, err := reader.ReadMsg()
 	if err != nil {

--- a/internal/server/mirror/window_test.go
+++ b/internal/server/mirror/window_test.go
@@ -2,13 +2,55 @@ package mirror
 
 import (
 	"context"
+	"errors"
 	"net"
+	"runtime"
 	"testing"
 	"time"
 
 	"github.com/weill-labs/amux/internal/config"
 	"github.com/weill-labs/amux/internal/proto"
 )
+
+// TestManagerWindowMirrorRetryBudgetEndsDead drives the window-mirror connect
+// retry loop to exhaustion against a failing dialer, covering the retry/error
+// state machine (runWindow, attachAndReadWindow, prepareWindowAttempt,
+// recordWindowError, markWindowDead).
+func TestManagerWindowMirrorRetryBudgetEndsDead(t *testing.T) {
+	t.Parallel()
+
+	mgr := NewManager(Config{
+		Hosts:       map[string]config.Host{"remote": {SSH: "ignored", Session: "main", SocketPath: "/tmp/amux-test"}},
+		Dialer:      failingDialer{err: errors.New("dial failed")},
+		RetryPolicy: remoteRetryPolicyForTest(2),
+	})
+	t.Cleanup(mgr.Close)
+
+	if err := mgr.TrackWindow(7, WindowRef{Host: "remote", Session: "main", WindowName: "amux"}, 80, 24); err != nil {
+		t.Fatalf("TrackWindow: %v", err)
+	}
+
+	waitForWindowMirrorState(t, mgr, 7, StateDead)
+	snap, ok := mgr.WindowSnapshot(7)
+	if !ok || snap.LastError == "" {
+		t.Fatalf("expected dead window mirror with an error, got %+v ok=%v", snap, ok)
+	}
+}
+
+// waitForWindowMirrorState polls the window mirror state, yielding the processor
+// (runtime.Gosched) between checks rather than blocking, so no sleep is needed.
+func waitForWindowMirrorState(t *testing.T, mgr *Manager, id uint32, want State) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if snap, ok := mgr.WindowSnapshot(id); ok && snap.State == want {
+			return
+		}
+		runtime.Gosched()
+	}
+	snap, _ := mgr.WindowSnapshot(id)
+	t.Fatalf("window mirror state = %s, want %s (last error %q)", snap.State, want, snap.LastError)
+}
 
 func TestManagerTrackWindowDeliversLayoutUpdates(t *testing.T) {
 	t.Parallel()

--- a/internal/server/mirror/window_test.go
+++ b/internal/server/mirror/window_test.go
@@ -1,7 +1,6 @@
 package mirror
 
 import (
-	"context"
 	"errors"
 	"net"
 	"runtime"
@@ -208,5 +207,4 @@ func TestManagerDetachWindowClosesLink(t *testing.T) {
 	if _, err := proto.NewReader(serverConn).ReadMsg(); err == nil {
 		t.Fatal("expected link to be closed after DetachWindow")
 	}
-	_ = context.Background()
 }

--- a/internal/server/mirror/window_test.go
+++ b/internal/server/mirror/window_test.go
@@ -25,7 +25,7 @@ func TestManagerTrackWindowDeliversLayoutUpdates(t *testing.T) {
 	})
 	t.Cleanup(mgr.Close)
 
-	if err := mgr.TrackWindow(7, WindowRef{Host: "h", Session: "main", WindowName: "amux"}); err != nil {
+	if err := mgr.TrackWindow(7, WindowRef{Host: "h", Session: "main", WindowName: "amux"}, 80, 24); err != nil {
 		t.Fatalf("TrackWindow: %v", err)
 	}
 
@@ -38,6 +38,9 @@ func TestManagerTrackWindowDeliversLayoutUpdates(t *testing.T) {
 	}
 	if sub.Type != proto.MsgTypeAttachWindow || sub.WindowName != "amux" {
 		t.Fatalf("subscription = type %d name %q, want AttachWindow amux", sub.Type, sub.WindowName)
+	}
+	if sub.Cols != 80 || sub.Rows != 24 {
+		t.Fatalf("subscription size = %dx%d, want 80x24", sub.Cols, sub.Rows)
 	}
 
 	if err := proto.NewWriter(serverConn).WriteMsg(&proto.Message{
@@ -54,6 +57,58 @@ func TestManagerTrackWindowDeliversLayoutUpdates(t *testing.T) {
 		}
 	case <-time.After(3 * time.Second):
 		t.Fatal("OnWindowLayout was not called")
+	}
+}
+
+func TestManagerResizeWindowPushesSize(t *testing.T) {
+	t.Parallel()
+
+	connected := make(chan struct{}, 1)
+	dialer := &pipeDialer{conns: make(chan net.Conn, 1)}
+	mgr := NewManager(Config{
+		Hosts:       map[string]config.Host{"h": {SSH: "x", Session: "main", SocketPath: "/tmp/x"}},
+		Dialer:      dialer,
+		RetryPolicy: remoteRetryPolicyForTest(2),
+		OnWindowLayout: func(uint32, WindowRef, *proto.LayoutSnapshot) {
+			select {
+			case connected <- struct{}{}:
+			default:
+			}
+		},
+	})
+	t.Cleanup(mgr.Close)
+
+	if err := mgr.TrackWindow(7, WindowRef{Host: "h", Session: "main", WindowName: "amux"}, 80, 24); err != nil {
+		t.Fatalf("TrackWindow: %v", err)
+	}
+	serverConn := <-dialer.conns
+	t.Cleanup(func() { _ = serverConn.Close() })
+
+	reader := proto.NewReader(serverConn)
+	if _, err := reader.ReadMsg(); err != nil { // drain the AttachWindow subscription
+		t.Fatalf("read subscription: %v", err)
+	}
+
+	// Pushing a layout proves the mirror is Connected (layouts are delivered only
+	// after markWindowConnected), so the subsequent ResizeWindow will send.
+	if err := proto.NewWriter(serverConn).WriteMsg(&proto.Message{
+		Type:   proto.MsgTypeLayout,
+		Layout: &proto.LayoutSnapshot{Windows: []proto.WindowSnapshot{{Name: "amux"}}},
+	}); err != nil {
+		t.Fatalf("write layout: %v", err)
+	}
+	<-connected
+
+	// net.Pipe is synchronous, so drive the write concurrently with the read
+	// (a real socket buffers and would not block here).
+	go mgr.ResizeWindow(7, 120, 30)
+
+	resize, err := reader.ReadMsg()
+	if err != nil {
+		t.Fatalf("read resize: %v", err)
+	}
+	if resize.Type != proto.MsgTypeResize || resize.Cols != 120 || resize.Rows != 30 {
+		t.Fatalf("resize = type %d %dx%d, want MsgTypeResize 120x30", resize.Type, resize.Cols, resize.Rows)
 	}
 }
 
@@ -75,7 +130,7 @@ func TestManagerTrackWindowValidation(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			if err := mgr.TrackWindow(tt.id, tt.ref); err == nil {
+			if err := mgr.TrackWindow(tt.id, tt.ref, 80, 24); err == nil {
 				t.Fatalf("expected error for %s", tt.name)
 			}
 		})
@@ -93,7 +148,7 @@ func TestManagerDetachWindowClosesLink(t *testing.T) {
 	})
 	t.Cleanup(mgr.Close)
 
-	if err := mgr.TrackWindow(7, WindowRef{Host: "h", Session: "main", WindowName: "amux"}); err != nil {
+	if err := mgr.TrackWindow(7, WindowRef{Host: "h", Session: "main", WindowName: "amux"}, 80, 24); err != nil {
 		t.Fatalf("TrackWindow: %v", err)
 	}
 	serverConn := <-dialer.conns

--- a/internal/server/mirror/window_test.go
+++ b/internal/server/mirror/window_test.go
@@ -1,0 +1,115 @@
+package mirror
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/weill-labs/amux/internal/config"
+	"github.com/weill-labs/amux/internal/proto"
+)
+
+func TestManagerTrackWindowDeliversLayoutUpdates(t *testing.T) {
+	t.Parallel()
+
+	got := make(chan *proto.LayoutSnapshot, 4)
+	dialer := &pipeDialer{conns: make(chan net.Conn, 1)}
+	mgr := NewManager(Config{
+		Hosts:       map[string]config.Host{"h": {SSH: "x", Session: "main", SocketPath: "/tmp/x"}},
+		Dialer:      dialer,
+		RetryPolicy: remoteRetryPolicyForTest(2),
+		OnWindowLayout: func(_ uint32, _ WindowRef, layout *proto.LayoutSnapshot) {
+			got <- layout
+		},
+	})
+	t.Cleanup(mgr.Close)
+
+	if err := mgr.TrackWindow(7, WindowRef{Host: "h", Session: "main", WindowName: "amux"}); err != nil {
+		t.Fatalf("TrackWindow: %v", err)
+	}
+
+	serverConn := <-dialer.conns
+	t.Cleanup(func() { _ = serverConn.Close() })
+
+	sub, err := proto.NewReader(serverConn).ReadMsg()
+	if err != nil {
+		t.Fatalf("read subscription: %v", err)
+	}
+	if sub.Type != proto.MsgTypeAttachWindow || sub.WindowName != "amux" {
+		t.Fatalf("subscription = type %d name %q, want AttachWindow amux", sub.Type, sub.WindowName)
+	}
+
+	if err := proto.NewWriter(serverConn).WriteMsg(&proto.Message{
+		Type:   proto.MsgTypeLayout,
+		Layout: &proto.LayoutSnapshot{Windows: []proto.WindowSnapshot{{ID: 1, Name: "amux"}}},
+	}); err != nil {
+		t.Fatalf("write layout: %v", err)
+	}
+
+	select {
+	case layout := <-got:
+		if len(layout.Windows) != 1 || layout.Windows[0].Name != "amux" {
+			t.Fatalf("unexpected layout: %+v", layout)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("OnWindowLayout was not called")
+	}
+}
+
+func TestManagerTrackWindowValidation(t *testing.T) {
+	t.Parallel()
+
+	mgr := NewManager(Config{})
+	t.Cleanup(mgr.Close)
+
+	tests := []struct {
+		name string
+		id   uint32
+		ref  WindowRef
+	}{
+		{name: "zero id", id: 0, ref: WindowRef{Host: "h", WindowName: "w"}},
+		{name: "no host", id: 1, ref: WindowRef{WindowName: "w"}},
+		{name: "no window name", id: 1, ref: WindowRef{Host: "h"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if err := mgr.TrackWindow(tt.id, tt.ref); err == nil {
+				t.Fatalf("expected error for %s", tt.name)
+			}
+		})
+	}
+}
+
+func TestManagerDetachWindowClosesLink(t *testing.T) {
+	t.Parallel()
+
+	dialer := &pipeDialer{conns: make(chan net.Conn, 1)}
+	mgr := NewManager(Config{
+		Hosts:       map[string]config.Host{"h": {SSH: "x", Session: "main", SocketPath: "/tmp/x"}},
+		Dialer:      dialer,
+		RetryPolicy: remoteRetryPolicyForTest(2),
+	})
+	t.Cleanup(mgr.Close)
+
+	if err := mgr.TrackWindow(7, WindowRef{Host: "h", Session: "main", WindowName: "amux"}); err != nil {
+		t.Fatalf("TrackWindow: %v", err)
+	}
+	serverConn := <-dialer.conns
+	t.Cleanup(func() { _ = serverConn.Close() })
+
+	// Drain the subscription so the link is fully connected.
+	if _, err := proto.NewReader(serverConn).ReadMsg(); err != nil {
+		t.Fatalf("read subscription: %v", err)
+	}
+
+	mgr.DetachWindow(7)
+
+	// After detach, the remote side observes the closed link via EOF.
+	_ = serverConn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	if _, err := proto.NewReader(serverConn).ReadMsg(); err == nil {
+		t.Fatal("expected link to be closed after DetachWindow")
+	}
+	_ = context.Background()
+}

--- a/internal/server/protocol.go
+++ b/internal/server/protocol.go
@@ -49,6 +49,9 @@ const (
 	MsgTypeListPanes  = proto.MsgTypeListPanes
 	MsgTypeAttachPane = proto.MsgTypeAttachPane
 
+	// Client → Server — window layout subscription (remote window mirroring).
+	MsgTypeAttachWindow = proto.MsgTypeAttachWindow
+
 	// Server → Client — work metadata/status for a restricted pane subscription.
 	MsgTypePaneMetaUpdate = proto.MsgTypePaneMetaUpdate
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1004,7 +1004,7 @@ func (s *Server) handleAttachWindow(cc *clientConn, msg *Message) {
 	cc.logger = sess.logger.With("client_id", cc.ID)
 	cc.startBootstrap()
 
-	res := sess.enqueueAttachWindowClient(cc, msg.WindowName)
+	res := sess.enqueueAttachWindowClient(cc, msg.WindowName, msg.Cols, msg.Rows)
 	if res.err != nil {
 		cc.sendProtocolError(res.err.Error())
 		cc.Close()

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -907,6 +907,8 @@ func (s *Server) handleConn(conn net.Conn) {
 		s.handleListPanes(cc, msg)
 	case MsgTypeAttachPane:
 		s.handleAttachPane(cc, msg)
+	case MsgTypeAttachWindow:
+		s.handleAttachWindow(cc, msg)
 	default:
 		cc.Close()
 	}
@@ -976,6 +978,35 @@ func (s *Server) handleAttachPane(cc *clientConn, msg *Message) {
 		return
 	}
 	cc.finishBootstrap(map[uint32]uint64{res.snapshot.paneID: res.snapshot.outputSeq})
+	cc.readLoop(s, sess)
+}
+
+// handleAttachWindow registers a window-scoped layout subscriber: it sends an
+// initial layout snapshot and then receives MsgTypeLayout on every layout
+// change. Used by remote window mirroring to track a remote window's structure.
+func (s *Server) handleAttachWindow(cc *clientConn, msg *Message) {
+	sess := s.sessionForProtocolMessage(msg)
+	if sess == nil {
+		cc.sendProtocolError("no session")
+		cc.Close()
+		return
+	}
+
+	cc.ID = fmt.Sprintf("client-%d", sess.ensureClientManager().nextClientOrdinal())
+	cc.logger = sess.logger.With("client_id", cc.ID)
+	cc.startBootstrap()
+
+	res := sess.enqueueAttachWindowClient(cc, msg.WindowName)
+	if res.err != nil {
+		cc.sendProtocolError(res.err.Error())
+		cc.Close()
+		return
+	}
+	if err := cc.Send(&Message{Type: MsgTypeLayout, Layout: res.layout}); err != nil {
+		cc.Close()
+		return
+	}
+	cc.finishBootstrap(nil)
 	cc.readLoop(s, sess)
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -110,6 +110,11 @@ type Session struct {
 	// panes are being reconstructed.
 	mirror *mirror.Manager
 
+	// windowMirrorSigs records the last structural signature applied per mirrored
+	// local window, so a window-layout broadcast that did not change structure is
+	// skipped. Accessed only on the session event loop.
+	windowMirrorSigs map[uint32]string
+
 	// Crash checkpoint coordination owns debounce/periodic scheduling and disk writes.
 	checkpointCoordinator crashCheckpointCoordinator
 	// watchdogRecoveryCheckpoint is a cheap last-known-good reload snapshot
@@ -518,7 +523,10 @@ func newSessionWithScrollbackConfigLogger(name string, scrollback ScrollbackConf
 	sess.terminalEventState = make(map[uint32]paneTerminalEventState)
 	sess.waiters = newWaiterManager()
 	sess.capture = newCaptureForwarder()
-	sess.mirror = mirror.NewManager(mirror.Config{OnMetaUpdate: sess.enqueueMirrorPaneMetaUpdate})
+	sess.mirror = mirror.NewManager(mirror.Config{
+		OnMetaUpdate:   sess.enqueueMirrorPaneMetaUpdate,
+		OnWindowLayout: sess.enqueueWindowLayoutReconcile,
+	})
 	sess.input = newInputRouter()
 	sess.checkpointCoordinator = newSessionCheckpointCoordinator(sess)
 	sess.undo = newUndoManager(undoManagerConfig{})

--- a/internal/server/session_broadcast.go
+++ b/internal/server/session_broadcast.go
@@ -25,6 +25,7 @@ func (s *Session) syncWindowSizeToEffectiveClient(w *mux.Window) {
 		return
 	}
 	w.Resize(cols, layoutH)
+	s.pushMirrorWindowSize(w)
 }
 
 func (s *Session) syncActiveWindowSize() {

--- a/internal/server/session_events_client.go
+++ b/internal/server/session_events_client.go
@@ -56,6 +56,8 @@ type attachPaneClientResult struct {
 type attachWindowClientEvent struct {
 	cc        *clientConn
 	windowRef string
+	cols      int
+	rows      int
 	reply     chan attachWindowClientResult
 }
 
@@ -88,6 +90,11 @@ func (e attachWindowClientEvent) handle(_ context.Context, s *Session) {
 	if w == nil {
 		e.reply <- attachWindowClientResult{err: fmt.Errorf("window %q not found", e.windowRef)}
 		return
+	}
+	// A mirror subscriber declares the size it wants the remote window rendered
+	// at. Apply it so the remote re-renders to match the local mirror window.
+	if e.cols > 0 && e.rows > 0 {
+		s.resizeMirrorTargetWindow(w, e.cols, e.rows)
 	}
 	snap := s.snapshotLayout(s.snapshotIdleState())
 	if snap == nil {
@@ -249,13 +256,13 @@ func (s *Session) enqueueAttachPaneClient(cc *clientConn, paneID uint32) attachP
 	}
 }
 
-func (s *Session) enqueueAttachWindowClient(cc *clientConn, windowRef string) attachWindowClientResult {
+func (s *Session) enqueueAttachWindowClient(cc *clientConn, windowRef string, cols, rows int) attachWindowClientResult {
 	ctx := s.context()
 	if cc != nil {
 		ctx = cc.context()
 	}
 	reply := make(chan attachWindowClientResult, 1)
-	if !s.enqueueEvent(ctx, attachWindowClientEvent{cc: cc, windowRef: windowRef, reply: reply}) {
+	if !s.enqueueEvent(ctx, attachWindowClientEvent{cc: cc, windowRef: windowRef, cols: cols, rows: rows, reply: reply}) {
 		if err := ctx.Err(); err != nil {
 			return attachWindowClientResult{err: err}
 		}

--- a/internal/server/session_events_client.go
+++ b/internal/server/session_events_client.go
@@ -94,7 +94,9 @@ func (e attachWindowClientEvent) handle(_ context.Context, s *Session) {
 	// A mirror subscriber declares the size it wants the remote window rendered
 	// at. Apply it so the remote re-renders to match the local mirror window.
 	if e.cols > 0 && e.rows > 0 {
-		s.resizeMirrorTargetWindow(w, e.cols, e.rows)
+		if s.resizeMirrorTargetWindow(w, e.cols, e.rows) {
+			s.broadcastLayoutNow()
+		}
 	}
 	snap := s.snapshotLayout(s.snapshotIdleState())
 	if snap == nil {

--- a/internal/server/session_events_client.go
+++ b/internal/server/session_events_client.go
@@ -53,6 +53,18 @@ type attachPaneClientResult struct {
 	err      error
 }
 
+type attachWindowClientEvent struct {
+	cc        *clientConn
+	windowRef string
+	reply     chan attachWindowClientResult
+}
+
+type attachWindowClientResult struct {
+	windowID uint32
+	layout   *proto.LayoutSnapshot
+	err      error
+}
+
 func (e detachClientEvent) handle(_ context.Context, s *Session) {
 	if !s.hasClient(e.cc) {
 		return
@@ -60,11 +72,32 @@ func (e detachClientEvent) handle(_ context.Context, s *Session) {
 	s.appendConnectionLog(connectionLogEventDetach, e.cc.ID, e.cc.cols, e.cc.rows, e.cc.disconnectReasonValue())
 	s.emitClientDisconnectEvent(e.cc, e.reason)
 	s.logClientDisconnect(e.cc, e.cc.disconnectReasonValue())
-	if e.cc.isPaneScoped() {
+	if e.cc.isPaneScoped() || e.cc.isWindowScoped() {
 		s.removeClientWithoutLayout(e.cc)
 		return
 	}
 	s.removeClient(e.cc)
+}
+
+// handle resolves the requested window, scopes the connection to layout-only
+// delivery, and registers it so subsequent layout broadcasts reach it. The
+// scope is set before addClient so the connection is never briefly treated as a
+// full client (which would receive pane output it should not).
+func (e attachWindowClientEvent) handle(_ context.Context, s *Session) {
+	w := s.resolveWindow(e.windowRef)
+	if w == nil {
+		e.reply <- attachWindowClientResult{err: fmt.Errorf("window %q not found", e.windowRef)}
+		return
+	}
+	snap := s.snapshotLayout(s.snapshotIdleState())
+	if snap == nil {
+		e.reply <- attachWindowClientResult{err: fmt.Errorf("no layout")}
+		return
+	}
+	e.cc.restrictToWindow(w.ID)
+	s.ensureClientManager().addClient(e.cc)
+	s.appendConnectionLog(connectionLogEventAttach, e.cc.ID, e.cc.cols, e.cc.rows, "")
+	e.reply <- attachWindowClientResult{windowID: w.ID, layout: snap}
 }
 
 func (e attachPaneClientEvent) handle(_ context.Context, s *Session) {
@@ -213,6 +246,28 @@ func (s *Session) enqueueAttachPaneClient(cc *clientConn, paneID uint32) attachP
 		return attachPaneClientResult{err: ctx.Err()}
 	case <-s.sessionEventDone:
 		return attachPaneClientResult{err: errSessionShuttingDown}
+	}
+}
+
+func (s *Session) enqueueAttachWindowClient(cc *clientConn, windowRef string) attachWindowClientResult {
+	ctx := s.context()
+	if cc != nil {
+		ctx = cc.context()
+	}
+	reply := make(chan attachWindowClientResult, 1)
+	if !s.enqueueEvent(ctx, attachWindowClientEvent{cc: cc, windowRef: windowRef, reply: reply}) {
+		if err := ctx.Err(); err != nil {
+			return attachWindowClientResult{err: err}
+		}
+		return attachWindowClientResult{err: errSessionShuttingDown}
+	}
+	select {
+	case res := <-reply:
+		return res
+	case <-ctx.Done():
+		return attachWindowClientResult{err: ctx.Err()}
+	case <-s.sessionEventDone:
+		return attachWindowClientResult{err: errSessionShuttingDown}
 	}
 }
 

--- a/internal/server/session_window_mirror.go
+++ b/internal/server/session_window_mirror.go
@@ -156,6 +156,53 @@ func (s *Session) resizeMirrorTargetWindow(w *mux.Window, cols, rows int) {
 	w.Resize(cols, rows)
 }
 
+// windowMirrorCheckpoints builds checkpoint records for the session's active
+// window mirrors so their layout subscriptions can resume after a reload.
+func windowMirrorCheckpoints(s *Session) map[uint32]checkpoint.RemoteWindowRef {
+	if s == nil || s.mirror == nil || len(s.windowMirrorSigs) == 0 {
+		return nil
+	}
+	infos := s.mirror.WindowMirrorInfos()
+	out := make(map[uint32]checkpoint.RemoteWindowRef, len(s.windowMirrorSigs))
+	for id, sig := range s.windowMirrorSigs {
+		info, ok := infos[id]
+		if !ok {
+			continue
+		}
+		out[id] = checkpoint.RemoteWindowRef{
+			Host:       info.Ref.Host,
+			Session:    info.Ref.Session,
+			WindowName: info.Ref.WindowName,
+			Cols:       info.Cols,
+			Rows:       info.Rows,
+			Signature:  sig,
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// restoreWindowMirrors re-establishes window layout subscriptions after a reload
+// and re-seeds their structural signatures so the first broadcast is a no-op.
+func (s *Session) restoreWindowMirrors(refs map[uint32]checkpoint.RemoteWindowRef) {
+	if s == nil || s.mirror == nil || len(refs) == 0 {
+		return
+	}
+	if s.windowMirrorSigs == nil {
+		s.windowMirrorSigs = make(map[uint32]string, len(refs))
+	}
+	for id, ref := range refs {
+		s.windowMirrorSigs[id] = ref.Signature
+		_ = s.mirror.TrackWindow(id, mirrorpkg.WindowRef{
+			Host:       ref.Host,
+			Session:    ref.Session,
+			WindowName: ref.WindowName,
+		}, ref.Cols, ref.Rows)
+	}
+}
+
 // pushMirrorWindowSize forwards a local mirror window's size to the remote so it
 // re-renders the window to match. A no-op for non-mirror windows. Event-loop only.
 func (s *Session) pushMirrorWindowSize(w *mux.Window) {

--- a/internal/server/session_window_mirror.go
+++ b/internal/server/session_window_mirror.go
@@ -100,13 +100,21 @@ func (mctx *MutationContext) applyWindowReconcile(in windowReconcileInput) comma
 	}
 
 	for remoteID, ref := range createdRefs {
-		_ = mctx.trackMirrorPane(paneMap[remoteID], ref)
+		if err := mctx.trackMirrorPane(paneMap[remoteID], ref); err != nil {
+			for _, cp := range created {
+				mctx.removePane(cp.ID)
+				mctx.ScheduleClose(cp)
+			}
+			return commandMutationResult{err: err}
+		}
 	}
 
 	// Rebuild the local window's split tree to match the remote structure,
 	// keeping the local window identity and refitting to local dimensions.
 	rebuilt := mux.RebuildWindowFromSnapshot(in.ws, w.Width, w.Height, paneMap)
 	w.Root = rebuilt.Root
+	// Remote lead/zoom pane IDs are scoped to the remote window. Clear local
+	// lead/zoom state after structural rebuilds so those IDs cannot dangle.
 	w.LeadPaneID = 0
 	w.ZoomedPaneID = 0
 	// RebuildWindowFromSnapshot already falls back to the first leaf when the
@@ -149,11 +157,12 @@ func existingMirrorPanesByRemoteName(sess *Session, w *mux.Window) map[string]*m
 
 // resizeMirrorTargetWindow applies a mirror subscriber's requested size to a
 // window. Called on the session event loop from the attach-window handler.
-func (s *Session) resizeMirrorTargetWindow(w *mux.Window, cols, rows int) {
+func (s *Session) resizeMirrorTargetWindow(w *mux.Window, cols, rows int) bool {
 	if w == nil || cols <= 0 || rows <= 0 || (w.Width == cols && w.Height == rows) {
-		return
+		return false
 	}
 	w.Resize(cols, rows)
+	return true
 }
 
 // windowMirrorCheckpoints builds checkpoint records for the session's active

--- a/internal/server/session_window_mirror.go
+++ b/internal/server/session_window_mirror.go
@@ -1,6 +1,8 @@
 package server
 
 import (
+	"context"
+
 	"github.com/weill-labs/amux/internal/checkpoint"
 	"github.com/weill-labs/amux/internal/mux"
 	"github.com/weill-labs/amux/internal/proto"
@@ -143,6 +145,51 @@ func existingMirrorPanesByRemoteName(sess *Session, w *mux.Window) map[string]*m
 		}
 	})
 	return out
+}
+
+// resizeMirrorTargetWindow applies a mirror subscriber's requested size to a
+// window. Called on the session event loop from the attach-window handler.
+func (s *Session) resizeMirrorTargetWindow(w *mux.Window, cols, rows int) {
+	if w == nil || cols <= 0 || rows <= 0 || (w.Width == cols && w.Height == rows) {
+		return
+	}
+	w.Resize(cols, rows)
+}
+
+// pushMirrorWindowSize forwards a local mirror window's size to the remote so it
+// re-renders the window to match. A no-op for non-mirror windows. Event-loop only.
+func (s *Session) pushMirrorWindowSize(w *mux.Window) {
+	if s == nil || w == nil || s.mirror == nil {
+		return
+	}
+	if _, ok := s.windowMirrorSigs[w.ID]; !ok {
+		return // not a mirrored window
+	}
+	s.mirror.ResizeWindow(w.ID, w.Width, w.Height)
+}
+
+// enqueueResizeMirrorWindow handles a resize a window-mirror subscriber sent over
+// its layout link, so the remote re-renders the window at the local size.
+func (s *Session) enqueueResizeMirrorWindow(windowID uint32, cols, rows int) {
+	if s == nil || s.shutdown.Load() || windowID == 0 || cols <= 0 || rows <= 0 {
+		return
+	}
+	s.enqueueEvent(s.context(), resizeMirrorWindowEvent{windowID: windowID, cols: cols, rows: rows})
+}
+
+type resizeMirrorWindowEvent struct {
+	windowID uint32
+	cols     int
+	rows     int
+}
+
+func (e resizeMirrorWindowEvent) handle(_ context.Context, s *Session) {
+	w := s.windowByID(e.windowID)
+	if w == nil || (w.Width == e.cols && w.Height == e.rows) {
+		return
+	}
+	w.Resize(e.cols, e.rows)
+	s.broadcastLayoutNow()
 }
 
 func mutationWindowByID(mctx *MutationContext, id uint32) *mux.Window {

--- a/internal/server/session_window_mirror.go
+++ b/internal/server/session_window_mirror.go
@@ -1,0 +1,155 @@
+package server
+
+import (
+	"github.com/weill-labs/amux/internal/checkpoint"
+	"github.com/weill-labs/amux/internal/mux"
+	"github.com/weill-labs/amux/internal/proto"
+	"github.com/weill-labs/amux/internal/remote"
+	mirrorpkg "github.com/weill-labs/amux/internal/server/mirror"
+)
+
+// windowReconcileInput carries the parsed remote window snapshot from the mirror
+// goroutine into the session event loop, where the reconcile runs.
+type windowReconcileInput struct {
+	localWindowID uint32
+	ref           mirrorpkg.WindowRef
+	ws            proto.WindowSnapshot
+	leaves        []remoteWindowLeaf
+	signature     string
+}
+
+// enqueueWindowLayoutReconcile is the mirror.Manager OnWindowLayout callback. It
+// runs on the mirror goroutine: it parses the remote layout, then enqueues a
+// mutation that reconciles the local mirror window. Non-structural broadcasts
+// (idle/busy, metadata) are filtered out by the structural signature inside the
+// mutation, so this stays cheap on the hot path.
+func (s *Session) enqueueWindowLayoutReconcile(localWindowID uint32, ref mirrorpkg.WindowRef, layout *proto.LayoutSnapshot) {
+	if s == nil || s.shutdown.Load() || layout == nil {
+		return
+	}
+	ws, err := remote.ResolveWindowFromLayout(layout, ref.WindowName)
+	if err != nil {
+		return
+	}
+	leaves, err := planRemoteWindowLeaves(ws)
+	if err != nil {
+		return
+	}
+	in := windowReconcileInput{
+		localWindowID: localWindowID,
+		ref:           ref,
+		ws:            ws,
+		leaves:        leaves,
+		signature:     remoteWindowSignature(ws),
+	}
+	s.enqueueCommandMutationContext(s.context(), func(mctx *MutationContext) commandMutationResult {
+		return mctx.applyWindowReconcile(in)
+	})
+}
+
+// applyWindowReconcile diffs the remote window structure against the local
+// mirror window and brings the local window into line: it adds proxy panes for
+// new remote panes, removes proxies whose remote pane is gone, and rebuilds the
+// split tree to match. Panes are matched across the two sides by remote name.
+func (mctx *MutationContext) applyWindowReconcile(in windowReconcileInput) commandMutationResult {
+	sess := mctx.sess
+	if sess == nil {
+		return commandMutationResult{}
+	}
+	if sess.windowMirrorSigs == nil {
+		sess.windowMirrorSigs = make(map[uint32]string)
+	}
+	if sess.windowMirrorSigs[in.localWindowID] == in.signature {
+		return commandMutationResult{} // structure unchanged — nothing to do
+	}
+
+	w := mutationWindowByID(mctx, in.localWindowID)
+	if w == nil {
+		// Local mirror window is gone: stop the subscription and forget it.
+		delete(sess.windowMirrorSigs, in.localWindowID)
+		sess.mirror.DetachWindow(in.localWindowID)
+		return commandMutationResult{}
+	}
+
+	existing := existingMirrorPanesByRemoteName(sess, w)
+
+	paneMap := make(map[uint32]*mux.Pane, len(in.leaves))
+	created := make([]*mux.Pane, 0)
+	createdRefs := make(map[uint32]checkpoint.RemoteRef)
+	keep := make(map[string]bool, len(in.leaves))
+	for _, leaf := range in.leaves {
+		keep[leaf.name] = true
+		if p, ok := existing[leaf.name]; ok {
+			paneMap[leaf.remoteID] = p
+			continue
+		}
+		ref := checkpoint.RemoteRef{Host: in.ref.Host, Session: in.ref.Session, PaneName: leaf.name}
+		pane, err := mctx.prepareMirrorPane(mux.PaneMeta{}, ref, leaf.cols, leaf.rows)
+		if err != nil {
+			for _, cp := range created {
+				mctx.removePane(cp.ID)
+				mctx.ScheduleClose(cp)
+			}
+			return commandMutationResult{err: err}
+		}
+		paneMap[leaf.remoteID] = pane
+		created = append(created, pane)
+		createdRefs[leaf.remoteID] = ref
+	}
+
+	for remoteID, ref := range createdRefs {
+		_ = mctx.trackMirrorPane(paneMap[remoteID], ref)
+	}
+
+	// Rebuild the local window's split tree to match the remote structure,
+	// keeping the local window identity and refitting to local dimensions.
+	rebuilt := mux.RebuildWindowFromSnapshot(in.ws, w.Width, w.Height, paneMap)
+	w.Root = rebuilt.Root
+	w.LeadPaneID = 0
+	w.ZoomedPaneID = 0
+	// RebuildWindowFromSnapshot already falls back to the first leaf when the
+	// active pane id is not mapped, so this is non-nil for any non-empty tree.
+	if rebuilt.ActivePane != nil {
+		w.ActivePane = rebuilt.ActivePane
+	}
+	w.Resize(w.Width, w.Height)
+
+	// Close proxies whose remote counterpart disappeared.
+	for name, pane := range existing {
+		if !keep[name] {
+			sess.mirror.Detach(pane.ID)
+			mctx.removePane(pane.ID)
+			mctx.ScheduleClose(pane)
+		}
+	}
+
+	sess.windowMirrorSigs[in.localWindowID] = in.signature
+	return commandMutationResult{broadcastLayout: true}
+}
+
+// existingMirrorPanesByRemoteName maps each of a window's proxy panes to the
+// remote pane name it mirrors, so reconcile can match panes across resyncs.
+func existingMirrorPanesByRemoteName(sess *Session, w *mux.Window) map[string]*mux.Pane {
+	out := make(map[string]*mux.Pane)
+	if w == nil || w.Root == nil {
+		return out
+	}
+	w.Root.Walk(func(c *mux.LayoutCell) {
+		if c.Pane == nil {
+			return
+		}
+		if ref, ok := sess.mirror.RemoteRef(c.Pane.ID); ok {
+			out[ref.PaneName] = c.Pane
+		}
+	})
+	return out
+}
+
+func mutationWindowByID(mctx *MutationContext, id uint32) *mux.Window {
+	for _, w := range mctx.Windows {
+		if w != nil && w.ID == id {
+			return w
+		}
+	}
+	return nil
+}

--- a/internal/server/session_window_mirror_test.go
+++ b/internal/server/session_window_mirror_test.go
@@ -1,0 +1,44 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/weill-labs/amux/internal/checkpoint"
+	"github.com/weill-labs/amux/internal/server/mirror"
+)
+
+// TestWindowMirrorCheckpointAndRestore covers the checkpoint capture and restore
+// of window-layout subscriptions. The host is left unconfigured so the mirror
+// stays pending (no dialing) while the map bookkeeping is exercised.
+func TestWindowMirrorCheckpointAndRestore(t *testing.T) {
+	t.Parallel()
+
+	srcMgr := mirror.NewManager(mirror.Config{})
+	t.Cleanup(srcMgr.Close)
+	if err := srcMgr.TrackWindow(7, mirror.WindowRef{Host: "h", Session: "main", WindowName: "amux"}, 200, 50); err != nil {
+		t.Fatalf("TrackWindow: %v", err)
+	}
+	src := &Session{mirror: srcMgr, windowMirrorSigs: map[uint32]string{7: "(0[a][b])"}}
+
+	cps := windowMirrorCheckpoints(src)
+	got, ok := cps[7]
+	if !ok {
+		t.Fatalf("window mirror 7 missing from checkpoint: %+v", cps)
+	}
+	want := checkpoint.RemoteWindowRef{Host: "h", Session: "main", WindowName: "amux", Cols: 200, Rows: 50, Signature: "(0[a][b])"}
+	if got != want {
+		t.Fatalf("checkpoint = %+v, want %+v", got, want)
+	}
+
+	dstMgr := mirror.NewManager(mirror.Config{})
+	t.Cleanup(dstMgr.Close)
+	dst := &Session{mirror: dstMgr}
+	dst.restoreWindowMirrors(cps)
+
+	if dst.windowMirrorSigs[7] != "(0[a][b])" {
+		t.Fatalf("restored signature = %q, want %q", dst.windowMirrorSigs[7], "(0[a][b])")
+	}
+	if _, ok := dstMgr.WindowSnapshot(7); !ok {
+		t.Fatal("window mirror was not re-tracked on restore")
+	}
+}

--- a/internal/server/session_window_mirror_test.go
+++ b/internal/server/session_window_mirror_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/weill-labs/amux/internal/checkpoint"
 	"github.com/weill-labs/amux/internal/mux"
+	"github.com/weill-labs/amux/internal/proto"
 	"github.com/weill-labs/amux/internal/server/mirror"
 )
 
@@ -66,5 +67,43 @@ func TestWindowMirrorCheckpointAndRestore(t *testing.T) {
 	}
 	if _, ok := dstMgr.WindowSnapshot(7); !ok {
 		t.Fatal("window mirror was not re-tracked on restore")
+	}
+}
+
+func TestApplyWindowReconcileRollsBackPaneTrackingFailure(t *testing.T) {
+	t.Parallel()
+
+	w := &mux.Window{ID: 7, Width: 80, Height: 24}
+	sess := &Session{
+		Windows:          []*mux.Window{w},
+		ActiveWindowID:   7,
+		windowMirrorSigs: map[uint32]string{7: "old"},
+	}
+	mctx := newMutationContext(sess)
+	in := windowReconcileInput{
+		localWindowID: 7,
+		ref:           mirror.WindowRef{Host: "remote", Session: "main", WindowName: "amux"},
+		ws: proto.WindowSnapshot{
+			Name:  "amux",
+			Root:  proto.CellSnapshot{IsLeaf: true, PaneID: 11, W: 80, H: 24},
+			Panes: []proto.PaneSnapshot{{ID: 11, Name: "pane-11"}},
+		},
+		leaves:    []remoteWindowLeaf{{remoteID: 11, name: "pane-11", cols: 80, rows: 23}},
+		signature: "new",
+	}
+
+	res := mctx.applyWindowReconcile(in)
+
+	if res.err == nil {
+		t.Fatal("expected tracking error")
+	}
+	if len(sess.Panes) != 0 {
+		t.Fatalf("created panes were not rolled back: %+v", sess.Panes)
+	}
+	if len(mctx.closePanes) != 1 {
+		t.Fatalf("scheduled closes = %d, want 1", len(mctx.closePanes))
+	}
+	if got := sess.windowMirrorSigs[7]; got != "old" {
+		t.Fatalf("signature = %q, want old", got)
 	}
 }

--- a/internal/server/session_window_mirror_test.go
+++ b/internal/server/session_window_mirror_test.go
@@ -4,8 +4,34 @@ import (
 	"testing"
 
 	"github.com/weill-labs/amux/internal/checkpoint"
+	"github.com/weill-labs/amux/internal/mux"
 	"github.com/weill-labs/amux/internal/server/mirror"
 )
+
+// TestPushMirrorWindowSize covers forwarding a local mirror window's size to the
+// remote (and the non-mirror-window early return).
+func TestPushMirrorWindowSize(t *testing.T) {
+	t.Parallel()
+
+	mgr := mirror.NewManager(mirror.Config{})
+	t.Cleanup(mgr.Close)
+	if err := mgr.TrackWindow(5, mirror.WindowRef{Host: "h", Session: "main", WindowName: "amux"}, 80, 24); err != nil {
+		t.Fatalf("TrackWindow: %v", err)
+	}
+	s := &Session{mirror: mgr, windowMirrorSigs: map[uint32]string{5: "sig"}}
+
+	// Non-mirror window: no-op (size stays at the tracked 80x24).
+	s.pushMirrorWindowSize(&mux.Window{ID: 99, Width: 150, Height: 40})
+	if info := mgr.WindowMirrorInfos()[5]; info.Cols != 80 || info.Rows != 24 {
+		t.Fatalf("unexpected size change for non-mirror window: %+v", info)
+	}
+
+	// Mirror window: size is forwarded to the manager.
+	s.pushMirrorWindowSize(&mux.Window{ID: 5, Width: 150, Height: 40})
+	if info := mgr.WindowMirrorInfos()[5]; info.Cols != 150 || info.Rows != 40 {
+		t.Fatalf("size = %dx%d, want 150x40", info.Cols, info.Rows)
+	}
+}
 
 // TestWindowMirrorCheckpointAndRestore covers the checkpoint capture and restore
 // of window-layout subscriptions. The host is left unconfigured so the mirror

--- a/test/attach_window_layout_test.go
+++ b/test/attach_window_layout_test.go
@@ -1,0 +1,79 @@
+package test
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/weill-labs/amux/internal/proto"
+	"github.com/weill-labs/amux/internal/server"
+)
+
+// TestAttachWindowStreamsLayoutUpdates verifies the MsgTypeAttachWindow
+// subscription: the connection receives an initial layout snapshot and then a
+// fresh MsgTypeLayout whenever the window's structure changes. This is the
+// server side of remote window-mirror dynamic resync.
+func TestAttachWindowStreamsLayoutUpdates(t *testing.T) {
+	t.Parallel()
+
+	h := newServerHarness(t)
+
+	conn, err := net.Dial("unix", server.SocketPath(h.session))
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+
+	if err := writeMsgOnConn(conn, &server.Message{
+		Type:       proto.MsgTypeAttachWindow,
+		Session:    h.session,
+		WindowName: "1", // first window, by index
+	}); err != nil {
+		t.Fatalf("attach-window write: %v", err)
+	}
+
+	init, err := readMsgOnConn(conn)
+	if err != nil {
+		t.Fatalf("initial layout read: %v", err)
+	}
+	if init.Type != proto.MsgTypeLayout || init.Layout == nil {
+		t.Fatalf("expected initial MsgTypeLayout, got type %d", init.Type)
+	}
+	before := activeWindowPaneCount(init.Layout)
+	if before < 1 {
+		t.Fatalf("initial pane count = %d, want >= 1", before)
+	}
+
+	// A structural change to the window must push a fresh layout.
+	h.runCmd("spawn", "--vertical")
+
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		if err := conn.SetReadDeadline(deadline); err != nil {
+			t.Fatalf("set deadline: %v", err)
+		}
+		msg, err := readMsgOnConn(conn)
+		if err != nil {
+			t.Fatalf("did not receive layout update with new pane (before=%d): %v", before, err)
+		}
+		if msg.Type != proto.MsgTypeLayout || msg.Layout == nil {
+			continue
+		}
+		if activeWindowPaneCount(msg.Layout) > before {
+			return // resync delivered the new pane
+		}
+	}
+}
+
+func activeWindowPaneCount(layout *proto.LayoutSnapshot) int {
+	if layout == nil {
+		return 0
+	}
+	if len(layout.Panes) > 0 {
+		return len(layout.Panes)
+	}
+	if len(layout.Windows) > 0 {
+		return len(layout.Windows[0].Panes)
+	}
+	return 0
+}

--- a/test/attach_window_layout_test.go
+++ b/test/attach_window_layout_test.go
@@ -60,6 +60,50 @@ func TestAttachWindowStreamsLayoutUpdates(t *testing.T) {
 	})
 }
 
+func TestAttachWindowInitialResizeBroadcasts(t *testing.T) {
+	t.Parallel()
+
+	h := newServerHarness(t)
+
+	observer, err := net.Dial("unix", server.SocketPath(h.session))
+	if err != nil {
+		t.Fatalf("observer dial: %v", err)
+	}
+	defer observer.Close()
+	if err := writeMsgOnConn(observer, &server.Message{
+		Type:       proto.MsgTypeAttachWindow,
+		Session:    h.session,
+		WindowName: "1",
+	}); err != nil {
+		t.Fatalf("observer attach-window write: %v", err)
+	}
+	if msg, err := readMsgOnConn(observer); err != nil || msg.Type != proto.MsgTypeLayout {
+		t.Fatalf("observer initial layout = (%v, %v), want MsgTypeLayout", msg, err)
+	}
+
+	subscriber, err := net.Dial("unix", server.SocketPath(h.session))
+	if err != nil {
+		t.Fatalf("subscriber dial: %v", err)
+	}
+	defer subscriber.Close()
+	if err := writeMsgOnConn(subscriber, &server.Message{
+		Type:       proto.MsgTypeAttachWindow,
+		Session:    h.session,
+		WindowName: "1",
+		Cols:       123,
+		Rows:       45,
+	}); err != nil {
+		t.Fatalf("subscriber attach-window write: %v", err)
+	}
+	if msg, err := readMsgOnConn(subscriber); err != nil || msg.Type != proto.MsgTypeLayout || msg.Layout.Width != 123 {
+		t.Fatalf("subscriber initial layout = (%+v, %v), want width 123", msg, err)
+	}
+
+	waitForWindowLayout(t, observer, "initial attach-window resize broadcast", func(layout *proto.LayoutSnapshot) bool {
+		return layout.Width == 123
+	})
+}
+
 func waitForWindowLayout(t *testing.T, conn net.Conn, what string, match func(*proto.LayoutSnapshot) bool) {
 	t.Helper()
 	deadline := time.Now().Add(5 * time.Second)
@@ -88,7 +132,28 @@ func activeWindowPaneCount(layout *proto.LayoutSnapshot) int {
 		return len(layout.Panes)
 	}
 	if len(layout.Windows) > 0 {
+		for _, w := range layout.Windows {
+			if w.ID == layout.ActiveWindowID {
+				return len(w.Panes)
+			}
+		}
 		return len(layout.Windows[0].Panes)
 	}
 	return 0
+}
+
+func TestActiveWindowPaneCountUsesActiveWindow(t *testing.T) {
+	t.Parallel()
+
+	layout := &proto.LayoutSnapshot{
+		ActiveWindowID: 2,
+		Windows: []proto.WindowSnapshot{
+			{ID: 1, Panes: []proto.PaneSnapshot{{ID: 10}}},
+			{ID: 2, Panes: []proto.PaneSnapshot{{ID: 20}, {ID: 21}}},
+		},
+	}
+
+	if got := activeWindowPaneCount(layout); got != 2 {
+		t.Fatalf("pane count = %d, want 2", got)
+	}
 }

--- a/test/attach_window_layout_test.go
+++ b/test/attach_window_layout_test.go
@@ -46,7 +46,22 @@ func TestAttachWindowStreamsLayoutUpdates(t *testing.T) {
 
 	// A structural change to the window must push a fresh layout.
 	h.runCmd("spawn", "--vertical")
+	waitForWindowLayout(t, conn, "new pane", func(layout *proto.LayoutSnapshot) bool {
+		return activeWindowPaneCount(layout) > before
+	})
 
+	// A resize sent over the subscription resizes the remote window (the size a
+	// window mirror pushes to match its local dimensions).
+	if err := writeMsgOnConn(conn, &server.Message{Type: proto.MsgTypeResize, Cols: 123, Rows: 45}); err != nil {
+		t.Fatalf("resize write: %v", err)
+	}
+	waitForWindowLayout(t, conn, "resized window", func(layout *proto.LayoutSnapshot) bool {
+		return layout.Width == 123
+	})
+}
+
+func waitForWindowLayout(t *testing.T, conn net.Conn, what string, match func(*proto.LayoutSnapshot) bool) {
+	t.Helper()
 	deadline := time.Now().Add(5 * time.Second)
 	for {
 		if err := conn.SetReadDeadline(deadline); err != nil {
@@ -54,13 +69,13 @@ func TestAttachWindowStreamsLayoutUpdates(t *testing.T) {
 		}
 		msg, err := readMsgOnConn(conn)
 		if err != nil {
-			t.Fatalf("did not receive layout update with new pane (before=%d): %v", before, err)
+			t.Fatalf("did not receive layout update (%s): %v", what, err)
 		}
 		if msg.Type != proto.MsgTypeLayout || msg.Layout == nil {
 			continue
 		}
-		if activeWindowPaneCount(msg.Layout) > before {
-			return // resync delivered the new pane
+		if match(msg.Layout) {
+			return
 		}
 	}
 }

--- a/test/remote_window_attach_test.go
+++ b/test/remote_window_attach_test.go
@@ -44,6 +44,40 @@ func TestRemoteCLIAttachWindow(t *testing.T) {
 	}
 }
 
+// TestRemoteCLIAttachWindowDynamicResync verifies the local mirror window tracks
+// the remote window's structure: adding a pane on the remote grows the mirror,
+// and removing one shrinks it.
+func TestRemoteCLIAttachWindowDynamicResync(t *testing.T) {
+	t.Parallel()
+
+	pair := newRemoteCLIPair(t)
+	pair.remote.runCmd("spawn", "--name", "remote-side", "--vertical")
+
+	attachOut := pair.local.runCmd("remote", "attach-window", remoteCLITestHost+":1")
+	if !strings.Contains(attachOut, "2 panes") {
+		t.Fatalf("attach-window output = %q", attachOut)
+	}
+	if got := len(localMirrorNames(pair.local.runCmd("list", "--no-cwd"), remoteCLITestHost)); got != 2 {
+		t.Fatalf("initial mirror pane count = %d, want 2", got)
+	}
+
+	// Adding a remote pane grows the local mirror to 3.
+	pair.remote.runCmd("spawn", "--name", "remote-third", "--vertical")
+	if !pair.local.waitForFunc(func(string) bool {
+		return len(localMirrorNames(pair.local.runCmd("list", "--no-cwd"), remoteCLITestHost)) == 3
+	}, 5*time.Second) {
+		t.Fatalf("resync did not grow local mirror to 3 panes")
+	}
+
+	// Removing a remote pane shrinks the local mirror back to 2.
+	pair.remote.runCmd("kill", "remote-third")
+	if !pair.local.waitForFunc(func(string) bool {
+		return len(localMirrorNames(pair.local.runCmd("list", "--no-cwd"), remoteCLITestHost)) == 2
+	}, 5*time.Second) {
+		t.Fatalf("resync did not shrink local mirror to 2 panes")
+	}
+}
+
 func localMirrorNames(listOut, host string) []string {
 	names := make([]string, 0)
 	for _, line := range strings.Split(listOut, "\n") {

--- a/test/remote_window_attach_test.go
+++ b/test/remote_window_attach_test.go
@@ -1,0 +1,56 @@
+package test
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestRemoteCLIAttachWindow mirrors a whole remote window (two panes in a split)
+// into a new local window and verifies output flows from a mirrored pane.
+func TestRemoteCLIAttachWindow(t *testing.T) {
+	t.Parallel()
+
+	pair := newRemoteCLIPair(t)
+	pair.remote.runCmd("rename", "pane-1", "remote-agent")
+	pair.remote.runCmd("spawn", "--name", "remote-side", "--vertical")
+
+	// remote windows lists the remote host's windows.
+	winsOut := pair.local.runCmd("remote", "windows", remoteCLITestHost)
+	for _, want := range []string{"NAME", "PANES", "INDEX"} {
+		if !strings.Contains(winsOut, want) {
+			t.Fatalf("remote windows missing %q:\n%s", want, winsOut)
+		}
+	}
+
+	// Attach the remote window by index -> a 2-pane local mirror window.
+	attachOut := pair.local.runCmd("remote", "attach-window", remoteCLITestHost+":1")
+	if !strings.Contains(attachOut, "as window") || !strings.Contains(attachOut, "2 panes") {
+		t.Fatalf("attach-window output = %q", attachOut)
+	}
+
+	// attach-window is synchronous: both mirror panes exist once it returns.
+	mirrors := localMirrorNames(pair.local.runCmd("list", "--no-cwd"), remoteCLITestHost)
+	if len(mirrors) != 2 {
+		t.Fatalf("expected 2 local mirror panes, got %d: %v", len(mirrors), mirrors)
+	}
+
+	// Output from the remote pane streams into the activated mirror window.
+	pair.remote.runCmd("send-keys", "remote-side", "printf REMOTE_WIN_ATTACH", "Enter")
+	if !pair.local.waitForFunc(func(s string) bool {
+		return strings.Contains(s, "REMOTE_WIN_ATTACH")
+	}, 5*time.Second) {
+		t.Fatalf("mirrored output not observed in window capture")
+	}
+}
+
+func localMirrorNames(listOut, host string) []string {
+	names := make([]string, 0)
+	for _, line := range strings.Split(listOut, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) >= 3 && fields[2] == host {
+			names = append(names, fields[1])
+		}
+	}
+	return names
+}

--- a/test/remote_window_attach_test.go
+++ b/test/remote_window_attach_test.go
@@ -78,6 +78,48 @@ func TestRemoteCLIAttachWindowDynamicResync(t *testing.T) {
 	}
 }
 
+// TestRemoteCLIDetachWindow tears down a mirrored window and verifies the local
+// panes are gone while the remote panes survive.
+func TestRemoteCLIDetachWindow(t *testing.T) {
+	t.Parallel()
+
+	pair := newRemoteCLIPair(t)
+	pair.remote.runCmd("spawn", "--name", "remote-side", "--vertical")
+
+	attachOut := pair.local.runCmd("remote", "attach-window", remoteCLITestHost+":1")
+	winName := windowNameFromAttach(attachOut)
+	if winName == "" {
+		t.Fatalf("could not parse window name from %q", attachOut)
+	}
+	if got := len(localMirrorNames(pair.local.runCmd("list", "--no-cwd"), remoteCLITestHost)); got != 2 {
+		t.Fatalf("expected 2 mirror panes, got %d", got)
+	}
+
+	detachOut := pair.local.runCmd("remote", "detach-window", winName)
+	if !strings.Contains(detachOut, "Detached mirror window") {
+		t.Fatalf("detach-window output = %q", detachOut)
+	}
+	if got := len(localMirrorNames(pair.local.runCmd("list", "--no-cwd"), remoteCLITestHost)); got != 0 {
+		t.Fatalf("mirror panes remain after detach-window: %d", got)
+	}
+	if remoteList := pair.remote.runCmd("list", "--no-cwd"); !strings.Contains(remoteList, "remote-side") {
+		t.Fatalf("detach-window destroyed remote panes:\n%s", remoteList)
+	}
+}
+
+func windowNameFromAttach(out string) string {
+	const marker = "as window "
+	i := strings.Index(out, marker)
+	if i < 0 {
+		return ""
+	}
+	rest := out[i+len(marker):]
+	if j := strings.Index(rest, " ("); j >= 0 {
+		return rest[:j]
+	}
+	return strings.TrimSpace(rest)
+}
+
 func localMirrorNames(listOut, host string) []string {
 	names := make([]string, 0)
 	for _, line := range strings.Split(listOut, "\n") {


### PR DESCRIPTION
## Motivation

`amux remote attach` could only mirror a single remote **pane**. For multi-pane remote windows (agent layouts like `orca`, `alphaos`, `hermes`), mirroring one sub-pane loses the surrounding context, and there was no way to list or mirror a whole remote window. This adds window-level mirroring: reconstruct a remote window's split layout locally, track its structure live, and keep it sized to match. Closes LAB-1984.

## Summary

New CLI verbs (separate from the pane forms):
- `amux remote windows <host>` — list a remote host's windows.
- `amux remote attach-window <host>:<window>` — mirror a whole remote window into a new local window (resolve by name or index).
- `amux remote detach-window <local-window>` — tear it down.

How it works:
- **Static mirror** — one local proxy pane per remote leaf pane; `mux.RebuildWindowFromSnapshot` reproduces the remote split tree. Each pane streams via the existing per-pane mirror path (input forwarding, `remote detach`/`resize`, and pane checkpoint/restore all reused unchanged).
- **Dynamic resync** — a new `MsgTypeAttachWindow` layout subscription (server-side: `scopedWindowID` on `clientConn`, `allowsServerMessage` passes `MsgTypeLayout`). On each remote layout change the local window is reconciled (panes added/removed/re-split), matching panes across sides by remote name. A structural signature gates the work so idle/busy/metadata broadcasts are no-ops.
- **Dimension matching** — the mirror declares its size on the `MsgTypeAttachWindow` message and sends `MsgTypeResize` on later local resizes; the remote re-renders the window to match. Most effective for headless remote windows; contends with a remote interactive client by design (the chosen "resize remote to match local" trade-off).
- **Reload survival** — `checkpoint.RemoteWindowRef` + `ServerCheckpoint.WindowMirrors` persist the subscription (host/session/window/size/signature) so resync resumes after a hot-reload.

## Testing

```
go test ./internal/remote/ ./internal/server/ ./internal/server/mirror/ ./internal/checkpoint/ -count=1
go test ./test/ -run 'TestRemoteCLIAttachWindow|TestRemoteCLIDetachWindow|TestAttachWindowStreamsLayout' -timeout 200s
cd test && go test -run TestRemoteCLIAttachWindow -count=5   # flake check
```

- Unit: window resolver, structural signature (resize-invariant / detects add-remove-resplit), leaf planner, mirror `TrackWindow`/`ResizeWindow`, checkpoint round-trip + capture/restore helpers.
- Integration (fake-ssh pair): `attach-window` mirrors a 2-pane window and streams output; dynamic resync grows the mirror to 3 panes on remote add and shrinks to 2 on remove; `detach-window` removes local panes while remote panes survive; `MsgTypeAttachWindow` streams a fresh layout on a structural change.
- Manually validated live against a real remote (hetzner): mirrored a 3-pane `orca` window, all panes streamed real output in the correct split.

Note: in the sandbox, unrelated packages (`auditlog`, `dialutil`, doctor, mouse/type-keys timing tests) fail on environment limits (socket `sun_path` length, FD inheritance, tempdir lifecycle, load timeouts) — they fail identically on untouched `origin/main`. All changed packages pass.

## Review focus

- `applyWindowReconcile` (session_window_mirror.go) — the live layout surgery: pane matching by remote name, tree rebuild, orphan soft-close, and the signature gate that prevents churn on non-structural broadcasts.
- `allowsServerMessage` window-scope branch + `restrictToWindow` ordering inside `attachWindowClientEvent.handle` (set before `addClient` so the conn is never briefly a full client).
- Dimension-matching trade-off: pushing local size to the remote contends with a remote interactive client.
- Checkpoint conflict resolution with LAB-1997's refactor (`buildReloadCheckpoint`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
