### PR TITLE
LAB-2008: Discover remote mirrors by session

### DIFF
--- a/internal/capture/capture.go
+++ b/internal/capture/capture.go
@@ -154,6 +154,7 @@ type PaneInput struct {
 	TrackedPRs    []proto.TrackedPR
 	TrackedIssues []proto.TrackedIssue
 	Mailbox       *proto.CaptureMailbox
+	Mirror        *proto.CaptureMirror
 	Cursor        proto.CaptureCursor
 	Terminal      *proto.CaptureTerminal
 	Content       []string
@@ -264,6 +265,7 @@ func BuildPane(input PaneInput, agentStatus map[uint32]proto.PaneAgentStatus) pr
 	if input.Mailbox != nil {
 		cp.Mailbox = proto.CloneCaptureMailbox(input.Mailbox)
 	}
+	cp.Mirror = proto.CloneCaptureMirror(input.Mirror)
 	cp.ApplyAgentStatus(agentStatus)
 	return cp
 }

--- a/internal/capture/capture_test.go
+++ b/internal/capture/capture_test.go
@@ -313,6 +313,35 @@ func TestBuildPane(t *testing.T) {
 	}
 }
 
+func TestBuildPaneIncludesMirrorMetadata(t *testing.T) {
+	t.Parallel()
+
+	mirror := &proto.CaptureMirror{
+		State:        "connected",
+		Host:         "hetzner-1",
+		Session:      "main",
+		PaneName:     "agent",
+		RemotePaneID: 42,
+	}
+	got := BuildPane(PaneInput{
+		ID:     7,
+		Name:   "pane-7",
+		Host:   "hetzner-1",
+		Mirror: mirror,
+	}, nil)
+	if got.Mirror == nil {
+		t.Fatal("BuildPane().Mirror = nil, want mirror metadata")
+	}
+	if *got.Mirror != *mirror {
+		t.Fatalf("BuildPane().Mirror = %+v, want %+v", got.Mirror, mirror)
+	}
+
+	mirror.State = "dead"
+	if got.Mirror.State != "connected" {
+		t.Fatalf("BuildPane should clone mirror metadata, got state %q", got.Mirror.State)
+	}
+}
+
 func TestHexColor(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cli/cli_usage.go
+++ b/internal/cli/cli_usage.go
@@ -23,7 +23,7 @@ const (
 	msgReadUsage      = "usage: amux msg read <msg-id> [--for pane] [--peek] [--format json]"
 	msgAckUsage       = "usage: amux msg ack <msg-id> [--for pane] [--status ok|error|seen] [--note text] [--format json]"
 	moveUsage         = "usage: amux move <pane> up|down | amux move <pane> (--before <target>|--after <target>|--to-column <target>)"
-	remoteUsage       = "usage: amux remote <add|list|rm|panes|windows|status|attach|attach-window|detach|detach-window|resize> ..."
+	remoteUsage       = "usage: amux remote <add|discover|list|rm|panes|windows|status|attach|attach-window|detach|detach-window|resize> ..."
 	spawnUsage        = "usage: amux spawn [--auto] [--at <pane>] [--window <name|id>] [--vertical|--horizontal] [--root] [--focus] [--attach <host>:<pane-name>] [--name NAME] [--task TASK] [--color COLOR]"
 	swapUsage         = "usage: amux swap <pane1> <pane2> [--tree] | amux swap forward | amux swap backward"
 	cursorUsage       = "usage: amux cursor <layout|clipboard|ui> [--client <id>]"

--- a/internal/proto/types.go
+++ b/internal/proto/types.go
@@ -116,6 +116,16 @@ type CaptureMeta struct {
 	TrackedIssues []TrackedIssue    `json:"tracked_issues,omitempty"`
 }
 
+// CaptureMirror describes the remote mirror backing a local proxy pane.
+type CaptureMirror struct {
+	State        string `json:"state"`
+	Host         string `json:"host"`
+	Session      string `json:"session"`
+	PaneName     string `json:"pane_name"`
+	RemotePaneID uint32 `json:"remote_pane_id,omitempty"`
+	LastError    string `json:"last_error,omitempty"`
+}
+
 // MailboxAddress identifies a pane in capture-safe mailbox summaries.
 type MailboxAddress struct {
 	ID   uint32 `json:"id"`
@@ -170,6 +180,7 @@ type CapturePane struct {
 	History     []string         `json:"history,omitempty"`
 	CopyMode    bool             `json:"copy_mode,omitempty"`
 	Mailbox     *CaptureMailbox  `json:"mailbox,omitempty"`
+	Mirror      *CaptureMirror   `json:"mirror,omitempty"`
 
 	// CWD/branch metadata.
 	Cwd       string `json:"cwd,omitempty"`
@@ -272,6 +283,14 @@ func (cp *CapturePane) ApplyAgentStatus(status map[uint32]PaneAgentStatus) {
 	cp.IdleSince = st.IdleSince
 	cp.CurrentCommand = st.CurrentCommand
 	cp.LastOutput = st.LastOutput
+}
+
+func CloneCaptureMirror(src *CaptureMirror) *CaptureMirror {
+	if src == nil {
+		return nil
+	}
+	dst := *src
+	return &dst
 }
 
 func EmptyCaptureMailbox() *CaptureMailbox {

--- a/internal/server/capture_history.go
+++ b/internal/server/capture_history.go
@@ -18,6 +18,7 @@ type capturePaneTarget struct {
 	zoomed      bool
 	lead        bool
 	mailbox     *proto.CaptureMailbox
+	mirror      *proto.CaptureMirror
 }
 
 func (s *Session) resolveCapturePaneTargetForActor(actorPaneID uint32, ref string) (capturePaneTarget, error) {
@@ -41,6 +42,7 @@ func (s *Session) resolveCapturePaneTargetForActor(actorPaneID uint32, ref strin
 			zoomed:      activeWindow != nil && activeWindow.ZoomedPaneID == pane.ID,
 			lead:        activeWindow != nil && activeWindow.LeadPaneID == pane.ID,
 			mailbox:     s.mailboxCaptureSummary(pane.ID),
+			mirror:      s.captureMirrorForPane(pane.ID),
 		}, nil
 	})
 }
@@ -96,6 +98,7 @@ func (s *Session) buildServerCapturePane(target capturePaneTarget, req caputil.R
 		TrackedPRs:    target.pane.Meta.TrackedPRs,
 		TrackedIssues: target.pane.Meta.TrackedIssues,
 		Mailbox:       target.mailbox,
+		Mirror:        target.mirror,
 		Cursor:        cursor,
 		Terminal:      caputil.TerminalFromState(textSnap.Terminal),
 		Content:       content,

--- a/internal/server/commands_remote.go
+++ b/internal/server/commands_remote.go
@@ -117,21 +117,25 @@ func runRemoteAdd(ctx *CommandContext) commandpkg.Result {
 	if err != nil {
 		return commandpkg.Result{Err: err}
 	}
+	if err := saveRemoteHostConfig(ctx, parsed.name, parsed.host); err != nil {
+		return commandpkg.Result{Err: err}
+	}
+	return commandpkg.Result{Output: fmt.Sprintf("Added remote %s\n", parsed.name)}
+}
+
+func saveRemoteHostConfig(ctx *CommandContext, name string, host config.Host) error {
 	cfg, err := loadRemoteConfig()
 	if err != nil {
-		return commandpkg.Result{Err: err}
+		return err
 	}
 	if cfg.Remote.Hosts == nil {
 		cfg.Remote.Hosts = make(map[string]config.Host)
 	}
-	cfg.Remote.Hosts[parsed.name] = parsed.host
+	cfg.Remote.Hosts[name] = host
 	if err := config.ValidateRemoteHosts(cfg.Remote.Hosts); err != nil {
-		return commandpkg.Result{Err: err}
+		return err
 	}
-	if err := saveRemoteConfig(ctx, cfg); err != nil {
-		return commandpkg.Result{Err: err}
-	}
-	return commandpkg.Result{Output: fmt.Sprintf("Added remote %s\n", parsed.name)}
+	return saveRemoteConfig(ctx, cfg)
 }
 
 func runRemoteList(ctx *CommandContext) commandpkg.Result {

--- a/internal/server/commands_remote.go
+++ b/internal/server/commands_remote.go
@@ -21,8 +21,9 @@ import (
 )
 
 const (
-	remoteCommandUsage      = "usage: remote <add|list|rm|panes|windows|status|attach|attach-window|detach|detach-window|resize> ..."
+	remoteCommandUsage      = "usage: remote <add|discover|list|rm|panes|windows|status|attach|attach-window|detach|detach-window|resize> ..."
 	remoteAddUsage          = "usage: remote add <name> --ssh <target> --socket <path> [--session <name>]"
+	remoteDiscoverUsage     = "usage: remote discover <name> [--ssh <target>] [--session <name>] [--print]"
 	remoteListUsage         = "usage: remote list"
 	remoteStatusUsage       = "usage: remote status"
 	remoteRmUsage           = "usage: remote rm <name>"
@@ -84,6 +85,8 @@ func runRemoteCommand(ctx *CommandContext) commandpkg.Result {
 	switch ctx.Args[0] {
 	case "add":
 		return runRemoteAdd(ctx)
+	case "discover":
+		return runRemoteDiscover(ctx)
 	case "list":
 		return runRemoteList(ctx)
 	case "status":

--- a/internal/server/commands_remote_discover.go
+++ b/internal/server/commands_remote_discover.go
@@ -133,18 +133,7 @@ func runRemoteDiscover(ctx *CommandContext) commandpkg.Result {
 		return commandpkg.Result{Err: err}
 	}
 	if !parsed.printOnly {
-		cfg, err := loadRemoteConfig()
-		if err != nil {
-			return commandpkg.Result{Err: err}
-		}
-		if cfg.Remote.Hosts == nil {
-			cfg.Remote.Hosts = make(map[string]config.Host)
-		}
-		cfg.Remote.Hosts[result.name] = result.host
-		if err := config.ValidateRemoteHosts(cfg.Remote.Hosts); err != nil {
-			return commandpkg.Result{Err: err}
-		}
-		if err := saveRemoteConfig(ctx, cfg); err != nil {
+		if err := saveRemoteHostConfig(ctx, result.name, result.host); err != nil {
 			return commandpkg.Result{Err: err}
 		}
 	}

--- a/internal/server/commands_remote_discover.go
+++ b/internal/server/commands_remote_discover.go
@@ -31,12 +31,15 @@ if ! command -v nc >/dev/null 2>&1; then
 	printf 'ERR\tnc_missing\n'
 	exit 0
 fi
-nc_help=$(nc -h 2>&1 || true)
-case "$nc_help" in
-	*"-U"*) ;;
-	*)
+# Probe option parsing against a non-socket path instead of trusting help text.
+# Supported variants fail with a target error; unsupported ones reject -U.
+nc_probe=$(printf '' | nc -U /dev/null 2>&1 || true)
+case "$nc_probe" in
+	*"invalid option"*|*"illegal option"*|*"unknown option"*|*"unrecognized option"*|*"bad option"*|*[Uu][Nn][Ii][Xx]*"not supported"*|*[Uu][Nn][Ii][Xx]*"unsupported"*)
 		printf 'ERR\tnc_no_unix\n'
 		exit 0
+		;;
+	*)
 		;;
 esac
 printf 'OK\t%s\t%s\n' "$uid" "$socket"
@@ -154,7 +157,7 @@ func discoverRemoteHost(ctx context.Context, args remoteDiscoverArgs, runner rem
 func parseRemoteDiscoverResponse(args remoteDiscoverArgs, output string) (remoteDiscoverResult, error) {
 	line := strings.TrimSpace(output)
 	fields := strings.Split(line, "\t")
-	if len(fields) == 0 || fields[0] == "" {
+	if fields[0] == "" {
 		return remoteDiscoverResult{}, fmt.Errorf("unexpected discovery response from %s: %q", args.ssh, line)
 	}
 	switch fields[0] {
@@ -224,5 +227,13 @@ func formatRemoteDiscoverResult(result remoteDiscoverResult, printOnly bool) str
 
 func remoteDiscoverAddCommand(result remoteDiscoverResult) string {
 	return fmt.Sprintf("amux remote add %s --ssh %s --session %s --socket %s",
-		result.name, result.host.SSH, result.host.Session, result.host.SocketPath)
+		remoteShellQuote(result.name),
+		remoteShellQuote(result.host.SSH),
+		remoteShellQuote(result.host.Session),
+		remoteShellQuote(result.host.SocketPath),
+	)
+}
+
+func remoteShellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
 }

--- a/internal/server/commands_remote_discover.go
+++ b/internal/server/commands_remote_discover.go
@@ -1,0 +1,239 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/weill-labs/amux/internal/config"
+	commandpkg "github.com/weill-labs/amux/internal/server/commands"
+)
+
+const remoteDiscoverProbeScript = `set -u
+session=$1
+if [ -z "$session" ]; then
+	printf 'ERR\tsession_missing\n'
+	exit 0
+fi
+uid=$(id -u 2>/dev/null) || {
+	printf 'ERR\tuid\n'
+	exit 0
+}
+socket="/tmp/amux-${uid}/${session}"
+if [ ! -S "$socket" ]; then
+	printf 'ERR\tsocket_missing\t%s\n' "$socket"
+	exit 0
+fi
+if ! command -v nc >/dev/null 2>&1; then
+	printf 'ERR\tnc_missing\n'
+	exit 0
+fi
+nc_help=$(nc -h 2>&1 || true)
+case "$nc_help" in
+	*"-U"*) ;;
+	*)
+		printf 'ERR\tnc_no_unix\n'
+		exit 0
+		;;
+esac
+printf 'OK\t%s\t%s\n' "$uid" "$socket"
+`
+
+type remoteDiscoverArgs struct {
+	name      string
+	ssh       string
+	session   string
+	printOnly bool
+}
+
+type remoteDiscoverResult struct {
+	name string
+	uid  string
+	host config.Host
+}
+
+type remoteDiscoverRunner interface {
+	Run(ctx context.Context, sshTarget, session, script string) (string, error)
+}
+
+type sshRemoteDiscoverRunner struct{}
+
+func (sshRemoteDiscoverRunner) Run(ctx context.Context, sshTarget, session, script string) (string, error) {
+	cmd := exec.CommandContext(ctx, "ssh", "-o", "BatchMode=yes", sshTarget, "--", "sh", "-s", "--", session)
+	cmd.Stdin = strings.NewReader(script)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	if err != nil {
+		if msg := strings.TrimSpace(stderr.String()); msg != "" {
+			return "", fmt.Errorf("%w: %s", err, msg)
+		}
+		return "", err
+	}
+	return string(out), nil
+}
+
+func parseRemoteDiscoverArgs(args []string) (remoteDiscoverArgs, error) {
+	if len(args) == 0 {
+		return remoteDiscoverArgs{}, errors.New(remoteDiscoverUsage)
+	}
+	parsed := remoteDiscoverArgs{
+		name:    args[0],
+		session: DefaultSessionName,
+	}
+	if parsed.name == "" || strings.HasPrefix(parsed.name, "-") {
+		return remoteDiscoverArgs{}, errors.New(remoteDiscoverUsage)
+	}
+	for i := 1; i < len(args); i++ {
+		switch args[i] {
+		case "--ssh":
+			if i+1 >= len(args) {
+				return remoteDiscoverArgs{}, errors.New(remoteDiscoverUsage)
+			}
+			parsed.ssh = args[i+1]
+			i++
+		case "--session":
+			if i+1 >= len(args) {
+				return remoteDiscoverArgs{}, errors.New(remoteDiscoverUsage)
+			}
+			parsed.session = args[i+1]
+			i++
+		case "--print":
+			parsed.printOnly = true
+		default:
+			return remoteDiscoverArgs{}, errors.New(remoteDiscoverUsage)
+		}
+	}
+	if parsed.ssh == "" {
+		parsed.ssh = parsed.name
+	}
+	parsed.ssh = strings.TrimSpace(parsed.ssh)
+	parsed.session = strings.TrimSpace(parsed.session)
+	if parsed.ssh == "" || strings.HasPrefix(parsed.ssh, "-") || parsed.session == "" {
+		return remoteDiscoverArgs{}, errors.New(remoteDiscoverUsage)
+	}
+	if strings.Contains(parsed.session, "/") {
+		return remoteDiscoverArgs{}, errors.New("remote session must not contain '/'")
+	}
+	return parsed, nil
+}
+
+func runRemoteDiscover(ctx *CommandContext) commandpkg.Result {
+	parsed, err := parseRemoteDiscoverArgs(ctx.Args[1:])
+	if err != nil {
+		return commandpkg.Result{Err: err}
+	}
+	discoverCtx, cancel := context.WithTimeout(ctx.context(), remoteCommandTimeout)
+	defer cancel()
+	result, err := discoverRemoteHost(discoverCtx, parsed, sshRemoteDiscoverRunner{})
+	if err != nil {
+		return commandpkg.Result{Err: err}
+	}
+	if !parsed.printOnly {
+		cfg, err := loadRemoteConfig()
+		if err != nil {
+			return commandpkg.Result{Err: err}
+		}
+		if cfg.Remote.Hosts == nil {
+			cfg.Remote.Hosts = make(map[string]config.Host)
+		}
+		cfg.Remote.Hosts[result.name] = result.host
+		if err := config.ValidateRemoteHosts(cfg.Remote.Hosts); err != nil {
+			return commandpkg.Result{Err: err}
+		}
+		if err := saveRemoteConfig(ctx, cfg); err != nil {
+			return commandpkg.Result{Err: err}
+		}
+	}
+	return commandpkg.Result{Output: formatRemoteDiscoverResult(result, parsed.printOnly)}
+}
+
+func discoverRemoteHost(ctx context.Context, args remoteDiscoverArgs, runner remoteDiscoverRunner) (remoteDiscoverResult, error) {
+	if runner == nil {
+		return remoteDiscoverResult{}, errors.New("remote discovery runner is required")
+	}
+	out, err := runner.Run(ctx, args.ssh, args.session, remoteDiscoverProbeScript)
+	if err != nil {
+		return remoteDiscoverResult{}, fmt.Errorf("checking remote %q over ssh: %w", args.ssh, err)
+	}
+	return parseRemoteDiscoverResponse(args, out)
+}
+
+func parseRemoteDiscoverResponse(args remoteDiscoverArgs, output string) (remoteDiscoverResult, error) {
+	line := strings.TrimSpace(output)
+	fields := strings.Split(line, "\t")
+	if len(fields) == 0 || fields[0] == "" {
+		return remoteDiscoverResult{}, fmt.Errorf("unexpected discovery response from %s: %q", args.ssh, line)
+	}
+	switch fields[0] {
+	case "OK":
+		if len(fields) != 3 {
+			return remoteDiscoverResult{}, fmt.Errorf("unexpected discovery response from %s: %q", args.ssh, line)
+		}
+		socket := strings.TrimSpace(fields[2])
+		if !strings.HasPrefix(socket, "/") {
+			return remoteDiscoverResult{}, fmt.Errorf("unexpected discovery socket from %s: %q", args.ssh, socket)
+		}
+		return remoteDiscoverResult{
+			name: args.name,
+			uid:  fields[1],
+			host: config.Host{
+				SSH:        args.ssh,
+				Session:    args.session,
+				SocketPath: socket,
+			},
+		}, nil
+	case "ERR":
+		return remoteDiscoverError(args, fields, line)
+	default:
+		return remoteDiscoverResult{}, fmt.Errorf("unexpected discovery response from %s: %q", args.ssh, line)
+	}
+}
+
+func remoteDiscoverError(args remoteDiscoverArgs, fields []string, line string) (remoteDiscoverResult, error) {
+	if len(fields) < 2 {
+		return remoteDiscoverResult{}, fmt.Errorf("unexpected discovery response from %s: %q", args.ssh, line)
+	}
+	switch fields[1] {
+	case "session_missing":
+		return remoteDiscoverResult{}, errors.New("remote session is required")
+	case "uid":
+		return remoteDiscoverResult{}, fmt.Errorf("remote host %s could not report its uid with id -u", args.ssh)
+	case "socket_missing":
+		socket := ""
+		if len(fields) > 2 {
+			socket = fields[2]
+		}
+		return remoteDiscoverResult{}, fmt.Errorf("remote amux socket %s does not exist for session %q on %s", socket, args.session, args.ssh)
+	case "nc_missing":
+		return remoteDiscoverResult{}, fmt.Errorf("remote host %s does not have nc in PATH; install netcat with Unix socket (-U) support", args.ssh)
+	case "nc_no_unix":
+		return remoteDiscoverResult{}, fmt.Errorf("remote host %s has nc but it does not support -U; install a netcat variant with Unix socket support", args.ssh)
+	default:
+		return remoteDiscoverResult{}, fmt.Errorf("unexpected discovery response from %s: %q", args.ssh, line)
+	}
+}
+
+func formatRemoteDiscoverResult(result remoteDiscoverResult, printOnly bool) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "Discovered remote %s\n", result.name)
+	if result.uid != "" {
+		fmt.Fprintf(&b, "UID: %s\n", result.uid)
+	}
+	fmt.Fprintf(&b, "Socket: %s\n", result.host.SocketPath)
+	fmt.Fprintf(&b, "%s\n", remoteDiscoverAddCommand(result))
+	if printOnly {
+		fmt.Fprintf(&b, "Not saved (--print)\n")
+	} else {
+		fmt.Fprintf(&b, "Saved remote %s\n", result.name)
+	}
+	return b.String()
+}
+
+func remoteDiscoverAddCommand(result remoteDiscoverResult) string {
+	return fmt.Sprintf("amux remote add %s --ssh %s --session %s --socket %s",
+		result.name, result.host.SSH, result.host.Session, result.host.SocketPath)
+}

--- a/internal/server/commands_remote_test.go
+++ b/internal/server/commands_remote_test.go
@@ -183,15 +183,37 @@ func TestDiscoverRemoteHostProbesExactSessionSocket(t *testing.T) {
 	if strings.Contains(runner.script, "ls ") || !strings.Contains(runner.script, `"/tmp/amux-${uid}/${session}"`) {
 		t.Fatalf("probe script should test the exact socket without listing /tmp; script:\n%s", runner.script)
 	}
+	if strings.Contains(runner.script, "nc -h") || !strings.Contains(runner.script, "nc -U /dev/null") {
+		t.Fatalf("probe script should test nc -U option parsing without relying on help text; script:\n%s", runner.script)
+	}
 	if result.host != (config.Host{SSH: "hetzner-1", Session: "main", SocketPath: "/tmp/amux-1000/main"}) {
 		t.Fatalf("discovered host = %+v, want socket derived from remote uid/session", result.host)
 	}
 	output := formatRemoteDiscoverResult(result, false)
-	if !strings.Contains(output, "amux remote add hetzner-1 --ssh hetzner-1 --session main --socket /tmp/amux-1000/main") {
+	if !strings.Contains(output, "amux remote add 'hetzner-1' --ssh 'hetzner-1' --session 'main' --socket '/tmp/amux-1000/main'") {
 		t.Fatalf("discover output missing copyable add command:\n%s", output)
 	}
 	if !strings.Contains(output, "Saved remote hetzner-1") {
 		t.Fatalf("discover output missing saved line:\n%s", output)
+	}
+}
+
+func TestRemoteDiscoverAddCommandShellQuotesArgs(t *testing.T) {
+	t.Parallel()
+
+	result := remoteDiscoverResult{
+		name: "prod server",
+		host: config.Host{
+			SSH:        "user@host with spaces",
+			Session:    "main'lab",
+			SocketPath: "/tmp/amux-1000/main socket",
+		},
+	}
+
+	got := remoteDiscoverAddCommand(result)
+	want := "amux remote add 'prod server' --ssh 'user@host with spaces' --session 'main'\\''lab' --socket '/tmp/amux-1000/main socket'"
+	if got != want {
+		t.Fatalf("remoteDiscoverAddCommand() = %q, want %q", got, want)
 	}
 }
 

--- a/internal/server/commands_remote_test.go
+++ b/internal/server/commands_remote_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"errors"
 	"reflect"
 	"strings"
@@ -73,6 +74,179 @@ func TestParseRemoteAddArgs(t *testing.T) {
 	}
 }
 
+func TestParseRemoteDiscoverArgs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		args        []string
+		want        remoteDiscoverArgs
+		wantErrText string
+	}{
+		{
+			name: "defaults ssh target and session",
+			args: []string{"hetzner-1"},
+			want: remoteDiscoverArgs{name: "hetzner-1", ssh: "hetzner-1", session: DefaultSessionName},
+		},
+		{
+			name: "explicit ssh target session and print",
+			args: []string{"prod", "--ssh", "root@example.test", "--session", "lab", "--print"},
+			want: remoteDiscoverArgs{name: "prod", ssh: "root@example.test", session: "lab", printOnly: true},
+		},
+		{
+			name:        "missing name",
+			wantErrText: remoteDiscoverUsage,
+		},
+		{
+			name:        "flag-like name",
+			args:        []string{"--bad"},
+			wantErrText: remoteDiscoverUsage,
+		},
+		{
+			name:        "missing ssh value",
+			args:        []string{"prod", "--ssh"},
+			wantErrText: remoteDiscoverUsage,
+		},
+		{
+			name:        "missing session value",
+			args:        []string{"prod", "--session"},
+			wantErrText: remoteDiscoverUsage,
+		},
+		{
+			name:        "unknown flag",
+			args:        []string{"prod", "--bogus"},
+			wantErrText: remoteDiscoverUsage,
+		},
+		{
+			name:        "session must stay a socket basename",
+			args:        []string{"prod", "--session", "../main"},
+			wantErrText: "remote session must not contain '/'",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := parseRemoteDiscoverArgs(tt.args)
+			if tt.wantErrText != "" {
+				if err == nil || err.Error() != tt.wantErrText {
+					t.Fatalf("parseRemoteDiscoverArgs(%v) error = %v, want %q", tt.args, err, tt.wantErrText)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseRemoteDiscoverArgs(%v): %v", tt.args, err)
+			}
+			if got != tt.want {
+				t.Fatalf("parseRemoteDiscoverArgs(%v) = %+v, want %+v", tt.args, got, tt.want)
+			}
+		})
+	}
+}
+
+type fakeRemoteDiscoverRunner struct {
+	output    string
+	err       error
+	calls     int
+	sshTarget string
+	session   string
+	script    string
+}
+
+func (f *fakeRemoteDiscoverRunner) Run(ctx context.Context, sshTarget, session, script string) (string, error) {
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+	f.calls++
+	f.sshTarget = sshTarget
+	f.session = session
+	f.script = script
+	return f.output, f.err
+}
+
+func TestDiscoverRemoteHostProbesExactSessionSocket(t *testing.T) {
+	t.Parallel()
+
+	runner := &fakeRemoteDiscoverRunner{output: "OK\t1000\t/tmp/amux-1000/main\n"}
+	result, err := discoverRemoteHost(context.Background(), remoteDiscoverArgs{
+		name:    "hetzner-1",
+		ssh:     "hetzner-1",
+		session: "main",
+	}, runner)
+	if err != nil {
+		t.Fatalf("discoverRemoteHost: %v", err)
+	}
+	if runner.calls != 1 || runner.sshTarget != "hetzner-1" || runner.session != "main" {
+		t.Fatalf("runner = calls %d ssh %q session %q, want one hetzner-1 main", runner.calls, runner.sshTarget, runner.session)
+	}
+	if strings.Contains(runner.script, "ls ") || !strings.Contains(runner.script, `"/tmp/amux-${uid}/${session}"`) {
+		t.Fatalf("probe script should test the exact socket without listing /tmp; script:\n%s", runner.script)
+	}
+	if result.host != (config.Host{SSH: "hetzner-1", Session: "main", SocketPath: "/tmp/amux-1000/main"}) {
+		t.Fatalf("discovered host = %+v, want socket derived from remote uid/session", result.host)
+	}
+	output := formatRemoteDiscoverResult(result, false)
+	if !strings.Contains(output, "amux remote add hetzner-1 --ssh hetzner-1 --session main --socket /tmp/amux-1000/main") {
+		t.Fatalf("discover output missing copyable add command:\n%s", output)
+	}
+	if !strings.Contains(output, "Saved remote hetzner-1") {
+		t.Fatalf("discover output missing saved line:\n%s", output)
+	}
+}
+
+func TestDiscoverRemoteHostActionableErrors(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		output string
+		err    error
+		want   string
+	}{
+		{
+			name: "ssh failure",
+			err:  errors.New("permission denied"),
+			want: `checking remote "hetzner-1" over ssh: permission denied`,
+		},
+		{
+			name:   "socket missing",
+			output: "ERR\tsocket_missing\t/tmp/amux-1000/main\n",
+			want:   `remote amux socket /tmp/amux-1000/main does not exist for session "main" on hetzner-1`,
+		},
+		{
+			name:   "nc missing",
+			output: "ERR\tnc_missing\n",
+			want:   `remote host hetzner-1 does not have nc in PATH; install netcat with Unix socket (-U) support`,
+		},
+		{
+			name:   "nc lacks unix sockets",
+			output: "ERR\tnc_no_unix\n",
+			want:   `remote host hetzner-1 has nc but it does not support -U; install a netcat variant with Unix socket support`,
+		},
+		{
+			name:   "malformed output",
+			output: "wat\n",
+			want:   `unexpected discovery response from hetzner-1: "wat"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := discoverRemoteHost(context.Background(), remoteDiscoverArgs{
+				name:    "hetzner-1",
+				ssh:     "hetzner-1",
+				session: "main",
+			}, &fakeRemoteDiscoverRunner{output: tt.output, err: tt.err})
+			if err == nil || err.Error() != tt.want {
+				t.Fatalf("discoverRemoteHost error = %v, want %q", err, tt.want)
+			}
+		})
+	}
+}
+
 func TestRunRemoteCommandUsageErrors(t *testing.T) {
 	t.Parallel()
 
@@ -84,6 +258,7 @@ func TestRunRemoteCommandUsageErrors(t *testing.T) {
 		{name: "missing subcommand", want: remoteCommandUsage},
 		{name: "unknown subcommand", args: []string{"bogus"}, want: remoteCommandUsage},
 		{name: "add usage", args: []string{"add"}, want: remoteAddUsage},
+		{name: "discover usage", args: []string{"discover"}, want: remoteDiscoverUsage},
 		{name: "list usage", args: []string{"list", "extra"}, want: remoteListUsage},
 		{name: "status usage", args: []string{"status", "extra"}, want: remoteStatusUsage},
 		{name: "rm usage", args: []string{"rm"}, want: remoteRmUsage},

--- a/internal/server/mirror/manager.go
+++ b/internal/server/mirror/manager.go
@@ -294,8 +294,17 @@ func (m *Manager) AgentStatus(paneID uint32) (proto.PaneAgentStatus, bool) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	ms := m.mirrors[paneID]
-	if ms == nil || !ms.hasAgentStatus {
+	if ms == nil {
 		return proto.PaneAgentStatus{}, false
+	}
+	if !ms.hasAgentStatus {
+		if ms.state != StateConnected {
+			return proto.PaneAgentStatus{}, false
+		}
+		return proto.PaneAgentStatus{
+			Exited:         false,
+			CurrentCommand: "remote:" + ms.ref.PaneName,
+		}, true
 	}
 	return ms.agentStatus, true
 }

--- a/internal/server/mirror/manager_test.go
+++ b/internal/server/mirror/manager_test.go
@@ -142,6 +142,30 @@ func TestManagerApplyPaneMetaUpdateStoresStatusAndDropsStaleGeneration(t *testin
 	}
 }
 
+func TestManagerConnectedMirrorAgentStatusFallback(t *testing.T) {
+	t.Parallel()
+
+	pane := newMirrorTestPane(t, 2)
+	mgr := NewManager(Config{})
+	t.Cleanup(mgr.Close)
+	mgr.mu.Lock()
+	mgr.mirrors[pane.ID] = &mirrorState{
+		pane:  pane,
+		ref:   checkpoint.RemoteRef{Host: "remote", Session: "main", PaneName: "agent"},
+		state: StateConnecting,
+	}
+	mgr.mu.Unlock()
+	mgr.markConnected(pane.ID, 42, nil)
+
+	status, ok := mgr.AgentStatus(pane.ID)
+	if !ok {
+		t.Fatal("AgentStatus ok=false, want connected mirror fallback")
+	}
+	if status.Exited || status.CurrentCommand != "remote:agent" {
+		t.Fatalf("AgentStatus = %+v, want non-exited remote:agent fallback", status)
+	}
+}
+
 func TestManagerRetryBudgetEndsDead(t *testing.T) {
 	t.Parallel()
 

--- a/internal/server/mirror/manager_test.go
+++ b/internal/server/mirror/manager_test.go
@@ -95,8 +95,8 @@ func TestManagerApplyPaneMetaUpdateStoresStatusAndDropsStaleGeneration(t *testin
 	if err := mgr.applyMessage(pane.ID, 1, stale); err != nil {
 		t.Fatalf("apply stale meta update: %v", err)
 	}
-	if status, ok := mgr.AgentStatus(pane.ID); ok || status.CurrentCommand != "" {
-		t.Fatalf("stale AgentStatus = (%+v, %v), want zero false", status, ok)
+	if status, ok := mgr.AgentStatus(pane.ID); !ok || status.CurrentCommand != "remote:agent" {
+		t.Fatalf("stale AgentStatus = (%+v, %v), want connected mirror fallback", status, ok)
 	}
 	select {
 	case update := <-updates:

--- a/internal/server/server_capture_full.go
+++ b/internal/server/server_capture_full.go
@@ -30,6 +30,7 @@ type serverCapturePane struct {
 	info     proto.PaneSnapshot
 	position proto.CapturePos
 	render   mux.PaneRenderSnapshot
+	mirror   *proto.CaptureMirror
 }
 
 func (s serverFullSessionCapture) lookup(paneID uint32) render.PaneData {
@@ -92,6 +93,7 @@ func (s serverFullSessionCapture) buildJSON(req caputil.Request, agentStatus map
 			TrackedPRs:    pane.info.TrackedPRs,
 			TrackedIssues: pane.info.TrackedIssues,
 			Mailbox:       pane.info.Mailbox,
+			Mirror:        pane.mirror,
 			Cursor: caputil.CursorFromState(
 				pane.render.CursorCol,
 				pane.render.CursorRow,
@@ -245,6 +247,7 @@ func (s *Session) captureFullSessionSnapshot() (serverFullSessionCapture, error)
 					Height: cell.H,
 				},
 				render: pane.CaptureRenderSnapshot(),
+				mirror: s.captureMirrorForPane(paneID),
 			}
 			panes = append(panes, capturePane)
 			panesByID[paneID] = capturePane

--- a/internal/server/session_mirror_meta.go
+++ b/internal/server/session_mirror_meta.go
@@ -175,3 +175,21 @@ func (s *Session) forwardedAgentStatusForPane(pane *mux.Pane) (proto.PaneAgentSt
 	}
 	return s.mirror.AgentStatus(pane.ID)
 }
+
+func (s *Session) captureMirrorForPane(paneID uint32) *proto.CaptureMirror {
+	if s == nil || s.mirror == nil {
+		return nil
+	}
+	snap, ok := s.mirror.Snapshot(paneID)
+	if !ok {
+		return nil
+	}
+	return &proto.CaptureMirror{
+		State:        string(snap.State),
+		Host:         snap.RemoteRef.Host,
+		Session:      snap.RemoteRef.Session,
+		PaneName:     snap.RemoteRef.PaneName,
+		RemotePaneID: snap.RemotePaneID,
+		LastError:    snap.LastError,
+	}
+}


### PR DESCRIPTION
## Motivation

Remote window mirroring needed a setup path that did not require users to derive /tmp/amux-$UID/<session> by hand or infer remote netcat support from noisy shell probing. Connected mirror panes also needed capture/status metadata that distinguishes a live remote proxy from a local exited shell.

## Summary

- Add `amux remote discover <name> [--ssh <target>] [--session <name>] [--print]` to probe SSH, the exact remote session socket, and `nc -U` support.
- Save discovered remote host config through the same validation path as `remote add`, while printing the equivalent manual add command.
- Add mirror metadata to JSON capture and report a connected mirror fallback status until forwarded remote agent status arrives.

## Testing

- `go test ./internal/server -run 'Test(ParseRemoteDiscoverArgs|DiscoverRemoteHostProbesExactSessionSocket|DiscoverRemoteHostActionableErrors|RunRemoteCommandUsageErrors)$' -count=100`
- `go test ./internal/server/mirror -run 'TestManager(ApplyPaneMetaUpdateStoresStatusAndDropsStaleGeneration|ConnectedMirrorAgentStatusFallback)$' -count=100`
- `go test ./internal/capture -run TestBuildPaneIncludesMirrorMetadata -count=100`
- `TMPDIR=/tmp go test ./internal/proto ./internal/capture ./internal/server ./internal/server/mirror ./internal/cli`
- `scripts/check-diff-coverage.sh` reported diff coverage 70.31% (135/192), above the 70% target. Local broad suites inside that script also reported macOS long Unix-socket path failures under `/var/folders/...` and integration startup timeouts; the focused and changed-package suites above passed.

## Review focus

- Check the remote probe script output contract and whether the `nc -h` `-U` detection is the right compatibility test across target hosts.
- Check the capture JSON `mirror` shape and the connected mirror fallback status before remote pane metadata has been forwarded.

Closes LAB-2008
