### PR TITLE
LAB-2011: Bind prefix X to close active windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,6 +391,7 @@ Higher-level prompt delegation now lives at the script layer: compose `wait idle
 | Command | Description |
 |---------|-------------|
 | `amux new-window [--name NAME]` | Create a new window |
+| `amux close-window` | Close the active window |
 | `amux list-windows` | List all windows |
 | `amux select-window <index\|name>` | Switch to a window |
 | `amux next-window` | Switch to next window |
@@ -436,6 +437,7 @@ Default prefix: `Ctrl-a`.
 | `Ctrl-a _` | Root-level split top/bottom |
 | `Ctrl-a a` | Spawn pane in column-fill order |
 | `Ctrl-a x` | Kill active pane |
+| `Ctrl-a X` | Close active window |
 | `Ctrl-a z` | Toggle zoom on active pane |
 | `Ctrl-a }` / `Ctrl-a {` | Swap active pane with next/previous |
 | `Ctrl-a o` | Cycle focus to next pane |

--- a/internal/cli/cli_commands_window.go
+++ b/internal/cli/cli_commands_window.go
@@ -7,6 +7,9 @@ func windowCLICommands() map[string]commandHandler {
 		"new-window": func(inv invocation, args []string) int {
 			return inv.runSessionCommand("new-window", args)
 		},
+		"close-window": func(inv invocation, args []string) int {
+			return inv.runSessionCommand("close-window", nil)
+		},
 		"list-windows": func(inv invocation, args []string) int {
 			return inv.runSessionCommand("list-windows", nil)
 		},

--- a/internal/cli/cli_parse.go
+++ b/internal/cli/cli_parse.go
@@ -40,6 +40,7 @@ var canonicalSessionCommands = map[string]sessionCommandSpec{
 	"list-clients":  {connectName: "list-clients", usage: listClientsUsage, argMode: sessionCommandNoArgs},
 	"list-windows":  {connectName: "list-windows", usage: listWindowsUsage, argMode: sessionCommandNoArgs},
 	"new-window":    {connectName: "new-window", usage: newWindowUsage, argMode: sessionCommandForwardArgs},
+	"close-window":  {connectName: "close-window", usage: closeWindowUsage, argMode: sessionCommandNoArgs},
 	"next-window":   {connectName: "next-window", usage: nextWindowUsage, argMode: sessionCommandNoArgs},
 	"prev-window":   {connectName: "prev-window", usage: prevWindowUsage, argMode: sessionCommandNoArgs},
 	"last-window":   {connectName: "last-window", usage: lastWindowUsage, argMode: sessionCommandNoArgs},

--- a/internal/cli/cli_usage.go
+++ b/internal/cli/cli_usage.go
@@ -295,6 +295,7 @@ Inside an amux session:
   Ctrl-a _                           Root-level split top/bottom
   Ctrl-a a                           Spawn pane in column-fill order
   Ctrl-a x                           Kill active pane
+  Ctrl-a X                           Close active window
   Ctrl-a z                           Toggle zoom on active pane
   Ctrl-a q                           Show pane labels and jump to a pane
   Ctrl-a }                           Swap active pane with next

--- a/internal/cli/cli_usage.go
+++ b/internal/cli/cli_usage.go
@@ -249,9 +249,9 @@ Usage:
   amux [-s session] msg read <msg-id> [--for pane] [--peek] [--format json]
   amux [-s session] msg ack <msg-id> [--for pane] [--status ok|error|seen] [--note text] [--format json]
                                        Manage pane mailbox messages
-	  amux [-s session] new-window         Create a new window
-	  amux [-s session] close-window       Close the active window
-	  amux [-s session] list-windows       List all windows
+  amux [-s session] new-window         Create a new window
+  amux [-s session] close-window       Close the active window
+  amux [-s session] list-windows       List all windows
   amux [-s session] select-window <n>  Switch to window by index or name
   amux [-s session] next-window        Switch to next window
   amux [-s session] prev-window        Switch to previous window

--- a/internal/cli/cli_usage.go
+++ b/internal/cli/cli_usage.go
@@ -42,6 +42,7 @@ const (
 	undoUsage         = "usage: amux undo"
 	waitUsage         = "usage: amux wait <idle|busy|exited|ready|content|layout|clipboard|checkpoint|ui|msg> ..."
 	newWindowUsage    = "usage: amux new-window [--name NAME]"
+	closeWindowUsage  = "usage: amux close-window"
 	nextWindowUsage   = "usage: amux next-window"
 	prevWindowUsage   = "usage: amux prev-window"
 	lastWindowUsage   = "usage: amux last-window"
@@ -75,6 +76,7 @@ var commandUsageByName = map[string]string{
 	"move":             moveUsage,
 	"new":              "usage: amux new [name]",
 	"new-window":       newWindowUsage,
+	"close-window":     closeWindowUsage,
 	"next-window":      nextWindowUsage,
 	"prev-window":      prevWindowUsage,
 	"last-window":      lastWindowUsage,
@@ -247,8 +249,9 @@ Usage:
   amux [-s session] msg read <msg-id> [--for pane] [--peek] [--format json]
   amux [-s session] msg ack <msg-id> [--for pane] [--status ok|error|seen] [--note text] [--format json]
                                        Manage pane mailbox messages
-  amux [-s session] new-window         Create a new window
-  amux [-s session] list-windows       List all windows
+	  amux [-s session] new-window         Create a new window
+	  amux [-s session] close-window       Close the active window
+	  amux [-s session] list-windows       List all windows
   amux [-s session] select-window <n>  Switch to window by index or name
   amux [-s session] next-window        Switch to next window
   amux [-s session] prev-window        Switch to previous window

--- a/internal/cli/main_test.go
+++ b/internal/cli/main_test.go
@@ -251,6 +251,12 @@ func TestResolveCanonicalSessionCommand(t *testing.T) {
 			wantHandled: true,
 		},
 		{
+			name:        "close-window uses no-arg session command",
+			args:        []string{"close-window"},
+			wantCmd:     "close-window",
+			wantHandled: true,
+		},
+		{
 			name:        "rename forwards pane and new name",
 			args:        []string{"rename", "pane-1", "logs"},
 			wantCmd:     "rename",
@@ -620,6 +626,12 @@ func TestMaybePrintCommandHelp(t *testing.T) {
 			wantStdout:  "usage: amux last-window\n",
 		},
 		{
+			name:        "close-window help",
+			args:        []string{"close-window", "--help"},
+			wantHandled: true,
+			wantStdout:  "usage: amux close-window\n",
+		},
+		{
 			name:        "rename help",
 			args:        []string{"rename", "--help"},
 			wantHandled: true,
@@ -803,6 +815,14 @@ func TestRunMainDispatchesCommands(t *testing.T) {
 			wantExit: 0,
 			wantCalls: []cliCall{
 				{kind: "server-command", session: resolvedSessionMarker, cmd: "last-window"},
+			},
+		},
+		{
+			name:     "close-window dispatches through server",
+			args:     []string{"close-window"},
+			wantExit: 0,
+			wantCalls: []cliCall{
+				{kind: "server-command", session: resolvedSessionMarker, cmd: "close-window"},
 			},
 		},
 		{

--- a/internal/cli/main_test.go
+++ b/internal/cli/main_test.go
@@ -683,6 +683,17 @@ func TestPrintUsageOmitsDelegate(t *testing.T) {
 	}
 }
 
+func TestPrintUsageIncludesCloseWindowKeybinding(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	WriteUsage(&buf)
+
+	if !strings.Contains(buf.String(), "Ctrl-a X                           Close active window") {
+		t.Fatalf("printUsage should include close-window keybinding:\n%s", buf.String())
+	}
+}
+
 func TestRunMainDefaultSession(t *testing.T) {
 	t.Run("attaches to resolved session", func(t *testing.T) {
 		t.Setenv("AMUX_CHECKPOINT", "")

--- a/internal/client/help_bar.go
+++ b/internal/client/help_bar.go
@@ -69,6 +69,7 @@ func buildHelpBar(kb *config.Keybindings) *helpBarState {
 		helpBarItemForKeys(helpBindingDisplay(kb, helpBindingSelector{action: "split", args: []string{"--focus"}}), "hsplit"),
 		helpBarItemForKeys(helpBindingDisplay(kb, helpBindingSelector{action: "equalize"}), "equalize"),
 		helpBarItemForKeys(helpBindingDisplay(kb, helpBindingSelector{action: "kill"}), "kill"),
+		helpBarItemForKeys(helpBindingDisplay(kb, helpBindingSelector{action: "close-window"}), "close-win"),
 		helpBarItemForKeys(helpBindingDisplay(kb, helpBindingSelector{action: "zoom"}), "zoom"),
 		helpBarItemForKeys(helpBindingDisplay(kb, helpBindingSelector{action: "undo"}), "undo"),
 		helpBarItemForKeys(helpBarJoinParts(

--- a/internal/client/help_bar_test.go
+++ b/internal/client/help_bar_test.go
@@ -29,7 +29,7 @@ func TestBuildHelpBarUsesBindingMap(t *testing.T) {
 	if !strings.Contains(view, "? close") {
 		t.Fatalf("help bar view = %q, want the toggle key to advertise close while active", view)
 	}
-	for _, want := range []string{"\\ root-vsplit", "_ root-hsplit", "x kill", "z zoom", ". rename-pane"} {
+	for _, want := range []string{"\\ root-vsplit", "_ root-hsplit", "x kill", "X close-win", "z zoom", ". rename-pane"} {
 		if !strings.Contains(view, want) {
 			t.Fatalf("help bar view = %q, want %q item", view, want)
 		}
@@ -89,7 +89,7 @@ func TestHelpBarDisplayOnlyAndDismiss(t *testing.T) {
 	cr.RenderDiff()
 
 	display := cr.CaptureDisplay()
-	for _, want := range []string{"? close", "x kill", "c new-win", ". rename-pane"} {
+	for _, want := range []string{"? close", "x kill", "X close-win", "c new-win", ". rename-pane"} {
 		if !strings.Contains(display, want) {
 			t.Fatalf("display capture should include %q in the bottom help bar, got:\n%s", want, display)
 		}

--- a/internal/config/keybindings.go
+++ b/internal/config/keybindings.go
@@ -37,6 +37,7 @@ func DefaultKeybindings() *Keybindings {
 			'L':  {Action: "resize-active", Args: []string{"right", "2"}},
 			'=':  {Action: "equalize"},
 			'x':  {Action: "kill"},
+			'X':  {Action: "close-window"},
 			'z':  {Action: "zoom"},
 			// Reserve lowercase m so it does not fall through as literal input.
 			'm': {Action: "compat-bell"},

--- a/internal/config/keybindings_test.go
+++ b/internal/config/keybindings_test.go
@@ -79,6 +79,11 @@ func TestDefaultKeybindings(t *testing.T) {
 			want: Binding{Action: "last-window"},
 		},
 		{
+			name: "capital x closes the active window",
+			key:  'X',
+			want: Binding{Action: "close-window"},
+		},
+		{
 			name: "m remains reserved for compat bell",
 			key:  'm',
 			want: Binding{Action: "compat-bell"},

--- a/internal/server/command_queue_test.go
+++ b/internal/server/command_queue_test.go
@@ -432,6 +432,42 @@ func TestQueuedCommandCloseWindowDetachesMirrorWindow(t *testing.T) {
 	})
 }
 
+func TestQueuedCommandCloseWindowLastWindowExitsSession(t *testing.T) {
+	t.Parallel()
+
+	_, sess, cleanup := newCommandTestSession(t)
+	defer cleanup()
+
+	p1 := newTestPane(sess, 1, "pane-1")
+	p2 := newTestPane(sess, 2, "pane-2")
+	w := newTestWindowWithPanes(t, sess, 1, "main", p1, p2)
+	setSessionLayoutForTest(t, sess, w.ID, []*mux.Window{w}, p1, p2)
+
+	res := runCloseWindow(&CommandContext{Sess: sess})
+
+	if res.Err != nil {
+		t.Fatalf("close-window error: %v", res.Err)
+	}
+	if !strings.Contains(res.Output, "Closed window main (session exiting)") {
+		t.Fatalf("close-window output = %q, want session exiting", res.Output)
+	}
+	if !res.SendExit {
+		t.Fatal("close-window should send session exit when closing the last window")
+	}
+	if !res.ShutdownServer {
+		t.Fatal("close-window should shut down the server when closing the last window")
+	}
+	mustSessionQuery(t, sess, func(sess *Session) struct{} {
+		if len(sess.Windows) != 0 {
+			t.Fatalf("windows after close = %+v, want none", sess.Windows)
+		}
+		if len(sess.Panes) != 0 {
+			t.Fatalf("panes after close = %+v, want none", sess.Panes)
+		}
+		return struct{}{}
+	})
+}
+
 func TestQueuedCommandSpawnLocal(t *testing.T) {
 	t.Parallel()
 

--- a/internal/server/command_queue_test.go
+++ b/internal/server/command_queue_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/weill-labs/amux/internal/config"
 	"github.com/weill-labs/amux/internal/mux"
+	"github.com/weill-labs/amux/internal/server/mirror"
 )
 
 func TestEnqueueCommandMutationReturnsOnSessionShutdown(t *testing.T) {
@@ -347,6 +348,88 @@ func TestQueuedCommandNewWindow(t *testing.T) {
 		t.Fatal("expected layout generation to increment")
 	}
 	assertSessionLayoutConsistent(t, sess)
+}
+
+func TestQueuedCommandCloseWindowClosesOnlyActiveWindow(t *testing.T) {
+	t.Parallel()
+
+	srv, sess, cleanup := newCommandTestSession(t)
+	defer cleanup()
+
+	p1 := newTestPane(sess, 1, "pane-1")
+	p2 := newTestPane(sess, 2, "pane-2")
+	p3 := newTestPane(sess, 3, "pane-3")
+	w1 := newTestWindowWithPanes(t, sess, 1, "main", p1)
+	w2 := newTestWindowWithPanes(t, sess, 2, "logs", p2, p3)
+	setSessionLayoutForTest(t, sess, w2.ID, []*mux.Window{w1, w2}, p1, p2, p3)
+
+	before := sess.generation.Load()
+	res := runTestCommand(t, srv, sess, "close-window")
+
+	if res.cmdErr != "" {
+		t.Fatalf("close-window error: %s", res.cmdErr)
+	}
+	if !strings.Contains(res.output, "Closed window logs") {
+		t.Fatalf("close-window output = %q", res.output)
+	}
+	if sess.generation.Load() <= before {
+		t.Fatal("expected layout generation to increment")
+	}
+	mustSessionQuery(t, sess, func(sess *Session) struct{} {
+		if len(sess.Windows) != 1 || sess.Windows[0].ID != w1.ID {
+			t.Fatalf("windows after close = %+v, want only main", sess.Windows)
+		}
+		if sess.ActiveWindowID != w1.ID {
+			t.Fatalf("active window = %d, want %d", sess.ActiveWindowID, w1.ID)
+		}
+		if len(sess.Panes) != 1 || sess.Panes[0].ID != p1.ID {
+			t.Fatalf("panes after close = %+v, want only pane-1", sess.Panes)
+		}
+		return struct{}{}
+	})
+	assertSessionLayoutConsistent(t, sess)
+}
+
+func TestQueuedCommandCloseWindowDetachesMirrorWindow(t *testing.T) {
+	t.Parallel()
+
+	srv, sess, cleanup := newCommandTestSession(t)
+	defer cleanup()
+
+	mgr := mirror.NewManager(mirror.Config{})
+	t.Cleanup(mgr.Close)
+	sess.mirror = mgr
+
+	p1 := newTestPane(sess, 1, "pane-1")
+	p2 := newTestPane(sess, 2, "mirror-left")
+	p3 := newTestPane(sess, 3, "mirror-right")
+	w1 := newTestWindowWithPanes(t, sess, 1, "main", p1)
+	w2 := newTestWindowWithPanes(t, sess, 2, "host:remote", p2, p3)
+	setSessionLayoutForTest(t, sess, w2.ID, []*mux.Window{w1, w2}, p1, p2, p3)
+	if err := mgr.TrackWindow(w2.ID, mirror.WindowRef{Host: "host", Session: "main", WindowName: "remote"}, w2.Width, w2.Height); err != nil {
+		t.Fatalf("TrackWindow: %v", err)
+	}
+	mustSessionMutation(t, sess, func(sess *Session) {
+		sess.windowMirrorSigs = map[uint32]string{w2.ID: "sig"}
+	})
+
+	res := runTestCommand(t, srv, sess, "close-window")
+
+	if res.cmdErr != "" {
+		t.Fatalf("close-window error: %s", res.cmdErr)
+	}
+	if _, ok := mgr.WindowSnapshot(w2.ID); ok {
+		t.Fatal("window mirror subscription should be detached")
+	}
+	mustSessionQuery(t, sess, func(sess *Session) struct{} {
+		if _, ok := sess.windowMirrorSigs[w2.ID]; ok {
+			t.Fatal("window mirror signature should be removed")
+		}
+		if len(sess.Windows) != 1 || sess.Windows[0].ID != w1.ID {
+			t.Fatalf("windows after close = %+v, want only main", sess.Windows)
+		}
+		return struct{}{}
+	})
 }
 
 func TestQueuedCommandSpawnLocal(t *testing.T) {

--- a/internal/server/commands.go
+++ b/internal/server/commands.go
@@ -197,6 +197,7 @@ var commandRegistry = map[string]CommandHandler{
 	"broadcast":           cmdBroadcast,
 	"status":              cmdStatus,
 	"new-window":          cmdNewWindow,
+	"close-window":        cmdCloseWindow,
 	"list-windows":        cmdListWindows,
 	"list-clients":        cmdListClients,
 	"connection-log":      cmdConnectionLog,

--- a/internal/server/commands/layout/commands.go
+++ b/internal/server/commands/layout/commands.go
@@ -27,6 +27,7 @@ type Context interface {
 	Undo() commandpkg.Result
 	CopyMode(actorPaneID uint32, opts CopyModeOptions) commandpkg.Result
 	NewWindow(name string) commandpkg.Result
+	CloseWindow() commandpkg.Result
 	SelectWindow(ref string) commandpkg.Result
 	NextWindow() commandpkg.Result
 	PrevWindow() commandpkg.Result
@@ -136,6 +137,10 @@ func NewWindow(ctx Context, args []string) commandpkg.Result {
 		}
 	}
 	return ctx.NewWindow(name)
+}
+
+func CloseWindow(ctx Context, _ []string) commandpkg.Result {
+	return ctx.CloseWindow()
 }
 
 func SelectWindow(ctx Context, args []string) commandpkg.Result {

--- a/internal/server/commands/layout/commands_test.go
+++ b/internal/server/commands/layout/commands_test.go
@@ -123,6 +123,10 @@ func (f *fakeLayoutContext) NewWindow(string) commandpkg.Result {
 	return commandpkg.Result{}
 }
 
+func (f *fakeLayoutContext) CloseWindow() commandpkg.Result {
+	return commandpkg.Result{}
+}
+
 func (f *fakeLayoutContext) SelectWindow(string) commandpkg.Result {
 	return commandpkg.Result{}
 }

--- a/internal/server/commands_layout.go
+++ b/internal/server/commands_layout.go
@@ -399,6 +399,10 @@ func (ctx layoutCommandContext) NewWindow(name string) commandpkg.Result {
 	return runNewWindow(ctx.CommandContext, name)
 }
 
+func (ctx layoutCommandContext) CloseWindow() commandpkg.Result {
+	return runCloseWindow(ctx.CommandContext)
+}
+
 func (ctx layoutCommandContext) SelectWindow(ref string) commandpkg.Result {
 	return runSelectWindow(ctx.CommandContext, ref)
 }
@@ -916,6 +920,79 @@ func runNewWindow(ctx *CommandContext, name string) commandpkg.Result {
 			broadcastLayout: true,
 		}
 	}))
+}
+
+func runCloseWindow(ctx *CommandContext) commandpkg.Result {
+	return toCommandResult(ctx.Sess.enqueueCommandMutationContext(ctx.context(), func(mctx *MutationContext) commandMutationResult {
+		w := mctx.activeWindow()
+		if w == nil {
+			return commandMutationResult{err: fmt.Errorf("no window")}
+		}
+		name := w.Name
+		paneIDs := windowPaneIDs(w)
+		if len(paneIDs) == 0 {
+			return commandMutationResult{err: fmt.Errorf("window %q has no panes", name)}
+		}
+
+		detachWindowMirror(mctx, w)
+
+		removedPanes := make([]*mux.Pane, 0, len(paneIDs))
+		removedCount := 0
+		for _, paneID := range paneIDs {
+			removed := mctx.softClosePane(paneID)
+			if removed.pane == nil {
+				continue
+			}
+			removedCount++
+			removedPanes = append(removedPanes, removed.pane)
+			mctx.appendPaneLog(paneLogEventExit, removed.pane, "closed window")
+			mctx.emitEvent(Event{
+				Type:     EventPaneExit,
+				PaneID:   removed.pane.ID,
+				PaneName: removed.paneName,
+				Host:     removed.pane.Meta.Host,
+				Reason:   "closed window",
+			})
+			if removed.sendExit {
+				for _, pane := range removedPanes {
+					mctx.ScheduleClose(pane)
+				}
+				return commandMutationResult{
+					output:         fmt.Sprintf("Closed window %s (session exiting)\n", name),
+					sendExit:       true,
+					shutdownServer: true,
+				}
+			}
+		}
+		if removedCount == 0 {
+			return commandMutationResult{err: fmt.Errorf("window %q has no panes to close", name)}
+		}
+		return commandMutationResult{
+			output:          fmt.Sprintf("Closed window %s (%s)\n", name, paneCountLabel(removedCount)),
+			broadcastLayout: true,
+			paneRenders:     activePaneRender(mctx.activeWindow()),
+		}
+	}))
+}
+
+func detachWindowMirror(mctx *MutationContext, w *mux.Window) {
+	if mctx == nil || mctx.sess == nil || w == nil {
+		return
+	}
+	if _, ok := mctx.sess.windowMirrorSigs[w.ID]; !ok {
+		return
+	}
+	if mctx.sess.mirror != nil {
+		mctx.sess.mirror.DetachWindow(w.ID)
+	}
+	delete(mctx.sess.windowMirrorSigs, w.ID)
+}
+
+func paneCountLabel(n int) string {
+	if n == 1 {
+		return "1 pane"
+	}
+	return fmt.Sprintf("%d panes", n)
 }
 
 func runSelectWindow(ctx *CommandContext, ref string) commandpkg.Result {

--- a/internal/server/commands_remote.go
+++ b/internal/server/commands_remote.go
@@ -584,8 +584,7 @@ func runRemoteDetachWindow(ctx *CommandContext) commandpkg.Result {
 		// Stop the layout subscription first, then soft-close each pane (which
 		// also detaches the per-pane mirror); closing the last pane removes the
 		// window.
-		mctx.sess.mirror.DetachWindow(w.ID)
-		delete(mctx.sess.windowMirrorSigs, w.ID)
+		detachWindowMirror(mctx, w)
 		for _, id := range paneIDs {
 			mctx.softClosePane(id)
 		}

--- a/internal/server/commands_window.go
+++ b/internal/server/commands_window.go
@@ -11,6 +11,10 @@ func cmdNewWindow(ctx *CommandContext) {
 	ctx.applyCommandResult(layoutcmd.NewWindow(layoutCommandContext{ctx}, ctx.Args))
 }
 
+func cmdCloseWindow(ctx *CommandContext) {
+	ctx.applyCommandResult(layoutcmd.CloseWindow(layoutCommandContext{ctx}, ctx.Args))
+}
+
 func cmdSelectWindow(ctx *CommandContext) {
 	ctx.applyCommandResult(layoutcmd.SelectWindow(layoutCommandContext{ctx}, ctx.Args))
 }

--- a/test/amux_harness_test.go
+++ b/test/amux_harness_test.go
@@ -132,12 +132,22 @@ func newAmuxHarnessHandle(tb testing.TB, outer *ServerHarness, inner, binPath st
 		outer:          outer,
 		inner:          inner,
 		innerBin:       binPath,
-		innerSocketDir: tb.TempDir(),
+		innerSocketDir: newInnerSocketDir(tb),
 		tb:             tb,
 		session:        inner,
 	}
 	tb.Cleanup(h.cleanup)
 	return h
+}
+
+func newInnerSocketDir(tb testing.TB) string {
+	tb.Helper()
+	dir, err := os.MkdirTemp(testSocketDir(), "inner-")
+	if err != nil {
+		tb.Fatalf("creating inner socket dir: %v", err)
+	}
+	tb.Cleanup(func() { _ = os.RemoveAll(dir) })
+	return dir
 }
 
 // cleanup detaches the inner client, then SIGTERMs the inner server.

--- a/test/border_test.go
+++ b/test/border_test.go
@@ -145,6 +145,10 @@ func TestVerticalBorderPartialColor(t *testing.T) {
 	h.splitV()
 	h.splitH()
 
+	if !h.waitFor("[pane-3]", 3*time.Second) {
+		t.Fatal("timed out waiting for pane-3 to appear in outer capture")
+	}
+
 	lines := strings.Split(h.captureANSI(), "\n")
 
 	hBorderRows := findANSIHorizontalBorderRows(lines)

--- a/test/server_harness_test.go
+++ b/test/server_harness_test.go
@@ -556,6 +556,7 @@ func formatHarnessCommandResult(cmdName string, msg *server.Message) string {
 var attachedClientCommands = map[string]bool{
 	"_layout-json": true,
 	"cursor":       true,
+	"close-window": true,
 	"focus":        true,
 	"new-window":   true,
 	"send-keys":    true,

--- a/test/window_test.go
+++ b/test/window_test.go
@@ -658,6 +658,42 @@ func TestLastWindowKeybinding(t *testing.T) {
 	}
 }
 
+func TestCloseWindowKeybinding(t *testing.T) {
+	t.Parallel()
+	h := newAmuxHarness(t)
+
+	gen := h.generation()
+	h.sendClientKeys("C-a", "c")
+	h.waitLayout(gen)
+	h.assertActive("pane-2")
+
+	gen = h.generation()
+	h.sendClientKeys("C-a", "|")
+	h.waitLayout(gen)
+	h.assertActive("pane-3")
+
+	gen = h.generation()
+	h.sendClientKeys("C-a", "x")
+	h.waitLayout(gen)
+	h.assertActive("pane-2")
+	if strings.Contains(h.capture(), "[pane-3]") {
+		t.Fatalf("lowercase Ctrl-a x should close only active pane-3.\nScreen:\n%s", h.capture())
+	}
+	if bar := h.globalBar(); !hasWindowTab(bar, 1) || !hasWindowTab(bar, 2) {
+		t.Fatalf("lowercase Ctrl-a x should preserve both windows, got bar %q", bar)
+	}
+
+	gen = h.generation()
+	h.sendClientKeys("C-a", "X")
+	if !h.waitLayoutOrTimeout(gen, "2s") {
+		t.Fatalf("capital Ctrl-a X should change the layout.\nScreen:\n%s", h.capture())
+	}
+	h.assertActive("pane-1")
+	if bar := h.globalBar(); hasWindowTab(bar, 2) {
+		t.Fatalf("capital Ctrl-a X should remove window 2, got bar %q", bar)
+	}
+}
+
 func TestWindowPaneIsolation(t *testing.T) {
 	t.Parallel()
 	h := newAmuxHarness(t)


### PR DESCRIPTION
## Motivation
`Ctrl-a x` only kills the active pane; users need a capital-prefix shortcut and CLI command to close the current window without touching other windows.

## Summary
- Add a `close-window` command path through CLI parsing, server dispatch, and the layout command context.
- Bind default `Ctrl-a X` to close the active window and advertise it in help and README docs.
- Close all panes in the active window, detach mirrored window subscriptions, and preserve lowercase `Ctrl-a x` as pane-only kill behavior.
- Keep nested harness socket paths short and wait for rendered pane output in the border color test to avoid CI-only socket/race failures exposed by the new integration coverage.

## Testing
- `go test ./internal/config ./internal/client ./internal/cli ./internal/server ./test -run 'TestDefaultKeybindings|TestBuildHelpBarUsesBindingMap|TestHelpBarDisplayOnlyAndDismiss|TestResolveCanonicalSessionCommand|TestMaybePrintCommandHelp|TestRunMainDispatchesCommands|TestQueuedCommandCloseWindow|TestCloseWindowKeybinding|TestRemoteCLIDetachWindow|TestVerticalBorderPartialColor' -count=100`
- `go test ./test -run 'TestOnlyActivePaneBordersColored|TestJunctionNotColoredOnInactiveBorder|TestVerticalBorderPartialColor|TestCloseWindowKeybinding' -count=3 -parallel 2 -timeout 360s`
- `go test ./test -run TestRemoteCLIDetachWindow -count=1`
- `go test ./... -timeout 120s` was attempted locally and failed on pre-existing/local-environment issues unrelated to this diff: long Unix socket path bind errors in several packages, `internal/auditlog` FD_CLOEXEC, `TestTypeKeysPacesEnterAfterText`, and remote chooser/doctor state failures.
- CI on rebased head: `test`, `codecov/patch`, `claude-review`, and `semgrep-cloud-platform/scan` all completed successfully.
- `git merge-tree --write-tree origin/main HEAD`

## Review focus
- `runCloseWindow` behavior around closing every pane in the active window, especially session-exit and mirror-detach paths.
- CLI and keybinding split between lowercase `x` and uppercase `X`.
- The nested harness socket-dir change, which keeps inner sockets under `/tmp/amux-$UID` instead of long per-test tempdir paths.

Closes LAB-2011