### PR TITLE
LAB-2009: Forward pane creation in mirrored windows

### DIFF
--- a/internal/remote/link.go
+++ b/internal/remote/link.go
@@ -190,17 +190,12 @@ func (SSHDialer) Dial(ctx context.Context, host config.Host) (net.Conn, error) {
 		return nil, fmt.Errorf("starting ssh: %w", err)
 	}
 
-	waitCh := make(chan error, 1)
-	go func() {
-		waitCh <- cmd.Wait()
-	}()
-
 	return &commandConn{
 		cmd:    cmd,
 		cancel: cancel,
 		stdin:  stdin,
 		stdout: stdout,
-		waitCh: waitCh,
+		wait:   cmd.Wait,
 	}, nil
 }
 
@@ -209,7 +204,7 @@ type commandConn struct {
 	cancel context.CancelFunc
 	stdin  io.WriteCloser
 	stdout io.ReadCloser
-	waitCh <-chan error
+	wait   func() error
 
 	closeOnce sync.Once
 	closeErr  error
@@ -235,11 +230,19 @@ func (c *commandConn) closeWithTimeout(grace, killWait time.Duration) error {
 		if c.stdin != nil {
 			_ = c.stdin.Close()
 		}
+		waitCh := make(chan error, 1)
+		if c.wait != nil {
+			go func() {
+				waitCh <- c.wait()
+			}()
+		} else {
+			waitCh <- nil
+		}
 		graceTimer := time.NewTimer(grace)
 		defer graceTimer.Stop()
 
 		select {
-		case err := <-c.waitCh:
+		case err := <-waitCh:
 			c.closeErr = acceptableWaitErr(err)
 		case <-graceTimer.C:
 			if c.cancel != nil {
@@ -251,7 +254,7 @@ func (c *commandConn) closeWithTimeout(grace, killWait time.Duration) error {
 			killTimer := time.NewTimer(killWait)
 			defer killTimer.Stop()
 			select {
-			case err := <-c.waitCh:
+			case err := <-waitCh:
 				c.closeErr = acceptableWaitErr(err)
 			case <-killTimer.C:
 				c.closeErr = errors.New("waiting for ssh process after kill: timeout")

--- a/internal/remote/link_test.go
+++ b/internal/remote/link_test.go
@@ -244,7 +244,7 @@ func TestCommandConnCloseCancelsOnNormalExit(t *testing.T) {
 		cancel: func() { cancelled = true },
 		stdin:  nopWriteCloser{},
 		stdout: nopReadCloser{},
-		waitCh: closedWait(nil),
+		wait:   func() error { return nil },
 	}
 
 	if err := conn.closeWithTimeout(time.Second, time.Second); err != nil {
@@ -259,11 +259,15 @@ func TestCommandConnCloseBoundsWaitAfterKill(t *testing.T) {
 	t.Parallel()
 
 	cancelled := false
+	waitCh := make(chan error)
+	defer close(waitCh)
 	conn := &commandConn{
 		cancel: func() { cancelled = true },
 		stdin:  nopWriteCloser{},
 		stdout: nopReadCloser{},
-		waitCh: make(chan error),
+		wait: func() error {
+			return <-waitCh
+		},
 	}
 
 	start := time.Now()
@@ -330,12 +334,6 @@ type nopReadCloser struct{}
 func (nopReadCloser) Read([]byte) (int, error) { return 0, errors.New("unexpected read") }
 
 func (nopReadCloser) Close() error { return nil }
-
-func closedWait(err error) <-chan error {
-	ch := make(chan error, 1)
-	ch <- err
-	return ch
-}
 
 type unixSocketDialer struct{}
 

--- a/internal/server/commands_layout.go
+++ b/internal/server/commands_layout.go
@@ -306,7 +306,12 @@ func queryCreatePaneSnapshot(sess *Session, actorPaneID uint32, command string, 
 		if w.ActivePane == nil {
 			return createPaneSnapshot{}, fmt.Errorf("no active pane")
 		}
-		return createPaneSnapshotWithMirrorTarget(sess, w, w.ActivePane, createPaneSnapshot{
+		mirrorTargetPane := w.ActivePane
+		if windowRef != "" {
+			// Explicit --window forwarding only needs the remote window name.
+			mirrorTargetPane = nil
+		}
+		return createPaneSnapshotWithMirrorTarget(sess, w, mirrorTargetPane, createPaneSnapshot{
 			inheritPane:              w.ActivePane,
 			windowWidth:              w.Width,
 			windowHeight:             w.Height,

--- a/internal/server/commands_layout.go
+++ b/internal/server/commands_layout.go
@@ -286,7 +286,7 @@ func queryCreatePaneSnapshot(sess *Session, actorPaneID uint32, command string, 
 			if resolvedWindow == nil {
 				return createPaneSnapshot{}, fmt.Errorf("pane not in any window")
 			}
-			snapshot := createPaneSnapshot{
+			return createPaneSnapshotWithMirrorTarget(sess, resolvedWindow, pane, createPaneSnapshot{
 				inheritPane:              pane,
 				windowWidth:              resolvedWindow.Width,
 				windowHeight:             resolvedWindow.Height,
@@ -294,11 +294,7 @@ func queryCreatePaneSnapshot(sess *Session, actorPaneID uint32, command string, 
 				inheritProxy:             pane.IsProxy(),
 				targetPaneID:             pane.ID,
 				treatLeadPaneAsWindowRef: command == "spawn",
-			}
-			if err := snapshotRemoteMirrorTarget(sess, resolvedWindow, pane, &snapshot); err != nil {
-				return createPaneSnapshot{}, err
-			}
-			return snapshot, nil
+			})
 		}
 		w, err := resolveCreatePaneTargetWindow(sess, actorPaneID, command, windowRef)
 		if err != nil {
@@ -310,7 +306,7 @@ func queryCreatePaneSnapshot(sess *Session, actorPaneID uint32, command string, 
 		if w.ActivePane == nil {
 			return createPaneSnapshot{}, fmt.Errorf("no active pane")
 		}
-		snapshot := createPaneSnapshot{
+		return createPaneSnapshotWithMirrorTarget(sess, w, w.ActivePane, createPaneSnapshot{
 			inheritPane:              w.ActivePane,
 			windowWidth:              w.Width,
 			windowHeight:             w.Height,
@@ -318,23 +314,19 @@ func queryCreatePaneSnapshot(sess *Session, actorPaneID uint32, command string, 
 			inheritProxy:             w.ActivePane.IsProxy(),
 			targetPaneID:             w.ActivePane.ID,
 			treatLeadPaneAsWindowRef: command == "spawn",
-		}
-		if err := snapshotRemoteMirrorTarget(sess, w, w.ActivePane, &snapshot); err != nil {
-			return createPaneSnapshot{}, err
-		}
-		return snapshot, nil
+		})
 	})
 }
 
-func snapshotRemoteMirrorTarget(sess *Session, w *mux.Window, pane *mux.Pane, snapshot *createPaneSnapshot) error {
+func createPaneSnapshotWithMirrorTarget(sess *Session, w *mux.Window, pane *mux.Pane, snapshot createPaneSnapshot) (createPaneSnapshot, error) {
 	target, ok, err := remoteMirrorCreatePaneTarget(sess, w, pane)
 	if err != nil {
-		return err
+		return createPaneSnapshot{}, err
 	}
 	if ok {
 		snapshot.mirrorTarget = &target
 	}
-	return nil
+	return snapshot, nil
 }
 
 func remoteMirrorCreatePaneTarget(sess *Session, w *mux.Window, pane *mux.Pane) (mirroredCreatePaneTarget, bool, error) {
@@ -414,7 +406,7 @@ func queryColumnFillCreatePaneSnapshot(sess *Session, actorPaneID uint32, comman
 	if plan.RootSplit {
 		targetPaneID = plan.InheritPaneID
 	}
-	snapshot := createPaneSnapshot{
+	return createPaneSnapshotWithMirrorTarget(sess, w, inheritPane, createPaneSnapshot{
 		inheritPane:   inheritPane,
 		windowWidth:   w.Width,
 		windowHeight:  w.Height,
@@ -422,11 +414,7 @@ func queryColumnFillCreatePaneSnapshot(sess *Session, actorPaneID uint32, comman
 		inheritProxy:  inheritPane.IsProxy(),
 		targetPaneID:  targetPaneID,
 		autoRootSplit: plan.RootSplit,
-	}
-	if err := snapshotRemoteMirrorTarget(sess, w, inheritPane, &snapshot); err != nil {
-		return createPaneSnapshot{}, err
-	}
-	return snapshot, nil
+	})
 }
 
 func resolveCreatePaneWindow(ctx *MutationContext, actorPaneID uint32, placement createPanePlacement, snapshot createPaneSnapshot) (*mux.Window, error) {

--- a/internal/server/commands_layout.go
+++ b/internal/server/commands_layout.go
@@ -11,6 +11,7 @@ import (
 	"github.com/weill-labs/amux/internal/render"
 	commandpkg "github.com/weill-labs/amux/internal/server/commands"
 	layoutcmd "github.com/weill-labs/amux/internal/server/commands/layout"
+	mirrorpkg "github.com/weill-labs/amux/internal/server/mirror"
 )
 
 const (
@@ -75,6 +76,12 @@ type createPaneSnapshot struct {
 	targetPaneID             uint32
 	autoRootSplit            bool
 	treatLeadPaneAsWindowRef bool
+	mirrorTarget             *mirroredCreatePaneTarget
+}
+
+type mirroredCreatePaneTarget struct {
+	windowRef      mirrorpkg.WindowRef
+	targetPaneName string
 }
 
 const (
@@ -116,6 +123,9 @@ func runCreatePane(ctx *CommandContext, actorPaneID uint32, command string, plac
 	if req.attach != nil {
 		return runCreateMirrorPane(ctx, actorPaneID, command, placement, req, keepFocus, snapshot)
 	}
+	if snapshot.mirrorTarget != nil {
+		return runCreatePaneInRemoteMirror(ctx, command, placement, req, keepFocus, snapshot)
+	}
 
 	meta := mux.PaneMeta{
 		Name:  req.name,
@@ -142,6 +152,84 @@ func runCreatePane(ctx *CommandContext, actorPaneID uint32, command string, plac
 			broadcastLayout: true,
 		}
 	}))
+}
+
+func runCreatePaneInRemoteMirror(ctx *CommandContext, command string, placement createPanePlacement, req createPaneRequest, keepFocus bool, snapshot createPaneSnapshot) commandpkg.Result {
+	target := snapshot.mirrorTarget
+	if target == nil {
+		return commandpkg.Result{Err: fmt.Errorf("remote mirror target is missing")}
+	}
+	host, err := lookupRemoteHost(target.windowRef.Host)
+	if err != nil {
+		return commandpkg.Result{Err: err}
+	}
+	args := remoteCreatePaneArgs(command, placement, req, keepFocus, *target)
+	msg, err := runRemoteOneShotCommand(ctx.context(), host, command, args)
+	if err != nil {
+		return commandpkg.Result{Err: err}
+	}
+	if msg == nil || msg.CmdOutput == "" {
+		return commandpkg.Result{Err: fmt.Errorf("%s forwarded to remote mirror produced no result", command)}
+	}
+	return commandpkg.Result{Output: msg.CmdOutput}
+}
+
+func remoteCreatePaneArgs(command string, placement createPanePlacement, req createPaneRequest, keepFocus bool, target mirroredCreatePaneTarget) []string {
+	args := make([]string, 0, 12)
+	if command == "split" {
+		if target.targetPaneName != "" {
+			args = append(args, target.targetPaneName)
+		}
+		if placement == createPanePlacementRootSplit {
+			args = append(args, "root")
+		}
+		args = appendCreatePaneDirArg(args, req.dir)
+		args = appendCreatePaneFocusArg(args, keepFocus)
+		return appendCreatePaneMetaArgs(args, req)
+	}
+
+	if placement == createPanePlacementColumnFill {
+		args = append(args, "--auto")
+	} else if placement == createPanePlacementRootSplit {
+		args = append(args, "--root")
+	}
+	if req.windowRef != "" {
+		args = append(args, "--window", target.windowRef.WindowName)
+	} else if target.targetPaneName != "" {
+		args = append(args, "--at", target.targetPaneName)
+	}
+	if placement != createPanePlacementColumnFill {
+		args = appendCreatePaneDirArg(args, req.dir)
+	}
+	args = appendCreatePaneFocusArg(args, keepFocus)
+	return appendCreatePaneMetaArgs(args, req)
+}
+
+func appendCreatePaneDirArg(args []string, dir mux.SplitDir) []string {
+	if dir == mux.SplitVertical {
+		return append(args, "--vertical")
+	}
+	return append(args, "--horizontal")
+}
+
+func appendCreatePaneFocusArg(args []string, keepFocus bool) []string {
+	if keepFocus {
+		return args
+	}
+	return append(args, "--focus")
+}
+
+func appendCreatePaneMetaArgs(args []string, req createPaneRequest) []string {
+	if req.name != "" {
+		args = append(args, "--name", req.name)
+	}
+	if req.task != "" {
+		args = append(args, "--task", req.task)
+	}
+	if req.color != "" {
+		args = append(args, "--color", req.color)
+	}
+	return args
 }
 
 func runCreateMirrorPane(ctx *CommandContext, actorPaneID uint32, command string, placement createPanePlacement, req createPaneRequest, keepFocus bool, snapshot createPaneSnapshot) commandpkg.Result {
@@ -198,7 +286,7 @@ func queryCreatePaneSnapshot(sess *Session, actorPaneID uint32, command string, 
 			if resolvedWindow == nil {
 				return createPaneSnapshot{}, fmt.Errorf("pane not in any window")
 			}
-			return createPaneSnapshot{
+			snapshot := createPaneSnapshot{
 				inheritPane:              pane,
 				windowWidth:              resolvedWindow.Width,
 				windowHeight:             resolvedWindow.Height,
@@ -206,7 +294,11 @@ func queryCreatePaneSnapshot(sess *Session, actorPaneID uint32, command string, 
 				inheritProxy:             pane.IsProxy(),
 				targetPaneID:             pane.ID,
 				treatLeadPaneAsWindowRef: command == "spawn",
-			}, nil
+			}
+			if err := snapshotRemoteMirrorTarget(sess, resolvedWindow, pane, &snapshot); err != nil {
+				return createPaneSnapshot{}, err
+			}
+			return snapshot, nil
 		}
 		w, err := resolveCreatePaneTargetWindow(sess, actorPaneID, command, windowRef)
 		if err != nil {
@@ -218,7 +310,7 @@ func queryCreatePaneSnapshot(sess *Session, actorPaneID uint32, command string, 
 		if w.ActivePane == nil {
 			return createPaneSnapshot{}, fmt.Errorf("no active pane")
 		}
-		return createPaneSnapshot{
+		snapshot := createPaneSnapshot{
 			inheritPane:              w.ActivePane,
 			windowWidth:              w.Width,
 			windowHeight:             w.Height,
@@ -226,8 +318,48 @@ func queryCreatePaneSnapshot(sess *Session, actorPaneID uint32, command string, 
 			inheritProxy:             w.ActivePane.IsProxy(),
 			targetPaneID:             w.ActivePane.ID,
 			treatLeadPaneAsWindowRef: command == "spawn",
-		}, nil
+		}
+		if err := snapshotRemoteMirrorTarget(sess, w, w.ActivePane, &snapshot); err != nil {
+			return createPaneSnapshot{}, err
+		}
+		return snapshot, nil
 	})
+}
+
+func snapshotRemoteMirrorTarget(sess *Session, w *mux.Window, pane *mux.Pane, snapshot *createPaneSnapshot) error {
+	target, ok, err := remoteMirrorCreatePaneTarget(sess, w, pane)
+	if err != nil {
+		return err
+	}
+	if ok {
+		snapshot.mirrorTarget = &target
+	}
+	return nil
+}
+
+func remoteMirrorCreatePaneTarget(sess *Session, w *mux.Window, pane *mux.Pane) (mirroredCreatePaneTarget, bool, error) {
+	if sess == nil || w == nil || sess.windowMirrorSigs == nil {
+		return mirroredCreatePaneTarget{}, false, nil
+	}
+	if _, ok := sess.windowMirrorSigs[w.ID]; !ok {
+		return mirroredCreatePaneTarget{}, false, nil
+	}
+	if sess.mirror == nil {
+		return mirroredCreatePaneTarget{}, false, fmt.Errorf("window %q is a remote mirror but mirror manager is not configured", w.Name)
+	}
+	info, ok := sess.mirror.WindowMirrorInfos()[w.ID]
+	if !ok {
+		return mirroredCreatePaneTarget{}, false, fmt.Errorf("window %q is not tracked by the remote mirror manager", w.Name)
+	}
+	target := mirroredCreatePaneTarget{windowRef: info.Ref}
+	if pane != nil {
+		ref, ok := sess.mirror.RemoteRef(pane.ID)
+		if !ok || ref == nil || ref.PaneName == "" {
+			return mirroredCreatePaneTarget{}, false, fmt.Errorf("pane %s is not tracked by the remote mirror manager", pane.Meta.Name)
+		}
+		target.targetPaneName = ref.PaneName
+	}
+	return target, true, nil
 }
 
 func resolveCreatePaneWindowHint(sess *Session, actorPaneID uint32, paneRef, windowRef string) (string, error) {
@@ -282,7 +414,7 @@ func queryColumnFillCreatePaneSnapshot(sess *Session, actorPaneID uint32, comman
 	if plan.RootSplit {
 		targetPaneID = plan.InheritPaneID
 	}
-	return createPaneSnapshot{
+	snapshot := createPaneSnapshot{
 		inheritPane:   inheritPane,
 		windowWidth:   w.Width,
 		windowHeight:  w.Height,
@@ -290,7 +422,11 @@ func queryColumnFillCreatePaneSnapshot(sess *Session, actorPaneID uint32, comman
 		inheritProxy:  inheritPane.IsProxy(),
 		targetPaneID:  targetPaneID,
 		autoRootSplit: plan.RootSplit,
-	}, nil
+	}
+	if err := snapshotRemoteMirrorTarget(sess, w, inheritPane, &snapshot); err != nil {
+		return createPaneSnapshot{}, err
+	}
+	return snapshot, nil
 }
 
 func resolveCreatePaneWindow(ctx *MutationContext, actorPaneID uint32, placement createPanePlacement, snapshot createPaneSnapshot) (*mux.Window, error) {

--- a/internal/server/commands_layout_remote_mirror_test.go
+++ b/internal/server/commands_layout_remote_mirror_test.go
@@ -1,0 +1,91 @@
+package server
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/weill-labs/amux/internal/checkpoint"
+	"github.com/weill-labs/amux/internal/mux"
+	mirrorpkg "github.com/weill-labs/amux/internal/server/mirror"
+)
+
+const remoteMirrorCreatePaneTestHost = "lab-2009-missing-host"
+
+func TestCommandSpawnAtMirroredWindowFailsWhenRemoteHostMissing(t *testing.T) {
+	t.Setenv("AMUX_CONFIG", t.TempDir()+"/config.toml")
+
+	srv, sess, cleanup := newCommandTestSession(t)
+	defer cleanup()
+
+	pane := seedMirroredCreatePaneWindow(t, sess, true, true)
+
+	res := runTestCommand(t, srv, sess, "spawn", "--at", pane.Meta.Name, "--name", "worker")
+	if !strings.Contains(res.cmdErr, `remote "lab-2009-missing-host" not found`) {
+		t.Fatalf("spawn error = %q, want missing remote host", res.cmdErr)
+	}
+	assertPaneCount(t, sess, 1)
+}
+
+func TestCommandSpawnWindowMirroredWindowFailsWhenWindowMirrorUntracked(t *testing.T) {
+	srv, sess, cleanup := newCommandTestSession(t)
+	defer cleanup()
+
+	seedMirroredCreatePaneWindow(t, sess, false, false)
+
+	res := runTestCommand(t, srv, sess, "spawn", "--window", "mirror-window", "--name", "worker")
+	if !strings.Contains(res.cmdErr, `window "mirror-window" is not tracked by the remote mirror manager`) {
+		t.Fatalf("spawn --window error = %q, want untracked mirror window", res.cmdErr)
+	}
+	assertPaneCount(t, sess, 1)
+}
+
+func TestCommandSplitMirroredPaneFailsWhenPaneMirrorUntracked(t *testing.T) {
+	srv, sess, cleanup := newCommandTestSession(t)
+	defer cleanup()
+
+	pane := seedMirroredCreatePaneWindow(t, sess, true, false)
+
+	res := runTestCommand(t, srv, sess, "split", pane.Meta.Name, "--name", "worker")
+	if !strings.Contains(res.cmdErr, "pane mirror-agent is not tracked by the remote mirror manager") {
+		t.Fatalf("split error = %q, want untracked mirror pane", res.cmdErr)
+	}
+	assertPaneCount(t, sess, 1)
+}
+
+func seedMirroredCreatePaneWindow(t *testing.T, sess *Session, trackWindow, trackPane bool) *mux.Pane {
+	t.Helper()
+
+	pane := newTestPane(sess, 1, "mirror-agent")
+	pane.Meta.Host = remoteMirrorCreatePaneTestHost
+	w := newTestWindowWithPanes(t, sess, 1, "mirror-window", pane)
+	setSessionLayoutForTest(t, sess, w.ID, []*mux.Window{w}, pane)
+
+	mustSessionMutation(t, sess, func(sess *Session) {
+		if sess.windowMirrorSigs == nil {
+			sess.windowMirrorSigs = make(map[uint32]string)
+		}
+		sess.windowMirrorSigs[w.ID] = "signature"
+		ref := mirrorpkg.WindowRef{Host: remoteMirrorCreatePaneTestHost, Session: "main", WindowName: "remote-main"}
+		if trackWindow {
+			if err := sess.mirror.TrackWindow(w.ID, ref, w.Width, w.Height); err != nil {
+				t.Fatalf("TrackWindow: %v", err)
+			}
+		}
+		if trackPane {
+			err := sess.trackMirrorPane(pane, checkpoint.RemoteRef{Host: remoteMirrorCreatePaneTestHost, PaneName: "remote-agent"})
+			if err != nil {
+				t.Fatalf("trackMirrorPane: %v", err)
+			}
+		}
+	})
+	return pane
+}
+
+func assertPaneCount(t *testing.T, sess *Session, want int) {
+	t.Helper()
+
+	got := mustSessionQuery(t, sess, func(sess *Session) int { return len(sess.Panes) })
+	if got != want {
+		t.Fatalf("pane count = %d, want %d", got, want)
+	}
+}

--- a/internal/server/commands_layout_remote_mirror_test.go
+++ b/internal/server/commands_layout_remote_mirror_test.go
@@ -41,6 +41,29 @@ func TestCommandSpawnWindowMirroredWindowFailsWhenWindowMirrorUntracked(t *testi
 	assertPaneCount(t, sess, 1)
 }
 
+func TestCommandSpawnWindowMirroredWindowDoesNotRequirePaneMirrorTracking(t *testing.T) {
+	t.Parallel()
+
+	_, sess, cleanup := newCommandTestSession(t)
+	defer cleanup()
+
+	seedMirroredCreatePaneWindow(t, sess, true, false)
+
+	snapshot, err := queryCreatePaneSnapshot(sess, 1, "spawn", createPanePlacementSplitAt, "", "mirror-window")
+	if err != nil {
+		t.Fatalf("queryCreatePaneSnapshot: %v", err)
+	}
+	if snapshot.mirrorTarget == nil {
+		t.Fatalf("mirror target is nil")
+	}
+	if got := snapshot.mirrorTarget.windowRef.WindowName; got != "remote-main" {
+		t.Fatalf("mirror window name = %q, want remote-main", got)
+	}
+	if got := snapshot.mirrorTarget.targetPaneName; got != "" {
+		t.Fatalf("target pane name = %q, want empty", got)
+	}
+}
+
 func TestCommandSplitMirroredPaneFailsWhenPaneMirrorUntracked(t *testing.T) {
 	t.Parallel()
 

--- a/internal/server/commands_layout_remote_mirror_test.go
+++ b/internal/server/commands_layout_remote_mirror_test.go
@@ -27,6 +27,8 @@ func TestCommandSpawnAtMirroredWindowFailsWhenRemoteHostMissing(t *testing.T) {
 }
 
 func TestCommandSpawnWindowMirroredWindowFailsWhenWindowMirrorUntracked(t *testing.T) {
+	t.Parallel()
+
 	srv, sess, cleanup := newCommandTestSession(t)
 	defer cleanup()
 
@@ -40,6 +42,8 @@ func TestCommandSpawnWindowMirroredWindowFailsWhenWindowMirrorUntracked(t *testi
 }
 
 func TestCommandSplitMirroredPaneFailsWhenPaneMirrorUntracked(t *testing.T) {
+	t.Parallel()
+
 	srv, sess, cleanup := newCommandTestSession(t)
 	defer cleanup()
 

--- a/test/remote_window_attach_test.go
+++ b/test/remote_window_attach_test.go
@@ -78,6 +78,115 @@ func TestRemoteCLIAttachWindowDynamicResync(t *testing.T) {
 	}
 }
 
+func TestRemoteCLISpawnWindowForwardsToMirroredWindow(t *testing.T) {
+	t.Parallel()
+
+	pair := newRemoteCLIPair(t)
+	pair.remote.runCmd("rename", "pane-1", "remote-agent")
+
+	attachOut := pair.local.runCmd("remote", "attach-window", remoteCLITestHost+":1")
+	winName := windowNameFromAttach(attachOut)
+	if winName == "" {
+		t.Fatalf("could not parse window name from %q", attachOut)
+	}
+
+	out := pair.local.runCmd("spawn", "--window", winName, "--name", "remote-by-window")
+	if !strings.Contains(out, "Spawned remote-by-window") {
+		t.Fatalf("spawn --window output = %q", out)
+	}
+	if remoteList := pair.remote.runCmd("list", "--no-cwd"); !strings.Contains(remoteList, "remote-by-window") {
+		t.Fatalf("spawn --window did not create a remote pane:\n%s", remoteList)
+	}
+	if !pair.local.waitForFunc(func(string) bool {
+		return len(localMirrorNames(pair.local.runCmd("list", "--no-cwd"), remoteCLITestHost)) == 2
+	}, 5*time.Second) {
+		t.Fatalf("local mirror did not reconcile the remote spawn")
+	}
+}
+
+func TestRemoteCLISpawnAtMirrorPaneForwardsToRemotePane(t *testing.T) {
+	t.Parallel()
+
+	pair := newRemoteCLIPair(t)
+	pair.remote.runCmd("rename", "pane-1", "remote-agent")
+
+	attachOut := pair.local.runCmd("remote", "attach-window", remoteCLITestHost+":1")
+	if !strings.Contains(attachOut, "1 panes") {
+		t.Fatalf("attach-window output = %q", attachOut)
+	}
+	mirrors := localMirrorNames(pair.local.runCmd("list", "--no-cwd"), remoteCLITestHost)
+	if len(mirrors) != 1 {
+		t.Fatalf("initial mirror panes = %v, want one", mirrors)
+	}
+
+	out := pair.local.runCmd("spawn", "--at", mirrors[0], "--name", "remote-by-at")
+	if !strings.Contains(out, "Spawned remote-by-at") {
+		t.Fatalf("spawn --at mirror output = %q", out)
+	}
+	if remoteList := pair.remote.runCmd("list", "--no-cwd"); !strings.Contains(remoteList, "remote-by-at") {
+		t.Fatalf("spawn --at mirror did not create a remote pane:\n%s", remoteList)
+	}
+	if !pair.local.waitForFunc(func(string) bool {
+		return len(localMirrorNames(pair.local.runCmd("list", "--no-cwd"), remoteCLITestHost)) == 2
+	}, 5*time.Second) {
+		t.Fatalf("local mirror did not reconcile the remote spawn")
+	}
+}
+
+func TestRemoteCLISpawnActiveMirrorWindowForwardsToRemotePane(t *testing.T) {
+	t.Parallel()
+
+	pair := newRemoteCLIPair(t)
+	pair.remote.runCmd("rename", "pane-1", "remote-agent")
+
+	attachOut := pair.local.runCmd("remote", "attach-window", remoteCLITestHost+":1")
+	if !strings.Contains(attachOut, "1 panes") {
+		t.Fatalf("attach-window output = %q", attachOut)
+	}
+
+	out := pair.local.runCmd("spawn", "--name", "remote-by-active")
+	if !strings.Contains(out, "Spawned remote-by-active") {
+		t.Fatalf("spawn active mirror output = %q", out)
+	}
+	if remoteList := pair.remote.runCmd("list", "--no-cwd"); !strings.Contains(remoteList, "remote-by-active") {
+		t.Fatalf("spawn active mirror did not create a remote pane:\n%s", remoteList)
+	}
+	if !pair.local.waitForFunc(func(string) bool {
+		return len(localMirrorNames(pair.local.runCmd("list", "--no-cwd"), remoteCLITestHost)) == 2
+	}, 5*time.Second) {
+		t.Fatalf("local mirror did not reconcile the active mirror spawn")
+	}
+}
+
+func TestRemoteCLISplitMirrorPaneForwardsToRemotePane(t *testing.T) {
+	t.Parallel()
+
+	pair := newRemoteCLIPair(t)
+	pair.remote.runCmd("rename", "pane-1", "remote-agent")
+
+	attachOut := pair.local.runCmd("remote", "attach-window", remoteCLITestHost+":1")
+	if !strings.Contains(attachOut, "1 panes") {
+		t.Fatalf("attach-window output = %q", attachOut)
+	}
+	mirrors := localMirrorNames(pair.local.runCmd("list", "--no-cwd"), remoteCLITestHost)
+	if len(mirrors) != 1 {
+		t.Fatalf("initial mirror panes = %v, want one", mirrors)
+	}
+
+	out := pair.local.runControlCmd("split", mirrors[0], "--name", "remote-by-split")
+	if !strings.Contains(out, "Split horizontal: new pane remote-by-split") {
+		t.Fatalf("split mirror output = %q", out)
+	}
+	if remoteList := pair.remote.runCmd("list", "--no-cwd"); !strings.Contains(remoteList, "remote-by-split") {
+		t.Fatalf("split mirror did not create a remote pane:\n%s", remoteList)
+	}
+	if !pair.local.waitForFunc(func(string) bool {
+		return len(localMirrorNames(pair.local.runCmd("list", "--no-cwd"), remoteCLITestHost)) == 2
+	}, 5*time.Second) {
+		t.Fatalf("local mirror did not reconcile the remote split")
+	}
+}
+
 // TestRemoteCLIDetachWindow tears down a mirrored window and verifies the local
 // panes are gone while the remote panes survive.
 func TestRemoteCLIDetachWindow(t *testing.T) {


### PR DESCRIPTION
## Motivation
Remote mirrored windows were accepting pane creation commands locally, which made the mirror diverge from the remote source of truth. Pane creation from a focused or explicitly targeted mirror should mutate the remote window and let window reconciliation update local state.

## Summary
- Forward `spawn`/`split` create-pane requests from mirrored windows to the tracked remote window or pane.
- Return errors when mirror window or pane metadata is missing, or when the remote command cannot produce a result.
- Delay SSH command process reaping until reads finish so one-shot remote command replies are not lost to stdout-pipe races.
- Add integration coverage for `spawn --window`, `spawn --at`, active mirrored-window spawn, and raw server `split` against a mirror pane.

## Testing
- `go test ./internal/server -run 'TestCommand(SpawnAtMirroredWindowFailsWhenRemoteHostMissing|SpawnWindowMirroredWindowFailsWhenWindowMirrorUntracked|SplitMirroredPaneFailsWhenPaneMirrorUntracked)$' -count=100 -timeout 120s`\n- `go test ./internal/remote -run 'TestSSHDialerUsesConfiguredCommandAndStreamsProtocol|TestCommandConnClose(CancelsOnNormalExit|BoundsWaitAfterKill)$' -count=100 -timeout 120s`\n- `go test ./test -run 'TestRemoteCLI(SpawnWindowForwardsToMirroredWindow|SpawnAtMirrorPaneForwardsToRemotePane|SpawnActiveMirrorWindowForwardsToRemotePane|SplitMirrorPaneForwardsToRemotePane)$' -count=100 -timeout 1200s`\n- `go test ./internal/server -run 'TestCommand(SpawnAtMirroredWindowFailsWhenRemoteHostMissing|SpawnWindowMirroredWindowFailsWhenWindowMirrorUntracked|SplitMirroredPaneFailsWhenPaneMirrorUntracked)$' -count=1 -timeout 120s`\n- `go test ./internal/remote -run 'TestSSHDialerUsesConfiguredCommandAndStreamsProtocol|TestCommandConnClose(CancelsOnNormalExit|BoundsWaitAfterKill)$' -count=1 -timeout 120s`\n- `go test ./test -run 'TestRemoteCLI(SpawnWindowForwardsToMirroredWindow|SpawnAtMirrorPaneForwardsToRemotePane|SpawnActiveMirrorWindowForwardsToRemotePane|SplitMirrorPaneForwardsToRemotePane)$|TestParallelAudit' -count=1 -timeout 180s`\n\n## Review focus\n- Confirm the remote argument mapping preserves split/spawn focus, root, auto, and metadata behavior.\n- Check that missing mirror bookkeeping fails before local pane creation.\n- Review the SSH command connection change for `StdoutPipe`/`Wait` ordering.\n\nCloses LAB-2009\n