### PR TITLE
LAB-2000: Preserve zoomed pane contents on split

### DIFF
--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -226,6 +226,44 @@ func twoPane80x23Zoomed(paneID uint32) *proto.LayoutSnapshot {
 	return snap
 }
 
+func zoomedPane1AfterSplit80x23() *proto.LayoutSnapshot {
+	root := proto.CellSnapshot{
+		X: 0, Y: 0, W: 80, H: 23,
+		Dir: int(mux.SplitVertical),
+		Children: []proto.CellSnapshot{
+			{
+				X: 0, Y: 0, W: 39, H: 23,
+				Dir: int(mux.SplitHorizontal),
+				Children: []proto.CellSnapshot{
+					{X: 0, Y: 0, W: 39, H: 11, IsLeaf: true, Dir: -1, PaneID: 1},
+					{X: 0, Y: 12, W: 39, H: 11, IsLeaf: true, Dir: -1, PaneID: 3},
+				},
+			},
+			{X: 40, Y: 0, W: 39, H: 23, IsLeaf: true, Dir: -1, PaneID: 2},
+		},
+	}
+	panes := []proto.PaneSnapshot{
+		{ID: 1, Name: "pane-1", Host: "local", Color: "f5e0dc", ColumnIndex: 0},
+		{ID: 2, Name: "pane-2", Host: "local", Color: "f2cdcd", ColumnIndex: 1},
+		{ID: 3, Name: "pane-3", Host: "local", Color: "cba6f7", ColumnIndex: 0},
+	}
+	return &proto.LayoutSnapshot{
+		SessionName:  "test",
+		ActivePaneID: 1,
+		ZoomedPaneID: 1,
+		Width:        80,
+		Height:       23,
+		Root:         root,
+		Panes:        panes,
+		Windows: []proto.WindowSnapshot{{
+			ID: 1, Name: "window-1", Index: 1, ActivePaneID: 1, ZoomedPaneID: 1,
+			Root:  root,
+			Panes: panes,
+		}},
+		ActiveWindowID: 1,
+	}
+}
+
 func buildManyPaneRenderer(t *testing.T, n int) *ClientRenderer {
 	t.Helper()
 	cr := NewClientRenderer(200, 24)
@@ -1020,6 +1058,45 @@ func TestClientRendererZoomedPaneSurvivesMetadataOnlyLayout(t *testing.T) {
 	lines := strings.Split(cr.CapturePaneText(2, false), "\n")
 	if len(lines) == 0 || lines[0] != wideLine {
 		t.Fatalf("pane-2 first line after idle layout = %q, want %q", lines[0], wideLine)
+	}
+}
+
+func TestRendererZoomedStructuralLayoutDoesNotResizeVisiblePane(t *testing.T) {
+	t.Parallel()
+
+	r := NewWithScrollback(80, 24, mux.DefaultScrollbackLines)
+	r.HandleLayout(twoPane80x23Zoomed(1))
+
+	const wideLine = "zoomed structural layout should not reflow this visible pane line"
+	r.HandlePaneOutput(1, []byte("\033[2J\033[H"+wideLine))
+
+	type resizeCall struct {
+		paneID uint32
+		w      int
+		h      int
+	}
+	var calls []resizeCall
+	r.OnPaneResize = func(paneID uint32, w, h int) {
+		calls = append(calls, resizeCall{paneID: paneID, w: w, h: h})
+	}
+
+	r.HandleLayout(zoomedPane1AfterSplit80x23())
+
+	for _, call := range calls {
+		if call.paneID == 1 {
+			t.Fatalf("zoomed pane resize calls after background split = %+v, want no pane-1 resize", calls)
+		}
+	}
+	w, h, ok := r.PaneSize(1)
+	if !ok {
+		t.Fatal("pane-1 emulator missing")
+	}
+	if w != 80 || h != 22 {
+		t.Fatalf("zoomed pane-1 size after background split = %dx%d, want 80x22", w, h)
+	}
+	lines := strings.Split(r.CapturePaneText(1, false), "\n")
+	if len(lines) == 0 || lines[0] != wideLine {
+		t.Fatalf("pane-1 first line after background split = %q, want %q", lines[0], wideLine)
 	}
 }
 

--- a/internal/client/renderer.go
+++ b/internal/client/renderer.go
@@ -154,10 +154,7 @@ func (r *Renderer) HandleLayout(snap *proto.LayoutSnapshot) bool {
 		if next.zoomedPaneID != 0 {
 			if emu := nextEmulators[next.zoomedPaneID]; emu != nil {
 				layoutH := st.compositor.LayoutHeight()
-				contentH := mux.PaneContentHeight(layoutH)
-				if !emulatorSizeMatches(emu, next.width, contentH) {
-					emu.Resize(next.width, contentH)
-				}
+				resizeEmulatorIfNeeded(emu, next.width, mux.PaneContentHeight(layoutH))
 			}
 		}
 
@@ -787,23 +784,23 @@ func (r *Renderer) resizeSnapshotEmulators(next *rendererSnapshot, emulators map
 		if emu := emulators[next.zoomedPaneID]; emu != nil {
 			layoutH := next.height - render.GlobalBarHeight
 			contentH := mux.PaneContentHeight(layoutH)
-			if emulatorSizeMatches(emu, next.width, contentH) {
-				return
-			}
-			emu.Resize(next.width, contentH)
-			if r.OnPaneResize != nil {
+			if resizeEmulatorIfNeeded(emu, next.width, contentH) && r.OnPaneResize != nil {
 				r.OnPaneResize(next.zoomedPaneID, next.width, contentH)
 			}
 		}
 	}
 }
 
-func emulatorSizeMatches(emu mux.TerminalEmulator, width, height int) bool {
+func resizeEmulatorIfNeeded(emu mux.TerminalEmulator, width, height int) bool {
 	if emu == nil {
 		return false
 	}
 	currentW, currentH := emu.Size()
-	return currentW == width && currentH == height
+	if currentW == width && currentH == height {
+		return false
+	}
+	emu.Resize(width, height)
+	return true
 }
 
 // HandleCaptureRequest processes capture args and returns a proto.Message

--- a/internal/client/renderer.go
+++ b/internal/client/renderer.go
@@ -154,7 +154,10 @@ func (r *Renderer) HandleLayout(snap *proto.LayoutSnapshot) bool {
 		if next.zoomedPaneID != 0 {
 			if emu := nextEmulators[next.zoomedPaneID]; emu != nil {
 				layoutH := st.compositor.LayoutHeight()
-				emu.Resize(next.width, mux.PaneContentHeight(layoutH))
+				contentH := mux.PaneContentHeight(layoutH)
+				if !emulatorSizeMatches(emu, next.width, contentH) {
+					emu.Resize(next.width, contentH)
+				}
 			}
 		}
 
@@ -784,12 +787,23 @@ func (r *Renderer) resizeSnapshotEmulators(next *rendererSnapshot, emulators map
 		if emu := emulators[next.zoomedPaneID]; emu != nil {
 			layoutH := next.height - render.GlobalBarHeight
 			contentH := mux.PaneContentHeight(layoutH)
+			if emulatorSizeMatches(emu, next.width, contentH) {
+				return
+			}
 			emu.Resize(next.width, contentH)
 			if r.OnPaneResize != nil {
 				r.OnPaneResize(next.zoomedPaneID, next.width, contentH)
 			}
 		}
 	}
+}
+
+func emulatorSizeMatches(emu mux.TerminalEmulator, width, height int) bool {
+	if emu == nil {
+		return false
+	}
+	currentW, currentH := emu.Size()
+	return currentW == width && currentH == height
 }
 
 // HandleCaptureRequest processes capture args and returns a proto.Message

--- a/internal/mux/window_resize.go
+++ b/internal/mux/window_resize.go
@@ -515,6 +515,10 @@ func (w *Window) restoreZoomedPaneSize() {
 	}
 	cell := w.Root.FindPane(w.ZoomedPaneID)
 	if cell != nil && cell.Pane != nil {
-		_ = cell.Pane.Resize(w.Width, PaneContentHeight(w.Height))
+		targetRows := PaneContentHeight(w.Height)
+		if cols, rows := cell.Pane.EmulatorSize(); cols == w.Width && rows == targetRows {
+			return
+		}
+		_ = cell.Pane.Resize(w.Width, targetRows)
 	}
 }

--- a/internal/mux/window_zoom_resize_test.go
+++ b/internal/mux/window_zoom_resize_test.go
@@ -18,6 +18,7 @@ type resizeRecordingEmulator struct {
 	TerminalEmulator
 	cols    int
 	rows    int
+	calls   []recordedResize
 	changes []recordedResize
 }
 
@@ -35,6 +36,7 @@ func newResizeRecordingPane(id uint32, cols, rows int) (*Pane, *resizeRecordingE
 }
 
 func (r *resizeRecordingEmulator) Resize(cols, rows int) {
+	r.calls = append(r.calls, recordedResize{cols: cols, rows: rows})
 	if r.cols != cols || r.rows != rows {
 		r.changes = append(r.changes, recordedResize{cols: cols, rows: rows})
 	}
@@ -48,6 +50,7 @@ func (r *resizeRecordingEmulator) Size() (int, int) {
 }
 
 func (r *resizeRecordingEmulator) reset() {
+	r.calls = nil
 	r.changes = nil
 }
 
@@ -115,6 +118,9 @@ func TestZoomPreservingMutationsDoNotResizeZoomedPaneToHiddenCell(t *testing.T) 
 
 			tt.mutate(t, w, p3)
 
+			if len(recorder.calls) != 0 {
+				t.Fatalf("zoomed pane resize calls = %v, want none while zoom viewport is unchanged", recorder.calls)
+			}
 			fullSize := recordedResize{cols: w.Width, rows: PaneContentHeight(w.Height)}
 			for _, got := range recorder.changes {
 				if got != fullSize {


### PR DESCRIPTION
## Motivation

Spawning or splitting a pane while another pane is zoomed should mutate only the hidden layout. The visible zoomed pane's PTY and client emulator must keep their current dimensions so buffered content is not resized or reflowed before the user unzooms or the client viewport changes.

## Summary

- Add a mux regression test that asserts zoom-preserving layout mutations make no resize call to the zoomed pane when the zoom viewport is unchanged.
- Add a client renderer regression test for a structural layout snapshot arriving while pane 1 remains zoomed.
- Skip no-op zoomed-pane resize calls on both the server restore path and the client renderer path.

## Testing

- `go test ./internal/mux -run '^TestZoomPreservingMutationsDoNotResizeZoomedPaneToHiddenCell$' -count=100`
- `go test ./internal/client -run '^TestRendererZoomedStructuralLayoutDoesNotResizeVisiblePane$' -count=100`
- `go test ./internal/mux ./internal/client -count=1`
- `go test ./internal/server -run 'TestCommandSplitAndSpawnKeepZoomAndFocus|TestCommandSpawnAutoKeepsZoomAndFocus' -count=1`
- `go test ./test -run 'Zoom' -count=1 -timeout 120s`
- `scripts/check-diff-coverage.sh` (patch coverage 88.24%; local run reported unrelated existing integration failures in SSH clipboard tests)
- Attempted `go test ./... -timeout 300s`; local full suite failed in unrelated SSH clipboard integration tests (`TestCopyModeClipboardUsesOSC52WhenInnerClientRunsOverSSH`, `TestCopyModeClipboardUsesTmuxPassthroughWhenInnerClientRunsOverSSHInTmux`).

## Review focus

Please check that the resize guard only skips same-size zoom restores. Real client/window size changes should still resize the zoomed pane when the target dimensions change.

Closes LAB-2000
