### PR TITLE
Share repeated command setup helpers

### DIFF
--- a/internal/cli/cli_debug.go
+++ b/internal/cli/cli_debug.go
@@ -154,6 +154,12 @@ type debugEndpointRequest struct {
 	outputPath     string
 }
 
+func (req *debugEndpointRequest) useClientPprof(sessionName string) {
+	req.sockPath = client.PprofSocketPath(sessionName)
+	req.missingHint = "pprof debug socket %s is not available; attach or restart a client after enabling [debug].pprof"
+	req.discoverSocket = false
+}
+
 func loadDebugConfig() (*config.Config, error) {
 	return config.Load(config.DefaultPath())
 }
@@ -223,18 +229,14 @@ func parseDebugCommandWithConfigLoader(sessionName string, args []string, loadCo
 		if len(args) != 1 {
 			return debugEndpointRequest{}, errors.New(debugUsage)
 		}
-		req.sockPath = client.PprofSocketPath(sessionName)
+		req.useClientPprof(sessionName)
 		req.path = "/debug/pprof/goroutine?debug=2"
-		req.missingHint = "pprof debug socket %s is not available; attach or restart a client after enabling [debug].pprof"
-		req.discoverSocket = false
 	case "client-heap":
 		if len(args) != 1 {
 			return debugEndpointRequest{}, errors.New(debugUsage)
 		}
-		req.sockPath = client.PprofSocketPath(sessionName)
+		req.useClientPprof(sessionName)
 		req.path = "/debug/pprof/heap?debug=1"
-		req.missingHint = "pprof debug socket %s is not available; attach or restart a client after enabling [debug].pprof"
-		req.discoverSocket = false
 	case "socket":
 		if len(args) != 1 {
 			return debugEndpointRequest{}, errors.New(debugUsage)
@@ -260,11 +262,9 @@ func parseDebugCommandWithConfigLoader(sessionName string, args []string, loadCo
 		if seconds < 1 {
 			seconds = 1
 		}
-		req.sockPath = client.PprofSocketPath(sessionName)
+		req.useClientPprof(sessionName)
 		req.timeout = duration + 5*time.Second
 		req.path = "/debug/pprof/profile?seconds=" + strconv.Itoa(seconds)
-		req.missingHint = "pprof debug socket %s is not available; attach or restart a client after enabling [debug].pprof"
-		req.discoverSocket = false
 	default:
 		return debugEndpointRequest{}, errors.New(debugUsage)
 	}

--- a/internal/server/commands_tree.go
+++ b/internal/server/commands_tree.go
@@ -59,6 +59,28 @@ type treeCommandContext struct {
 	*CommandContext
 }
 
+func runActorWindowMutation(ctx *CommandContext, actorPaneID uint32, mutate func(*mux.Window) commandMutationResult) commandpkg.Result {
+	return toCommandResult(ctx.Sess.enqueueCommandMutationContext(ctx.context(), func(mctx *MutationContext) commandMutationResult {
+		w := mctx.windowForActor(actorPaneID)
+		if w == nil {
+			return commandMutationResult{err: fmt.Errorf("no session")}
+		}
+		return mutate(w)
+	}))
+}
+
+func resolvePanePair(w *mux.Window, firstRef, secondRef string) (*mux.Pane, *mux.Pane, error) {
+	first, err := w.ResolvePane(firstRef)
+	if err != nil {
+		return nil, nil, err
+	}
+	second, err := w.ResolvePane(secondRef)
+	if err != nil {
+		return nil, nil, err
+	}
+	return first, second, nil
+}
+
 func (ctx treeCommandContext) SwapForward(actorPaneID uint32) commandpkg.Result {
 	return runSwapForward(ctx.CommandContext, actorPaneID)
 }
@@ -92,43 +114,26 @@ func (ctx treeCommandContext) Rotate(forward bool) commandpkg.Result {
 }
 
 func runSwapForward(ctx *CommandContext, actorPaneID uint32) commandpkg.Result {
-	return toCommandResult(ctx.Sess.enqueueCommandMutationContext(ctx.context(), func(mctx *MutationContext) commandMutationResult {
-		w := mctx.windowForActor(actorPaneID)
-		if w == nil {
-			return commandMutationResult{err: fmt.Errorf("no session")}
-		}
+	return runActorWindowMutation(ctx, actorPaneID, func(w *mux.Window) commandMutationResult {
 		if err := w.SwapPaneForward(); err != nil {
 			return commandMutationResult{err: err}
 		}
 		return commandMutationResult{output: "Swapped\n", broadcastLayout: true}
-	}))
+	})
 }
 
 func runSwapBackward(ctx *CommandContext, actorPaneID uint32) commandpkg.Result {
-	return toCommandResult(ctx.Sess.enqueueCommandMutationContext(ctx.context(), func(mctx *MutationContext) commandMutationResult {
-		w := mctx.windowForActor(actorPaneID)
-		if w == nil {
-			return commandMutationResult{err: fmt.Errorf("no session")}
-		}
+	return runActorWindowMutation(ctx, actorPaneID, func(w *mux.Window) commandMutationResult {
 		if err := w.SwapPaneBackward(); err != nil {
 			return commandMutationResult{err: err}
 		}
 		return commandMutationResult{output: "Swapped\n", broadcastLayout: true}
-	}))
+	})
 }
 
 func runSwap(ctx *CommandContext, actorPaneID uint32, paneRef, targetRef string) commandpkg.Result {
-	return toCommandResult(ctx.Sess.enqueueCommandMutationContext(ctx.context(), func(mctx *MutationContext) commandMutationResult {
-		w := mctx.windowForActor(actorPaneID)
-		if w == nil {
-			return commandMutationResult{err: fmt.Errorf("no session")}
-		}
-
-		pane1, err := w.ResolvePane(paneRef)
-		if err != nil {
-			return commandMutationResult{err: err}
-		}
-		pane2, err := w.ResolvePane(targetRef)
+	return runActorWindowMutation(ctx, actorPaneID, func(w *mux.Window) commandMutationResult {
+		pane1, pane2, err := resolvePanePair(w, paneRef, targetRef)
 		if err != nil {
 			return commandMutationResult{err: err}
 		}
@@ -136,7 +141,7 @@ func runSwap(ctx *CommandContext, actorPaneID uint32, paneRef, targetRef string)
 			return commandMutationResult{err: err}
 		}
 		return commandMutationResult{output: "Swapped\n", broadcastLayout: true}
-	}))
+	})
 }
 
 func cmdSwap(ctx *CommandContext) {
@@ -144,17 +149,8 @@ func cmdSwap(ctx *CommandContext) {
 }
 
 func runSwapTree(ctx *CommandContext, actorPaneID uint32, paneRef, targetRef string) commandpkg.Result {
-	return toCommandResult(ctx.Sess.enqueueCommandMutationContext(ctx.context(), func(mctx *MutationContext) commandMutationResult {
-		w := mctx.windowForActor(actorPaneID)
-		if w == nil {
-			return commandMutationResult{err: fmt.Errorf("no session")}
-		}
-
-		pane1, err := w.ResolvePane(paneRef)
-		if err != nil {
-			return commandMutationResult{err: err}
-		}
-		pane2, err := w.ResolvePane(targetRef)
+	return runActorWindowMutation(ctx, actorPaneID, func(w *mux.Window) commandMutationResult {
+		pane1, pane2, err := resolvePanePair(w, paneRef, targetRef)
 		if err != nil {
 			return commandMutationResult{err: err}
 		}
@@ -162,7 +158,7 @@ func runSwapTree(ctx *CommandContext, actorPaneID uint32, paneRef, targetRef str
 			return commandMutationResult{err: err}
 		}
 		return commandMutationResult{output: "Swapped tree\n", broadcastLayout: true}
-	}))
+	})
 }
 
 func cmdSwapTree(ctx *CommandContext) {
@@ -170,17 +166,8 @@ func cmdSwapTree(ctx *CommandContext) {
 }
 
 func runMove(ctx *CommandContext, actorPaneID uint32, paneRef, targetRef string, before bool) commandpkg.Result {
-	return toCommandResult(ctx.Sess.enqueueCommandMutationContext(ctx.context(), func(mctx *MutationContext) commandMutationResult {
-		w := mctx.windowForActor(actorPaneID)
-		if w == nil {
-			return commandMutationResult{err: fmt.Errorf("no session")}
-		}
-
-		pane, err := w.ResolvePane(paneRef)
-		if err != nil {
-			return commandMutationResult{err: err}
-		}
-		target, err := w.ResolvePane(targetRef)
+	return runActorWindowMutation(ctx, actorPaneID, func(w *mux.Window) commandMutationResult {
+		pane, target, err := resolvePanePair(w, paneRef, targetRef)
 		if err != nil {
 			return commandMutationResult{err: err}
 		}
@@ -196,7 +183,7 @@ func runMove(ctx *CommandContext, actorPaneID uint32, paneRef, targetRef string,
 			output:          fmt.Sprintf("Moved %s %s %s\n", pane.Meta.Name, pos, target.Meta.Name),
 			broadcastLayout: true,
 		}
-	}))
+	})
 }
 
 func cmdMove(ctx *CommandContext) {
@@ -204,17 +191,8 @@ func cmdMove(ctx *CommandContext) {
 }
 
 func runMoveTo(ctx *CommandContext, actorPaneID uint32, paneRef, targetRef string) commandpkg.Result {
-	return toCommandResult(ctx.Sess.enqueueCommandMutationContext(ctx.context(), func(mctx *MutationContext) commandMutationResult {
-		w := mctx.windowForActor(actorPaneID)
-		if w == nil {
-			return commandMutationResult{err: fmt.Errorf("no session")}
-		}
-
-		pane, err := w.ResolvePane(paneRef)
-		if err != nil {
-			return commandMutationResult{err: err}
-		}
-		target, err := w.ResolvePane(targetRef)
+	return runActorWindowMutation(ctx, actorPaneID, func(w *mux.Window) commandMutationResult {
+		pane, target, err := resolvePanePair(w, paneRef, targetRef)
 		if err != nil {
 			return commandMutationResult{err: err}
 		}
@@ -226,7 +204,7 @@ func runMoveTo(ctx *CommandContext, actorPaneID uint32, paneRef, targetRef strin
 			output:          fmt.Sprintf("Moved %s to %s's column\n", pane.Meta.Name, target.Meta.Name),
 			broadcastLayout: true,
 		}
-	}))
+	})
 }
 
 func cmdMoveTo(ctx *CommandContext) {
@@ -297,12 +275,7 @@ func cmdDropPane(ctx *CommandContext) {
 }
 
 func runMoveSibling(ctx *CommandContext, actorPaneID uint32, paneRef, direction string) commandpkg.Result {
-	return toCommandResult(ctx.Sess.enqueueCommandMutationContext(ctx.context(), func(mctx *MutationContext) commandMutationResult {
-		w := mctx.windowForActor(actorPaneID)
-		if w == nil {
-			return commandMutationResult{err: fmt.Errorf("no session")}
-		}
-
+	return runActorWindowMutation(ctx, actorPaneID, func(w *mux.Window) commandMutationResult {
 		pane, err := w.ResolvePane(paneRef)
 		if err != nil {
 			return commandMutationResult{err: err}
@@ -324,7 +297,7 @@ func runMoveSibling(ctx *CommandContext, actorPaneID uint32, paneRef, direction 
 			output:          fmt.Sprintf("Moved %s %s\n", pane.Meta.Name, direction),
 			broadcastLayout: true,
 		}
-	}))
+	})
 }
 
 func cmdMoveUp(ctx *CommandContext) {


### PR DESCRIPTION
## Motivation

Several tree command handlers repeated the same actor-window lookup, `no session` guard, and pane-pair resolution before applying different layout mutations. The debug CLI parser also repeated the client pprof socket setup across the client debug subcommands.

## Summary

- Added local tree-command helpers for actor-window mutations and two-pane resolution.
- Routed swap, swap-tree, move, move-to, and move-up/down handlers through the shared helpers while preserving existing outputs and errors.
- Added `debugEndpointRequest.useClientPprof` for the repeated client pprof request setup.

## Testing

- `go test ./internal/server -run 'Test(Parse(Move|DropPane)|DropPanePlacement|QueuedCommand(SwapTree|Move|MoveTo|MoveUpDown|DropPane))' -count=1`
- `go test ./internal/cli -run 'Test(ParseDebugCommand|RunDebug|EnsureDebugSocket|FetchDebugEndpoint)' -count=1`
- `go test ./internal/server ./internal/cli -count=1`
- `git diff --check`
- `go test ./... -timeout 120s` failed in `test` doctor checks because this machine has 89 stale `/tmp/amux-1000` runtime entries older than 7 days; the failure is unrelated to this refactor.
- Pre-push merged coverage hit the same local doctor stale-runtime warning, then reported diff coverage `100.00% (36/36 executable changed lines covered; target 70.00%)` and allowed the push.

## Review focus

- Confirm the tree-command helpers are local and direct enough for the command flow.
- Check that command errors and success output strings are unchanged.
