### PR TITLE
LAB-2010: Mark remote mirror windows in selector

### DIFF
--- a/internal/client/mouse.go
+++ b/internal/client/mouse.go
@@ -510,14 +510,7 @@ func globalBarWindowInfos(cr *ClientRenderer) []render.WindowInfo {
 
 	infos := make([]render.WindowInfo, len(windows))
 	for i, ws := range windows {
-		infos[i] = render.WindowInfo{
-			Index:          ws.Index,
-			Name:           ws.Name,
-			IsActive:       ws.ID == activeWindowID,
-			Panes:          len(ws.Panes),
-			Zoomed:         ws.Zoomed || ws.ZoomedPaneID != 0,
-			IsRemoteMirror: ws.RemoteMirror,
-		}
+		infos[i] = windowInfoFromWindowSnapshot(ws, activeWindowID)
 	}
 	return infos
 }

--- a/internal/client/mouse.go
+++ b/internal/client/mouse.go
@@ -511,11 +511,12 @@ func globalBarWindowInfos(cr *ClientRenderer) []render.WindowInfo {
 	infos := make([]render.WindowInfo, len(windows))
 	for i, ws := range windows {
 		infos[i] = render.WindowInfo{
-			Index:    ws.Index,
-			Name:     ws.Name,
-			IsActive: ws.ID == activeWindowID,
-			Panes:    len(ws.Panes),
-			Zoomed:   ws.Zoomed || ws.ZoomedPaneID != 0,
+			Index:          ws.Index,
+			Name:           ws.Name,
+			IsActive:       ws.ID == activeWindowID,
+			Panes:          len(ws.Panes),
+			Zoomed:         ws.Zoomed || ws.ZoomedPaneID != 0,
+			IsRemoteMirror: ws.RemoteMirror,
 		}
 	}
 	return infos

--- a/internal/client/renderer_capture_snapshot.go
+++ b/internal/client/renderer_capture_snapshot.go
@@ -227,16 +227,20 @@ func windowInfoFromSnapshot(windows []proto.WindowSnapshot, activeWinID uint32) 
 	}
 	out := make([]render.WindowInfo, len(windows))
 	for i, ws := range windows {
-		out[i] = render.WindowInfo{
-			Index:          ws.Index,
-			Name:           ws.Name,
-			IsActive:       ws.ID == activeWinID,
-			Panes:          len(ws.Panes),
-			Zoomed:         ws.Zoomed || ws.ZoomedPaneID != 0,
-			IsRemoteMirror: ws.RemoteMirror,
-		}
+		out[i] = windowInfoFromWindowSnapshot(ws, activeWinID)
 	}
 	return out
+}
+
+func windowInfoFromWindowSnapshot(ws proto.WindowSnapshot, activeWinID uint32) render.WindowInfo {
+	return render.WindowInfo{
+		Index:          ws.Index,
+		Name:           ws.Name,
+		IsActive:       ws.ID == activeWinID,
+		Panes:          len(ws.Panes),
+		Zoomed:         ws.Zoomed || ws.ZoomedPaneID != 0,
+		IsRemoteMirror: ws.RemoteMirror,
+	}
 }
 
 func (s *rendererSnapshot) paneLookupFromCaptureSnapshot(paneID uint32) render.PaneData {

--- a/internal/client/renderer_capture_snapshot.go
+++ b/internal/client/renderer_capture_snapshot.go
@@ -228,11 +228,12 @@ func windowInfoFromSnapshot(windows []proto.WindowSnapshot, activeWinID uint32) 
 	out := make([]render.WindowInfo, len(windows))
 	for i, ws := range windows {
 		out[i] = render.WindowInfo{
-			Index:    ws.Index,
-			Name:     ws.Name,
-			IsActive: ws.ID == activeWinID,
-			Panes:    len(ws.Panes),
-			Zoomed:   ws.Zoomed || ws.ZoomedPaneID != 0,
+			Index:          ws.Index,
+			Name:           ws.Name,
+			IsActive:       ws.ID == activeWinID,
+			Panes:          len(ws.Panes),
+			Zoomed:         ws.Zoomed || ws.ZoomedPaneID != 0,
+			IsRemoteMirror: ws.RemoteMirror,
 		}
 	}
 	return out

--- a/internal/proto/types.go
+++ b/internal/proto/types.go
@@ -30,6 +30,7 @@ type WindowSnapshot struct {
 	ActivePaneID uint32         `json:"active_pane_id"`
 	Zoomed       bool           `json:"zoomed"`
 	ZoomedPaneID uint32         `json:"zoomed_pane_id"`
+	RemoteMirror bool           `json:"remote_mirror,omitempty"`
 	LeadPaneID   uint32         `json:"lead_pane_id,omitempty"`
 	Root         CellSnapshot   `json:"root"`
 	Panes        []PaneSnapshot `json:"panes"`

--- a/internal/render/compositor.go
+++ b/internal/render/compositor.go
@@ -24,6 +24,8 @@ type WindowInfo struct {
 	IsActive bool
 	Panes    int
 	Zoomed   bool
+	// IsRemoteMirror marks windows created by remote attach-window.
+	IsRemoteMirror bool
 }
 
 // RenderStats captures lightweight render counters alongside ANSI output.

--- a/internal/render/lipgloss_styles.go
+++ b/internal/render/lipgloss_styles.go
@@ -109,6 +109,12 @@ func (s statusBarStyles) pane(role paneStatusSegmentRole) lipgloss.Style {
 }
 
 func (s statusBarStyles) windowTab(window WindowInfo) lipgloss.Style {
+	if window.IsRemoteMirror {
+		if window.IsActive {
+			return s.success.Bold(true)
+		}
+		return s.success
+	}
 	if window.IsActive {
 		return s.focused
 	}

--- a/internal/render/statusbar.go
+++ b/internal/render/statusbar.go
@@ -1025,7 +1025,6 @@ func buildPowerlineGlobalBarCells(sessionName string, paneCount int, width int, 
 			}
 			if tab.window.IsRemoteMirror {
 				style.fgHex = config.GreenHex
-				style.bold = tab.window.IsActive
 			}
 			cells = appendStyledStatusCells(cells, tab.display, style)
 			cells = appendStyledStatusCells(cells, " ", baseStyle)

--- a/internal/render/statusbar.go
+++ b/internal/render/statusbar.go
@@ -949,6 +949,9 @@ func globalBarWindowName(window WindowInfo) string {
 }
 
 func globalBarTabColorHex(window WindowInfo) string {
+	if window.IsRemoteMirror {
+		return config.GreenHex
+	}
 	if window.IsActive {
 		return config.BlueHex
 	}
@@ -1019,6 +1022,10 @@ func buildPowerlineGlobalBarCells(sessionName string, paneCount int, width int, 
 			style := baseStyle
 			if tab.window.IsActive {
 				style = focusedStyle
+			}
+			if tab.window.IsRemoteMirror {
+				style.fgHex = config.GreenHex
+				style.bold = tab.window.IsActive
 			}
 			cells = appendStyledStatusCells(cells, tab.display, style)
 			cells = appendStyledStatusCells(cells, " ", baseStyle)

--- a/internal/render/testdata/powerline_remote_mirror_window_selector.color
+++ b/internal/render/testdata/powerline_remote_mirror_window_selector.color
@@ -1,0 +1,1 @@
+        ||||||| gggggggggggggggg ||||||

--- a/internal/render/testdata/powerline_remote_mirror_window_selector.golden
+++ b/internal/render/testdata/powerline_remote_mirror_window_selector.golden
@@ -1,0 +1,1 @@
+ amux  1:local 2:hetzner-1:main 3:logs             4 panes  ? help  12:34

--- a/internal/render/testdata/remote_mirror_window_selector.color
+++ b/internal/render/testdata/remote_mirror_window_selector.color
@@ -1,0 +1,1 @@
+        BBBBBBB GGGGGGGGGGGGGGGG ||||||

--- a/internal/render/testdata/remote_mirror_window_selector.golden
+++ b/internal/render/testdata/remote_mirror_window_selector.golden
@@ -1,0 +1,1 @@
+ amux │ 1:local 2:hetzner-1:main 3:logs │            4 panes │ ? help │ 12:34

--- a/internal/render/window_selector_golden_test.go
+++ b/internal/render/window_selector_golden_test.go
@@ -1,0 +1,83 @@
+package render
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/weill-labs/amux/internal/config"
+)
+
+const windowSelectorGoldenWidth = 78
+
+func TestGoldenRemoteMirrorWindowSelector(t *testing.T) {
+	t.Parallel()
+
+	grid := NewScreenGrid(windowSelectorGoldenWidth, 1)
+	buildGlobalBarCells(grid, "session", 4, windowSelectorGoldenWidth, 0, []WindowInfo{
+		{Index: 1, Name: "local", IsActive: true},
+		{Index: 2, Name: "hetzner-1:main", IsRemoteMirror: true},
+		{Index: 3, Name: "logs"},
+	}, "", time.Date(2025, 1, 1, 12, 34, 0, 0, time.UTC))
+
+	assertWindowSelectorGolden(t, "remote_mirror_window_selector.golden", strings.TrimRight(gridRowText(grid, 0, windowSelectorGoldenWidth), " ")+"\n")
+	assertWindowSelectorGolden(t, "remote_mirror_window_selector.color", windowSelectorColorMap(grid, 0,
+		"1:local",
+		"2:hetzner-1:main",
+		"3:logs",
+	)+"\n")
+}
+
+func assertWindowSelectorGolden(t *testing.T, name, actual string) {
+	t.Helper()
+
+	path := filepath.Join("testdata", name)
+	expected, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading golden %s: %v\nActual:\n%s", path, err, actual)
+	}
+	if actual != string(expected) {
+		t.Fatalf("golden mismatch: %s\n\n--- expected ---\n%s\n--- actual ---\n%s", path, expected, actual)
+	}
+}
+
+func windowSelectorColorMap(grid *ScreenGrid, y int, labels ...string) string {
+	row := strings.Repeat(" ", grid.Width)
+	rowBytes := []byte(row)
+	for _, label := range labels {
+		start := findRowLabel(grid, y, grid.Width, label)
+		if start < 0 {
+			continue
+		}
+		for offset := 0; offset < len(label); offset++ {
+			rowBytes[start+offset] = windowSelectorColorLetter(grid.Get(start+offset, y))
+		}
+	}
+	return strings.TrimRight(string(rowBytes), " ")
+}
+
+func windowSelectorColorLetter(cell ScreenCell) byte {
+	switch {
+	case cellColorMatches(cell, config.BlueHex):
+		return 'B'
+	case cellColorMatches(cell, config.GreenHex):
+		return 'G'
+	case cellColorMatches(cell, config.TextColorHex):
+		return '|'
+	default:
+		return '?'
+	}
+}
+
+func cellColorMatches(cell ScreenCell, wantHex string) bool {
+	if cell.Style.Fg == nil {
+		return false
+	}
+	got, ok := cell.Style.Fg.(interface {
+		RGBA() (uint32, uint32, uint32, uint32)
+	})
+	want := hexToColor(wantHex)
+	return ok && sameColor(got, want)
+}

--- a/internal/render/window_selector_golden_test.go
+++ b/internal/render/window_selector_golden_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	uv "github.com/charmbracelet/ultraviolet"
 	"github.com/weill-labs/amux/internal/config"
 )
 
@@ -24,6 +25,24 @@ func TestGoldenRemoteMirrorWindowSelector(t *testing.T) {
 
 	assertWindowSelectorGolden(t, "remote_mirror_window_selector.golden", strings.TrimRight(gridRowText(grid, 0, windowSelectorGoldenWidth), " ")+"\n")
 	assertWindowSelectorGolden(t, "remote_mirror_window_selector.color", windowSelectorColorMap(grid, 0,
+		"1:local",
+		"2:hetzner-1:main",
+		"3:logs",
+	)+"\n")
+}
+
+func TestGoldenPowerlineRemoteMirrorWindowSelector(t *testing.T) {
+	t.Parallel()
+
+	grid := NewScreenGrid(windowSelectorGoldenWidth, 1)
+	buildGlobalBarCellsWithStyle(grid, "session", 4, windowSelectorGoldenWidth, 0, []WindowInfo{
+		{Index: 1, Name: "local"},
+		{Index: 2, Name: "hetzner-1:main", IsActive: true, IsRemoteMirror: true},
+		{Index: 3, Name: "logs"},
+	}, "", time.Date(2025, 1, 1, 12, 34, 0, 0, time.UTC), config.StatusStylePowerline)
+
+	assertWindowSelectorGolden(t, "powerline_remote_mirror_window_selector.golden", strings.TrimRight(gridRowText(grid, 0, windowSelectorGoldenWidth), " ")+"\n")
+	assertWindowSelectorGolden(t, "powerline_remote_mirror_window_selector.color", windowSelectorColorMap(grid, 0,
 		"1:local",
 		"2:hetzner-1:main",
 		"3:logs",
@@ -62,6 +81,8 @@ func windowSelectorColorLetter(cell ScreenCell) byte {
 	switch {
 	case cellColorMatches(cell, config.BlueHex):
 		return 'B'
+	case cellColorMatches(cell, config.GreenHex) && cell.Style.Attrs&uv.AttrBold != 0:
+		return 'g'
 	case cellColorMatches(cell, config.GreenHex):
 		return 'G'
 	case cellColorMatches(cell, config.TextColorHex):

--- a/internal/server/server_capture_full.go
+++ b/internal/server/server_capture_full.go
@@ -264,14 +264,14 @@ func (s *Session) captureFullSessionSnapshot() (serverFullSessionCapture, error)
 				Index:  windowSnap.Index,
 				Zoomed: windowSnap.Zoomed || windowSnap.ZoomedPaneID != 0,
 			},
-			windows:   serverWindowInfo(s.Windows, s.ActiveWindowID),
+			windows:   serverWindowInfo(s.Windows, s.ActiveWindowID, s.windowMirrorSigs),
 			panes:     panes,
 			panesByID: panesByID,
 		}, nil
 	})
 }
 
-func serverWindowInfo(windows []*mux.Window, activeWindowID uint32) []render.WindowInfo {
+func serverWindowInfo(windows []*mux.Window, activeWindowID uint32, windowMirrorSigs map[uint32]string) []render.WindowInfo {
 	if len(windows) == 0 {
 		return nil
 	}
@@ -281,11 +281,12 @@ func serverWindowInfo(windows []*mux.Window, activeWindowID uint32) []render.Win
 			continue
 		}
 		out = append(out, render.WindowInfo{
-			Index:    i + 1,
-			Name:     window.Name,
-			IsActive: window.ID == activeWindowID,
-			Panes:    window.PaneCount(),
-			Zoomed:   window.ZoomedPaneID != 0,
+			Index:          i + 1,
+			Name:           window.Name,
+			IsActive:       window.ID == activeWindowID,
+			Panes:          window.PaneCount(),
+			Zoomed:         window.ZoomedPaneID != 0,
+			IsRemoteMirror: isRemoteMirrorWindowID(windowMirrorSigs, window.ID),
 		})
 	}
 	return out

--- a/internal/server/session_broadcast.go
+++ b/internal/server/session_broadcast.go
@@ -179,7 +179,9 @@ func (s *Session) snapshotLayout(idleSnap map[uint32]bool) *proto.LayoutSnapshot
 	snap.Notice = s.notice
 
 	for i, win := range s.Windows {
-		snap.Windows = append(snap.Windows, win.SnapshotWindow(i+1))
+		windowSnap := win.SnapshotWindow(i + 1)
+		windowSnap.RemoteMirror = s.isRemoteMirrorWindow(win.ID)
+		snap.Windows = append(snap.Windows, windowSnap)
 	}
 
 	for i := range snap.Panes {

--- a/internal/server/session_window_mirror.go
+++ b/internal/server/session_window_mirror.go
@@ -212,6 +212,18 @@ func (s *Session) restoreWindowMirrors(refs map[uint32]checkpoint.RemoteWindowRe
 	}
 }
 
+func (s *Session) isRemoteMirrorWindow(windowID uint32) bool {
+	if s == nil {
+		return false
+	}
+	return isRemoteMirrorWindowID(s.windowMirrorSigs, windowID)
+}
+
+func isRemoteMirrorWindowID(windowMirrorSigs map[uint32]string, windowID uint32) bool {
+	_, ok := windowMirrorSigs[windowID]
+	return ok
+}
+
 // pushMirrorWindowSize forwards a local mirror window's size to the remote so it
 // re-renders the window to match. A no-op for non-mirror windows. Event-loop only.
 func (s *Session) pushMirrorWindowSize(w *mux.Window) {

--- a/internal/server/session_window_mirror_test.go
+++ b/internal/server/session_window_mirror_test.go
@@ -70,6 +70,36 @@ func TestWindowMirrorCheckpointAndRestore(t *testing.T) {
 	}
 }
 
+func TestSnapshotLayoutMarksRemoteMirrorWindowsFromState(t *testing.T) {
+	t.Parallel()
+
+	localNameLooksRemote := mux.NewWindow(&mux.Pane{ID: 1, Meta: mux.PaneMeta{Name: "pane-1"}}, 80, 23)
+	localNameLooksRemote.ID = 1
+	localNameLooksRemote.Name = "hetzner-1:main"
+
+	remoteMirror := mux.NewWindow(&mux.Pane{ID: 2, Meta: mux.PaneMeta{Name: "pane-2"}}, 80, 23)
+	remoteMirror.ID = 2
+	remoteMirror.Name = "logs"
+
+	sess := &Session{
+		Name:             "session",
+		Windows:          []*mux.Window{localNameLooksRemote, remoteMirror},
+		ActiveWindowID:   localNameLooksRemote.ID,
+		windowMirrorSigs: map[uint32]string{remoteMirror.ID: "mirror-signature"},
+	}
+
+	snap := sess.snapshotLayout(map[uint32]bool{})
+	if snap == nil || len(snap.Windows) != 2 {
+		t.Fatalf("snapshot windows = %+v, want 2 windows", snap)
+	}
+	if snap.Windows[0].RemoteMirror {
+		t.Fatalf("local window with remote-looking name was marked as a mirror: %+v", snap.Windows[0])
+	}
+	if !snap.Windows[1].RemoteMirror {
+		t.Fatalf("window with mirror state was not marked as a mirror: %+v", snap.Windows[1])
+	}
+}
+
 func TestApplyWindowReconcileRollsBackPaneTrackingFailure(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Motivation
Remote mirror windows created by `remote attach-window` looked identical to ordinary local windows in the global window selector, which made it hard to distinguish local work from mirrored remote context at a glance.

## Summary
- Add a `remote_mirror` flag to window layout snapshots and carry it through client/server render metadata.
- Mark mirror windows from `Session.windowMirrorSigs`, not from window-name parsing.
- Render remote mirror tabs with Catppuccin green while preserving the existing local active/inactive colors.
- Add focused golden/color coverage for selector text and colors plus server coverage for state-based mirror detection.

## Testing
- `go test ./internal/render ./internal/server -run 'TestGoldenRemoteMirrorWindowSelector|TestSnapshotLayoutMarksRemoteMirrorWindowsFromState' -count=100`
- `TMPDIR=/tmp go test ./internal/proto ./internal/render ./internal/client ./internal/server`
- `go test ./internal/proto ./internal/render ./internal/client ./internal/server` was also run once with the default temp dir; `internal/server` hit unrelated macOS Unix-socket path length failures under `/var/folders/...`, then passed with `TMPDIR=/tmp`.

## Review focus
- Check the protocol field naming and whether `Session.windowMirrorSigs` is the right source of truth for mirrored window identity.
- Check the color precedence for an active remote mirror tab: remote green remains the differentiator, with bold preserving active emphasis.

Closes LAB-2010
